### PR TITLE
fix: backfill publicId in bulk UPDATEs instead of exhausting the connection pool

### DIFF
--- a/lib/database/sql/publicIdMigration.test.ts
+++ b/lib/database/sql/publicIdMigration.test.ts
@@ -494,6 +494,61 @@ describe('public ids migration', () => {
     )
   })
 
+  it('backfills in bulk statements instead of one query per row', async () => {
+    // The backfill used to issue one UPDATE per row and fan the whole batch out
+    // with Promise.all. knex's pool defaults to 10 connections, so the rest
+    // queued in tarn and the batch had to drain inside a single 60s
+    // acquireConnectionTimeout — against a large table on a remote database
+    // that eventually times out and kills the migration mid-run with "Timeout
+    // acquiring a connection. The pool is probably full."
+    const rowCount = 450
+    await database('statuses').insert(
+      Array.from({ length: rowCount }, (_, index) => ({
+        id: `https://llun.test/users/a/statuses/${String(index).padStart(4, '0')}`,
+        createdAt: Date.UTC(2024, 10, 1) + index * 60_000
+      }))
+    )
+
+    let updateStatements = 0
+    let inFlight = 0
+    let maxConcurrentQueries = 0
+    const onQuery = ({ sql }: { sql: string }) => {
+      if (/^update /i.test(sql)) updateStatements += 1
+      inFlight += 1
+      maxConcurrentQueries = Math.max(maxConcurrentQueries, inFlight)
+    }
+    const onSettled = () => {
+      inFlight -= 1
+    }
+    database.on('query', onQuery)
+    database.on('query-response', onSettled)
+    database.on('query-error', onSettled)
+
+    try {
+      await migration.up(database)
+    } finally {
+      database.off('query', onQuery)
+      database.off('query-response', onSettled)
+      database.off('query-error', onSettled)
+    }
+
+    const missing = await database('statuses')
+      .whereNull('publicId')
+      .count({ cnt: '*' })
+    expect(Number(missing[0].cnt)).toBe(0)
+    const distinct = await database('statuses').countDistinct({
+      cnt: 'publicId'
+    })
+    expect(Number(distinct[0].cnt)).toBe(rowCount)
+
+    // 450 rows fold into three 200-row chunks, so anything near one statement
+    // per row means the fan-out is back.
+    expect(updateStatements).toBeLessThanOrEqual(5)
+    // And nothing is fanned out concurrently: the backfill holds one pooled
+    // connection at a time, leaving the rest of the budget to the live app.
+    expect(maxConcurrentQueries).toBe(1)
+  })
+
   it('rolls back cleanly', async () => {
     await migration.up(database)
     await migration.down(database)

--- a/migrations/20260808000000_add_public_ids.js
+++ b/migrations/20260808000000_add_public_ids.js
@@ -82,6 +82,60 @@ const addPublicIdColumn = async (knex, tableName, indexName) => {
 
 const BATCH_SIZE = 500
 
+// Rows folded into a single bulk UPDATE. Each row contributes three bind
+// parameters (the CASE match, the CASE value, and the id in the IN list), so
+// 200 rows is 600 parameters — under the 999-parameter floor of the most
+// conservatively built SQLite, and nowhere near PostgreSQL's 65535.
+const UPDATE_CHUNK_SIZE = 200
+
+// One UPDATE per chunk, awaited one chunk at a time.
+//
+// This used to be a per-row UPDATE fanned out with Promise.all over the whole
+// BATCH_SIZE. knex's pool defaults to 10 connections, so 490 of those 500
+// queries sat in tarn's acquire queue and the entire batch had to drain within
+// a single 60s acquireConnectionTimeout. On a large table against a remote
+// database that is also serving traffic, the queue eventually outlives that
+// timeout and the migration dies mid-backfill with "Timeout acquiring a
+// connection. The pool is probably full."
+//
+// Awaiting sequentially means the backfill holds exactly ONE pooled connection
+// at any moment: it cannot starve its own pool, and it leaves the database's
+// connection budget to the app running alongside it. It is also far faster —
+// 174k rows go from 174k round trips to ~900.
+const bulkUpdatePublicIds = async (knex, tableName, updates) => {
+  let updated = 0
+
+  for (let offset = 0; offset < updates.length; offset += UPDATE_CHUNK_SIZE) {
+    const chunk = updates.slice(offset, offset + UPDATE_CHUNK_SIZE)
+
+    // `else ??` is unreachable — the IN list below restricts the statement to
+    // exactly the ids the CASE enumerates — but it keeps the expression total,
+    // so a row can never be blanked, and it gives PostgreSQL a typed branch to
+    // resolve the otherwise-unknown parameters against.
+    const caseSql = `case ?? ${chunk.map(() => 'when ? then ?').join(' ')} else ?? end`
+    const caseBindings = [
+      'id',
+      ...chunk.flatMap(({ id, publicId }) => [id, publicId]),
+      'publicId'
+    ]
+
+    // Built through the query builder rather than knex.raw so the return value
+    // is knex's normalised affected-row count on every dialect (a raw UPDATE
+    // hands back the driver's own result shape instead).
+    const affected = await knex(tableName)
+      .whereIn(
+        'id',
+        chunk.map(({ id }) => id)
+      )
+      .whereNull('publicId')
+      .update({ publicId: knex.raw(caseSql, caseBindings) })
+
+    updated += Number(affected ?? 0)
+  }
+
+  return updated
+}
+
 // Upper bound on sweepMissingPublicIds() passes, so a silently ineffective
 // UPDATE can never spin forever. At BATCH_SIZE rows per pass this covers far
 // more stragglers than an online migration can realistically accumulate; if it
@@ -175,15 +229,14 @@ const sweepMissingPublicIds = async (knex, tableName) => {
       .limit(BATCH_SIZE)
     if (rows.length === 0) break
 
-    const results = await Promise.all(
-      rows.map((row) =>
-        knex(tableName)
-          .where('id', row.id)
-          .whereNull('publicId')
-          .update({ publicId: mintPublicId(row.createdAt) })
-      )
+    const filled = await bulkUpdatePublicIds(
+      knex,
+      tableName,
+      rows.map((row) => ({
+        id: row.id,
+        publicId: mintPublicId(row.createdAt)
+      }))
     )
-    const filled = results.reduce((sum, count) => sum + Number(count ?? 0), 0)
     swept += filled
     console.log(
       `  ${tableName}: sweep pass ${pass} - ${filled}/${rows.length} filled (${swept} total)`
@@ -250,21 +303,16 @@ const backfillPublicIds = async (knex, tableName) => {
 
     lastId = rows[rows.length - 1].id
 
-    const updatePromises = []
-    for (const row of rows) {
-      if (row.publicId) continue
-      updatePromises.push(
-        knex(tableName)
-          .where('id', row.id)
-          .whereNull('publicId')
-          .update({ publicId: mintPublicId(row.createdAt) })
-      )
-    }
-
-    if (updatePromises.length > 0) {
-      await Promise.all(updatePromises)
-      updated += updatePromises.length
-    }
+    updated += await bulkUpdatePublicIds(
+      knex,
+      tableName,
+      rows
+        .filter((row) => !row.publicId)
+        .map((row) => ({
+          id: row.id,
+          publicId: mintPublicId(row.createdAt)
+        }))
+    )
 
     processed += rows.length
     console.log(


### PR DESCRIPTION
## Problem

`NODE_ENV=production yarn migrate` dies partway through the publicId backfill:

```
  statuses: 22000/174526 (13%) - 22000 updated
Acquire connection error: Error: operation timed out for an unknown reason
    at async Promise.all (index 487)
    at async backfillPublicIds (migrations/20260808000000_add_public_ids.js:265:7)
migration failed with error: Knex: Timeout acquiring a connection. The pool is probably full.
```

`backfillPublicIds()` issued **one UPDATE per row** and fanned the whole `BATCH_SIZE` (500) out with `Promise.all`. knex's pool defaults to 10 connections, so ~490 of those queries sat in tarn's acquire queue and the entire batch had to drain inside a single 60s `acquireConnectionTimeout`. Against a 174k-row table on a remote database that is also serving traffic, the queue eventually outlives that timeout and the migration dies mid-run. `sweepMissingPublicIds()` had the same fan-out.

The `Promise.all (index 487)` frame in the trace is the smoking gun — index 487 of a 500-wide fan-out.

## Fix

Both loops now fold rows into a single `UPDATE ... SET "publicId" = CASE "id" WHEN ? THEN ? ... END WHERE "id" IN (...) AND "publicId" IS NULL` per 200-row chunk, awaited **one chunk at a time**.

- The backfill holds exactly **one** pooled connection at any moment. It cannot starve its own pool, and it leaves the database's connection budget to the app running alongside it.
- 200 rows is 600 bind parameters — under the 999-parameter floor of the most conservatively built SQLite, and far under PostgreSQL's 65535.
- Built through the query builder rather than `knex.raw` so the return value is knex's normalised affected-row count on every dialect.
- `else "publicId"` in the CASE is unreachable (the `IN` list restricts the statement to exactly the ids the CASE enumerates) but keeps the expression total and gives PostgreSQL a typed branch to resolve the otherwise-unknown parameters against.
- Much faster as a side effect: 174k rows go from 174k round trips to ~900.

`updated` now counts rows actually affected rather than rows attempted.

Behaviour is otherwise unchanged — idempotency, the forward keyset walk, the self-healing sweep, the NULL-id skip, the converged-vs-stuck exit semantics and every log message are all as before.

## Resuming the failed production run

No manual repair needed. knex records nothing for a failed migration and `up()` is idempotent, so `yarn migrate` re-runs it: the walk restarts at cursor `''`, skips the ~22k rows that already have a `publicId`, and fills the rest.

## Verification

- `yarn run prettier --write .`, `yarn lint` (124 warnings, byte-identical to `main`), `yarn build`, `yarn test` (757 files / 8251 tests) all pass.
- Verified against a throwaway **PostgreSQL 17** with a deliberately hostile `pool: { max: 2 }` and a 5s `acquireConnectionTimeout` — the old code would blow that up instantly:
  - 2301 rows backfilled in **15 UPDATE statements** (was 2301)
  - **max 1 concurrent query**
  - 0 rows left with a NULL `publicId`, 2300/2300 distinct publicIds, v7 timestamps matching `createdAt`
  - NULL-id actor correctly skipped and reported
  - re-run preserved existing values
- New regression test `backfills in bulk statements instead of one query per row` asserts both the statement count and `maxConcurrentQueries === 1`. Confirmed it actually catches the regression: forcing `UPDATE_CHUNK_SIZE = 1` fails it with `expected 450 to be less than or equal to 5`.

No schema change, so no dump regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeGQjQipQhVc6vK4tTtzrx