### PR TITLE
Bump version to v1.124.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.124.0",
+  "version": "1.124.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.124.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.124.0`
- Base main SHA: `cb71a9b501ccf73c3027ee5ebfc3a3cc836c65a8`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
