### PR TITLE
none: fix TEST_DATABASE_TYPE=pg test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,8 +630,15 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   `CI Success` aggregate job; `Schema Dump Sync` is not a required check.
   The test job pins `TEST_DATABASE_TYPE: sqlite`; `lib/database/testUtils.ts`
   also supports `TEST_DATABASE_TYPE=pg` (with `TEST_DATABASE_HOST` /
-  `TEST_DATABASE_USERNAME` / `TEST_DATABASE_PASSWORD`) for running the suite
-  against a throwaway **local** PostgreSQL.
+  `TEST_DATABASE_USERNAME` / `TEST_DATABASE_PASSWORD`; the port is fixed at 5432) for running the suite against a throwaway **local** PostgreSQL. In that
+  mode each Vitest worker drops and recreates its **own** database named
+  `test_<VITEST_POOL_ID>` — a single shared database would let one worker
+  destroy the schema another worker is mid-test on. The schema loader also has
+  to `RESET search_path` on the connection it loads `migrations/schema.sql`
+  into, because pg_dump's leading
+  `SELECT pg_catalog.set_config('search_path', '', false)` is session-scoped and
+  would otherwise leave that pooled connection unable to resolve any unqualified
+  table name for the rest of its life.
 - **To grab a mocked module and configure it, use `vi.importMock<T>('@/path')`,
   not `(await import('@/path')) as unknown as T`.** `vi.importMock` is the
   Vitest equivalent of the old `jest.requireMock`: it is purpose-built, always

