### PR TITLE
Bump version to v1.123.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.6",
+  "version": "1.123.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.6`
- Base main SHA: `cacf94b77f44010b031b797907ac1c97acdec2ac`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
