### PR TITLE
feat: export an actor's full data as an ActivityPub archive

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -225,6 +225,7 @@ If you have been running with a blank media path, treat it as a **credential exp
 
 - a legacy root `config.json` (`application/json`), which on older instances held the whole configuration: `secretPhase`, database credentials, and auth and email secrets (S3 credentials were never in it — those come from the AWS SDK chain);
 - `backups/production-archives/*.tar.gz` (`application/gzip`), the default output directory of `scripts/backup/productionArchive.ts` — a full database and media archive;
+- `backups/actor-archives/*.tar.gz` (`application/gzip`), the default output directory of `scripts/backup/exportActorArchive.ts` — one account's full ActivityPub archive (every status regardless of visibility, media, fitness files, likes, bookmarks, and follows);
 - key material such as `.p8` (the Apple Maps signing key), `.pem`, `.crt`, `.p12` and `.pfx`;
 - `.conf`, `.ini`, `.toml` and `.txt`, plus source files (`.ts`, `.js`, `.json`, `.md`, `.yml`, `.sql`).
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -115,6 +115,70 @@ The script includes several safety features:
 
 **Warning**: Always run with `--dry-run` first to verify the files to be deleted are indeed orphaned.
 
+## Actor Archive Export
+
+The `exportActorArchive.ts` script exports everything belonging to one **local**
+actor into a Mastodon-compatible ActivityPub archive (`.tar.gz`): every status
+regardless of visibility (public, unlisted, followers-only, direct), media
+attachment bytes, fitness activity files and route maps (an extension beyond
+the Mastodon archive format — includes imported activities that were never
+posted), the actor profile, likes, bookmarks, and follow lists. It is
+read-only against the database and storage.
+
+### Usage
+
+```bash
+NODE_ENV=production ./scripts/backup/exportActorArchive.ts --username alice
+NODE_ENV=production ./scripts/backup/exportActorArchive.ts --actor-id https://your-domain.tld/users/alice
+NODE_ENV=production ./scripts/backup/exportActorArchive.ts --email alice@example.com
+
+# Preview the flags without connecting to anything
+./scripts/backup/exportActorArchive.ts --help
+```
+
+Pass exactly one of `--username` (optionally with `--domain`, defaulting to
+the configured host), `--actor-id`, or `--email` to select the actor.
+
+### Options
+
+- `--env-file <path>` — env file to load (default `.env.production`; use
+  `.env.local` for a local export)
+- `--output-dir <path>` — output directory (default `backups/actor-archives`)
+- `--page-size <n>` — pagination batch size for every collection (default 100)
+- `--allow-missing-storage` — warn and continue instead of aborting when a
+  referenced media or fitness file is missing from storage; failures are
+  recorded per-file in the archive's `manifest.json`
+- `--skip-storage` — write only the JSON/CSV files, no media or fitness bytes
+- `--fetch-remote-attachments` — download attachments hosted on other servers
+  into the archive too (by default their absolute URL is kept as-is, since
+  the export only owns the actor's own storage)
+
+### Archive layout
+
+```
+actor.json                    Person profile (avatar/header rewritten to local files)
+outbox.json                   OrderedCollection of Create/Announce activities, every status
+likes.json / bookmarks.json   OrderedCollections of status URIs
+following_accounts.csv        Mastodon-import-compatible CSV
+followers.csv                 Extension: one handle per line
+avatar.* / header.*           Profile images, when present
+media_attachments/files/      Attachment, thumbnail, and route-map bytes
+media_attachments/remote/     Only with --fetch-remote-attachments
+fitness_files/files/          .fit/.gpx/.tcx bytes
+fitness_files/fitness.json    Every fitness activity, including ones with no post
+status_history.json           Edit history for edited statuses
+manifest.json                 Counts, storage results, and warnings
+```
+
+Unlike the ActivityPub outbox route, every attachment on a status is kept
+(the federation format truncates to a handful and drops fitness attachments),
+and every visibility is included — this is an owner's export, not a
+visitor's view. Like `productionArchive.ts`, it prints the resolved database
+connection before doing anything, and `@next/env` loads `.env.local` at
+higher precedence than `.env.production` even under `NODE_ENV=production` —
+verify the printed banner shows the database you intend before trusting the
+output.
+
 ## Other Scripts
 
 ### Create Mock User

--- a/scripts/backup/actorArchive.test.ts
+++ b/scripts/backup/actorArchive.test.ts
@@ -1,0 +1,509 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
+import { Attachment } from '@/lib/types/domain/attachment'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import {
+  buildActorJson,
+  buildExportActivity,
+  buildFollowersCsv,
+  buildFollowingCsv,
+  createOrderedCollectionWriter,
+  csvEscape,
+  forEachActorStatus,
+  forEachFitnessFile,
+  forEachLike,
+  getArchiveFitnessPath,
+  getArchiveMediaPath,
+  getMediaStoragePathFromUrl,
+  parseExportActorArgs
+} from './actorArchive'
+
+const buildAttachment = (overrides: Partial<Attachment> = {}): Attachment => ({
+  id: 'attachment-1',
+  actorId: 'https://example.test/users/alice',
+  statusId: 'status-1',
+  type: 'Document',
+  mediaType: 'image/jpeg',
+  url: 'https://example.test/api/v1/files/ab/cd.webp',
+  name: 'a photo',
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const buildStatus = (overrides: Partial<Status> = {}): Status =>
+  ({
+    id: 'https://example.test/users/alice/statuses/1',
+    actorId: 'https://example.test/users/alice',
+    actor: null,
+
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+
+    isLocalActor: true,
+    createdAt: 1,
+    updatedAt: 1,
+
+    type: StatusType.enum.Note,
+    url: 'https://example.test/@alice/1',
+    text: 'hello world',
+    reply: '',
+    replies: [],
+
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    totalLikes: 0,
+    totalShares: 0,
+
+    attachments: [],
+    tags: [],
+
+    ...overrides
+  }) as Status
+
+describe('parseExportActorArgs', () => {
+  it('throws when no actor selector is given', () => {
+    expect(() => parseExportActorArgs([])).toThrow()
+  })
+
+  it('throws when more than one actor selector is given', () => {
+    expect(() =>
+      parseExportActorArgs(['--username', 'alice', '--email', 'a@example.test'])
+    ).toThrow()
+  })
+
+  it('applies defaults for a bare --username selector', () => {
+    const args = parseExportActorArgs(['--username', 'alice'])
+    expect(args).toMatchObject({
+      username: 'alice',
+      domain: undefined,
+      actorId: undefined,
+      email: undefined,
+      envFile: '.env.production',
+      outputDir: 'backups/actor-archives',
+      pageSize: 100,
+      allowMissingStorage: false,
+      skipStorage: false,
+      fetchRemoteAttachments: false
+    })
+  })
+
+  it('parses --key=value form and boolean flags', () => {
+    const args = parseExportActorArgs([
+      '--actor-id=https://example.test/users/alice',
+      '--page-size=25',
+      '--allow-missing-storage',
+      '--skip-storage',
+      '--fetch-remote-attachments'
+    ])
+    expect(args).toMatchObject({
+      actorId: 'https://example.test/users/alice',
+      pageSize: 25,
+      allowMissingStorage: true,
+      skipStorage: true,
+      fetchRemoteAttachments: true
+    })
+  })
+
+  it('throws on a non-numeric --page-size', () => {
+    expect(() =>
+      parseExportActorArgs(['--username', 'alice', '--page-size', 'nope'])
+    ).toThrow()
+  })
+})
+
+describe('getMediaStoragePathFromUrl', () => {
+  it.each([
+    [
+      'a media file URL',
+      'https://example.test/api/v1/files/ab/cd.webp',
+      'ab/cd.webp'
+    ],
+    [
+      'a media file URL with an encoded space',
+      'https://example.test/api/v1/files/ab%20cd/ef.webp',
+      'ab cd/ef.webp'
+    ],
+    [
+      'a fitness-file URL',
+      'https://example.test/api/v1/fitness-files/id-1',
+      null
+    ],
+    ['a foreign host URL', 'https://other.example/some/path.jpg', null],
+    ['a non-absolute string', 'not-a-url', null]
+  ])('returns %s -> %s', (_description, url, expected) => {
+    expect(getMediaStoragePathFromUrl(url)).toBe(expected)
+  })
+})
+
+describe('getArchiveMediaPath / getArchiveFitnessPath', () => {
+  it('prefixes storage paths with the archive directory', () => {
+    expect(getArchiveMediaPath('ab/cd.webp')).toBe(
+      'media_attachments/files/ab/cd.webp'
+    )
+    expect(getArchiveFitnessPath('ab/cd.fit')).toBe(
+      'fitness_files/files/ab/cd.fit'
+    )
+  })
+})
+
+describe('csvEscape / buildFollowingCsv / buildFollowersCsv', () => {
+  it('leaves plain values untouched', () => {
+    expect(csvEscape('alice@example.test')).toBe('alice@example.test')
+  })
+
+  it('quotes and escapes values containing commas or quotes', () => {
+    expect(csvEscape('a "quoted", value')).toBe('"a ""quoted"", value"')
+  })
+
+  it('builds a Mastodon-import-compatible following CSV', () => {
+    const csv = buildFollowingCsv([
+      {
+        handle: 'alice@example.test',
+        showBoosts: true,
+        notify: false,
+        languages: null
+      },
+      {
+        handle: 'bob@example.test',
+        showBoosts: false,
+        notify: true,
+        languages: ['en', 'th']
+      }
+    ])
+    expect(csv).toBe(
+      'Account address,Show boosts,Notify on new posts,Languages\n' +
+        'alice@example.test,true,false,\n' +
+        'bob@example.test,false,true,"en, th"\n'
+    )
+  })
+
+  it('builds a followers CSV with just the handle column', () => {
+    const csv = buildFollowersCsv(['alice@example.test', 'bob@example.test'])
+    expect(csv).toBe('Account address\nalice@example.test\nbob@example.test\n')
+  })
+})
+
+describe('buildActorJson', () => {
+  it('rewrites icon and image URLs to the archived file names', () => {
+    const actorJson = buildActorJson({
+      person: {
+        id: 'https://example.test/users/alice',
+        icon: { type: 'Image', mediaType: 'image/jpeg', url: 'https://old' },
+        image: { type: 'Image', mediaType: 'image/png', url: 'https://old' }
+      },
+      avatarFileName: 'avatar.webp',
+      headerFileName: 'header.webp'
+    })
+
+    expect(actorJson.icon).toEqual({
+      type: 'Image',
+      mediaType: 'image/jpeg',
+      url: 'avatar.webp'
+    })
+    expect(actorJson.image).toEqual({
+      type: 'Image',
+      mediaType: 'image/png',
+      url: 'header.webp'
+    })
+  })
+
+  it('leaves icon/image untouched when no local copy exists', () => {
+    const actorJson = buildActorJson({
+      person: { id: 'https://example.test/users/alice' },
+      avatarFileName: null,
+      headerFileName: null
+    })
+    expect(actorJson.icon).toBeUndefined()
+    expect(actorJson.image).toBeUndefined()
+  })
+})
+
+describe('buildExportActivity', () => {
+  const urlToArchivePath = (url: string) =>
+    url === 'https://example.test/api/v1/files/ab/cd.webp'
+      ? 'media_attachments/files/ab/cd.webp'
+      : url
+
+  it('shapes an Announce as a reference to the boosted status id', () => {
+    const originalStatus = buildStatus({
+      id: 'https://example.test/users/bob/statuses/1'
+    })
+    const status = buildStatus({
+      id: 'https://example.test/users/alice/statuses/announce-1',
+      type: StatusType.enum.Announce,
+      originalStatus
+    } as Partial<Status>)
+
+    const activity = buildExportActivity({ status, urlToArchivePath })
+
+    expect(activity).toMatchObject({
+      id: status.id,
+      type: 'Announce',
+      object: originalStatus.id
+    })
+    expect(activity).not.toHaveProperty('attachment')
+  })
+
+  it('keeps every attachment, beyond the federation cap, and rewrites local URLs', () => {
+    const attachments = Array.from(
+      { length: MAX_FEDERATION_MEDIA_ATTACHMENTS + 1 },
+      (_, index) =>
+        buildAttachment({
+          id: `attachment-${index}`,
+          url: `https://example.test/api/v1/files/photo-${index}.webp`
+        })
+    )
+    // One attachment resolves through the local-file URL map; the rest are
+    // left as absolute URLs (as a remote/unmapped attachment would be).
+    attachments[0] = buildAttachment({
+      id: 'attachment-0',
+      url: 'https://example.test/api/v1/files/ab/cd.webp'
+    })
+    const status = buildStatus({ attachments })
+
+    const activity = buildExportActivity({ status, urlToArchivePath })
+    const object = activity.object as { attachment: { url: string }[] }
+
+    expect(object.attachment).toHaveLength(attachments.length)
+    expect(object.attachment[0].url).toBe('media_attachments/files/ab/cd.webp')
+    expect(object.attachment[1].url).toBe(attachments[1].url)
+  })
+
+  it('keeps fitness attachments, which the federation serializer drops', () => {
+    const status = buildStatus({
+      attachments: [
+        buildAttachment({
+          id: 'fitness-attachment',
+          mediaType: 'application/vnd.ant.fit',
+          url: 'https://example.test/api/v1/fitness-files/abc',
+          name: 'ride.fit'
+        })
+      ]
+    })
+
+    const activity = buildExportActivity({ status, urlToArchivePath })
+    const object = activity.object as { attachment: { url: string }[] }
+
+    expect(object.attachment).toHaveLength(1)
+  })
+
+  it('strips embedded reply objects but keeps the totalItems count', () => {
+    const status = buildStatus({
+      replies: [buildStatus({ id: 'reply-1' })]
+    })
+
+    const activity = buildExportActivity({ status, urlToArchivePath })
+    const object = activity.object as {
+      replies: { totalItems: number; items?: unknown }
+    }
+
+    expect(object.replies.totalItems).toBe(1)
+    expect(object.replies).not.toHaveProperty('items')
+  })
+
+  it('shapes a Poll as a Create wrapping a Question with attachments retained', () => {
+    const status = buildStatus({
+      type: StatusType.enum.Poll,
+      choices: [
+        {
+          statusId: 'status-1',
+          title: 'A',
+          totalVotes: 1,
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          statusId: 'status-1',
+          title: 'B',
+          totalVotes: 2,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      endAt: Date.now() + 1000,
+      pollType: 'oneOf',
+      attachments: [buildAttachment()]
+    } as Partial<Status>)
+
+    const activity = buildExportActivity({ status, urlToArchivePath })
+    const object = activity.object as {
+      type: string
+      attachment: unknown[]
+    }
+
+    expect(activity.type).toBe('Create')
+    expect(object.type).toBe('Question')
+    expect(object.attachment).toHaveLength(1)
+  })
+})
+
+describe('createOrderedCollectionWriter', () => {
+  it('round-trips items into a valid OrderedCollection JSON document', async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'actor-archive-writer-test-')
+    )
+    const filePath = path.join(dir, 'collection.json')
+
+    try {
+      const writer = createOrderedCollectionWriter(
+        filePath,
+        'https://example.test/users/alice/outbox'
+      )
+      writer.addItem({ id: 'a' })
+      writer.addItem({ id: 'b' })
+      const count = await writer.close()
+
+      expect(count).toBe(2)
+
+      const parsed = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+      expect(parsed).toEqual({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://example.test/users/alice/outbox',
+        type: 'OrderedCollection',
+        orderedItems: [{ id: 'a' }, { id: 'b' }],
+        totalItems: 2
+      })
+    } finally {
+      await fs.rm(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('produces an empty orderedItems array when no item is added', async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'actor-archive-writer-test-')
+    )
+    const filePath = path.join(dir, 'collection.json')
+
+    try {
+      const writer = createOrderedCollectionWriter(filePath, 'id-1')
+      const count = await writer.close()
+      expect(count).toBe(0)
+
+      const parsed = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+      expect(parsed.orderedItems).toEqual([])
+      expect(parsed.totalItems).toBe(0)
+    } finally {
+      await fs.rm(dir, { force: true, recursive: true })
+    }
+  })
+})
+
+describe('database-backed collectors', () => {
+  const database = getTestSQLDatabase()
+  const domain = 'actor-archive-test.llun.test'
+  let actorId: string
+  let followersUrl: string
+
+  beforeAll(async () => {
+    await database.migrate()
+
+    await database.createAccount({
+      domain,
+      email: 'archive-owner@example.test',
+      username: 'archiveowner',
+      privateKey: 'test-private-key',
+      publicKey: 'test-public-key',
+      passwordHash: 'unused'
+    })
+    const actor = await database.getActorFromUsername({
+      username: 'archiveowner',
+      domain
+    })
+    if (!actor) throw new Error('Failed to seed actor for actorArchive tests')
+    actorId = actor.id
+    followersUrl = actor.followersUrl
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  describe('forEachActorStatus', () => {
+    it('paginates past a page smaller than the total and includes non-public statuses', async () => {
+      const total = 5
+      for (let index = 0; index < total; index += 1) {
+        await database.createNote({
+          id: `${actorId}/statuses/pagination-${index}`,
+          actorId,
+          // Every status is included regardless of audience: the last one
+          // carries no public recipient at all.
+          to: index === total - 1 ? [] : [ACTIVITY_STREAM_PUBLIC],
+          cc: index === total - 1 ? [] : [followersUrl],
+          url: `https://${domain}/statuses/pagination-${index}`,
+          text: `status ${index}`,
+          createdAt: Date.now() + index
+        })
+      }
+
+      const collected: string[] = []
+      for await (const status of forEachActorStatus(database, actorId, 2)) {
+        collected.push(status.id)
+      }
+
+      expect(collected).toHaveLength(total)
+      expect(new Set(collected).size).toBe(total)
+      expect(collected).toContain(`${actorId}/statuses/pagination-${total - 1}`)
+    })
+  })
+
+  describe('forEachFitnessFile', () => {
+    it('paginates past a page smaller than the total', async () => {
+      const total = 3
+      for (let index = 0; index < total; index += 1) {
+        await database.createFitnessFile({
+          actorId,
+          path: `mock/${actorId}/pagination-${index}.gpx`,
+          fileName: `pagination-${index}.gpx`,
+          fileType: 'gpx',
+          mimeType: 'application/gpx+xml',
+          bytes: 100
+        })
+      }
+
+      const collected: string[] = []
+      for await (const file of forEachFitnessFile(database, actorId, 2)) {
+        collected.push(file.id)
+      }
+
+      expect(collected).toHaveLength(total)
+      expect(new Set(collected).size).toBe(total)
+    })
+  })
+
+  describe('forEachLike', () => {
+    it('paginates using the composite favourite cursor', async () => {
+      const total = 3
+      const statusIds: string[] = []
+      for (let index = 0; index < total; index += 1) {
+        const status = await database.createNote({
+          id: `${actorId}/statuses/like-target-${index}`,
+          actorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          url: `https://${domain}/statuses/like-target-${index}`,
+          text: `like target ${index}`,
+          createdAt: Date.now() + index
+        })
+        statusIds.push(status.id)
+        await database.createLike({ actorId, statusId: status.id })
+      }
+
+      const collected: string[] = []
+      for await (const like of forEachLike(database, actorId, 2)) {
+        collected.push(like.statusId)
+      }
+
+      expect(collected).toHaveLength(total)
+      expect(new Set(collected)).toEqual(new Set(statusIds))
+    })
+  })
+})

--- a/scripts/backup/actorArchive.ts
+++ b/scripts/backup/actorArchive.ts
@@ -1,0 +1,1017 @@
+/**
+ * Exports everything belonging to one local actor into a Mastodon-compatible
+ * ActivityPub archive (tar.gz): every status regardless of visibility, media
+ * attachment bytes, fitness activity files (an extension beyond the Mastodon
+ * format), the actor profile, likes/bookmarks, and follow lists.
+ *
+ * Read-only against the database and storage. Reuses the staging/tar/storage
+ * machinery from ./productionArchive rather than duplicating it.
+ */
+import crypto from 'crypto'
+import { createWriteStream } from 'fs'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { encodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
+import { Database } from '@/lib/database/types'
+import { getEffectiveFitnessStorageConfig } from '@/lib/services/fitness-files'
+import { getMediaFileUrl } from '@/lib/services/medias/mediaFileUrl'
+import {
+  AnnounceAction,
+  CreateAction
+} from '@/lib/types/activitypub/activities'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+import {
+  GetMediaByIdsForAccountParams,
+  Like,
+  StatusEditRevision
+} from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import {
+  Attachment,
+  getDocumentFromAttachment
+} from '@/lib/types/domain/attachment'
+import { Bookmark } from '@/lib/types/domain/bookmark'
+import { Follow } from '@/lib/types/domain/follow'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus,
+  hasStatusBeenEdited,
+  toActivityPubObject
+} from '@/lib/types/domain/status'
+import { getLocalActorOutboxId } from '@/lib/utils/activitypubId'
+import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
+
+import { printDatabaseBanner } from '../fitness/describeConnection'
+import {
+  archiveStorage,
+  buildStoragePlan,
+  createTarArchive,
+  fetchPublicStorageResponse,
+  getBooleanArg,
+  getStringArg,
+  loadEnvFile,
+  parseKeyValueArgs
+} from './productionArchive'
+
+const ARCHIVE_VERSION = 1
+const DEFAULT_ENV_FILE = '.env.production'
+const DEFAULT_OUTPUT_DIR = 'backups/actor-archives'
+const DEFAULT_PAGE_SIZE = 100
+const MEDIA_ID_BATCH_SIZE = 100
+const MEDIA_ARCHIVE_DIR = 'media_attachments/files'
+const REMOTE_MEDIA_ARCHIVE_DIR = 'media_attachments/remote'
+const FITNESS_ARCHIVE_DIR = 'fitness_files/files'
+const MEDIA_FILE_URL_SEGMENT = '/api/v1/files/'
+
+export const EXPORT_ACTOR_USAGE = `Usage: NODE_ENV=production scripts/backup/exportActorArchive.ts \\
+  (--username <name> [--domain <domain>] | --actor-id <https://host/users/name> | --email <email>) \\
+  [--env-file .env.production] \\
+  [--output-dir backups/actor-archives] \\
+  [--page-size 100] \\
+  [--allow-missing-storage] \\
+  [--skip-storage] \\
+  [--fetch-remote-attachments]`
+
+export interface ExportActorArchiveArgs {
+  username?: string
+  domain?: string
+  actorId?: string
+  email?: string
+  envFile: string
+  outputDir: string
+  pageSize: number
+  allowMissingStorage: boolean
+  skipStorage: boolean
+  fetchRemoteAttachments: boolean
+}
+
+export const parseExportActorArgs = (
+  args: string[]
+): ExportActorArchiveArgs => {
+  const parsed = parseKeyValueArgs(args)
+
+  const username = getStringArg(parsed, 'username')
+  const actorId = getStringArg(parsed, 'actor-id')
+  const email = getStringArg(parsed, 'email')
+  const selectorCount = [username, actorId, email].filter(Boolean).length
+  if (selectorCount !== 1) {
+    throw new Error(
+      'Pass exactly one of --username, --actor-id, or --email to select the actor.'
+    )
+  }
+
+  const pageSizeArg = getStringArg(
+    parsed,
+    'page-size',
+    String(DEFAULT_PAGE_SIZE)
+  )!
+  const pageSize = Number(pageSizeArg)
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw new Error(`Invalid value for --page-size: ${pageSizeArg}`)
+  }
+
+  return {
+    username,
+    domain: getStringArg(parsed, 'domain'),
+    actorId,
+    email,
+    envFile: getStringArg(parsed, 'env-file', DEFAULT_ENV_FILE)!,
+    outputDir: getStringArg(parsed, 'output-dir', DEFAULT_OUTPUT_DIR)!,
+    pageSize,
+    allowMissingStorage: getBooleanArg(parsed, 'allow-missing-storage'),
+    skipStorage: getBooleanArg(parsed, 'skip-storage'),
+    fetchRemoteAttachments: getBooleanArg(parsed, 'fetch-remote-attachments')
+  }
+}
+
+export const resolveActor = async (
+  database: Database,
+  args: ExportActorArchiveArgs,
+  defaultDomain: string
+): Promise<Actor> => {
+  const actor = args.actorId
+    ? await database.getActorFromId({ id: args.actorId })
+    : args.email
+      ? await database.getActorFromEmail({ email: args.email })
+      : await database.getActorFromUsername({
+          username: args.username!,
+          domain: args.domain ?? defaultDomain
+        })
+
+  if (!actor) {
+    throw new Error('Actor not found.')
+  }
+  if (!actor.account) {
+    throw new Error('Actor is not a local actor (no linked account).')
+  }
+  return actor
+}
+
+export const getHandleFromActor = (actor: {
+  username: string
+  domain: string
+}) => `${actor.username}@${actor.domain}`
+
+/**
+ * Recovers the storage-relative path from a URL built by getMediaFileUrl
+ * (`https://<host>/api/v1/files/<path>`). Returns null for fitness-file URLs
+ * (served from a different route) and for foreign/remote URLs.
+ */
+export const getMediaStoragePathFromUrl = (url: string): string | null => {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  if (!parsed.pathname.startsWith(MEDIA_FILE_URL_SEGMENT)) return null
+
+  const encodedPath = parsed.pathname.slice(MEDIA_FILE_URL_SEGMENT.length)
+  if (!encodedPath) return null
+
+  try {
+    return decodeURIComponent(encodedPath)
+  } catch {
+    return encodedPath
+  }
+}
+
+export const getArchiveMediaPath = (storagePath: string) =>
+  `${MEDIA_ARCHIVE_DIR}/${storagePath}`
+
+export const getArchiveFitnessPath = (storagePath: string) =>
+  `${FITNESS_ARCHIVE_DIR}/${storagePath}`
+
+export type UrlToArchivePath = (url: string) => string
+
+/**
+ * Shapes one status as the Create/Announce activity the ActivityPub outbox
+ * would emit, mirroring app/api/users/[username]/outbox/route.ts, but for an
+ * OWNER export rather than a federation response: every attachment is kept
+ * (the federation serializer truncates to MAX_FEDERATION_MEDIA_ATTACHMENTS and
+ * drops fitness attachments), attachment URLs are rewritten to their
+ * archive-relative path, and embedded reply objects are stripped (they belong
+ * to other actors and only bloat the file).
+ */
+export const buildExportActivity = ({
+  status,
+  urlToArchivePath
+}: {
+  status: Status
+  urlToArchivePath: UrlToArchivePath
+}): Record<string, unknown> => {
+  if (status.type === StatusType.enum.Announce) {
+    return {
+      id: status.id,
+      type: AnnounceAction,
+      actor: status.actorId,
+      published: getISOTimeUTC(status.createdAt),
+      to: status.to,
+      cc: status.cc,
+      object: status.originalStatus.id
+    }
+  }
+
+  const object = toActivityPubObject(status) as unknown as Record<
+    string,
+    unknown
+  >
+
+  object.attachment = status.attachments.map((attachment) => ({
+    ...getDocumentFromAttachment(attachment),
+    url: urlToArchivePath(attachment.url)
+  }))
+
+  if (
+    object.replies &&
+    typeof object.replies === 'object' &&
+    'items' in (object.replies as Record<string, unknown>)
+  ) {
+    const replies = { ...(object.replies as Record<string, unknown>) }
+    delete replies.items
+    object.replies = replies
+  }
+
+  return {
+    id: `${status.id}/activity`,
+    type: CreateAction,
+    actor: status.actorId,
+    published: getISOTimeUTC(status.createdAt),
+    to: status.to,
+    cc: status.cc,
+    object
+  }
+}
+
+export const buildActorJson = ({
+  person,
+  avatarFileName,
+  headerFileName
+}: {
+  person: Record<string, unknown>
+  avatarFileName: string | null
+  headerFileName: string | null
+}): Record<string, unknown> => {
+  const actorJson = { ...person }
+
+  if (avatarFileName && actorJson.icon && typeof actorJson.icon === 'object') {
+    actorJson.icon = {
+      ...(actorJson.icon as Record<string, unknown>),
+      url: avatarFileName
+    }
+  }
+
+  if (
+    headerFileName &&
+    actorJson.image &&
+    typeof actorJson.image === 'object'
+  ) {
+    actorJson.image = {
+      ...(actorJson.image as Record<string, unknown>),
+      url: headerFileName
+    }
+  }
+
+  return actorJson
+}
+
+const buildStatusHistoryEntry = (
+  revision: StatusEditRevision,
+  urlToArchivePath: UrlToArchivePath
+) => ({
+  text: revision.text,
+  summary: revision.summary,
+  sensitive: revision.sensitive,
+  attachments: revision.attachments
+    ? revision.attachments.map((attachment) => ({
+        ...getDocumentFromAttachment(attachment),
+        url: urlToArchivePath(attachment.url)
+      }))
+    : null,
+  pollOptions: revision.pollOptions,
+  supersededAt: getISOTimeUTC(revision.supersededAt)
+})
+
+const buildFitnessArchiveEntry = (file: FitnessFile) => ({
+  id: file.id,
+  statusId: file.statusId ?? null,
+  fileName: file.fileName,
+  fileType: file.fileType,
+  mimeType: file.mimeType,
+  bytes: file.bytes,
+  description: file.description ?? null,
+  activityType: file.activityType ?? null,
+  activityStartTime: file.activityStartTime
+    ? getISOTimeUTC(file.activityStartTime)
+    : null,
+  totalDistanceMeters: file.totalDistanceMeters ?? null,
+  totalDurationSeconds: file.totalDurationSeconds ?? null,
+  movingTimeSeconds: file.movingTimeSeconds ?? null,
+  elevationGainMeters: file.elevationGainMeters ?? null,
+  deviceManufacturer: file.deviceManufacturer ?? null,
+  deviceName: file.deviceName ?? null,
+  sourceUrl: file.sourceUrl ?? null,
+  importBatchId: file.importBatchId ?? null,
+  archivePath: getArchiveFitnessPath(file.path),
+  mapImageArchivePath: file.mapImagePath
+    ? getArchiveMediaPath(file.mapImagePath)
+    : null
+})
+
+export const csvEscape = (value: string) => {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replaceAll('"', '""')}"`
+  }
+  return value
+}
+
+export interface FollowingCsvRow {
+  handle: string
+  showBoosts: boolean
+  notify: boolean
+  languages: string[] | null
+}
+
+export const buildFollowingCsv = (rows: FollowingCsvRow[]) => {
+  const header = 'Account address,Show boosts,Notify on new posts,Languages'
+  const lines = rows.map((row) =>
+    [
+      csvEscape(row.handle),
+      row.showBoosts ? 'true' : 'false',
+      row.notify ? 'true' : 'false',
+      csvEscape((row.languages ?? []).join(', '))
+    ].join(',')
+  )
+  return `${[header, ...lines].join('\n')}\n`
+}
+
+export const buildFollowersCsv = (handles: string[]) => {
+  const header = 'Account address'
+  const lines = handles.map((handle) => csvEscape(handle))
+  return `${[header, ...lines].join('\n')}\n`
+}
+
+/**
+ * Streams an OrderedCollection to disk one item at a time so a large account
+ * never holds the whole outbox in memory.
+ */
+export const createOrderedCollectionWriter = (filePath: string, id: string) => {
+  const stream = createWriteStream(filePath)
+  let wroteFirst = false
+  let count = 0
+
+  stream.write(
+    `{"@context":${JSON.stringify(ACTIVITY_STREAM_URL)},"id":${JSON.stringify(
+      id
+    )},"type":"OrderedCollection","orderedItems":[`
+  )
+
+  return {
+    addItem: (item: unknown) => {
+      if (wroteFirst) stream.write(',')
+      stream.write(JSON.stringify(item))
+      wroteFirst = true
+      count += 1
+    },
+    close: async () => {
+      stream.write(`],"totalItems":${count}}\n`)
+      await new Promise<void>((resolve, reject) => {
+        stream.once('error', reject)
+        stream.end(() => resolve())
+      })
+      return count
+    }
+  }
+}
+
+export async function* forEachActorStatus(
+  database: Database,
+  actorId: string,
+  pageSize: number
+): AsyncGenerator<Status> {
+  let maxStatusId: string | undefined
+
+  for (;;) {
+    // Every visibility is included: publicOnly/visibleToActorId/
+    // includeFollowersOnly are deliberately omitted so this is a complete
+    // export of the actor's own statuses, not a visitor's view of them.
+    const batch = await database.getActorStatuses({
+      actorId,
+      limit: pageSize,
+      ...(maxStatusId ? { maxStatusId } : null)
+    })
+    if (batch.length === 0) return
+
+    for (const status of batch) yield status
+
+    if (batch.length < pageSize) return
+    maxStatusId = batch[batch.length - 1].id
+  }
+}
+
+export async function* forEachLike(
+  database: Database,
+  actorId: string,
+  pageSize: number
+): AsyncGenerator<Like> {
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getLikes({
+      actorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) return
+
+    for (const like of batch) yield like
+
+    if (batch.length < pageSize) return
+    const last = batch[batch.length - 1]
+    maxId = encodeFavouriteCursor({
+      createdAt: last.createdAt,
+      statusId: last.statusId
+    })
+  }
+}
+
+export async function* forEachBookmark(
+  database: Database,
+  actorId: string,
+  pageSize: number
+): AsyncGenerator<Bookmark> {
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getBookmarks({
+      actorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) return
+
+    for (const bookmark of batch) yield bookmark
+
+    if (batch.length < pageSize) return
+    maxId = batch[batch.length - 1].id
+  }
+}
+
+export async function* forEachFollowing(
+  database: Database,
+  actorId: string,
+  pageSize: number
+): AsyncGenerator<Follow> {
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getFollowing({
+      actorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) return
+
+    for (const follow of batch) yield follow
+
+    if (batch.length < pageSize) return
+    maxId = batch[batch.length - 1].id
+  }
+}
+
+export async function* forEachFollower(
+  database: Database,
+  targetActorId: string,
+  pageSize: number
+): AsyncGenerator<Follow> {
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getFollowers({
+      targetActorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) return
+
+    for (const follow of batch) yield follow
+
+    if (batch.length < pageSize) return
+    maxId = batch[batch.length - 1].id
+  }
+}
+
+export async function* forEachFitnessFile(
+  database: Database,
+  actorId: string,
+  pageSize: number
+): AsyncGenerator<FitnessFile> {
+  let offset = 0
+
+  for (;;) {
+    const batch = await database.getFitnessFilesByActor({
+      actorId,
+      limit: pageSize,
+      offset
+    })
+    if (batch.length === 0) return
+
+    for (const file of batch) yield file
+
+    if (batch.length < pageSize) return
+    offset += batch.length
+  }
+}
+
+// Resolves the target/source handle for each follow page in one batched
+// getActorsFromIds call instead of one lookup per row.
+const collectFollowingRows = async (
+  database: Database,
+  actorId: string,
+  pageSize: number
+): Promise<FollowingCsvRow[]> => {
+  const rows: FollowingCsvRow[] = []
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getFollowing({
+      actorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) break
+
+    const targets = await database.getActorsFromIds({
+      ids: batch.map((follow) => follow.targetActorId)
+    })
+    const targetsById = new Map(targets.map((actor) => [actor.id, actor]))
+
+    for (const follow of batch) {
+      const target = targetsById.get(follow.targetActorId)
+      rows.push({
+        handle: target
+          ? getHandleFromActor(target)
+          : `unknown@${follow.targetActorHost}`,
+        showBoosts: follow.reblogs,
+        notify: follow.notify,
+        languages: follow.languages
+      })
+    }
+
+    if (batch.length < pageSize) break
+    maxId = batch[batch.length - 1].id
+  }
+
+  return rows
+}
+
+const collectFollowerHandles = async (
+  database: Database,
+  targetActorId: string,
+  pageSize: number
+): Promise<string[]> => {
+  const handles: string[] = []
+  let maxId: string | undefined
+
+  for (;;) {
+    const batch = await database.getFollowers({
+      targetActorId,
+      limit: pageSize,
+      ...(maxId ? { maxId } : null)
+    })
+    if (batch.length === 0) break
+
+    const sources = await database.getActorsFromIds({
+      ids: batch.map((follow) => follow.actorId)
+    })
+    const sourcesById = new Map(sources.map((actor) => [actor.id, actor]))
+
+    for (const follow of batch) {
+      const source = sourcesById.get(follow.actorId)
+      handles.push(
+        source ? getHandleFromActor(source) : `unknown@${follow.actorHost}`
+      )
+    }
+
+    if (batch.length < pageSize) break
+    maxId = batch[batch.length - 1].id
+  }
+
+  return handles
+}
+
+const pathExists = async (target: string) => {
+  try {
+    await fs.access(target)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const relocateStorageDir = async (
+  stagingDir: string,
+  sourceRelativePath: string,
+  destinationRelativePath: string
+) => {
+  const source = path.join(stagingDir, sourceRelativePath)
+  if (!(await pathExists(source))) return
+
+  const destination = path.join(stagingDir, destinationRelativePath)
+  await fs.rm(destination, { force: true, recursive: true })
+  await fs.mkdir(path.dirname(destination), { recursive: true })
+  await fs.rename(source, destination)
+}
+
+const copyProfileImage = async ({
+  stagingDir,
+  storagePath,
+  fileNamePrefix,
+  warnings
+}: {
+  stagingDir: string
+  storagePath: string | null
+  fileNamePrefix: 'avatar' | 'header'
+  warnings: string[]
+}): Promise<string | null> => {
+  if (!storagePath) return null
+
+  const extension = path.extname(storagePath) || '.bin'
+  const fileName = `${fileNamePrefix}${extension}`
+  const source = path.join(stagingDir, MEDIA_ARCHIVE_DIR, storagePath)
+
+  try {
+    await fs.copyFile(source, path.join(stagingDir, fileName))
+    return fileName
+  } catch {
+    warnings.push(
+      `Could not copy ${fileNamePrefix} image from storage: ${storagePath}`
+    )
+    return null
+  }
+}
+
+const registerAttachmentUrl = async ({
+  attachment,
+  fetchRemoteAttachments,
+  mediaPaths,
+  mediaIds,
+  urlToArchivePath,
+  stagingDir,
+  warnings
+}: {
+  attachment: Attachment
+  fetchRemoteAttachments: boolean
+  mediaPaths: Set<string>
+  mediaIds: Set<string>
+  urlToArchivePath: Map<string, string>
+  stagingDir: string
+  warnings: string[]
+}) => {
+  if (urlToArchivePath.has(attachment.url)) return
+
+  const storagePath = getMediaStoragePathFromUrl(attachment.url)
+  if (storagePath) {
+    mediaPaths.add(storagePath)
+    urlToArchivePath.set(attachment.url, getArchiveMediaPath(storagePath))
+    if (attachment.mediaId) mediaIds.add(attachment.mediaId)
+    return
+  }
+
+  if (!fetchRemoteAttachments) {
+    warnings.push(`Remote attachment kept as absolute URL: ${attachment.url}`)
+    return
+  }
+
+  try {
+    const response = await fetchPublicStorageResponse(attachment.url)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    const hash = crypto
+      .createHash('sha256')
+      .update(attachment.url)
+      .digest('hex')
+      .slice(0, 16)
+    const extension = path.extname(new URL(attachment.url).pathname)
+    const relativePath = `${REMOTE_MEDIA_ARCHIVE_DIR}/${hash}${extension}`
+    const absolutePath = path.join(stagingDir, relativePath)
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true })
+    await fs.writeFile(absolutePath, buffer)
+    urlToArchivePath.set(attachment.url, relativePath)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    warnings.push(
+      `Failed to fetch remote attachment ${attachment.url}: ${message}`
+    )
+  }
+}
+
+const createArchiveTimestamp = () =>
+  new Date().toISOString().replaceAll(':', '').replaceAll('.', '')
+
+export const exportActorArchive = async (
+  cliArgs: string[] = process.argv.slice(2)
+): Promise<number> => {
+  if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+    console.log(EXPORT_ACTOR_USAGE)
+    return 0
+  }
+
+  const args = parseExportActorArgs(cliArgs)
+  await loadEnvFile(args.envFile)
+  printDatabaseBanner()
+
+  const config = getConfig()
+  const database = getDatabase()
+  if (!database) {
+    console.error('Database not available.')
+    return 1
+  }
+
+  const actor = await resolveActor(database, args, config.host)
+  const accountId = actor.account!.id
+  const handle = getHandleFromActor(actor)
+
+  const stagingDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'activitynext-actor-archive-')
+  )
+
+  const warnings: string[] = []
+  const mediaPaths = new Set<string>()
+  const fitnessPaths = new Set<string>()
+  const mediaIds = new Set<string>()
+  const urlToArchivePath = new Map<string, string>()
+  const resolveArchivePath: UrlToArchivePath = (url) =>
+    urlToArchivePath.get(url) ?? url
+  const statusHistory: Record<string, unknown[]> = {}
+
+  try {
+    const outboxWriter = createOrderedCollectionWriter(
+      path.join(stagingDir, 'outbox.json'),
+      getLocalActorOutboxId(actor.id)
+    )
+
+    let statusCount = 0
+    for await (const status of forEachActorStatus(
+      database,
+      actor.id,
+      args.pageSize
+    )) {
+      statusCount += 1
+
+      if (status.type !== StatusType.enum.Announce) {
+        for (const attachment of status.attachments) {
+          await registerAttachmentUrl({
+            attachment,
+            fetchRemoteAttachments: args.fetchRemoteAttachments,
+            mediaPaths,
+            mediaIds,
+            urlToArchivePath,
+            stagingDir,
+            warnings
+          })
+        }
+
+        if (hasStatusBeenEdited(status)) {
+          const revisions = await database.getStatusEditHistory({
+            statusId: status.id
+          })
+          statusHistory[status.id] = revisions.map((revision) =>
+            buildStatusHistoryEntry(revision, resolveArchivePath)
+          )
+        }
+      }
+
+      outboxWriter.addItem(
+        buildExportActivity({ status, urlToArchivePath: resolveArchivePath })
+      )
+    }
+    await outboxWriter.close()
+
+    // Thumbnails aren't referenced by any URL on the status, so they only
+    // enter the archive by resolving each attachment's mediaId.
+    if (!args.skipStorage && mediaIds.size > 0) {
+      const idList = [...mediaIds]
+      for (let index = 0; index < idList.length; index += MEDIA_ID_BATCH_SIZE) {
+        const chunk = idList.slice(index, index + MEDIA_ID_BATCH_SIZE)
+        const medias = await database.getMediaByIdsForAccount({
+          mediaIds: chunk,
+          accountId
+        } satisfies GetMediaByIdsForAccountParams)
+        for (const media of medias) {
+          mediaPaths.add(media.original.path)
+          if (media.thumbnail?.path) mediaPaths.add(media.thumbnail.path)
+        }
+      }
+    }
+
+    const fitnessEntries: unknown[] = []
+    let fitnessCount = 0
+    for await (const file of forEachFitnessFile(
+      database,
+      actor.id,
+      args.pageSize
+    )) {
+      fitnessCount += 1
+      fitnessPaths.add(file.path)
+      if (file.mapImagePath) mediaPaths.add(file.mapImagePath)
+      if (file.mapImageEmailPath) mediaPaths.add(file.mapImageEmailPath)
+      fitnessEntries.push(buildFitnessArchiveEntry(file))
+    }
+
+    const iconPath = actor.iconUrl
+      ? getMediaStoragePathFromUrl(actor.iconUrl)
+      : null
+    const headerPath = actor.headerImageUrl
+      ? getMediaStoragePathFromUrl(actor.headerImageUrl)
+      : null
+    if (iconPath) mediaPaths.add(iconPath)
+    if (headerPath) mediaPaths.add(headerPath)
+
+    const likesWriter = createOrderedCollectionWriter(
+      path.join(stagingDir, 'likes.json'),
+      `${actor.id}/likes-archive`
+    )
+    let likeCount = 0
+    for await (const like of forEachLike(database, actor.id, args.pageSize)) {
+      likeCount += 1
+      likesWriter.addItem(like.statusId)
+    }
+    await likesWriter.close()
+
+    const bookmarksWriter = createOrderedCollectionWriter(
+      path.join(stagingDir, 'bookmarks.json'),
+      `${actor.id}/bookmarks-archive`
+    )
+    let bookmarkCount = 0
+    for await (const bookmark of forEachBookmark(
+      database,
+      actor.id,
+      args.pageSize
+    )) {
+      bookmarkCount += 1
+      bookmarksWriter.addItem(bookmark.statusId)
+    }
+    await bookmarksWriter.close()
+
+    const followingRows = await collectFollowingRows(
+      database,
+      actor.id,
+      args.pageSize
+    )
+    const followerHandles = await collectFollowerHandles(
+      database,
+      actor.id,
+      args.pageSize
+    )
+
+    const effectiveFitnessStorage = getEffectiveFitnessStorageConfig()
+    if (!args.skipStorage) {
+      if (mediaPaths.size > 0 && !config.mediaStorage) {
+        warnings.push(
+          'Media storage is not configured; referenced media files were not archived.'
+        )
+      }
+      if (fitnessPaths.size > 0 && !effectiveFitnessStorage) {
+        warnings.push(
+          'Fitness storage is not configured; referenced fitness files were not archived.'
+        )
+      }
+    }
+
+    const storageManifest = args.skipStorage
+      ? []
+      : await archiveStorage(
+          buildStoragePlan({
+            fitnessFilePaths: [...fitnessPaths],
+            fitnessStorage: effectiveFitnessStorage,
+            mediaFilePaths: [...mediaPaths],
+            mediaStorage: config.mediaStorage,
+            scope: 'referenced'
+          }),
+          stagingDir,
+          { allowMissingStorage: args.allowMissingStorage }
+        )
+
+    await relocateStorageDir(
+      stagingDir,
+      'storage/media/files',
+      MEDIA_ARCHIVE_DIR
+    )
+    await relocateStorageDir(
+      stagingDir,
+      'storage/fitness/files',
+      FITNESS_ARCHIVE_DIR
+    )
+    await fs.rm(path.join(stagingDir, 'storage'), {
+      force: true,
+      recursive: true
+    })
+
+    const person = getPersonFromActor(actor)
+    const avatarFileName = await copyProfileImage({
+      stagingDir,
+      storagePath: iconPath,
+      fileNamePrefix: 'avatar',
+      warnings
+    })
+    const headerFileName = await copyProfileImage({
+      stagingDir,
+      storagePath: headerPath,
+      fileNamePrefix: 'header',
+      warnings
+    })
+
+    await fs.writeFile(
+      path.join(stagingDir, 'actor.json'),
+      `${JSON.stringify(
+        buildActorJson({
+          person: person as unknown as Record<string, unknown>,
+          avatarFileName,
+          headerFileName
+        }),
+        null,
+        2
+      )}\n`
+    )
+
+    await fs.writeFile(
+      path.join(stagingDir, 'following_accounts.csv'),
+      buildFollowingCsv(followingRows)
+    )
+    await fs.writeFile(
+      path.join(stagingDir, 'followers.csv'),
+      buildFollowersCsv(followerHandles)
+    )
+
+    await fs.mkdir(path.join(stagingDir, 'fitness_files'), {
+      recursive: true
+    })
+    await fs.writeFile(
+      path.join(stagingDir, 'fitness_files', 'fitness.json'),
+      `${JSON.stringify(fitnessEntries, null, 2)}\n`
+    )
+
+    await fs.writeFile(
+      path.join(stagingDir, 'status_history.json'),
+      `${JSON.stringify(statusHistory, null, 2)}\n`
+    )
+
+    await fs.writeFile(
+      path.join(stagingDir, 'manifest.json'),
+      `${JSON.stringify(
+        {
+          kind: 'actor-archive',
+          version: ARCHIVE_VERSION,
+          createdAt: new Date().toISOString(),
+          actor: { id: actor.id, handle, domain: actor.domain },
+          counts: {
+            statuses: statusCount,
+            likes: likeCount,
+            bookmarks: bookmarkCount,
+            following: followingRows.length,
+            followers: followerHandles.length,
+            fitnessFiles: fitnessCount
+          },
+          storage: storageManifest,
+          warnings
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    const outputDir = path.resolve(process.cwd(), args.outputDir)
+    const archivePath = path.join(
+      outputDir,
+      `actor-archive-${actor.username}-${createArchiveTimestamp()}.tar.gz`
+    )
+    await createTarArchive(stagingDir, archivePath)
+
+    console.log(`Archive written: ${archivePath}`)
+    console.log(
+      `Statuses: ${statusCount}, Likes: ${likeCount}, Bookmarks: ${bookmarkCount}, ` +
+        `Following: ${followingRows.length}, Followers: ${followerHandles.length}, ` +
+        `Fitness files: ${fitnessCount}`
+    )
+    if (warnings.length > 0) {
+      console.log(`Warnings (${warnings.length}):`)
+      for (const warning of warnings) console.log(`  - ${warning}`)
+    }
+
+    return 0
+  } finally {
+    await database.destroy()
+    await fs.rm(stagingDir, { force: true, recursive: true })
+  }
+}

--- a/scripts/backup/exportActorArchive.ts
+++ b/scripts/backup/exportActorArchive.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Exports everything belonging to one local actor (statuses at every
+ * visibility, media and fitness files, profile, likes/bookmarks, follows)
+ * into a Mastodon-compatible ActivityPub archive.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/backup/exportActorArchive.ts --username alice
+ *
+ * See ./actorArchive.ts EXPORT_ACTOR_USAGE for the full flag reference.
+ */
+import { exportActorArchive } from './actorArchive'
+
+if (require.main === module) {
+  exportActorArchive()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Actor archive export failed:', error)
+      process.exit(1)
+    })
+}

--- a/scripts/backup/productionArchive.ts
+++ b/scripts/backup/productionArchive.ts
@@ -170,7 +170,7 @@ const RESTORE_USAGE = `Usage: scripts/backup/restoreProductionArchive.ts \\
   [--preserve-files] \\
   [--allow-non-local-database]`
 
-const parseKeyValueArgs = (args: string[]) => {
+export const parseKeyValueArgs = (args: string[]) => {
   const parsed = new Map<string, string | true>()
 
   for (let index = 0; index < args.length; index += 1) {
@@ -198,7 +198,7 @@ const parseKeyValueArgs = (args: string[]) => {
   return parsed
 }
 
-const getStringArg = (
+export const getStringArg = (
   args: Map<string, string | true>,
   key: string,
   defaultValue?: string
@@ -209,7 +209,10 @@ const getStringArg = (
   return value
 }
 
-const getBooleanArg = (args: Map<string, string | true>, key: string) => {
+export const getBooleanArg = (
+  args: Map<string, string | true>,
+  key: string
+) => {
   const value = args.get(key)
   if (value === undefined) return false
   if (value === true) return true
@@ -661,7 +664,7 @@ const isS3FitnessStorage = (
 
 export const parseEnvFile = (envPath: string) => dotenvFlow.parse(envPath)
 
-const loadEnvFile = async (envFile: string) => {
+export const loadEnvFile = async (envFile: string) => {
   const envPath = path.resolve(process.cwd(), envFile)
   const values = parseEnvFile(envPath)
 
@@ -1524,7 +1527,10 @@ const writeManifest = async (stagingDir: string, manifest: ArchiveManifest) => {
   )
 }
 
-const createTarArchive = async (stagingDir: string, archivePath: string) => {
+export const createTarArchive = async (
+  stagingDir: string,
+  archivePath: string
+) => {
   await fs.mkdir(path.dirname(archivePath), { recursive: true })
   await execFileAsync('tar', ['-czf', archivePath, '-C', stagingDir, '.'])
 }


### PR DESCRIPTION
## Summary
- Add `scripts/backup/exportActorArchive.ts` / `scripts/backup/actorArchive.ts`, a read-only script that exports everything belonging to one local actor into a Mastodon-compatible ActivityPub archive (`.tar.gz`): every status regardless of visibility (public/unlisted/followers-only/direct) with all attachments kept (the federation serializer truncates to 4 and drops fitness attachments), the actor profile, likes/bookmarks, follow lists, and fitness activity files/route maps (including imports never turned into a post).
- Reuses the existing staging/tar/S3-and-local-storage machinery from `scripts/backup/productionArchive.ts` (exported five previously-private helpers there — `parseKeyValueArgs`, `getStringArg`, `getBooleanArg`, `loadEnvFile`, `createTarArchive` — no behavior change) instead of duplicating it.
- Supports `--username`/`--actor-id`/`--email` actor selection, `--env-file` for running against production read-only (prints the resolved database banner first), `--allow-missing-storage` (warn-and-continue, recorded per-file in `manifest.json`), `--skip-storage`, and `--fetch-remote-attachments`.
- Documents the script in `docs/maintenance.md` and adds the new default output directory to the sensitive-file list in `docs/environment-variables.md`.

## Test plan
- [x] `yarn run prettier --write .` → `yarn lint` → `yarn build` → `yarn test` all pass (750 test files / 8055 tests)
- [x] New `scripts/backup/actorArchive.test.ts`: pure-function tests (arg parsing, URL→storage-path recovery, activity shaping incl. >4 attachments and fitness attachments retained, CSV building, the streaming OrderedCollection writer) plus DB-backed pagination tests against a real SQLite instance (`forEachActorStatus` includes non-public statuses and pages correctly, `forEachFitnessFile`, `forEachLike`)
- [x] `scripts/backup/productionArchive.test.ts` still passes unchanged, confirming the new `export` keywords are inert
- [x] Manual end-to-end run against a local SQLite dev database seeded with `createMockUser.ts`/`createMockStatuses.ts`/`createMockFitnessData.ts`: verified the produced archive's `outbox.json` (a 7-image status keeps all 7 attachments, private/no-public-recipient statuses included), `actor.json`, `fitness.json` (including a statusId-less activity), and `manifest.json`; verified the default fail-fast behavior on a missing storage file and the `--allow-missing-storage` warn-and-continue path with per-file failure records; verified a real local avatar and attachment are downloaded, relocated into `media_attachments/files/`, and correctly rewritten in both `actor.json` and `outbox.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)