### PR TITLE
Bump version to v1.123.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.5",
+  "version": "1.123.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.5`
- Base main SHA: `f2972615665f14fb7252d4397bdd60be920b3e7f`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
