### PR TITLE
Bump version to v1.123.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.7",
+  "version": "1.123.8",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.7`
- Base main SHA: `6baf0b5fd1e2ef181aabfe8a6d90534ef3a17de6`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
