### PR TITLE
fix: bulk-update in backfillPublicIds so it cannot starve the app connection pool

### DIFF
--- a/scripts/maintenance/backfillPublicIds.test.ts
+++ b/scripts/maintenance/backfillPublicIds.test.ts
@@ -3,7 +3,7 @@ import knex from 'knex'
 import { getPublicIdTimestamp, isPublicId } from '@/lib/utils/publicId'
 import * as migration from '@/migrations/20260808000000_add_public_ids'
 
-import { mintPublicId, parseArgs } from './backfillPublicIds'
+import { backfillTable, mintPublicId, parseArgs } from './backfillPublicIds'
 
 describe('backfillPublicIds parseArgs', () => {
   it('defaults to a live run with the standard batch size', () => {
@@ -107,5 +107,229 @@ describe('backfillPublicIds mintPublicId', () => {
     const older = mintPublicId(new Date(Date.UTC(2020, 0, 1)))
     const newer = mintPublicId(new Date(Date.UTC(2023, 5, 15)))
     expect(older < newer).toBe(true)
+  })
+})
+
+describe('backfillTable', () => {
+  let database: knex.Knex
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    await database.schema.createTable('statuses', (table) => {
+      table.string('id').primary()
+      table.datetime('createdAt')
+      table.string('publicId', 36).nullable().unique()
+    })
+    await database.schema.createTable('actors', (table) => {
+      table.string('id')
+      table.datetime('createdAt')
+      table.string('publicId', 36).nullable().unique()
+    })
+  })
+
+  afterEach(async () => {
+    await database.destroy()
+  })
+
+  const insertStatuses = (count: number, offset = 0) =>
+    database('statuses').insert(
+      Array.from({ length: count }, (_, index) => ({
+        id: `https://llun.test/users/a/statuses/${String(offset + index).padStart(4, '0')}`,
+        createdAt: Date.UTC(2024, 10, 1) + (offset + index) * 60_000
+      }))
+    )
+
+  it('fills every addressable row with a distinct v7 id matching createdAt', async () => {
+    await insertStatuses(120)
+
+    const report = await backfillTable(database, 'statuses', {
+      dryRun: false,
+      batchSize: 50
+    })
+
+    expect(report).toMatchObject({
+      table: 'statuses',
+      backfilled: 120,
+      unaddressable: 0,
+      remaining: 0,
+      stopReason: null
+    })
+
+    const rows = await database('statuses').select('publicId', 'createdAt')
+    expect(rows.every((row) => isPublicId(row.publicId))).toBe(true)
+    expect(new Set(rows.map((row) => row.publicId)).size).toBe(120)
+    for (const row of rows) {
+      expect(getPublicIdTimestamp(row.publicId)).toBe(row.createdAt)
+    }
+  })
+
+  it('backfills in bulk statements instead of one query per row', async () => {
+    // The backfill used to issue one UPDATE per row and fan the whole
+    // --batch-size out with Promise.all. This script runs on the APP's pool,
+    // which caps at ACTIVITIES_DATABASE_PG_POOL_MAX (5 in production, 1 if
+    // unset), so the rest queued in tarn and the batch had to drain inside a
+    // single 60s acquireConnectionTimeout — the same failure that killed the
+    // migration, on a tighter pool.
+    const rowCount = 450
+    await insertStatuses(rowCount)
+
+    let updateStatements = 0
+    let inFlight = 0
+    let maxConcurrentQueries = 0
+    const onQuery = ({ sql }: { sql: string }) => {
+      if (/^update /i.test(sql)) updateStatements += 1
+      inFlight += 1
+      maxConcurrentQueries = Math.max(maxConcurrentQueries, inFlight)
+    }
+    const onSettled = () => {
+      inFlight -= 1
+    }
+    database.on('query', onQuery)
+    database.on('query-response', onSettled)
+    database.on('query-error', onSettled)
+
+    try {
+      await backfillTable(database, 'statuses', {
+        dryRun: false,
+        batchSize: 500
+      })
+    } finally {
+      database.off('query', onQuery)
+      database.off('query-response', onSettled)
+      database.off('query-error', onSettled)
+    }
+
+    // 450 rows fold into three 200-row chunks, so anything near one statement
+    // per row means the fan-out is back.
+    expect(updateStatements).toBeLessThanOrEqual(5)
+    // And nothing is fanned out concurrently: the backfill holds one pooled
+    // connection at a time, leaving the rest of the budget to the live app.
+    expect(maxConcurrentQueries).toBe(1)
+
+    const missing = await database('statuses')
+      .whereNull('publicId')
+      .count({ cnt: '*' })
+    expect(Number(missing[0].cnt)).toBe(0)
+  })
+
+  it('mints ids identical to the migration for the same rows', async () => {
+    // The script and the migration carry separate copies of the minting logic
+    // (the migration is plain ESM the knex CLI runs with no `@/` aliases), and
+    // a row repaired here must be indistinguishable from one the migration
+    // filled — same table, same rows, same publicIds.
+    const other = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    try {
+      await other.schema.createTable('statuses', (table) => {
+        table.string('id').primary()
+        table.datetime('createdAt')
+      })
+      await other.schema.createTable('actors', (table) => {
+        table.string('id')
+        table.datetime('createdAt')
+      })
+      const rows = Array.from({ length: 30 }, (_, index) => ({
+        id: `https://llun.test/users/a/statuses/${String(index).padStart(4, '0')}`,
+        createdAt: Date.UTC(2024, 10, 1) + index * 60_000
+      }))
+      await other('statuses').insert(rows)
+      await database('statuses').insert(rows)
+
+      await migration.up(other)
+      await backfillTable(database, 'statuses', {
+        dryRun: false,
+        batchSize: 500
+      })
+
+      const fromMigration = await other('statuses')
+        .select('id', 'publicId')
+        .orderBy('id')
+      const fromScript = await database('statuses')
+        .select('id', 'publicId')
+        .orderBy('id')
+      expect(fromScript.map((row) => row.id)).toEqual(
+        fromMigration.map((row) => row.id)
+      )
+      for (const [index, row] of fromScript.entries()) {
+        expect(getPublicIdTimestamp(row.publicId)).toBe(
+          getPublicIdTimestamp(fromMigration[index].publicId)
+        )
+      }
+    } finally {
+      await other.destroy()
+    }
+  })
+
+  it('skips rows with a null id and reports them as unaddressable', async () => {
+    await database('actors').insert([
+      { id: null, createdAt: Date.UTC(2024, 9, 1) },
+      { id: null, createdAt: Date.UTC(2024, 9, 2) },
+      { id: 'https://llun.test/users/a', createdAt: Date.UTC(2024, 9, 3) }
+    ])
+
+    const report = await backfillTable(database, 'actors', {
+      dryRun: false,
+      batchSize: 500
+    })
+
+    expect(report).toMatchObject({
+      backfilled: 1,
+      unaddressable: 2,
+      remaining: 0,
+      stopReason: null
+    })
+    const skipped = await database('actors').select('publicId').whereNull('id')
+    expect(skipped.every((row) => row.publicId === null)).toBe(true)
+  })
+
+  it('stops instead of looping when its UPDATEs take no effect', async () => {
+    await insertStatuses(3)
+    // RAISE(IGNORE) in a BEFORE UPDATE trigger models an UPDATE that silently
+    // changes nothing: the rows stay selectable, so without the no-progress
+    // check the pass would re-select them forever.
+    await database.raw(`
+      CREATE TRIGGER ignore_public_id_writes
+      BEFORE UPDATE OF "publicId" ON "statuses"
+      BEGIN
+        SELECT RAISE(IGNORE);
+      END;
+    `)
+
+    const report = await backfillTable(database, 'statuses', {
+      dryRun: false,
+      batchSize: 500
+    })
+
+    expect(report.backfilled).toBe(0)
+    expect(report.remaining).toBe(3)
+    expect(report.stopReason).toBe('made no progress on 3 row(s)')
+  })
+
+  it('writes nothing in dry-run mode but still reports what is pending', async () => {
+    await insertStatuses(10)
+
+    const report = await backfillTable(database, 'statuses', {
+      dryRun: true,
+      batchSize: 500
+    })
+
+    expect(report).toMatchObject({
+      backfilled: 0,
+      unaddressable: 0,
+      remaining: 10,
+      stopReason: null
+    })
+    const missing = await database('statuses')
+      .whereNull('publicId')
+      .count({ cnt: '*' })
+    expect(Number(missing[0].cnt)).toBe(10)
   })
 })

