### PR TITLE
Bump version to v1.124.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.8",
+  "version": "1.124.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.124.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.123.8`
- Base main SHA: `d1f2f82f5f7e104373d52e0d0838caa86bcfbcd9`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
