### PR TITLE
Bump version to v1.125.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.124.1",
+  "version": "1.125.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.125.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.124.1`
- Base main SHA: `f781cc8e52cbb366af06809a0d79213c37171e8e`
- Included commits: `11`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
