### PR TITLE
none: store full ActivityPub URI as status id in mock seeders

### DIFF
--- a/scripts/mock/createMockFitnessData.ts
+++ b/scripts/mock/createMockFitnessData.ts
@@ -14,7 +14,10 @@ import crypto from 'crypto'
 
 import { getConfig } from '@/lib/config'
 import { getDatabase, getKnex } from '@/lib/database'
+import { getMention } from '@/lib/types/domain/actor'
+import { getLocalStatusId } from '@/lib/utils/activitypubId'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { generatePublicId } from '@/lib/utils/publicId'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -127,14 +130,22 @@ async function createMockFitnessData() {
     // "Recent activities" feed has content.
     let statusId: string | null = null
     if (index < 3) {
-      const id = crypto.randomUUID()
-      const url = `https://${domain}/users/${username}/statuses/${id}`
+      // Mirror `createLocalOnlyFitnessStatus` in
+      // `lib/jobs/importFitnessFilesJob.ts`: the id is the full ActivityPub URI
+      // whose tail is the client-facing publicId (backdated to the activity
+      // start so it sorts with it), and the url is the `@username` web form. A
+      // bare uuid here would make seeded posts behave unlike real ones —
+      // `urlToId` parses it as a hostname, so client calls such as
+      // `/api/v1/statuses/<id>/favourited_by` resolve to no status and 404.
+      const publicId = generatePublicId(startedAtMs)
+      const id = getLocalStatusId({ actorId: actor.id, statusId: publicId })
       await database.createNote({
         id,
+        publicId,
         actorId: actor.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: [actor.followersUrl],
-        url,
+        url: `https://${actor.domain}/${getMention(actor)}/${publicId}`,
         text: `<p>${template.text}</p>`,
         createdAt: startedAtMs
       })

--- a/scripts/mock/createMockStatuses.ts
+++ b/scripts/mock/createMockStatuses.ts
@@ -2,7 +2,10 @@
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { Timeline } from '@/lib/services/timelines/types'
+import { getMention } from '@/lib/types/domain/actor'
+import { getLocalStatusId } from '@/lib/utils/activitypubId'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { generatePublicId } from '@/lib/utils/publicId'
 
 async function createMockStatuses() {
   const database = getDatabase()
@@ -107,16 +110,29 @@ async function createMockStatuses() {
     imageSize: { width: number; height: number }
     attachmentName: (index: number) => string
   }) => {
-    const uuid = crypto.randomUUID()
-    const statusUrl = `https://${author.domain}/users/${author.username}/statuses/${uuid}`
-    // Local statuses use a bare UUID as the id (the local convention); remote
-    // ones use their canonical URL as the id (the federation convention).
-    const id = local ? uuid : statusUrl
     const createdAt = Date.now() + timeOffset // Future/recent so it sorts to the top
+    // Local statuses follow `lib/actions/createNote.ts`: the id is the full
+    // ActivityPub URI whose tail is the client-facing publicId, and the url is
+    // the `@username` web form. Remote ones keep their origin's canonical URI
+    // as both, the way federation delivers them, and let the database mint
+    // their publicId.
+    //
+    // Storing a bare uuid as a local id (which this script used to do) makes
+    // seeded posts behave unlike real ones: `urlToId` parses a bare uuid as a
+    // hostname, so client calls such as `/api/v1/statuses/<id>/favourited_by`
+    // resolve to no status and 404.
+    const publicId = local ? generatePublicId(createdAt) : undefined
+    const id = publicId
+      ? getLocalStatusId({ actorId: author.id, statusId: publicId })
+      : `https://${author.domain}/users/${author.username}/statuses/${crypto.randomUUID()}`
+    const statusUrl = publicId
+      ? `https://${author.domain}/${getMention(author)}/${publicId}`
+      : id
     const body = local ? `${text} (${imageCount} images)` : text
 
     const status = await database.createNote({
       id,
+      publicId,
       actorId: author.id,
       to: [ACTIVITY_STREAM_PUBLIC],
       cc: [author.followersUrl],


### PR DESCRIPTION
## Summary

The mock seeders stored a **bare uuid** as a local status `id`, with a comment calling it "the local convention". The app does not do that — `lib/actions/createNote.ts` stores the full ActivityPub URI (`https://<domain>/users/<username>/statuses/<publicId>`) as `statuses.id`, and `createLocalOnlyFitnessStatus` in `lib/jobs/importFitnessFilesJob.ts` does the same for fitness posts.

That made locally-seeded data behave unlike real data. `urlToId()` parses a bare uuid as a hostname and yields `<uuid>:`, which resolves to no status, so the status detail page's `favourited_by` lookup 404'd on every load of a seeded post. Statuses created through the real composer send `apurl_…` and return 200.

The call site is `StatusBox.tsx`, which passes the raw `actualStatus.id` into `getStatusFavouritedBy` → `urlToId()` — so it is the **stored id** that decides this, not the `publicId` column.

This is pre-existing and unrelated to the UUIDv7 publicId work (#1393 / #1396); it was surfaced while browser-verifying those.

## Changes

Both seeders now mirror their production counterparts:

- **`scripts/mock/createMockStatuses.ts`** — local statuses use `getLocalStatusId(...)` for the id (full AP URI whose tail is the client-facing publicId), the `@username` web form for the url, and pass `publicId` so URI tail, web url and stored publicId agree. Remote (external-actor) statuses keep their origin's canonical URI as both id and url and let the database mint their publicId, the way federation delivers them.
- **`scripts/mock/createMockFitnessData.ts`** — same shape, backdating the publicId to the activity start time so the URI tail sorts with the activity (matching `createLocalOnlyFitnessStatus`).

## Verification

`scripts/` is neither linted nor covered by CI, so this was verified by actually running the seeders against a **local throwaway SQLite** database per the "Local Manual / Browser Testing" section of `AGENTS.md`. Both the old and the fixed script were seeded into the same database so the two variants could be compared on the same page, signed in.

| Seeded by | `statuses.id` | request issued by `StatusLikes` | result |
| --- | --- | --- | --- |
| old script | `d86ff5dd-…` (bare uuid) | `/api/v1/statuses/d86ff5dd-…:/favourited_by?limit=5` | **404** |
| fixed script | `https://localhost:3000/users/test1/statuses/019fe59f-…` | `/api/v1/statuses/apurl_aHR0cHM6…/favourited_by?limit=5` | **200** |
| fixed fitness script | `https://localhost:3000/users/test1/statuses/019fe594-…` | `/api/v1/statuses/apurl_aHR0cHM6…/favourited_by?limit=5` | **200** |

The trailing colon in the 404 URL reproduces the reported symptom exactly.

## Notes

- No migration, no schema change, no runtime code touched — `scripts/mock/` only.
- Pre-existing bare-uuid rows in an existing local dev database keep 404ing; the fix only affects newly seeded rows.

## Test plan

- [x] `yarn run prettier --write .` — no drift
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — passes
- [x] `yarn test` — 757 files, 8250 tests passed
- [x] Browser-verified against local SQLite as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