--- a/lib/database/testUtils.ts
+++ b/lib/database/testUtils.ts
@@ -33,7 +33,25 @@ const applySqliteSchema = async (instance: Knex) => {
 
 const applyPostgresSchema = async (instance: Knex) => {
   const sql = readFileSync(POSTGRES_SCHEMA_PATH, 'utf8')
-  await instance.raw(sql)
+  // pg_dump opens the dump with `SELECT pg_catalog.set_config('search_path', '',
+  // false)`. The `false` makes it *session*-scoped rather than transaction-scoped,
+  // so it outlives the load: the pooled connection that ran the dump keeps an
+  // empty search_path for the rest of its life. Every table in the dump is
+  // `public.`-qualified and so is created fine, but any later unqualified query
+  // that the pool happens to route back to that connection cannot resolve it
+  // (`relation "accounts" does not exist`). Hold one connection for both
+  // statements so the reset lands on the connection that was poisoned — knex's
+  // own `searchPath` config would not do, as it is applied when a connection is
+  // created, which is before the dump runs. `RESET` restores the server default
+  // (`"$user", public`), leaving this connection identical to a freshly created
+  // one rather than pinning it to a hardcoded schema list.
+  const connection = await instance.client.acquireConnection()
+  try {
+    await instance.raw(sql).connection(connection)
+    await instance.raw('RESET search_path').connection(connection)
+  } finally {
+    await instance.client.releaseConnection(connection)
+  }
 }
 
 // Replaces the production `migrate()` (which runs Knex migrations) with a fast
@@ -47,7 +65,18 @@ const withSchemaDumpMigrate = (
   return database
 }
 
-const TEST_PG_TABLE = 'test'
+// Each Vitest worker needs its own PostgreSQL database. `prepare()` drops and
+// recreates the database before loading the schema, so a single shared name lets
+// one worker destroy the database another worker is running tests against — which
+// surfaces as `relation "..." does not exist` or `Connection terminated
+// unexpectedly` in whichever file lost the race. Vitest hands files to a worker
+// one at a time, so a name per worker is enough isolation; `VITEST_POOL_ID` is
+// unique across the workers running concurrently. Strip it to digits: it is
+// interpolated into `CREATE`/`DROP DATABASE`, which cannot be parameterised.
+const TEST_PG_WORKER_ID = (process.env.VITEST_POOL_ID ?? '').replace(/\D/g, '')
+const TEST_PG_DATABASE = TEST_PG_WORKER_ID
+  ? `test_${TEST_PG_WORKER_ID}`
+  : 'test'
 const TEST_PG_CONNECTION = {
   host: process.env.TEST_DATABASE_HOST,
   port: 5432,
@@ -89,7 +118,7 @@ const DATABASES: Record<string, GetTestDatabase> = {
       client: 'pg',
       connection: {
         ...TEST_PG_CONNECTION,
-        database: TEST_PG_TABLE
+        database: TEST_PG_DATABASE
       }
     })
     return {
@@ -106,9 +135,9 @@ const DATABASES: Record<string, GetTestDatabase> = {
         })
         await client.connect()
         await client.query(
-          `DROP DATABASE IF EXISTS ${TEST_PG_TABLE} WITH (FORCE)`
+          `DROP DATABASE IF EXISTS ${TEST_PG_DATABASE} WITH (FORCE)`
         )
-        await client.query(`CREATE DATABASE ${TEST_PG_TABLE}`)
+        await client.query(`CREATE DATABASE ${TEST_PG_DATABASE}`)
         await client.end()
       }
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,14 @@ export default defineConfig({
       '**/coverage/**'
     ],
     testTimeout: 30000,
+    // Match testTimeout. Vitest's 10s default is too tight for the
+    // `TEST_DATABASE_TYPE=pg` harness: every test file's `beforeAll` drops and
+    // recreates its worker's database and replays the whole of
+    // `migrations/schema.sql`, and one worker per core doing that at once
+    // against a cold PostgreSQL overran 10s. SQLite hooks finish in
+    // milliseconds, so this only raises the ceiling before a hung hook is
+    // declared failed — it does not slow a passing run down.
+    hookTimeout: 30000,
     server: {
       deps: {
         // These ship ESM that should be transformed/inlined by Vitest.


### PR DESCRIPTION
## Summary

`TEST_DATABASE_TYPE=pg` was completely broken — every test skipped and the suite
failed with `relation "accounts" does not exist`. AGENTS.md documents the mode as
supported, but CI pins `TEST_DATABASE_TYPE=sqlite`, so nothing caught it.

There were **two** independent harness bugs. The second was hidden behind the
first, so fixing only the reported one would have looked correct on a single
file and still failed on a parallel run.

### 1. The connection that loaded the schema was poisoned

`pg_dump` opens `migrations/schema.sql` with
`SELECT pg_catalog.set_config('search_path', '', false)`. The `false` makes it
**session**-scoped rather than transaction-scoped, so the pooled connection that
replayed the dump kept an empty `search_path` for the rest of its life. Every
table is `public.`-qualified and so was created fine, but any later *unqualified*
query the pool routed back to that connection could not resolve it.

Measured directly — only the loader connection is affected:

| pid | `search_path` | `to_regclass('accounts')` |
|---|---|---|
| 110 (loaded dump) | `""` | **null** |
| 111–114 | `"$user", public` | `accounts` |

The dump and a `RESET search_path` now run on one explicitly held connection, so
the reset lands on the connection that was poisoned.

Two things worth recording, because both are easy to reach for and neither works:

- **knex's `searchPath` config cannot fix this.** It is applied in
  `acquireRawConnection` — at connection *creation*, which is before the dump
  runs.
- **A bare follow-up `instance.raw('SET search_path …')` is unreliable**, since
  it is only correct if the pool happens to hand back the same connection.

`RESET` (rather than a hardcoded `SET … TO public`) restores the server default
`"$user", public`, leaving the loader connection identical to a freshly created
one instead of pinning it to a schema list.

### 2. Every worker shared one `test` database

Each file's `prepare()` runs `DROP DATABASE IF EXISTS test WITH (FORCE)` +
`CREATE DATABASE`. In a parallel run one worker destroys the database another is
mid-test on, which surfaces as the *same* `relation ... does not exist` message
plus `Connection terminated unexpectedly`. Each worker now gets its own
`test_<VITEST_POOL_ID>` database (unique across concurrent workers; Vitest hands
files to a worker sequentially, so per-worker is sufficient).

### `hookTimeout`

With per-worker databases, one worker per core replays the whole schema dump at
once, which overran Vitest's 10s default `hookTimeout` against a cold
PostgreSQL. Raised to match the existing `testTimeout: 30000`. SQLite hooks
finish in milliseconds, so this only raises the ceiling before a hung hook is
declared failed.

## Verification

| | before | after |
|---|---|---|
| `lib/database/sql/` on PostgreSQL | suite failed, 31/31 skipped on the repro file | **67 files / 1210 tests pass** |
| same, wall clock | n/a (forced serial: 61s) | **12s parallel** |
| full suite on SQLite | 8754 pass | **8754 pass, unchanged** |

- Repro from the report goes from a failed suite to 31/31 passing.
- Parallel and `--no-file-parallelism` runs both verified.
- Repeatable across runs, including from a **cold** container (the condition that
  first exposed the `hookTimeout` issue).
- `prettier` / `lint` / `build` / `test` all green.

## Known failures this does NOT fix (follow-up)

7 tests still fail on PostgreSQL. They are **not** harness bugs — they are
exactly the cross-backend coverage this restores. All stem from `medias.id`
being a real `integer` on PostgreSQL while SQLite's dynamic typing accepts
strings.

**One is a genuine PostgreSQL-only production bug.**
`getMediaByIdForAccount` (`lib/database/sql/media.ts`) passes `mediaId` straight
into `where('medias.id', mediaId)`, so a non-numeric id is a database *error*,
not a miss — `GET /api/v1/media/<non-numeric>` returns **500 instead of 404**,
and the route does no numeric validation. Its sibling
`getMediaByIdsForAccount`, twenty lines below, already documents this exact
hazard and guards against it; the singular method was never given the guard. The
same path is reachable from status creation via `getAttachmentsFromMediaIds`.
The failing test asserts the *correct* behaviour.

The other 6 (`status.test.ts` → `updateNote`) are unrealistic fixtures inserting
`attachments.mediaId` values like `'old-media'`. Related and worth knowing: the
two reference schema dumps legitimately disagree on that column (`integer` on
PostgreSQL, `varchar(255)` on SQLite) because
`20260207223000_fix_attachments_media_id_type.js` is a deliberate PostgreSQL-only
conversion — that is **not** dump drift.

Both are left out of scope here: the media fix is a production behaviour change
that deserves its own tests and PR.

## Notes

- No runtime code changes — test harness, Vitest config, and AGENTS.md only,
  hence the `none:` prefix.
- The PostgreSQL test port is still hardcoded to 5432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