--- a/scripts/maintenance/backfillPublicIds.ts
+++ b/scripts/maintenance/backfillPublicIds.ts
@@ -20,11 +20,13 @@
  * the `publicId IS NULL` guard, so a value written concurrently by the app is
  * never clobbered, and a second run over a clean database is a no-op.
  *
- * Rows with a NULL `id` cannot be addressed by a per-row UPDATE (knex compiles
- * `.where('id', null)` to `id IS NULL`, which would match every null-id row at
- * once and write one publicId to all of them, and the unique index would reject
- * it). `actors.id` is nullable in both schema dumps, so they can exist; they are
- * skipped and reported instead.
+ * Rows with a NULL `id` cannot be addressed at all: the bulk UPDATE matches on
+ * `id IN (...)`, and SQL never matches NULL with IN. (Addressing them one row at
+ * a time would be worse than useless — knex compiles `.where('id', null)` to
+ * `id IS NULL`, which matches every null-id row at once and would write one
+ * publicId to all of them, which the unique index rejects.) `actors.id` is
+ * nullable in both schema dumps, so such rows can exist; they are skipped and
+ * reported instead.
  *
  * EXIT CODE. 0 only when no NULL publicId remains anywhere — that is the deploy
  * gate for the follow-up "emit publicIds" change. 1 when any row still has one,
@@ -150,6 +152,75 @@ export const parseArgs = (args: string[]) => {
   return CliArgs.parse({ dryRun, batchSize })
 }
 
+// Rows folded into a single bulk UPDATE, matching the migration's constant of
+// the same name. Each row contributes three bind parameters (the CASE match,
+// the CASE value, and the id in the IN list), so 200 rows is 600 parameters —
+// under the 999-parameter floor of the most conservatively built SQLite, and
+// nowhere near PostgreSQL's 65535.
+const UPDATE_CHUNK_SIZE = 200
+
+interface PublicIdUpdate {
+  id: string
+  publicId: string
+}
+
+// One UPDATE per chunk, awaited one chunk at a time.
+//
+// This used to be a per-row UPDATE fanned out with Promise.all over the whole
+// --batch-size (500 by default). The pool this script runs on is the APP's
+// (`getDatabaseConfig()`), which caps at ACTIVITIES_DATABASE_PG_POOL_MAX — 5 in
+// production and 1 if unset — so the other 495 queries sat in tarn's acquire
+// queue and the whole batch had to drain inside a single 60s
+// acquireConnectionTimeout. That is the same failure that killed the migration
+// mid-backfill ("Timeout acquiring a connection. The pool is probably full."),
+// only on a tighter pool; see the matching bulkUpdatePublicIds() in
+// migrations/20260808000000_add_public_ids.js.
+//
+// Awaiting sequentially means the backfill holds exactly ONE pooled connection
+// at any moment: it cannot starve its own pool, and it leaves the rest of the
+// connection budget to the app serving traffic — which matters here precisely
+// because this script is meant to run against a live production database.
+const bulkUpdatePublicIds = async (
+  database: knex.Knex,
+  tableName: TableName,
+  updates: PublicIdUpdate[]
+) => {
+  let updated = 0
+
+  for (let offset = 0; offset < updates.length; offset += UPDATE_CHUNK_SIZE) {
+    const chunk = updates.slice(offset, offset + UPDATE_CHUNK_SIZE)
+
+    // `else ??` is unreachable — the IN list restricts the statement to exactly
+    // the ids the CASE enumerates — but it keeps the expression total, so a row
+    // can never be blanked, and it gives PostgreSQL a typed branch to resolve
+    // the otherwise-unknown parameters against.
+    const caseSql = `case ?? ${chunk.map(() => 'when ? then ?').join(' ')} else ?? end`
+    const caseBindings = [
+      'id',
+      ...chunk.flatMap(({ id, publicId }) => [id, publicId]),
+      'publicId'
+    ]
+
+    // Built through the query builder rather than database.raw so the return
+    // value is knex's normalised affected-row count on every dialect (a raw
+    // UPDATE hands back the driver's own result shape instead).
+    const affected = await database(tableName)
+      .whereIn(
+        'id',
+        chunk.map(({ id }) => id)
+      )
+      // The same guard the migration uses: a publicId written by the app
+      // between the SELECT and this UPDATE wins, and re-running the script
+      // never rewrites a row that already has one.
+      .whereNull('publicId')
+      .update({ publicId: database.raw(caseSql, caseBindings) })
+
+    updated += Number(affected ?? 0)
+  }
+
+  return updated
+}
+
 interface TableReport {
   table: TableName
   backfilled: number
@@ -158,8 +229,9 @@ interface TableReport {
   stopReason: string | null
 }
 
-// Rows still missing a publicId, split by whether a per-row UPDATE can address
-// them at all. `addressable: false` counts the NULL-id rows described above.
+// Rows still missing a publicId, split by whether an id-based UPDATE can
+// address them at all. `addressable: false` counts the NULL-id rows described
+// above — `id IN (...)` never matches NULL.
 const countMissingPublicIds = async (
   database: knex.Knex,
   tableName: TableName,
@@ -174,7 +246,7 @@ const countMissingPublicIds = async (
   return Number(result?.cnt ?? 0)
 }
 
-const backfillTable = async (
+export const backfillTable = async (
   database: knex.Knex,
   tableName: TableName,
   { dryRun, batchSize }: { dryRun: boolean; batchSize: number }
@@ -204,20 +276,13 @@ const backfillTable = async (
         .limit(batchSize)
       if (rows.length === 0) break
 
-      const results = await Promise.all(
-        rows.map((row: { id: string; createdAt: unknown }) =>
-          database(tableName)
-            // The same guard the migration uses: a publicId written by the app
-            // between this SELECT and this UPDATE wins, and re-running the
-            // script never rewrites a row that already has one.
-            .where('id', row.id)
-            .whereNull('publicId')
-            .update({ publicId: mintPublicId(row.createdAt) })
-        )
-      )
-      const filled = results.reduce(
-        (sum: number, count) => sum + Number(count ?? 0),
-        0
+      const filled = await bulkUpdatePublicIds(
+        database,
+        tableName,
+        rows.map((row: { id: string; createdAt: unknown }) => ({
+          id: row.id,
+          publicId: mintPublicId(row.createdAt)
+        }))
       )
       backfilled += filled
       console.log(
@@ -306,7 +371,7 @@ async function backfillPublicIds(args = process.argv.slice(2)) {
 
     if (totals.unaddressable > 0) {
       console.log(
-        `\n${totals.unaddressable} row(s) have a NULL id and cannot be addressed by a per-row UPDATE.\n` +
+        `\n${totals.unaddressable} row(s) have a NULL id and cannot be addressed by an id-based UPDATE.\n` +
           'Repair their id first — until then they can never carry a publicId.'
       )
     }


### PR DESCRIPTION
Follow-up to #1397, which fixed this same bug in the migration but left the maintenance script untouched.

## Problem

`scripts/maintenance/backfillPublicIds.ts` still built **one UPDATE per row** and fired the whole `--batch-size` (500 by default) through `Promise.all`:

```ts
const results = await Promise.all(
  rows.map((row) =>
    database(tableName).where('id', row.id).whereNull('publicId')
      .update({ publicId: mintPublicId(row.createdAt) })
  )
)
```

This is the same failure mode as the migration, **on a tighter pool**. The migration runs on the knex CLI's default pool of 10; this script runs on the *app's* config (`getDatabaseConfig()`), which caps at `ACTIVITIES_DATABASE_PG_POOL_MAX` — **5 in production, and 1 when unset**. So 495 of those queries queue in tarn and the whole batch has to drain inside a single 60s `acquireConnectionTimeout` — exactly the `Timeout acquiring a connection. The pool is probably full.` that killed the migration mid-backfill.

It hasn't bitten yet only because the one production run had **zero** rows to fill (the minting build was already live when the migration ran, so there was no rollout residue). A real post-rollout backfill would have hit it.

## Fix

Ported the migration's `bulkUpdatePublicIds`: rows fold into a single `UPDATE ... SET "publicId" = CASE "id" WHEN ? THEN ? ... END WHERE "id" IN (...) AND "publicId" IS NULL` per 200-row chunk, awaited **one chunk at a time**.

- The script holds exactly **one** pooled connection at any moment. That matters more here than in the migration — this script is explicitly designed to run against a *live production database*, so the rest of the connection budget stays with the app serving traffic.
- 200 rows is 600 bind parameters, matching the migration's constant and reasoning.
- `--batch-size` keeps its meaning: the SELECT page size. It is no longer also a concurrency dial.
- The `publicId IS NULL` guard is preserved, so a value written concurrently by the app is still never clobbered.

NULL-id rows are still skipped and reported, for a slightly different reason now — `id IN (...)` never matches NULL, rather than `.where('id', null)` compiling to `id IS NULL` and hitting every such row at once. Updated the two comments and the operator-facing message that described the old mechanism.

`backfillTable` is now exported so the bulk path is directly testable.

## Verification

**New tests** (`backfillTable` suite) cover the bulk path end to end: every row filled with a distinct v7 id whose timestamp matches `createdAt`; parity with the migration's minting on the same rows; the NULL-id skip; the no-progress stop; and dry-run writing nothing. The regression guard asserts both the statement count and `maxConcurrentQueries === 1` — and it genuinely catches the regression: forcing `UPDATE_CHUNK_SIZE = 1` fails it with `expected 450 to be less than or equal to 5`.

**Real PostgreSQL 17**, running the actual CLI against a throwaway database with the production pool (`max: 5`):

- 2300 statuses + 1 actor backfilled across 5 passes
- 2300/2300 distinct publicIds, 0 malformed, 0 v7-timestamp mismatches
- NULL-id actor skipped and reported, exit 1 (gate correctly unmet)
- after repairing that id, gate satisfied with exit 0
- re-run over a clean database is a no-op, exit 0

**Full gate**: `prettier`, `yarn lint` (124 warnings, byte-identical to `main`), `yarn build`, `yarn test` (760 files / 8349 tests) all pass.

No schema change, so no dump regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeGQjQipQhVc6vK4tTtzrx