### PR TITLE
none: add fitness gear import and Strava export converter scripts

### DIFF
--- a/docs/fitness-file-storage.md
+++ b/docs/fitness-file-storage.md
@@ -166,6 +166,8 @@ Fitness maintenance scripts live in `scripts/`:
 - `scripts/fitness/importStoredFitnessFile.ts` — rebuilds a post from the already-stored file with no Strava call (deleted-from-Strava case); merges same-ride files into one post
 - `scripts/fitness/repairStravaActivityFiles.ts` — pass `--delete-missing` to hard-delete activities Strava 404s (default: report only; deletion is irreversible)
 - `scripts/fitness/backfillFitnessMovingTime.ts` — recomputes `movingTimeSeconds` for already-stored files so their average pace/speed switches from elapsed-time to moving-time (matching Strava); idempotent, supports `--dry-run` and `--force`
+- `scripts/fitness/importFitnessGear.ts` — creates gear and component history from a JSON file and attributes existing activities to it by matching `activityStartTime`, for activities imported before gear tracking existed; idempotent, supports `--dry-run`, `--overwrite` and `--tolerance-seconds`
+- `scripts/fitness/convertStravaExportToGearImport.ts` — builds that import file's assignments from a Strava export's `activities.csv` (the only record of which gear each historical activity used), merged with a hand-authored gear description
 - `scripts/fitness/retrigerStravaActivities.ts`
 - `scripts/fitness/runImportStravaActivity.ts`
 - `scripts/fitness/listStravaWebhooks.ts`

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -357,6 +357,7 @@ NODE_ENV=production ./scripts/fitness/fixStuckFitnessProcessing.ts --actor-id ht
 NODE_ENV=production ./scripts/fitness/recreateFitnessRouteHeatmaps.ts --actor-id https://your-domain.tld/users/username --dry-run
 NODE_ENV=production ./scripts/fitness/repairStravaActivityFiles.ts --actor-id https://your-domain.tld/users/username --dry-run
 NODE_ENV=production ./scripts/fitness/backfillFitnessMovingTime.ts --actor-id https://your-domain.tld/users/username --dry-run
+NODE_ENV=production ./scripts/fitness/importFitnessGear.ts --actor-id https://your-domain.tld/users/username --input ./gear-import.json --dry-run
 NODE_ENV=production ./scripts/fitness/retrigerStravaActivities.ts --actor-id https://your-domain.tld/users/username --activity-id 123456789
 NODE_ENV=production ./scripts/fitness/listStravaWebhooks.ts @username@your-domain.tld
 ```
@@ -366,6 +367,88 @@ NODE_ENV=production ./scripts/fitness/listStravaWebhooks.ts @username@your-domai
 > **Note:** `repairStravaActivityFiles.ts` only **reports** activities that Strava 404s by default; pass `--delete-missing` to hard-delete their stored file, DB record, and post (irreversible). Every recovery script prints the resolved database target on start — verify it is production (`.env.local` shadows `.env.production` even under `NODE_ENV=production`).
 >
 > **Note:** `backfillFitnessMovingTime.ts` recomputes `movingTimeSeconds` for already-stored activity files by re-parsing them, so their average pace/speed switches from elapsed-time to moving-time (matching Strava). New imports already compute it during processing; this only needs running once over historical records. It skips files that already have a moving time (pass `--force` to recompute anyway) and supports `--dry-run` to preview.
+
+#### Backfilling gear onto activities imported before gear tracking existed
+
+Gear tracking arrived after most activities did, so anything imported earlier has
+no gear at all. Re-importing would duplicate the posts, and the Strava import
+paths only attribute activities they import themselves, so
+`scripts/fitness/importFitnessGear.ts` fills the gap: it creates the gear and its
+component history from a JSON file, then attributes existing activities by
+matching each entry's timestamp against `activityStartTime`.
+
+Assignments are matched to the nearest activity within `--tolerance-seconds`
+(default 60). An entry that matches nothing, ties between two activities, or
+lands on an activity another entry already claimed is reported and skipped —
+never guessed at. Activities that already carry gear are left alone unless
+`--overwrite` is given, so re-running is free and never undoes a manual
+correction. Always `--dry-run` first: the report lists how far the nearest
+activity was for every unmatched entry, so a systematic clock problem shows up as
+a uniform offset before anything is written.
+
+```jsonc
+{
+  "gears": [
+    {
+      "name": "Moots", // required; the name assignments refer to
+      "kind": "bike", // "bike" | "shoes"
+      "brand": "Moots",
+      "model": "Vamoots RSL disc",
+      "bikeType": "Road bike", // bikes only
+      "weightKilograms": 8.0, // bikes only
+      "alertDistanceMeters": null, // shoes only
+      "defaultSports": [], // sport keys this gear auto-claims (see below)
+      "stravaGearId": null, // optional; keeps Strava sync from creating a duplicate
+      "retired": false,
+      "components": [
+        {
+          "type": "Chain",
+          "brand": "Shimano",
+          "model": "CN-HG901-11",
+          "addedAt": "2019-09-24", // omit for "since the gear's beginning"
+          "removedAt": "2020-04-01" // omit while still installed
+        }
+      ],
+      "windows": [
+        // Fallback for activities no assignment names. Half-open [from, to);
+        // omit "sports" to cover every sport of the gear's kind.
+        { "from": "2018-09-07", "to": null, "sports": ["ride", "virtual_ride"] }
+      ]
+    }
+  ],
+  "assignments": [{ "time": "2015-10-06T09:44:23Z", "gear": "Brompton S6R" }]
+}
+```
+
+Dates are either a `YYYY-MM-DD` day (read as UTC midnight) or a full datetime
+carrying an explicit `Z`/offset — a bare local datetime is rejected, because
+JavaScript would read it in the running machine's zone and silently shift every
+activity by hours. The whole file is validated before anything is written.
+
+`scripts/fitness/convertStravaExportToGearImport.ts` builds the `assignments`
+half from a Strava export. The export's `activities.csv` records which gear each
+activity used against a UTC timestamp, but `components.csv` carries no dates at
+all — install and removal dates exist only on Strava's gear pages, so the `gears`
+half is hand-authored from those pages and merged in:
+
+```bash
+./scripts/fitness/convertStravaExportToGearImport.ts \
+  --export-dir ./strava-export --gears ./gears.json --output ./gear-import.json
+```
+
+It reports per-gear activity counts and Strava's own distance totals, which
+should match what the Strava gear page shows — the cheapest check that the gear
+names were transcribed correctly.
+
+> **Note:** `defaultSports` decides which gear future uploads auto-attach to, and
+> a sport belongs to one gear at a time — giving it to imported gear takes it
+> from whatever holds it now (the script warns when it is about to). A purely
+> historical import should leave it empty.
+>
+> **Note:** the import does not evaluate service reminders, so backfilling years
+> of activities sends no alerts. The next real activity on gear whose new total
+> already exceeds its threshold fires one — that is the reminder working, not a
+> bug.
 
 #### Recovering an import that stored the file but never created the post
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -380,11 +380,19 @@ matching each entry's timestamp against `activityStartTime`.
 Assignments are matched to the nearest activity within `--tolerance-seconds`
 (default 60). An entry that matches nothing, ties between two activities, or
 lands on an activity another entry already claimed is reported and skipped —
-never guessed at. Activities that already carry gear are left alone unless
-`--overwrite` is given, so re-running is free and never undoes a manual
-correction. Always `--dry-run` first: the report lists how far the nearest
-activity was for every unmatched entry, so a systematic clock problem shows up as
-a uniform offset before anything is written.
+never guessed at, and a skipped entry still reserves the activities it named so a
+date window cannot quietly attribute them to a different gear. Activities that
+already carry gear are left alone unless `--overwrite` is given, so re-running is
+free and never undoes a manual correction. Always `--dry-run` first: the report
+lists how far the nearest activity was for every unmatched entry, so a systematic
+clock problem shows up as a uniform offset before anything is written.
+
+The script refuses to write at all when the actor has no activities but the file
+has assignments (almost always the wrong `--actor-id`, and creating the gear
+there would strip default sports off that actor's real gear), when two entries
+resolve to the same existing gear, or when a gear exists with a different `kind`.
+It exits non-zero if no assignment reached any activity, so a wrong target cannot
+pass for a clean run in a script.
 
 ```jsonc
 {

--- a/scripts/fitness/convertStravaExportToGearImport.test.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.test.ts
@@ -1,0 +1,168 @@
+import {
+  buildAssignments,
+  parseArgs,
+  parseStravaActivitiesCsv,
+  parseStravaExportDate
+} from './convertStravaExportToGearImport'
+
+// The real export repeats five header names; "Distance" appears twice and only
+// the second one is in meters.
+const HEADER =
+  'Activity ID,Activity Date,Activity Name,Activity Type,Distance,Activity Gear,Filename,Distance'
+
+const csvOf = (...rows: string[]) => [HEADER, ...rows].join('\n')
+
+describe('parseArgs', () => {
+  it('requires every path', () => {
+    expect(() => parseArgs([])).toThrow()
+    expect(() => parseArgs(['--export-dir', './export'])).toThrow()
+  })
+
+  it('reads the three paths', () => {
+    expect(
+      parseArgs([
+        '--export-dir',
+        './export',
+        '--gears=./gears.json',
+        '--output',
+        './out.json'
+      ])
+    ).toEqual({
+      exportDir: './export',
+      gears: './gears.json',
+      output: './out.json'
+    })
+  })
+})
+
+describe('parseStravaExportDate', () => {
+  it.each([
+    {
+      description: 'an afternoon time',
+      value: 'Aug 10, 2026, 3:43:45 PM',
+      expected: Date.UTC(2026, 7, 10, 15, 43, 45)
+    },
+    {
+      description: 'a morning time',
+      value: 'Oct 6, 2015, 9:44:23 AM',
+      expected: Date.UTC(2015, 9, 6, 9, 44, 23)
+    },
+    {
+      description: 'midnight',
+      value: 'Jan 1, 2020, 12:05:00 AM',
+      expected: Date.UTC(2020, 0, 1, 0, 5, 0)
+    },
+    {
+      description: 'noon',
+      value: 'Jan 1, 2020, 12:05:00 PM',
+      expected: Date.UTC(2020, 0, 1, 12, 5, 0)
+    }
+  ])('reads $description as UTC', ({ value, expected }) => {
+    expect(parseStravaExportDate(value)).toBe(expected)
+  })
+
+  it.each([
+    { description: 'an empty value', value: '' },
+    { description: 'an ISO date', value: '2026-08-10T15:43:45Z' },
+    { description: 'a 24-hour time', value: 'Aug 10, 2026, 15:43:45 PM' },
+    { description: 'a non-English month', value: 'Aoû 10, 2026, 3:43:45 PM' }
+  ])('throws on $description', ({ value }) => {
+    expect(() => parseStravaExportDate(value)).toThrow()
+  })
+})
+
+describe('parseStravaActivitiesCsv', () => {
+  it('reads the meters column rather than the first Distance', () => {
+    const rows = parseStravaActivitiesCsv(
+      csvOf(
+        '123,"Oct 6, 2015, 9:44:23 AM",Morning Ride,Ride,12.5,Moots,activities/123.gpx,12500'
+      )
+    )
+    expect(rows).toEqual([
+      {
+        activityId: '123',
+        timeMilliseconds: Date.UTC(2015, 9, 6, 9, 44, 23),
+        activityType: 'Ride',
+        gear: 'Moots',
+        fileName: 'activities/123.gpx',
+        distanceMeters: 12500
+      }
+    ])
+  })
+
+  it('reads a row with no gear', () => {
+    const rows = parseStravaActivitiesCsv(
+      csvOf(
+        '124,"Oct 7, 2015, 9:44:23 AM",Gym,Weight Training,,,activities/124.fit.gz,'
+      )
+    )
+    expect(rows[0]).toMatchObject({ gear: '', distanceMeters: null })
+  })
+
+  it('throws when a required column is missing', () => {
+    expect(() =>
+      parseStravaActivitiesCsv(
+        'Activity ID,Activity Date\n1,"Oct 6, 2015, 9:44:23 AM"'
+      )
+    ).toThrow(/missing the "Activity Type" column/)
+  })
+
+  it('throws on an empty file', () => {
+    expect(() => parseStravaActivitiesCsv('')).toThrow(/empty/)
+  })
+})
+
+describe('buildAssignments', () => {
+  const rows = [
+    {
+      activityId: '123',
+      timeMilliseconds: Date.UTC(2015, 9, 6, 9, 44, 23),
+      activityType: 'Ride',
+      gear: 'Moots',
+      fileName: 'activities/123.fit.gz',
+      distanceMeters: 12500
+    },
+    {
+      activityId: '124',
+      timeMilliseconds: Date.UTC(2015, 9, 7, 9, 44, 23),
+      activityType: 'Weight Training',
+      gear: '',
+      fileName: 'activities/124.fit.gz',
+      distanceMeters: null
+    }
+  ]
+
+  it('emits one assignment per activity that names gear', () => {
+    const result = buildAssignments({ rows, knownGearNames: ['Moots'] })
+    expect(result.assignments).toEqual([
+      {
+        time: '2015-10-06T09:44:23.000Z',
+        gear: 'Moots',
+        stravaActivityId: '123',
+        filename: '123.fit'
+      }
+    ])
+  })
+
+  it('counts the activities it skipped by type', () => {
+    const result = buildAssignments({ rows, knownGearNames: ['Moots'] })
+    expect(result.skippedByType).toEqual({ 'Weight Training': 1 })
+  })
+
+  it('totals distance per gear for cross-checking', () => {
+    const result = buildAssignments({ rows, knownGearNames: ['Moots'] })
+    expect(result.reports).toEqual([
+      { gearName: 'Moots', assignmentCount: 1, distanceMeters: 12500 }
+    ])
+  })
+
+  it('collects gear names the gears file does not describe', () => {
+    const result = buildAssignments({ rows, knownGearNames: ['Giant'] })
+    expect(result.unknownGear).toEqual(['Moots'])
+  })
+
+  it('matches known gear names case-insensitively', () => {
+    const result = buildAssignments({ rows, knownGearNames: ['moots'] })
+    expect(result.unknownGear).toHaveLength(0)
+  })
+})

--- a/scripts/fitness/convertStravaExportToGearImport.test.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.test.ts
@@ -123,6 +123,20 @@ describe('parseStravaActivitiesCsv', () => {
       /line 3 \(8 columns\): Unparseable Strava activity date: not-a-date/
     )
   })
+
+  it('reports the physical line when earlier records span several', () => {
+    // A description with embedded newlines is normal in a real export. Counting
+    // records rather than lines would report 3 here and send the operator to an
+    // unrelated row.
+    expect(() =>
+      parseStravaActivitiesCsv(
+        csvOf(
+          '123,"Oct 6, 2015, 9:44:23 AM",Ride,"a\nmulti\nline note",12.5,Moots,f.gpx,12500',
+          '124,not-a-date,Ride,Ride,12.5,Moots,f.gpx,12500'
+        )
+      )
+    ).toThrow(/line 5 \(8 columns\)/)
+  })
 })
 
 describe('buildAssignments', () => {

--- a/scripts/fitness/convertStravaExportToGearImport.test.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.test.ts
@@ -110,6 +110,19 @@ describe('parseStravaActivitiesCsv', () => {
   it('throws on an empty file', () => {
     expect(() => parseStravaActivitiesCsv('')).toThrow(/empty/)
   })
+
+  it('names the line and column count of a row it cannot read', () => {
+    expect(() =>
+      parseStravaActivitiesCsv(
+        csvOf(
+          '123,"Oct 6, 2015, 9:44:23 AM",Ride,Ride,12.5,Moots,f.gpx,12500',
+          '124,not-a-date,Ride,Ride,12.5,Moots,f.gpx,12500'
+        )
+      )
+    ).toThrow(
+      /line 3 \(8 columns\): Unparseable Strava activity date: not-a-date/
+    )
+  })
 })
 
 describe('buildAssignments', () => {
@@ -164,5 +177,14 @@ describe('buildAssignments', () => {
   it('matches known gear names case-insensitively', () => {
     const result = buildAssignments({ rows, knownGearNames: ['moots'] })
     expect(result.unknownGear).toHaveLength(0)
+  })
+
+  it('counts gear rows whose distance would not parse', () => {
+    const result = buildAssignments({
+      rows: [{ ...rows[0], distanceMeters: null }],
+      knownGearNames: ['Moots']
+    })
+    expect(result.unreadableDistanceCount).toBe(1)
+    expect(result.reports[0].distanceMeters).toBe(0)
   })
 })

--- a/scripts/fitness/convertStravaExportToGearImport.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.ts
@@ -144,16 +144,21 @@ export interface StravaActivityRow {
  * conversion, so it has to be addressed by position.
  */
 export const parseStravaActivitiesCsv = (csv: string): StravaActivityRow[] => {
-  const rows = parse(csv, {
+  // `info` carries the physical line each record ends on. Counting records
+  // instead would drift low for everything after the first blank line or
+  // multi-line description — and a line number that is confidently wrong is
+  // worse than none, because the operator trusts it and reads an unrelated row.
+  const parsed = parse(csv, {
     bom: true,
     relax_column_count: true,
     relax_quotes: true,
-    skip_empty_lines: true
-  }) as string[][]
+    skip_empty_lines: true,
+    info: true
+  }) as { record: string[]; info: { lines: number } }[]
 
-  if (rows.length === 0) throw new Error('activities.csv is empty')
+  if (parsed.length === 0) throw new Error('activities.csv is empty')
 
-  const header = rows[0]
+  const header = parsed[0].record
   const indexOf = (name: string, occurrence = 1): number => {
     let seen = 0
     for (let index = 0; index < header.length; index += 1) {
@@ -187,11 +192,11 @@ export const parseStravaActivitiesCsv = (csv: string): StravaActivityRow[] => {
     distanceIndex = null
   }
 
-  return rows.slice(1).map((row, offset) => {
+  return parsed.slice(1).map(({ record: row, info }) => {
     // `relax_column_count` lets short and mis-quoted rows through on purpose —
     // Strava descriptions carry newlines and stray quotes — so a row that fails
     // here has to name itself or it is unfindable in a 1,700-row file.
-    const line = offset + 2
+    const line = info.lines
     try {
       const rawDistance =
         distanceIndex === null ? '' : (row[distanceIndex] ?? '')

--- a/scripts/fitness/convertStravaExportToGearImport.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.ts
@@ -175,21 +175,40 @@ export const parseStravaActivitiesCsv = (csv: string): StravaActivityRow[] => {
   let distanceIndex: number | null = null
   try {
     distanceIndex = indexOf('Distance', 2)
-  } catch {
+  } catch (error) {
+    // Not fatal — the assignments are still correct without it — but the totals
+    // it feeds are the only cheap check that the gear names were transcribed
+    // right, and a confident "0.0 km" reads like the activities have no
+    // distance rather than like the column is missing.
+    console.warn(
+      `Warning: ${(error as Error).message}. Per-gear distances will read 0.0 km ` +
+        'and cannot be cross-checked against the Strava gear pages.'
+    )
     distanceIndex = null
   }
 
-  return rows.slice(1).map((row) => {
-    const rawDistance = distanceIndex === null ? '' : (row[distanceIndex] ?? '')
-    const distanceMeters = rawDistance.trim() ? Number(rawDistance) : NaN
+  return rows.slice(1).map((row, offset) => {
+    // `relax_column_count` lets short and mis-quoted rows through on purpose —
+    // Strava descriptions carry newlines and stray quotes — so a row that fails
+    // here has to name itself or it is unfindable in a 1,700-row file.
+    const line = offset + 2
+    try {
+      const rawDistance =
+        distanceIndex === null ? '' : (row[distanceIndex] ?? '')
+      const distanceMeters = rawDistance.trim() ? Number(rawDistance) : NaN
 
-    return {
-      activityId: (row[activityIdIndex] ?? '').trim(),
-      timeMilliseconds: parseStravaExportDate(row[dateIndex] ?? ''),
-      activityType: (row[typeIndex] ?? '').trim(),
-      gear: (row[gearIndex] ?? '').trim(),
-      fileName: (row[fileNameIndex] ?? '').trim(),
-      distanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null
+      return {
+        activityId: (row[activityIdIndex] ?? '').trim(),
+        timeMilliseconds: parseStravaExportDate(row[dateIndex] ?? ''),
+        activityType: (row[typeIndex] ?? '').trim(),
+        gear: (row[gearIndex] ?? '').trim(),
+        fileName: (row[fileNameIndex] ?? '').trim(),
+        distanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null
+      }
+    } catch (error) {
+      throw new Error(
+        `line ${line} (${row.length} columns): ${(error as Error).message}`
+      )
     }
   })
 }
@@ -210,6 +229,8 @@ export interface ConversionResult {
   reports: ConversionReport[]
   skippedByType: Record<string, number>
   unknownGear: string[]
+  /** Gear-carrying rows whose distance would not parse; the totals are low by these. */
+  unreadableDistanceCount: number
 }
 
 /**
@@ -231,6 +252,7 @@ export const buildAssignments = ({
   const totals = new Map<string, { count: number; distanceMeters: number }>()
   const skippedByType: Record<string, number> = {}
   const unknownGear = new Set<string>()
+  let unreadableDistanceCount = 0
 
   for (const row of rows) {
     if (!row.gear) {
@@ -252,6 +274,8 @@ export const buildAssignments = ({
         : {})
     })
 
+    if (row.distanceMeters === null) unreadableDistanceCount += 1
+
     const total = totals.get(row.gear) ?? { count: 0, distanceMeters: 0 }
     total.count += 1
     total.distanceMeters += row.distanceMeters ?? 0
@@ -268,7 +292,8 @@ export const buildAssignments = ({
       }))
       .sort((left, right) => right.assignmentCount - left.assignmentCount),
     skippedByType,
-    unknownGear: [...unknownGear]
+    unknownGear: [...unknownGear],
+    unreadableDistanceCount
   }
 }
 
@@ -312,13 +337,14 @@ async function convertStravaExportToGearImportScript(
     return 1
   }
 
+  const activitiesPath = join(input.exportDir, 'activities.csv')
   let rows: StravaActivityRow[]
   try {
-    rows = parseStravaActivitiesCsv(
-      readFileSync(join(input.exportDir, 'activities.csv'), 'utf-8')
-    )
+    rows = parseStravaActivitiesCsv(readFileSync(activitiesPath, 'utf-8'))
   } catch (error) {
-    console.error(`Error: ${(error as Error).message}`)
+    console.error(
+      `Error reading ${activitiesPath}: ${(error as Error).message}`
+    )
     return 1
   }
 
@@ -332,6 +358,17 @@ async function convertStravaExportToGearImportScript(
       `Error: activities.csv names gear that ${input.gears} does not describe:`
     )
     for (const name of result.unknownGear) console.error(`  - ${name}`)
+    return 1
+  }
+
+  // Writing an empty assignment list would validate and exit 0, and the import
+  // that consumed it would create the gear and attribute nothing — two green
+  // runs and no attribution, discovered days later on the fitness page.
+  if (rows.length > 0 && result.assignments.length === 0) {
+    console.error(
+      `Error: none of the ${rows.length} activities in ${activitiesPath} name any gear ` +
+        '(the "Activity Gear" column is empty on every row) — nothing to convert.'
+    )
     return 1
   }
 
@@ -357,6 +394,12 @@ async function convertStravaExportToGearImportScript(
     console.log(
       `  ${report.gearName}: ${report.assignmentCount} activities, ` +
         `${(report.distanceMeters / 1000).toFixed(1)} km`
+    )
+  }
+  if (result.unreadableDistanceCount > 0) {
+    console.log(
+      `  (${result.unreadableDistanceCount} activities had an unreadable distance, ` +
+        'so the totals above are low by that much.)'
     )
   }
 

--- a/scripts/fitness/convertStravaExportToGearImport.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.ts
@@ -1,0 +1,386 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Builds a gear import file from a Strava data export and a hand-authored gear
+ * description.
+ *
+ * The export's `activities.csv` is the only place that records which gear each
+ * historical activity used, and it names the gear by display name against a UTC
+ * timestamp. That is exactly what `importFitnessGear.ts` matches on, so this
+ * script is a straight transcription: one assignment per activity that carries
+ * gear.
+ *
+ * What the export does NOT contain is component history — `components.csv` lists
+ * parts with no dates at all. Install and removal dates live only on Strava's
+ * gear pages, so the `gears` half of the import file is hand-authored (read off
+ * those pages) and passed in with `--gears`; this script merges the two and
+ * validates the result before writing it.
+ *
+ * Usage:
+ *   scripts/fitness/convertStravaExportToGearImport.ts \
+ *     --export-dir ./strava-export \
+ *     --gears ./gears.json \
+ *     --output ./gear-import.json
+ */
+import { parse } from 'csv-parse/sync'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+
+import { parseGearImportFile } from './gearImportPlan'
+
+const CliArgs = z.object({
+  exportDir: z.string().min(1),
+  gears: z.string().min(1),
+  output: z.string().min(1)
+})
+
+const USAGE = `Usage: scripts/fitness/convertStravaExportToGearImport.ts \\
+  --export-dir ./strava-export \\
+  --gears ./gears.json \\
+  --output ./gear-import.json`
+
+export const parseArgs = (args: string[]) => {
+  const parsed: Record<string, string> = {}
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
+    const nextValue = inlineValue ?? args[index + 1]
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for --${rawKey}`)
+    }
+    if (inlineValue === undefined) index += 1
+    parsed[rawKey] = nextValue
+  }
+
+  return CliArgs.parse({
+    exportDir: parsed['export-dir'],
+    gears: parsed['gears'],
+    output: parsed['output']
+  })
+}
+
+const MONTHS: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11
+}
+
+const ACTIVITY_DATE =
+  /^([A-Za-z]{3}) (\d{1,2}), (\d{4}), (\d{1,2}):(\d{2}):(\d{2}) ([AP]M)$/
+
+/**
+ * Parses Strava's export date (`Aug 10, 2026, 3:43:45 PM`) as UTC.
+ *
+ * The column is UTC despite looking local — it matches the `<time>` element of
+ * the exported GPX for the same activity to the second, which is what makes
+ * matching on it reliable. Parsing is hand-rolled rather than delegated because
+ * every library route back to a UTC instant needs either a timezone package the
+ * project does not carry or a reference-date trick that reads as a bug.
+ *
+ * Throws on anything else, including a non-English export: guessing at a month
+ * name would shift a year's activities by weeks.
+ */
+export const parseStravaExportDate = (value: string): number => {
+  const matched = ACTIVITY_DATE.exec(value.trim())
+  if (!matched) {
+    throw new Error(`Unparseable Strava activity date: ${value}`)
+  }
+
+  const [, month, day, year, hour, minute, second, meridiem] = matched
+  const monthIndex = MONTHS[month]
+  if (monthIndex === undefined) {
+    throw new Error(
+      `Unknown month "${month}" in "${value}" — is this an English export?`
+    )
+  }
+
+  const hour12 = Number(hour)
+  if (hour12 < 1 || hour12 > 12) {
+    throw new Error(`Invalid hour in Strava activity date: ${value}`)
+  }
+  const hour24 = (hour12 % 12) + (meridiem === 'PM' ? 12 : 0)
+
+  return Date.UTC(
+    Number(year),
+    monthIndex,
+    Number(day),
+    hour24,
+    Number(minute),
+    Number(second)
+  )
+}
+
+export interface StravaActivityRow {
+  activityId: string
+  timeMilliseconds: number
+  activityType: string
+  gear: string
+  fileName: string
+  distanceMeters: number | null
+}
+
+/**
+ * Reads `activities.csv` into rows.
+ *
+ * Parsed as arrays rather than objects on purpose: the file repeats five header
+ * names ("Distance", "Elapsed Time", "Max Heart Rate", "Relative Effort",
+ * "Commute"), and object mode keeps only the last of each. The second "Distance"
+ * is the one in meters, and it is the only column that reproduces the totals
+ * Strava shows on the gear pages — which makes it the checksum for this whole
+ * conversion, so it has to be addressed by position.
+ */
+export const parseStravaActivitiesCsv = (csv: string): StravaActivityRow[] => {
+  const rows = parse(csv, {
+    bom: true,
+    relax_column_count: true,
+    relax_quotes: true,
+    skip_empty_lines: true
+  }) as string[][]
+
+  if (rows.length === 0) throw new Error('activities.csv is empty')
+
+  const header = rows[0]
+  const indexOf = (name: string, occurrence = 1): number => {
+    let seen = 0
+    for (let index = 0; index < header.length; index += 1) {
+      if (header[index].trim() !== name) continue
+      seen += 1
+      if (seen === occurrence) return index
+    }
+    throw new Error(
+      `activities.csv is missing the "${name}" column${occurrence > 1 ? ` (occurrence ${occurrence})` : ''}`
+    )
+  }
+
+  const activityIdIndex = indexOf('Activity ID')
+  const dateIndex = indexOf('Activity Date')
+  const typeIndex = indexOf('Activity Type')
+  const gearIndex = indexOf('Activity Gear')
+  const fileNameIndex = indexOf('Filename')
+  // The first "Distance" is kilometres for display; the second is meters.
+  let distanceIndex: number | null = null
+  try {
+    distanceIndex = indexOf('Distance', 2)
+  } catch {
+    distanceIndex = null
+  }
+
+  return rows.slice(1).map((row) => {
+    const rawDistance = distanceIndex === null ? '' : (row[distanceIndex] ?? '')
+    const distanceMeters = rawDistance.trim() ? Number(rawDistance) : NaN
+
+    return {
+      activityId: (row[activityIdIndex] ?? '').trim(),
+      timeMilliseconds: parseStravaExportDate(row[dateIndex] ?? ''),
+      activityType: (row[typeIndex] ?? '').trim(),
+      gear: (row[gearIndex] ?? '').trim(),
+      fileName: (row[fileNameIndex] ?? '').trim(),
+      distanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null
+    }
+  })
+}
+
+export interface ConversionReport {
+  gearName: string
+  assignmentCount: number
+  distanceMeters: number
+}
+
+export interface ConversionResult {
+  assignments: {
+    time: string
+    gear: string
+    stravaActivityId?: string
+    filename?: string
+  }[]
+  reports: ConversionReport[]
+  skippedByType: Record<string, number>
+  unknownGear: string[]
+}
+
+/**
+ * Turns activity rows into assignments, keeping only the ones that name gear.
+ *
+ * A gear name the `gears` file does not describe is collected rather than
+ * dropped: the import would fail validation on it anyway, and knowing which name
+ * is missing is the difference between a one-line fix and a hunt.
+ */
+export const buildAssignments = ({
+  rows,
+  knownGearNames
+}: {
+  rows: StravaActivityRow[]
+  knownGearNames: string[]
+}): ConversionResult => {
+  const known = new Set(knownGearNames.map((name) => name.trim().toLowerCase()))
+  const assignments: ConversionResult['assignments'] = []
+  const totals = new Map<string, { count: number; distanceMeters: number }>()
+  const skippedByType: Record<string, number> = {}
+  const unknownGear = new Set<string>()
+
+  for (const row of rows) {
+    if (!row.gear) {
+      const type = row.activityType || '(unknown)'
+      skippedByType[type] = (skippedByType[type] ?? 0) + 1
+      continue
+    }
+
+    if (!known.has(row.gear.toLowerCase())) unknownGear.add(row.gear)
+
+    assignments.push({
+      time: new Date(row.timeMilliseconds).toISOString(),
+      gear: row.gear,
+      ...(row.activityId ? { stravaActivityId: row.activityId } : {}),
+      // The archive importer stores the basename with `.gz` stripped, so this
+      // lines up with `fitness_files.fileName` for anything imported that way.
+      ...(row.fileName
+        ? { filename: row.fileName.split('/').pop()?.replace(/\.gz$/, '') }
+        : {})
+    })
+
+    const total = totals.get(row.gear) ?? { count: 0, distanceMeters: 0 }
+    total.count += 1
+    total.distanceMeters += row.distanceMeters ?? 0
+    totals.set(row.gear, total)
+  }
+
+  return {
+    assignments,
+    reports: [...totals.entries()]
+      .map(([gearName, total]) => ({
+        gearName,
+        assignmentCount: total.count,
+        distanceMeters: total.distanceMeters
+      }))
+      .sort((left, right) => right.assignmentCount - left.assignmentCount),
+    skippedByType,
+    unknownGear: [...unknownGear]
+  }
+}
+
+async function convertStravaExportToGearImportScript(
+  args = process.argv.slice(2)
+) {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE)
+    return 0
+  }
+
+  let input: z.infer<typeof CliArgs>
+  try {
+    input = parseArgs(args)
+  } catch (error) {
+    console.error((error as Error).message)
+    console.error(USAGE)
+    return 1
+  }
+
+  let gearsInput: unknown
+  try {
+    gearsInput = JSON.parse(readFileSync(input.gears, 'utf-8'))
+  } catch (error) {
+    console.error(
+      `Error: cannot read ${input.gears}: ${(error as Error).message}`
+    )
+    return 1
+  }
+
+  // The gears file is the import file minus its assignments, so it goes through
+  // the same schema — a bad component date should surface here, not after the
+  // 1,500-line assignment list has been generated on top of it.
+  const gearsOnly = parseGearImportFile({
+    gears: (gearsInput as { gears?: unknown })?.gears ?? gearsInput,
+    assignments: []
+  })
+  if (!gearsOnly.ok) {
+    console.error(`Error: ${input.gears} is not a valid gear description:`)
+    for (const error of gearsOnly.errors) console.error(`  - ${error}`)
+    return 1
+  }
+
+  let rows: StravaActivityRow[]
+  try {
+    rows = parseStravaActivitiesCsv(
+      readFileSync(join(input.exportDir, 'activities.csv'), 'utf-8')
+    )
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`)
+    return 1
+  }
+
+  const result = buildAssignments({
+    rows,
+    knownGearNames: gearsOnly.file.gears.map((gear) => gear.name)
+  })
+
+  if (result.unknownGear.length > 0) {
+    console.error(
+      `Error: activities.csv names gear that ${input.gears} does not describe:`
+    )
+    for (const name of result.unknownGear) console.error(`  - ${name}`)
+    return 1
+  }
+
+  const output = {
+    gears: (gearsInput as { gears?: unknown })?.gears ?? gearsInput,
+    assignments: result.assignments
+  }
+
+  const validated = parseGearImportFile(output)
+  if (!validated.ok) {
+    console.error('Error: the generated import file failed validation:')
+    for (const error of validated.errors) console.error(`  - ${error}`)
+    return 1
+  }
+
+  writeFileSync(input.output, `${JSON.stringify(output, null, 2)}\n`, 'utf-8')
+
+  console.log(
+    `\n${rows.length} activities read, ${result.assignments.length} assignments written to ${input.output}.`
+  )
+  console.log("\nPer gear (distance is Strava's own, for cross-checking):")
+  for (const report of result.reports) {
+    console.log(
+      `  ${report.gearName}: ${report.assignmentCount} activities, ` +
+        `${(report.distanceMeters / 1000).toFixed(1)} km`
+    )
+  }
+
+  const skipped = Object.entries(result.skippedByType).sort(
+    (left, right) => right[1] - left[1]
+  )
+  if (skipped.length > 0) {
+    const total = skipped.reduce((sum, [, count]) => sum + count, 0)
+    console.log(`\nSkipped ${total} activities with no gear:`)
+    for (const [type, count] of skipped) console.log(`  ${type}: ${count}`)
+  }
+
+  return 0
+}
+
+if (require.main === module) {
+  convertStravaExportToGearImportScript()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Script failed:', error)
+      process.exit(1)
+    })
+}
+
+export { convertStravaExportToGearImportScript }

--- a/scripts/fitness/convertStravaExportToGearImport.ts
+++ b/scripts/fitness/convertStravaExportToGearImport.ts
@@ -148,13 +148,15 @@ export const parseStravaActivitiesCsv = (csv: string): StravaActivityRow[] => {
   // instead would drift low for everything after the first blank line or
   // multi-line description — and a line number that is confidently wrong is
   // worse than none, because the operator trusts it and reads an unrelated row.
+  // The cast goes through `unknown` because csv-parse's sync signature always
+  // declares `string[][]`; it does not model how `info` changes the shape.
   const parsed = parse(csv, {
     bom: true,
     relax_column_count: true,
     relax_quotes: true,
     skip_empty_lines: true,
     info: true
-  }) as { record: string[]; info: { lines: number } }[]
+  }) as unknown as { record: string[]; info: { lines: number } }[]
 
   if (parsed.length === 0) throw new Error('activities.csv is empty')
 

--- a/scripts/fitness/gearImportPlan.test.ts
+++ b/scripts/fitness/gearImportPlan.test.ts
@@ -223,7 +223,7 @@ describe('matchAssignmentsToFiles', () => {
       fileId: 'file-1',
       deltaMilliseconds: 0
     })
-    expect([...result.claimedFileIds]).toEqual(['file-1'])
+    expect([...result.reservedFileIds]).toEqual(['file-1'])
   })
 
   it.each([
@@ -267,7 +267,9 @@ describe('matchAssignmentsToFiles', () => {
       ]
     })
     expect(result.matches[0].outcome.kind).toBe('ambiguous')
-    expect(result.claimedFileIds.size).toBe(0)
+    // Reserved even though unresolved, so a window cannot take a ride the file
+    // already said belonged to a different gear.
+    expect([...result.reservedFileIds].sort()).toEqual(['after', 'before'])
   })
 
   it('reports a second assignment landing on a claimed file', () => {
@@ -286,6 +288,7 @@ describe('matchAssignmentsToFiles', () => {
       fileId: 'file-1',
       claimedByAssignmentIndex: 0
     })
+    expect([...result.reservedFileIds]).toEqual(['file-1'])
   })
 
   it('never matches a file without a start time', () => {
@@ -344,7 +347,7 @@ describe('applyWindows', () => {
     const assignments = applyWindows({
       gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
       files: [ride('a', Date.UTC(2020, 5, 1))],
-      claimedFileIds: new Set()
+      reservedFileIds: new Set()
     })
     expect(assignments).toEqual([
       {
@@ -371,7 +374,7 @@ describe('applyWindows', () => {
     const assignments = applyWindows({
       gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
       files: [ride('a', time)],
-      claimedFileIds: new Set()
+      reservedFileIds: new Set()
     })
     expect(assignments).toHaveLength(assigned ? 1 : 0)
   })
@@ -410,7 +413,7 @@ describe('applyWindows', () => {
     const assignments = applyWindows({
       gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
       files,
-      claimedFileIds: new Set(claimed)
+      reservedFileIds: new Set(claimed)
     })
     expect(assignments).toHaveLength(0)
   })
@@ -425,7 +428,7 @@ describe('applyWindows', () => {
         ride('outdoor', Date.UTC(2020, 5, 1)),
         ride('indoor', Date.UTC(2020, 5, 2), { activityType: 'VirtualRide' })
       ],
-      claimedFileIds: new Set()
+      reservedFileIds: new Set()
     })
     expect(assignments.map((assignment) => assignment.fileId)).toEqual([
       'indoor'
@@ -436,7 +439,43 @@ describe('applyWindows', () => {
     const assignments = applyWindows({
       gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
       files: [ride('a', Date.UTC(2019, 5, 1))],
-      claimedFileIds: new Set()
+      reservedFileIds: new Set()
+    })
+    expect(assignments).toHaveLength(0)
+  })
+
+  it('never takes an activity an unresolved assignment named', () => {
+    // Two activities share a start time, so the assignment naming Moots ties and
+    // is skipped. A window on another bike covering the same period must not
+    // then take them: the file says those rides were on the Moots.
+    const parsed = parseGearImportFile({
+      gears: [
+        { name: 'Moots', kind: 'bike' },
+        { name: 'Giant', kind: 'bike', windows: [{ from: '2024-01-01' }] }
+      ],
+      assignments: [{ time: '2024-06-01T10:00:00Z', gear: 'Moots' }]
+    })
+    if (!parsed.ok) throw new Error(parsed.errors.join('; '))
+
+    const twins = [
+      ride('fit', Date.UTC(2024, 5, 1, 10)),
+      ride('gpx', Date.UTC(2024, 5, 1, 10))
+    ]
+    const { matches, reservedFileIds } = matchAssignmentsToFiles({
+      assignments: parsed.file.assignments,
+      files: twins,
+      toleranceMilliseconds: 60_000,
+      gearKindByName: new Map([
+        ['moots', 'bike'],
+        ['giant', 'bike']
+      ])
+    })
+    expect(matches[0].outcome.kind).toBe('ambiguous')
+
+    const assignments = applyWindows({
+      gears: parsed.file.gears,
+      files: twins,
+      reservedFileIds
     })
     expect(assignments).toHaveLength(0)
   })

--- a/scripts/fitness/gearImportPlan.test.ts
+++ b/scripts/fitness/gearImportPlan.test.ts
@@ -1,0 +1,517 @@
+import {
+  ImportGear,
+  MatchableFitnessFile,
+  applyWindows,
+  diffGearComponents,
+  matchAssignmentsToFiles,
+  parseGearImportFile
+} from './gearImportPlan'
+
+const gearEntry = (overrides: Partial<ImportGear> = {}) => ({
+  name: 'Moots',
+  kind: 'bike' as const,
+  ...overrides
+})
+
+const validFile = (overrides: Record<string, unknown> = {}) => ({
+  gears: [gearEntry()],
+  assignments: [],
+  ...overrides
+})
+
+const parseOrThrow = (input: unknown) => {
+  const result = parseGearImportFile(input)
+  if (!result.ok) throw new Error(result.errors.join('; '))
+  return result.file
+}
+
+describe('parseGearImportFile', () => {
+  it('parses a minimal file', () => {
+    const file = parseOrThrow(validFile())
+    expect(file.gears[0]).toMatchObject({
+      name: 'Moots',
+      kind: 'bike',
+      retired: false,
+      components: [],
+      windows: []
+    })
+  })
+
+  it.each([
+    {
+      description: 'duplicate gear names differing only by case',
+      input: validFile({ gears: [gearEntry(), gearEntry({ name: 'moots' })] }),
+      error: /duplicate gear name/
+    },
+    {
+      description: 'bikeType on shoes',
+      input: validFile({
+        gears: [gearEntry({ kind: 'shoes', bikeType: 'Road bike' })]
+      }),
+      error: /bikeType is only valid for a bike/
+    },
+    {
+      description: 'alertDistanceMeters on a bike',
+      input: validFile({
+        gears: [gearEntry({ alertDistanceMeters: 500_000 })]
+      }),
+      error: /alertDistanceMeters is only valid for shoes/
+    },
+    {
+      description: 'a run default sport on a bike',
+      input: validFile({ gears: [gearEntry({ defaultSports: ['run'] })] }),
+      error: /run is not a bike sport/
+    },
+    {
+      description: 'the same default sport on two gears',
+      input: validFile({
+        gears: [
+          gearEntry({ defaultSports: ['ride'] }),
+          gearEntry({ name: 'Giant', defaultSports: ['ride'] })
+        ]
+      }),
+      error: /claimed by both/
+    },
+    {
+      description: 'a duplicate stravaGearId',
+      input: validFile({
+        gears: [
+          gearEntry({ stravaGearId: 'b123' }),
+          gearEntry({ name: 'Giant', stravaGearId: 'b123' })
+        ]
+      }),
+      error: /is used by both/
+    },
+    {
+      description: 'an assignment naming unknown gear',
+      input: validFile({
+        assignments: [{ time: '2024-01-06T10:26:21Z', gear: 'Brompton' }]
+      }),
+      error: /unknown gear "Brompton"/
+    },
+    {
+      description: 'an assignment time without a zone',
+      input: validFile({
+        assignments: [{ time: '2024-01-06T10:26:21', gear: 'Moots' }]
+      }),
+      error: /explicit Z\/offset/
+    },
+    {
+      description: 'removedAt before addedAt',
+      input: validFile({
+        gears: [
+          gearEntry({
+            components: [
+              { type: 'Chain', addedAt: '2024-02-01', removedAt: '2024-01-01' }
+            ]
+          })
+        ]
+      }),
+      error: /removedAt must be after addedAt/
+    },
+    {
+      description: 'overlapping windows claiming the same sport',
+      input: validFile({
+        gears: [
+          gearEntry({ windows: [{ from: '2020-01-01', to: '2022-01-01' }] }),
+          gearEntry({
+            name: 'Giant',
+            windows: [{ from: '2021-01-01', to: '2023-01-01' }]
+          })
+        ]
+      }),
+      error: /overlap in time and both claim/
+    },
+    {
+      description: 'a window listing a sport of the wrong kind',
+      input: validFile({
+        gears: [
+          gearEntry({ windows: [{ from: '2020-01-01', sports: ['run'] }] })
+        ]
+      }),
+      error: /is not a bike sport/
+    }
+  ])('rejects $description', ({ input, error }) => {
+    const result = parseGearImportFile(input)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.join('; ')).toMatch(error)
+  })
+
+  it('reads a day-precision date as UTC midnight', () => {
+    const file = parseOrThrow(
+      validFile({
+        gears: [
+          gearEntry({ components: [{ type: 'Chain', addedAt: '2020-10-19' }] })
+        ]
+      })
+    )
+    expect(file.gears[0].components[0].addedAt).toBe(Date.UTC(2020, 9, 19))
+  })
+
+  it('keeps the offset of a full datetime', () => {
+    const file = parseOrThrow(
+      validFile({
+        assignments: [{ time: '2015-10-06T11:44:23+02:00', gear: 'Moots' }]
+      })
+    )
+    expect(file.assignments[0].time).toBe(Date.UTC(2015, 9, 6, 9, 44, 23))
+  })
+
+  it('leaves an absent addedAt absent', () => {
+    const file = parseOrThrow(
+      validFile({ gears: [gearEntry({ components: [{ type: 'Frame' }] })] })
+    )
+    expect(file.gears[0].components[0].addedAt).toBeUndefined()
+  })
+
+  it('allows windows of different gears to overlap on different sports', () => {
+    const result = parseGearImportFile(
+      validFile({
+        gears: [
+          gearEntry({ windows: [{ from: '2020-01-01', sports: ['ride'] }] }),
+          gearEntry({
+            name: 'Rocket',
+            windows: [{ from: '2020-01-01', sports: ['virtual_ride'] }]
+          })
+        ]
+      })
+    )
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('matchAssignmentsToFiles', () => {
+  const baseTime = Date.UTC(2024, 0, 6, 10, 26, 21)
+  const gearKindByName = new Map<string, 'bike' | 'shoes'>([
+    ['moots', 'bike'],
+    ['asics dynamis', 'shoes']
+  ])
+
+  const file = (
+    overrides: Partial<MatchableFitnessFile> = {}
+  ): MatchableFitnessFile => ({
+    id: 'file-1',
+    fileName: 'ride.gpx',
+    activityStartTime: baseTime,
+    activityType: 'Ride',
+    ...overrides
+  })
+
+  const match = ({
+    files,
+    time = baseTime,
+    gear = 'Moots',
+    toleranceMilliseconds = 60_000
+  }: {
+    files: MatchableFitnessFile[]
+    time?: number
+    gear?: string
+    toleranceMilliseconds?: number
+  }) =>
+    matchAssignmentsToFiles({
+      assignments: [{ time, gear, stravaActivityId: null }],
+      files,
+      toleranceMilliseconds,
+      gearKindByName
+    })
+
+  it('matches an exact timestamp', () => {
+    const result = match({ files: [file()] })
+    expect(result.matches[0].outcome).toMatchObject({
+      kind: 'matched',
+      fileId: 'file-1',
+      deltaMilliseconds: 0
+    })
+    expect([...result.claimedFileIds]).toEqual(['file-1'])
+  })
+
+  it.each([
+    { description: 'inside the tolerance', offset: 59_000, kind: 'matched' },
+    { description: 'outside the tolerance', offset: 61_000, kind: 'unmatched' }
+  ])('reports a file $description', ({ offset, kind }) => {
+    const result = match({
+      files: [file({ activityStartTime: baseTime + offset })]
+    })
+    expect(result.matches[0].outcome.kind).toBe(kind)
+  })
+
+  it('reports how far the nearest activity was when nothing matched', () => {
+    const result = match({
+      files: [file({ activityStartTime: baseTime + 3_600_000 })]
+    })
+    expect(result.matches[0].outcome).toEqual({
+      kind: 'unmatched',
+      nearestDeltaMilliseconds: 3_600_000
+    })
+  })
+
+  it('picks the nearest of two candidates', () => {
+    const result = match({
+      files: [
+        file({ id: 'far', activityStartTime: baseTime + 40_000 }),
+        file({ id: 'near', activityStartTime: baseTime + 5_000 })
+      ]
+    })
+    expect(result.matches[0].outcome).toMatchObject({
+      kind: 'matched',
+      fileId: 'near'
+    })
+  })
+
+  it('skips equidistant candidates rather than guessing', () => {
+    const result = match({
+      files: [
+        file({ id: 'before', activityStartTime: baseTime - 10_000 }),
+        file({ id: 'after', activityStartTime: baseTime + 10_000 })
+      ]
+    })
+    expect(result.matches[0].outcome.kind).toBe('ambiguous')
+    expect(result.claimedFileIds.size).toBe(0)
+  })
+
+  it('reports a second assignment landing on a claimed file', () => {
+    const result = matchAssignmentsToFiles({
+      assignments: [
+        { time: baseTime, gear: 'Moots', stravaActivityId: null },
+        { time: baseTime + 1_000, gear: 'Moots', stravaActivityId: null }
+      ],
+      files: [file()],
+      toleranceMilliseconds: 60_000,
+      gearKindByName
+    })
+    expect(result.matches[0].outcome.kind).toBe('matched')
+    expect(result.matches[1].outcome).toMatchObject({
+      kind: 'conflict',
+      fileId: 'file-1',
+      claimedByAssignmentIndex: 0
+    })
+  })
+
+  it('never matches a file without a start time', () => {
+    const result = match({
+      files: [file({ activityStartTime: undefined })]
+    })
+    expect(result.matches[0].outcome.kind).toBe('unmatched')
+    expect(result.timestamplessFileCount).toBe(1)
+  })
+
+  it('flags a run assigned to a bike', () => {
+    const result = match({ files: [file({ activityType: 'Run' })] })
+    expect(result.matches[0].outcome).toMatchObject({ kindMismatch: true })
+  })
+
+  it.each([
+    { description: 'an unrecognised activity type', activityType: 'Yoga' },
+    { description: 'a matching sport', activityType: 'GravelRide' }
+  ])('does not flag $description', ({ activityType }) => {
+    const result = match({ files: [file({ activityType })] })
+    expect(result.matches[0].outcome).toMatchObject({ kindMismatch: false })
+  })
+
+  it('reports a matched file that already carries gear', () => {
+    const result = match({ files: [file({ gearId: 'gear-1' })] })
+    expect(result.matches[0].outcome).toMatchObject({ alreadyAssigned: true })
+  })
+})
+
+describe('applyWindows', () => {
+  const gear = (overrides: Partial<ImportGear> = {}) =>
+    parseGearImportFile({
+      gears: [{ name: 'Moots', kind: 'bike', ...overrides }],
+      assignments: []
+    })
+
+  const gearsOf = (overrides: Partial<ImportGear> = {}): ImportGear[] => {
+    const result = gear(overrides)
+    if (!result.ok) throw new Error(result.errors.join('; '))
+    return result.file.gears
+  }
+
+  const ride = (
+    id: string,
+    startTime: number,
+    overrides: Partial<MatchableFitnessFile> = {}
+  ): MatchableFitnessFile => ({
+    id,
+    fileName: `${id}.gpx`,
+    activityStartTime: startTime,
+    activityType: 'Ride',
+    ...overrides
+  })
+
+  it('assigns an activity inside the window', () => {
+    const assignments = applyWindows({
+      gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
+      files: [ride('a', Date.UTC(2020, 5, 1))],
+      claimedFileIds: new Set()
+    })
+    expect(assignments).toEqual([
+      {
+        fileId: 'a',
+        fileName: 'a.gpx',
+        gearName: 'Moots',
+        activityStartTime: Date.UTC(2020, 5, 1)
+      }
+    ])
+  })
+
+  it.each([
+    {
+      description: 'the start instant',
+      time: Date.UTC(2020, 0, 1),
+      assigned: true
+    },
+    {
+      description: 'the end instant',
+      time: Date.UTC(2021, 0, 1),
+      assigned: false
+    }
+  ])('treats the window as half-open at $description', ({ time, assigned }) => {
+    const assignments = applyWindows({
+      gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
+      files: [ride('a', time)],
+      claimedFileIds: new Set()
+    })
+    expect(assignments).toHaveLength(assigned ? 1 : 0)
+  })
+
+  it.each([
+    {
+      description: 'a file an assignment already claimed',
+      files: [ride('a', Date.UTC(2020, 5, 1))],
+      claimed: ['a']
+    },
+    {
+      description: 'a file that already has gear',
+      files: [ride('a', Date.UTC(2020, 5, 1), { gearId: 'gear-1' })],
+      claimed: []
+    },
+    {
+      description: 'a sport of the wrong kind',
+      files: [ride('a', Date.UTC(2020, 5, 1), { activityType: 'Run' })],
+      claimed: []
+    },
+    {
+      description: 'an activity the normalizer has no opinion on',
+      files: [
+        ride('a', Date.UTC(2020, 5, 1), { activityType: 'Weight Training' })
+      ],
+      claimed: []
+    },
+    {
+      description: 'a file with no start time',
+      files: [
+        ride('a', Date.UTC(2020, 5, 1), { activityStartTime: undefined })
+      ],
+      claimed: []
+    }
+  ])('skips $description', ({ files, claimed }) => {
+    const assignments = applyWindows({
+      gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
+      files,
+      claimedFileIds: new Set(claimed)
+    })
+    expect(assignments).toHaveLength(0)
+  })
+
+  it('honours a window restricted to specific sports', () => {
+    const gears = gearsOf({
+      windows: [{ from: '2020-01-01', sports: ['virtual_ride'] }]
+    })
+    const assignments = applyWindows({
+      gears,
+      files: [
+        ride('outdoor', Date.UTC(2020, 5, 1)),
+        ride('indoor', Date.UTC(2020, 5, 2), { activityType: 'VirtualRide' })
+      ],
+      claimedFileIds: new Set()
+    })
+    expect(assignments.map((assignment) => assignment.fileId)).toEqual([
+      'indoor'
+    ])
+  })
+
+  it('leaves an activity outside every window unassigned', () => {
+    const assignments = applyWindows({
+      gears: gearsOf({ windows: [{ from: '2020-01-01', to: '2021-01-01' }] }),
+      files: [ride('a', Date.UTC(2019, 5, 1))],
+      claimedFileIds: new Set()
+    })
+    expect(assignments).toHaveLength(0)
+  })
+})
+
+describe('diffGearComponents', () => {
+  const chain = (addedAt?: number) => ({
+    type: 'Chain',
+    brand: 'Shimano',
+    model: 'CN-HG901-11',
+    addedAt
+  })
+
+  it('skips a component that already exists', () => {
+    const missing = diffGearComponents({
+      components: [chain(Date.UTC(2020, 0, 1))],
+      existing: [
+        {
+          componentType: 'Chain',
+          brand: 'Shimano',
+          model: 'CN-HG901-11',
+          addedAt: Date.UTC(2020, 0, 1)
+        }
+      ]
+    })
+    expect(missing).toHaveLength(0)
+  })
+
+  it('creates a replacement fitted on a different date', () => {
+    const missing = diffGearComponents({
+      components: [chain(Date.UTC(2020, 0, 1)), chain(Date.UTC(2021, 0, 1))],
+      existing: [
+        {
+          componentType: 'Chain',
+          brand: 'Shimano',
+          model: 'CN-HG901-11',
+          addedAt: Date.UTC(2020, 0, 1)
+        }
+      ]
+    })
+    expect(missing).toEqual([chain(Date.UTC(2021, 0, 1))])
+  })
+
+  it('matches a component installed since the beginning', () => {
+    const missing = diffGearComponents({
+      components: [{ type: 'Frame', brand: 'Moots', model: 'Vamoots' }],
+      existing: [{ componentType: 'Frame', brand: 'Moots', model: 'Vamoots' }]
+    })
+    expect(missing).toHaveLength(0)
+  })
+
+  it('ignores a changed removal date', () => {
+    const missing = diffGearComponents({
+      components: [
+        { ...chain(Date.UTC(2020, 0, 1)), removedAt: Date.UTC(2022, 0, 1) }
+      ],
+      existing: [
+        {
+          componentType: 'Chain',
+          brand: 'Shimano',
+          model: 'CN-HG901-11',
+          addedAt: Date.UTC(2020, 0, 1)
+        }
+      ]
+    })
+    expect(missing).toHaveLength(0)
+  })
+
+  it('compares names case-insensitively', () => {
+    const missing = diffGearComponents({
+      components: [{ type: 'chain', brand: 'shimano', model: 'cn-hg901-11' }],
+      existing: [
+        { componentType: 'Chain', brand: 'Shimano', model: 'CN-HG901-11' }
+      ]
+    })
+    expect(missing).toHaveLength(0)
+  })
+})

--- a/scripts/fitness/gearImportPlan.ts
+++ b/scripts/fitness/gearImportPlan.ts
@@ -1,0 +1,588 @@
+/**
+ * Pure planning for `importFitnessGear.ts`: the import-file schema, the
+ * assignment matcher, the date-window fallback and the component diff.
+ *
+ * Everything here is a pure function over plain data so the CLI entry keeps only
+ * database calls and printing, and so the interesting decisions — which activity
+ * an assignment lands on, which components already exist — are unit-testable
+ * without a database.
+ */
+import { z } from 'zod'
+
+import {
+  SPORT_KEYS,
+  SPORT_KIND,
+  SportKey,
+  getSportKeysForKind,
+  normalizeActivityTypeToSportKey
+} from '@/lib/services/fitness-files/sportTypes'
+import { getGearKindFieldError } from '@/lib/services/fitness-gears/gearRequests'
+import { FitnessGearKind } from '@/lib/types/database/fitnessGear'
+
+// Column widths, same as lib/services/fitness-gears/gearRequests.ts.
+const VARCHAR_MAX = 255
+const NOTES_MAX = 2000
+const MAX_WEIGHT_KILOGRAMS = 1000
+const MAX_DISTANCE_METERS = 100_000_000
+
+const DAY_PRECISION = /^\d{4}-\d{2}-\d{2}$/
+const EXPLICIT_OFFSET = /(Z|[+-]\d{2}:?\d{2})$/
+
+/**
+ * A date the file gives us, as epoch milliseconds.
+ *
+ * A bare `2024-01-06T10:26:21` is parsed as LOCAL time by `Date.parse` (only the
+ * date-only form is UTC per ES2015+), so an import authored in one zone would
+ * land hours away from the activity it names — far enough to match nothing, or
+ * worse, to match a neighbour. Requiring an explicit `Z`/offset on any datetime
+ * makes that impossible to express; a day-precision date is read as UTC midnight,
+ * which is what both Strava's gear pages and this format mean by a bare date.
+ */
+const utcInstant = z
+  .string()
+  .trim()
+  .refine(
+    (value) => DAY_PRECISION.test(value) || EXPLICIT_OFFSET.test(value),
+    'must be a YYYY-MM-DD date or a datetime with an explicit Z/offset'
+  )
+  .transform((value) =>
+    DAY_PRECISION.test(value)
+      ? Date.parse(`${value}T00:00:00.000Z`)
+      : Date.parse(value)
+  )
+  .refine((milliseconds) => Number.isFinite(milliseconds), 'unparseable date')
+
+const optionalText = (max: number) =>
+  z
+    .string()
+    .trim()
+    .max(max)
+    .transform((value) => value || null)
+    .nullish()
+
+const optionalPositiveNumber = (max: number) =>
+  z.number().positive().max(max).nullish()
+
+const ImportComponentSchema = z
+  .object({
+    type: z.string().trim().min(1).max(VARCHAR_MAX),
+    brand: optionalText(VARCHAR_MAX),
+    model: optionalText(VARCHAR_MAX),
+    // Absent or null means "installed since the gear's beginning" / "still
+    // installed", matching the nullable columns.
+    addedAt: utcInstant.nullish(),
+    removedAt: utcInstant.nullish(),
+    serviceDistanceMeters: optionalPositiveNumber(MAX_DISTANCE_METERS)
+  })
+  .refine(
+    (component) =>
+      !component.addedAt ||
+      !component.removedAt ||
+      component.removedAt > component.addedAt,
+    { message: 'removedAt must be after addedAt' }
+  )
+
+const ImportWindowSchema = z
+  .object({
+    from: utcInstant.nullish(),
+    to: utcInstant.nullish(),
+    sports: z.array(z.enum(SPORT_KEYS)).min(1).max(SPORT_KEYS.length).optional()
+  })
+  .refine((window) => !window.from || !window.to || window.to > window.from, {
+    message: 'to must be after from'
+  })
+
+const ImportGearSchema = z.object({
+  name: z.string().trim().min(1).max(VARCHAR_MAX),
+  kind: z.enum(['bike', 'shoes']),
+  brand: optionalText(VARCHAR_MAX),
+  model: optionalText(VARCHAR_MAX),
+  bikeType: optionalText(VARCHAR_MAX),
+  weightKilograms: optionalPositiveNumber(MAX_WEIGHT_KILOGRAMS),
+  defaultSports: z.array(z.enum(SPORT_KEYS)).max(SPORT_KEYS.length).optional(),
+  alertDistanceMeters: optionalPositiveNumber(MAX_DISTANCE_METERS),
+  notes: optionalText(NOTES_MAX),
+  stravaGearId: optionalText(VARCHAR_MAX),
+  retired: z.boolean().default(false),
+  components: z.array(ImportComponentSchema).default([]),
+  windows: z.array(ImportWindowSchema).default([])
+})
+
+const ImportAssignmentSchema = z.object({
+  time: z
+    .string()
+    .trim()
+    .refine(
+      (value) => EXPLICIT_OFFSET.test(value),
+      'assignment time needs an explicit Z/offset'
+    )
+    .transform((value) => Date.parse(value))
+    .refine(
+      (milliseconds) => Number.isFinite(milliseconds),
+      'unparseable date'
+    ),
+  gear: z.string().trim().min(1).max(VARCHAR_MAX),
+  // Diagnostics only — carried through to the reports so an unmatched entry can
+  // be traced back to its Strava activity without re-deriving it from the time.
+  stravaActivityId: optionalText(VARCHAR_MAX),
+  filename: optionalText(VARCHAR_MAX)
+})
+
+export const GearImportFileSchema = z.object({
+  gears: z.array(ImportGearSchema).min(1),
+  assignments: z.array(ImportAssignmentSchema).default([])
+})
+
+export type GearImportFile = z.infer<typeof GearImportFileSchema>
+export type ImportGear = GearImportFile['gears'][number]
+export type ImportComponent = ImportGear['components'][number]
+export type ImportWindow = ImportGear['windows'][number]
+export type ImportAssignment = GearImportFile['assignments'][number]
+
+export type ParseGearImportFileResult =
+  { ok: true; file: GearImportFile } | { ok: false; errors: string[] }
+
+const normalizeGearName = (name: string): string => name.trim().toLowerCase()
+
+const getWindowSports = (gear: ImportGear, window: ImportWindow): SportKey[] =>
+  window.sports ?? getSportKeysForKind(gear.kind)
+
+const windowsOverlap = (left: ImportWindow, right: ImportWindow): boolean => {
+  const leftFrom = left.from ?? Number.NEGATIVE_INFINITY
+  const leftTo = left.to ?? Number.POSITIVE_INFINITY
+  const rightFrom = right.from ?? Number.NEGATIVE_INFINITY
+  const rightTo = right.to ?? Number.POSITIVE_INFINITY
+  return leftFrom < rightTo && rightFrom < leftTo
+}
+
+/**
+ * Checks the whole file before anything is written: a typo in a gear name should
+ * fail the run, not silently drop the several hundred activities that named it.
+ */
+const validateGearImportFile = (file: GearImportFile): string[] => {
+  const errors: string[] = []
+
+  const gearsByName = new Map<string, ImportGear>()
+  for (const gear of file.gears) {
+    const key = normalizeGearName(gear.name)
+    if (gearsByName.has(key)) {
+      // `findFitnessGearByName` compares trimmed and lowercased, so two entries
+      // differing only by case would resolve to a single database row and the
+      // second would silently absorb the first's assignments.
+      errors.push(`gears: duplicate gear name "${gear.name}"`)
+      continue
+    }
+    gearsByName.set(key, gear)
+  }
+
+  const sportOwners = new Map<SportKey, string>()
+  const stravaGearIdOwners = new Map<string, string>()
+
+  for (const gear of file.gears) {
+    const kindError = getGearKindFieldError(gear.kind, {
+      bikeType: gear.bikeType,
+      weightKilograms: gear.weightKilograms,
+      alertDistanceMeters: gear.alertDistanceMeters,
+      defaultSports: gear.defaultSports
+    })
+    if (kindError) errors.push(`gears: "${gear.name}" ${kindError}`)
+
+    for (const sportKey of gear.defaultSports ?? []) {
+      const owner = sportOwners.get(sportKey)
+      if (owner) {
+        // Creating the second gear would steal the sport from the first, so the
+        // file's own intent decides silently by creation order.
+        errors.push(
+          `gears: default sport "${sportKey}" is claimed by both "${owner}" and "${gear.name}"`
+        )
+        continue
+      }
+      sportOwners.set(sportKey, gear.name)
+    }
+
+    if (gear.stravaGearId) {
+      const owner = stravaGearIdOwners.get(gear.stravaGearId)
+      if (owner) {
+        // The (actorId, stravaGearId) unique index would reject the second one
+        // mid-run, after the first gear was already created.
+        errors.push(
+          `gears: stravaGearId "${gear.stravaGearId}" is used by both "${owner}" and "${gear.name}"`
+        )
+      } else {
+        stravaGearIdOwners.set(gear.stravaGearId, gear.name)
+      }
+    }
+
+    gear.windows.forEach((window, index) => {
+      const sports = getWindowSports(gear, window)
+      const mismatched = sports.find(
+        (sportKey) => SPORT_KIND[sportKey] !== gear.kind
+      )
+      if (mismatched) {
+        errors.push(
+          `gears: "${gear.name}" window ${index + 1} lists "${mismatched}", which is not a ${gear.kind} sport`
+        )
+      }
+    })
+  }
+
+  // Two windows covering the same sport at the same time have no defined winner
+  // — whichever gear the loop reaches first would take the activity.
+  const allWindows = file.gears.flatMap((gear) =>
+    gear.windows.map((window, index) => ({ gear, window, index }))
+  )
+  for (let left = 0; left < allWindows.length; left += 1) {
+    for (let right = left + 1; right < allWindows.length; right += 1) {
+      const first = allWindows[left]
+      const second = allWindows[right]
+      if (!windowsOverlap(first.window, second.window)) continue
+
+      const firstSports = new Set(getWindowSports(first.gear, first.window))
+      const shared = getWindowSports(second.gear, second.window).filter(
+        (sportKey) => firstSports.has(sportKey)
+      )
+      if (shared.length === 0) continue
+
+      errors.push(
+        `gears: window ${first.index + 1} of "${first.gear.name}" and window ${second.index + 1} of ` +
+          `"${second.gear.name}" overlap in time and both claim ${shared.join(', ')}`
+      )
+    }
+  }
+
+  file.assignments.forEach((assignment, index) => {
+    if (!gearsByName.has(normalizeGearName(assignment.gear))) {
+      errors.push(
+        `assignments[${index}]: unknown gear "${assignment.gear}" — add it to gears[]`
+      )
+    }
+  })
+
+  return errors
+}
+
+export const parseGearImportFile = (
+  input: unknown
+): ParseGearImportFileResult => {
+  const parsed = GearImportFileSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map(
+        (issue) =>
+          `${issue.path.length > 0 ? issue.path.join('.') : '(root)'}: ${issue.message}`
+      )
+    }
+  }
+
+  const errors = validateGearImportFile(parsed.data)
+  if (errors.length > 0) return { ok: false, errors }
+
+  return { ok: true, file: parsed.data }
+}
+
+/** The subset of a fitness file row the planning functions read. */
+export interface MatchableFitnessFile {
+  id: string
+  fileName: string
+  activityStartTime?: number
+  activityType?: string
+  gearId?: string
+}
+
+export type AssignmentOutcome =
+  | {
+      kind: 'matched'
+      fileId: string
+      fileName: string
+      deltaMilliseconds: number
+      kindMismatch: boolean
+      alreadyAssigned: boolean
+    }
+  | { kind: 'unmatched'; nearestDeltaMilliseconds?: number }
+  | { kind: 'ambiguous'; fileIds: string[] }
+  | { kind: 'conflict'; fileId: string; claimedByAssignmentIndex: number }
+
+export interface AssignmentMatch {
+  index: number
+  timeMilliseconds: number
+  gearName: string
+  stravaActivityId?: string | null
+  outcome: AssignmentOutcome
+}
+
+export interface MatchAssignmentsResult {
+  matches: AssignmentMatch[]
+  /** Files claimed by a match, so the window pass never touches them. */
+  claimedFileIds: Set<string>
+  /** Files with no `activityStartTime` — unplaceable in time, reported instead. */
+  timestamplessFileCount: number
+}
+
+const getFileSportKind = (
+  file: MatchableFitnessFile
+): FitnessGearKind | null => {
+  const sportKey = normalizeActivityTypeToSportKey(file.activityType)
+  // A null sport key means the normalizer has no opinion (gym work, swimming,
+  // free-form text), which is not evidence of a mismatch.
+  return sportKey ? SPORT_KIND[sportKey] : null
+}
+
+/** Index of the first entry whose start time is >= `target`. */
+const lowerBound = (
+  files: MatchableFitnessFile[],
+  target: number,
+  startTimeOf: (file: MatchableFitnessFile) => number
+): number => {
+  let low = 0
+  let high = files.length
+  while (low < high) {
+    const middle = (low + high) >>> 1
+    if (startTimeOf(files[middle]) < target) low = middle + 1
+    else high = middle
+  }
+  return low
+}
+
+/**
+ * Matches each assignment to the activity closest to its timestamp, within
+ * `toleranceMilliseconds`.
+ *
+ * Two activities are never both plausible in practice — the closest gap in a
+ * decade of real data is minutes, not seconds — so a tie means something is
+ * genuinely duplicated (a repaired import twin, say) and the entry is skipped
+ * rather than guessed at. Likewise a second assignment landing on an
+ * already-claimed file is reported instead of cascading to its second choice,
+ * which would quietly mis-attribute a ride.
+ */
+export const matchAssignmentsToFiles = ({
+  assignments,
+  files,
+  toleranceMilliseconds,
+  gearKindByName
+}: {
+  assignments: Pick<ImportAssignment, 'time' | 'gear' | 'stravaActivityId'>[]
+  files: MatchableFitnessFile[]
+  toleranceMilliseconds: number
+  gearKindByName: Map<string, FitnessGearKind>
+}): MatchAssignmentsResult => {
+  const startTimeOf = (file: MatchableFitnessFile): number =>
+    file.activityStartTime as number
+
+  const candidates = files
+    .filter((file) => typeof file.activityStartTime === 'number')
+    .sort((left, right) => startTimeOf(left) - startTimeOf(right))
+
+  const claimedBy = new Map<string, number>()
+  const matches: AssignmentMatch[] = []
+
+  assignments.forEach((assignment, index) => {
+    const target = assignment.time
+    const gearKind = gearKindByName.get(normalizeGearName(assignment.gear))
+
+    const withinTolerance: MatchableFitnessFile[] = []
+    let nearestDelta = Number.POSITIVE_INFINITY
+
+    const pivot = lowerBound(candidates, target, startTimeOf)
+    for (let cursor = pivot; cursor < candidates.length; cursor += 1) {
+      const delta = Math.abs(startTimeOf(candidates[cursor]) - target)
+      nearestDelta = Math.min(nearestDelta, delta)
+      if (delta > toleranceMilliseconds) break
+      withinTolerance.push(candidates[cursor])
+    }
+    for (let cursor = pivot - 1; cursor >= 0; cursor -= 1) {
+      const delta = Math.abs(startTimeOf(candidates[cursor]) - target)
+      nearestDelta = Math.min(nearestDelta, delta)
+      if (delta > toleranceMilliseconds) break
+      withinTolerance.push(candidates[cursor])
+    }
+
+    const base = {
+      index,
+      timeMilliseconds: target,
+      gearName: assignment.gear,
+      stravaActivityId: assignment.stravaActivityId
+    }
+
+    if (withinTolerance.length === 0) {
+      matches.push({
+        ...base,
+        outcome: {
+          kind: 'unmatched',
+          nearestDeltaMilliseconds: Number.isFinite(nearestDelta)
+            ? nearestDelta
+            : undefined
+        }
+      })
+      return
+    }
+
+    const deltaOf = (file: MatchableFitnessFile): number =>
+      Math.abs(startTimeOf(file) - target)
+    const minimumDelta = Math.min(...withinTolerance.map(deltaOf))
+    const nearest = withinTolerance.filter(
+      (file) => deltaOf(file) === minimumDelta
+    )
+
+    if (nearest.length > 1) {
+      matches.push({
+        ...base,
+        outcome: {
+          kind: 'ambiguous',
+          fileIds: nearest.map((file) => file.id)
+        }
+      })
+      return
+    }
+
+    const file = nearest[0]
+    const claimingIndex = claimedBy.get(file.id)
+    if (claimingIndex !== undefined) {
+      matches.push({
+        ...base,
+        outcome: {
+          kind: 'conflict',
+          fileId: file.id,
+          claimedByAssignmentIndex: claimingIndex
+        }
+      })
+      return
+    }
+
+    claimedBy.set(file.id, index)
+    const fileKind = getFileSportKind(file)
+    matches.push({
+      ...base,
+      outcome: {
+        kind: 'matched',
+        fileId: file.id,
+        fileName: file.fileName,
+        deltaMilliseconds: minimumDelta,
+        kindMismatch: Boolean(gearKind && fileKind && fileKind !== gearKind),
+        alreadyAssigned: Boolean(file.gearId)
+      }
+    })
+  })
+
+  return {
+    matches,
+    claimedFileIds: new Set(claimedBy.keys()),
+    timestamplessFileCount: files.filter(
+      (file) => typeof file.activityStartTime !== 'number'
+    ).length
+  }
+}
+
+export interface WindowAssignment {
+  fileId: string
+  fileName: string
+  gearName: string
+  activityStartTime: number
+}
+
+/**
+ * Fills in the activities no explicit assignment named, using each gear's date
+ * windows.
+ *
+ * Windows are the coarse rule and assignments are the fine one, so anything a
+ * match already claimed is skipped even when a window also covers it. A file
+ * that already carries gear is left alone too: this pass never overwrites, since
+ * a window is a statement about a period, not about a specific ride the owner
+ * may have corrected by hand.
+ */
+export const applyWindows = ({
+  gears,
+  files,
+  claimedFileIds
+}: {
+  gears: ImportGear[]
+  files: MatchableFitnessFile[]
+  claimedFileIds: Set<string>
+}): WindowAssignment[] => {
+  const assignments: WindowAssignment[] = []
+  const taken = new Set(claimedFileIds)
+
+  for (const file of files) {
+    if (taken.has(file.id) || file.gearId) continue
+    if (typeof file.activityStartTime !== 'number') continue
+
+    const sportKey = normalizeActivityTypeToSportKey(file.activityType)
+    if (!sportKey) continue
+
+    for (const gear of gears) {
+      if (SPORT_KIND[sportKey] !== gear.kind) continue
+
+      const window = gear.windows.find((candidate) => {
+        const from = candidate.from ?? Number.NEGATIVE_INFINITY
+        const to = candidate.to ?? Number.POSITIVE_INFINITY
+        // Half-open [from, to) so back-to-back windows share a boundary date
+        // without both claiming the activity that starts exactly on it.
+        const time = file.activityStartTime as number
+        if (time < from || time >= to) return false
+        return getWindowSports(gear, candidate).includes(sportKey)
+      })
+      if (!window) continue
+
+      taken.add(file.id)
+      assignments.push({
+        fileId: file.id,
+        fileName: file.fileName,
+        gearName: gear.name,
+        activityStartTime: file.activityStartTime
+      })
+      break
+    }
+  }
+
+  return assignments
+}
+
+export interface ExistingComponent {
+  componentType: string
+  brand?: string
+  model?: string
+  addedAt?: number
+}
+
+/**
+ * Which of a gear's components are not in the database yet.
+ *
+ * Identity is (type, brand, model, addedAt): a bike carries several chains over
+ * its life, identical but for when they went on. `removedAt` is deliberately not
+ * part of it, so correcting a removal date in the file and re-running does not
+ * create a duplicate — this script, like the rest of the import paths, never
+ * mutates a row the owner may have edited.
+ */
+export const diffGearComponents = ({
+  components,
+  existing
+}: {
+  components: ImportComponent[]
+  existing: ExistingComponent[]
+}): ImportComponent[] => {
+  const identityOf = (component: {
+    type: string
+    brand?: string | null
+    model?: string | null
+    addedAt?: number | null
+  }) =>
+    JSON.stringify([
+      component.type.trim().toLowerCase(),
+      component.brand?.trim().toLowerCase() ?? null,
+      component.model?.trim().toLowerCase() ?? null,
+      component.addedAt ?? null
+    ])
+
+  const known = new Set(
+    existing.map((component) =>
+      identityOf({
+        type: component.componentType,
+        brand: component.brand,
+        model: component.model,
+        addedAt: component.addedAt
+      })
+    )
+  )
+
+  return components.filter((component) => !known.has(identityOf(component)))
+}

--- a/scripts/fitness/gearImportPlan.ts
+++ b/scripts/fitness/gearImportPlan.ts
@@ -288,6 +288,7 @@ export interface MatchableFitnessFile {
   activityStartTime?: number
   activityType?: string
   gearId?: string
+  processingStatus?: string
 }
 
 export type AssignmentOutcome =
@@ -313,8 +314,17 @@ export interface AssignmentMatch {
 
 export interface MatchAssignmentsResult {
   matches: AssignmentMatch[]
-  /** Files claimed by a match, so the window pass never touches them. */
-  claimedFileIds: Set<string>
+  /**
+   * Files an explicit assignment has spoken for, whether or not it resolved.
+   *
+   * Matched files are the obvious case. The files behind an `ambiguous` tie and
+   * the target of a `conflict` belong here too: the import file states which
+   * gear those rides were on, and a window covering the same period is the
+   * coarser rule. Leaving them out would let a window attribute a ride to a
+   * different gear than the entry that named it — a wrong answer arrived at
+   * precisely because the right one was too uncertain to use.
+   */
+  reservedFileIds: Set<string>
   /** Files with no `activityStartTime` — unplaceable in time, reported instead. */
   timestamplessFileCount: number
 }
@@ -374,6 +384,7 @@ export const matchAssignmentsToFiles = ({
     .sort((left, right) => startTimeOf(left) - startTimeOf(right))
 
   const claimedBy = new Map<string, number>()
+  const reservedFileIds = new Set<string>()
   const matches: AssignmentMatch[] = []
 
   assignments.forEach((assignment, index) => {
@@ -425,6 +436,7 @@ export const matchAssignmentsToFiles = ({
     )
 
     if (nearest.length > 1) {
+      for (const file of nearest) reservedFileIds.add(file.id)
       matches.push({
         ...base,
         outcome: {
@@ -438,6 +450,7 @@ export const matchAssignmentsToFiles = ({
     const file = nearest[0]
     const claimingIndex = claimedBy.get(file.id)
     if (claimingIndex !== undefined) {
+      reservedFileIds.add(file.id)
       matches.push({
         ...base,
         outcome: {
@@ -450,6 +463,7 @@ export const matchAssignmentsToFiles = ({
     }
 
     claimedBy.set(file.id, index)
+    reservedFileIds.add(file.id)
     const fileKind = getFileSportKind(file)
     matches.push({
       ...base,
@@ -466,7 +480,7 @@ export const matchAssignmentsToFiles = ({
 
   return {
     matches,
-    claimedFileIds: new Set(claimedBy.keys()),
+    reservedFileIds,
     timestamplessFileCount: files.filter(
       (file) => typeof file.activityStartTime !== 'number'
     ).length
@@ -484,23 +498,24 @@ export interface WindowAssignment {
  * Fills in the activities no explicit assignment named, using each gear's date
  * windows.
  *
- * Windows are the coarse rule and assignments are the fine one, so anything a
- * match already claimed is skipped even when a window also covers it. A file
- * that already carries gear is left alone too: this pass never overwrites, since
- * a window is a statement about a period, not about a specific ride the owner
- * may have corrected by hand.
+ * Windows are the coarse rule and assignments are the fine one, so any file an
+ * assignment spoke for is skipped even when a window also covers it — including
+ * the files behind an assignment that could not be resolved (see
+ * `reservedFileIds`). A file that already carries gear is left alone too: this
+ * pass never overwrites, since a window is a statement about a period, not about
+ * a specific ride the owner may have corrected by hand.
  */
 export const applyWindows = ({
   gears,
   files,
-  claimedFileIds
+  reservedFileIds
 }: {
   gears: ImportGear[]
   files: MatchableFitnessFile[]
-  claimedFileIds: Set<string>
+  reservedFileIds: Set<string>
 }): WindowAssignment[] => {
   const assignments: WindowAssignment[] = []
-  const taken = new Set(claimedFileIds)
+  const taken = new Set(reservedFileIds)
 
   for (const file of files) {
     if (taken.has(file.id) || file.gearId) continue

--- a/scripts/fitness/importFitnessGear.test.ts
+++ b/scripts/fitness/importFitnessGear.test.ts
@@ -1,0 +1,88 @@
+import { parseArgs } from './importFitnessGear'
+
+describe('importFitnessGear parseArgs', () => {
+  it('requires an actor id and an input path', () => {
+    expect(() => parseArgs([])).toThrow()
+    expect(() => parseArgs(['--actor-id', 'actor-1'])).toThrow()
+    expect(() => parseArgs(['--input', 'gear.json'])).toThrow()
+  })
+
+  it('defaults tolerance, overwrite and dry-run', () => {
+    expect(
+      parseArgs(['--actor-id', 'actor-1', '--input', 'gear.json'])
+    ).toEqual({
+      actorId: 'actor-1',
+      input: 'gear.json',
+      toleranceSeconds: 60,
+      overwrite: false,
+      dryRun: false
+    })
+  })
+
+  it('accepts bare, inline, and space-separated boolean flags', () => {
+    expect(
+      parseArgs([
+        '--actor-id',
+        'actor-1',
+        '--input',
+        'gear.json',
+        '--overwrite',
+        '--dry-run'
+      ])
+    ).toMatchObject({ overwrite: true, dryRun: true })
+    expect(
+      parseArgs([
+        '--actor-id=actor-1',
+        '--input=gear.json',
+        '--dry-run=false',
+        '--overwrite=true'
+      ])
+    ).toMatchObject({ overwrite: true, dryRun: false })
+    expect(
+      parseArgs(['--dry-run', '--actor-id', 'actor-1', '--input', 'gear.json'])
+    ).toMatchObject({ overwrite: false, dryRun: true })
+  })
+
+  it('reads the tolerance as a number', () => {
+    expect(
+      parseArgs([
+        '--actor-id',
+        'actor-1',
+        '--input',
+        'gear.json',
+        '--tolerance-seconds',
+        '5'
+      ])
+    ).toMatchObject({ toleranceSeconds: 5 })
+  })
+
+  it.each([
+    { description: 'a non-numeric tolerance', value: 'abc' },
+    { description: 'a zero tolerance', value: '0' },
+    { description: 'a tolerance beyond an hour', value: '3601' }
+  ])('rejects $description', ({ value }) => {
+    expect(() =>
+      parseArgs([
+        '--actor-id',
+        'actor-1',
+        '--input',
+        'gear.json',
+        '--tolerance-seconds',
+        value
+      ])
+    ).toThrow()
+  })
+
+  it('rejects invalid boolean values', () => {
+    expect(() =>
+      parseArgs([
+        '--actor-id',
+        'actor-1',
+        '--input',
+        'gear.json',
+        '--dry-run',
+        'maybe'
+      ])
+    ).toThrow('Invalid boolean value: maybe. Use true or false.')
+  })
+})

--- a/scripts/fitness/importFitnessGear.ts
+++ b/scripts/fitness/importFitnessGear.ts
@@ -1,0 +1,574 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Imports fitness gear from a JSON file and attributes existing activities to it
+ * by start time.
+ *
+ * Gear tracking arrived after most people's activities did, so every ride
+ * imported before it exists with no gear at all. Re-importing is not an option —
+ * it would duplicate the posts — and the app's own Strava paths only attribute
+ * activities they import themselves. This script closes that gap: it creates the
+ * gear and its component history, then walks a list of {time, gear} entries and
+ * assigns each to the activity whose `activityStartTime` it names.
+ *
+ * Assignments are the precise instrument; per-gear date windows are the blunt
+ * one, applied afterwards to whatever is still unassigned. Both leave an
+ * activity that already carries gear alone unless `--overwrite` is given, so a
+ * re-run costs nothing and never undoes a manual correction.
+ *
+ * Use `scripts/fitness/convertStravaExportToGearImport.ts` to build the
+ * assignments from a Strava export.
+ *
+ * IMPORTANT: run this with the PRODUCTION database env configured. `@next/env`
+ * loads `.env.local` above `.env.production` even under NODE_ENV=production, so
+ * a stray local file points this at SQLite and it reports nothing to do — the
+ * banner it prints first is there to catch exactly that.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/fitness/importFitnessGear.ts \
+ *     --actor-id https://<host>/users/<username> \
+ *     --input ./gear-import.json \
+ *     [--tolerance-seconds 60] [--overwrite] [--dry-run [true|false]]
+ */
+import { loadEnvConfig } from '@next/env'
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { SportKey } from '@/lib/services/fitness-files/sportTypes'
+import { FitnessGear, FitnessGearKind } from '@/lib/types/database/fitnessGear'
+
+import { printDatabaseBanner } from './describeConnection'
+import {
+  AssignmentMatch,
+  ImportGear,
+  MatchableFitnessFile,
+  applyWindows,
+  diffGearComponents,
+  matchAssignmentsToFiles,
+  parseGearImportFile
+} from './gearImportPlan'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+const CliArgs = z.object({
+  actorId: z.string().min(1),
+  input: z.string().min(1),
+  toleranceSeconds: z.coerce.number().int().positive().max(3600).default(60),
+  overwrite: z.boolean().default(false),
+  dryRun: z.boolean().default(false)
+})
+
+const USAGE = `Usage: NODE_ENV=production scripts/fitness/importFitnessGear.ts \\
+  --actor-id https://<host>/users/<username> \\
+  --input ./gear-import.json \\
+  [--tolerance-seconds 60] [--overwrite] [--dry-run [true|false]]`
+
+const ACTOR_SCAN_PAGE_SIZE = 200
+const BOOLEAN_FLAGS = new Set(['overwrite', 'dry-run'])
+
+const parseBooleanFlagValue = (value?: string) => {
+  if (value === undefined || value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`Invalid boolean value: ${value}. Use true or false.`)
+}
+
+export const parseArgs = (args: string[]) => {
+  const parsed: Record<string, string | boolean> = {}
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
+
+    if (BOOLEAN_FLAGS.has(rawKey)) {
+      const nextValue = args[index + 1]
+      if (inlineValue !== undefined) {
+        parsed[rawKey] = parseBooleanFlagValue(inlineValue)
+        continue
+      }
+      if (nextValue && !nextValue.startsWith('--')) {
+        parsed[rawKey] = parseBooleanFlagValue(nextValue)
+        index += 1
+        continue
+      }
+      parsed[rawKey] = true
+      continue
+    }
+
+    const nextValue = inlineValue ?? args[index + 1]
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for --${rawKey}`)
+    }
+    if (inlineValue === undefined) index += 1
+    parsed[rawKey] = nextValue
+  }
+
+  return CliArgs.parse({
+    actorId: parsed['actor-id'],
+    input: parsed['input'],
+    toleranceSeconds: parsed['tolerance-seconds'] ?? 60,
+    overwrite: parsed['overwrite'] ?? false,
+    dryRun: parsed['dry-run'] ?? false
+  })
+}
+
+const normalizeGearName = (name: string): string => name.trim().toLowerCase()
+
+interface ResolvedGear {
+  entry: ImportGear
+  existing: FitnessGear | null
+}
+
+/**
+ * Finds the gear this entry refers to, by name first and Strava id second.
+ *
+ * The order matters on a re-run: if the owner renamed the gear in the UI, the
+ * name lookup misses, and creating it again would hit the unique
+ * (actorId, stravaGearId) index — which `createFitnessGear` does not recover
+ * from, so the run would die partway through.
+ */
+const resolveExistingGear = async (
+  database: Database,
+  actorId: string,
+  entry: ImportGear
+): Promise<FitnessGear | null> => {
+  const byName = await database.findFitnessGearByName({
+    actorId,
+    name: entry.name
+  })
+  if (byName) return byName
+
+  if (!entry.stravaGearId) return null
+
+  const byStravaGearId = await database.findFitnessGearByStravaGearId({
+    actorId,
+    stravaGearId: entry.stravaGearId
+  })
+  if (byStravaGearId) {
+    console.log(
+      `  Note: "${entry.name}" matched existing gear "${byStravaGearId.name}" by Strava id ${entry.stravaGearId}`
+    )
+  }
+  return byStravaGearId
+}
+
+const loadActorFitnessFiles = async (
+  database: Database,
+  actorId: string
+): Promise<MatchableFitnessFile[]> => {
+  const files: MatchableFitnessFile[] = []
+  let offset = 0
+
+  for (;;) {
+    // Primary files only: a batch upload of the same ride from two devices
+    // shares one post, and only the primary row counts toward gear totals.
+    const page = await database.getFitnessFilesByActor({
+      actorId,
+      limit: ACTOR_SCAN_PAGE_SIZE,
+      offset,
+      isPrimary: true
+    })
+    if (page.length === 0) break
+
+    for (const file of page) {
+      files.push({
+        id: file.id,
+        fileName: file.fileName,
+        activityStartTime: file.activityStartTime,
+        activityType: file.activityType,
+        gearId: file.gearId
+      })
+    }
+
+    if (page.length < ACTOR_SCAN_PAGE_SIZE) break
+    offset += ACTOR_SCAN_PAGE_SIZE
+  }
+
+  return files
+}
+
+const formatTime = (milliseconds: number): string =>
+  new Date(milliseconds).toISOString()
+
+const describeAssignmentSource = (match: AssignmentMatch): string =>
+  match.stravaActivityId
+    ? `${formatTime(match.timeMilliseconds)} (strava ${match.stravaActivityId})`
+    : formatTime(match.timeMilliseconds)
+
+async function importFitnessGearScript(args = process.argv.slice(2)) {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE)
+    return 0
+  }
+
+  let input: z.infer<typeof CliArgs>
+  try {
+    input = parseArgs(args)
+  } catch (error) {
+    console.error((error as Error).message)
+    console.error(USAGE)
+    return 1
+  }
+
+  let rawFile: unknown
+  try {
+    rawFile = JSON.parse(readFileSync(input.input, 'utf-8'))
+  } catch (error) {
+    console.error(
+      `Error: cannot read ${input.input}: ${(error as Error).message}`
+    )
+    return 1
+  }
+
+  const parsed = parseGearImportFile(rawFile)
+  if (!parsed.ok) {
+    console.error(`Error: ${input.input} is not a valid gear import file:`)
+    for (const error of parsed.errors) console.error(`  - ${error}`)
+    return 1
+  }
+  const file = parsed.file
+
+  printDatabaseBanner()
+
+  const database = getDatabase()
+  if (!database) {
+    console.error('Error: Database is not available')
+    return 1
+  }
+
+  try {
+    const actor = await database.getActorFromId({ id: input.actorId })
+    if (!actor) {
+      console.error(`Error: Actor not found: ${input.actorId}`)
+      return 1
+    }
+
+    // --- Read phase -------------------------------------------------------
+    const resolved: ResolvedGear[] = []
+    const errors: string[] = []
+
+    for (const entry of file.gears) {
+      const existing = await resolveExistingGear(database, actor.id, entry)
+      if (existing && existing.kind !== entry.kind) {
+        // `kind` decides which fields and sports are meaningful and is immutable
+        // once components hang off the gear.
+        errors.push(
+          `gear "${entry.name}" exists as ${existing.kind}, but the file says ${entry.kind}`
+        )
+      }
+      resolved.push({ entry, existing })
+    }
+
+    // A default sport belongs to one gear at a time, so creating gear that
+    // claims one silently takes it from whoever holds it now.
+    const claimedSports = new Map<SportKey, string>()
+    for (const { entry } of resolved) {
+      for (const sportKey of entry.defaultSports ?? []) {
+        claimedSports.set(sportKey, entry.name)
+      }
+    }
+    if (claimedSports.size > 0) {
+      const fileGearNames = new Set(
+        file.gears.map((gear) => normalizeGearName(gear.name))
+      )
+      const actorGears = await database.getFitnessGearsByActor({
+        actorId: actor.id
+      })
+      for (const gear of actorGears) {
+        if (fileGearNames.has(normalizeGearName(gear.name))) continue
+        for (const sportKey of gear.defaultSports) {
+          const claimant = claimedSports.get(sportKey as SportKey)
+          if (!claimant) continue
+          console.log(
+            `  ! "${claimant}" will take default sport "${sportKey}" from existing gear "${gear.name}"`
+          )
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error('Error: import cannot proceed:')
+      for (const error of errors) console.error(`  - ${error}`)
+      return 1
+    }
+
+    const files = await loadActorFitnessFiles(database, actor.id)
+
+    const gearKindByName = new Map<string, FitnessGearKind>(
+      file.gears.map((gear) => [normalizeGearName(gear.name), gear.kind])
+    )
+
+    // --- Plan phase -------------------------------------------------------
+    const { matches, claimedFileIds, timestamplessFileCount } =
+      matchAssignmentsToFiles({
+        assignments: file.assignments,
+        files,
+        toleranceMilliseconds: input.toleranceSeconds * 1000,
+        gearKindByName
+      })
+
+    const windowAssignments = applyWindows({
+      gears: file.gears,
+      files,
+      claimedFileIds
+    })
+
+    const componentPlan = new Map<
+      string,
+      ReturnType<typeof diffGearComponents>
+    >()
+    for (const { entry, existing } of resolved) {
+      const existingComponents = existing
+        ? await database.getFitnessGearComponents({
+            gearId: existing.id,
+            actorId: actor.id
+          })
+        : []
+      componentPlan.set(
+        normalizeGearName(entry.name),
+        diffGearComponents({
+          components: entry.components,
+          existing: existingComponents
+        })
+      )
+    }
+
+    // --- Report -----------------------------------------------------------
+    const matchedByGear = new Map<string, number>()
+    for (const match of matches) {
+      if (match.outcome.kind !== 'matched') continue
+      const key = normalizeGearName(match.gearName)
+      matchedByGear.set(key, (matchedByGear.get(key) ?? 0) + 1)
+    }
+    const windowsByGear = new Map<string, number>()
+    for (const assignment of windowAssignments) {
+      const key = normalizeGearName(assignment.gearName)
+      windowsByGear.set(key, (windowsByGear.get(key) ?? 0) + 1)
+    }
+
+    console.log(
+      `\nActor ${actor.id}: ${files.length} primary activities, ` +
+        `${file.gears.length} gear entries, ${file.assignments.length} assignments.`
+    )
+    if (timestamplessFileCount > 0) {
+      console.log(
+        `  ${timestamplessFileCount} activities have no start time and cannot be matched.`
+      )
+    }
+
+    console.log('\nGear:')
+    for (const { entry, existing } of resolved) {
+      const key = normalizeGearName(entry.name)
+      const components = componentPlan.get(key) ?? []
+      const parts = [
+        existing ? 'reuse' : 'create',
+        `${components.length}/${entry.components.length} components to add`,
+        `${matchedByGear.get(key) ?? 0} matched`,
+        `${windowsByGear.get(key) ?? 0} by window`
+      ]
+      const retiredChange =
+        existing && Boolean(existing.retiredAt) !== entry.retired
+          ? `, ${entry.retired ? 'retire' : 'unretire'}`
+          : ''
+      console.log(
+        `  ${entry.name} [${entry.kind}]: ${parts.join(', ')}${retiredChange}`
+      )
+    }
+
+    const unmatched = matches.filter(
+      (match) => match.outcome.kind === 'unmatched'
+    )
+    const ambiguous = matches.filter(
+      (match) => match.outcome.kind === 'ambiguous'
+    )
+    const conflicts = matches.filter(
+      (match) => match.outcome.kind === 'conflict'
+    )
+    const kindMismatches = matches.filter(
+      (match) => match.outcome.kind === 'matched' && match.outcome.kindMismatch
+    )
+
+    if (unmatched.length > 0) {
+      console.log(`\nUnmatched assignments (${unmatched.length}):`)
+      for (const match of unmatched.slice(0, 20)) {
+        const outcome = match.outcome as { nearestDeltaMilliseconds?: number }
+        const nearest =
+          outcome.nearestDeltaMilliseconds === undefined
+            ? 'no activities to compare'
+            : `nearest activity ${Math.round(outcome.nearestDeltaMilliseconds / 1000)}s away`
+        console.log(
+          `  ${describeAssignmentSource(match)} → ${match.gearName}: ${nearest}`
+        )
+      }
+      if (unmatched.length > 20) {
+        console.log(`  ... and ${unmatched.length - 20} more`)
+      }
+    }
+
+    for (const [label, group] of [
+      ['Ambiguous', ambiguous],
+      ['Conflicting', conflicts]
+    ] as const) {
+      if (group.length === 0) continue
+      console.log(`\n${label} assignments (${group.length}, skipped):`)
+      for (const match of group.slice(0, 20)) {
+        console.log(`  ${describeAssignmentSource(match)} → ${match.gearName}`)
+      }
+      if (group.length > 20) console.log(`  ... and ${group.length - 20} more`)
+    }
+
+    if (kindMismatches.length > 0) {
+      console.log(
+        `\n! ${kindMismatches.length} assignments put a bike sport on shoes (or the reverse) — assigned anyway.`
+      )
+    }
+
+    if (input.dryRun) {
+      console.log('\nDry run: nothing was written.')
+      return 0
+    }
+
+    // --- Execute ----------------------------------------------------------
+    // Every step is individually idempotent, so no wrapping transaction: a
+    // crash leaves a state a re-run completes from, and `createFitnessGear`
+    // already opens its own transaction.
+    const totals = {
+      gearsCreated: 0,
+      gearsReused: 0,
+      retiredChanged: 0,
+      componentsCreated: 0,
+      assigned: 0,
+      alreadyAssigned: 0,
+      windowAssigned: 0,
+      failed: 0
+    }
+
+    const gearIdByName = new Map<string, string>()
+
+    for (const { entry, existing } of resolved) {
+      const key = normalizeGearName(entry.name)
+      let gear = existing
+
+      if (gear) {
+        totals.gearsReused += 1
+      } else {
+        gear = await database.createFitnessGear({
+          actorId: actor.id,
+          kind: entry.kind,
+          name: entry.name,
+          brand: entry.brand,
+          model: entry.model,
+          bikeType: entry.bikeType,
+          weightKilograms: entry.weightKilograms,
+          defaultSports: entry.defaultSports ?? [],
+          alertDistanceMeters: entry.alertDistanceMeters,
+          notes: entry.notes,
+          stravaGearId: entry.stravaGearId
+        })
+        totals.gearsCreated += 1
+        console.log(`  Created gear ${entry.name}`)
+      }
+
+      gearIdByName.set(key, gear.id)
+
+      if (Boolean(gear.retiredAt) !== entry.retired) {
+        await database.setFitnessGearRetired({
+          id: gear.id,
+          actorId: actor.id,
+          retired: entry.retired
+        })
+        totals.retiredChanged += 1
+      }
+
+      for (const component of componentPlan.get(key) ?? []) {
+        const created = await database.createFitnessGearComponent({
+          gearId: gear.id,
+          actorId: actor.id,
+          componentType: component.type,
+          brand: component.brand,
+          model: component.model,
+          addedAt: component.addedAt ? new Date(component.addedAt) : null,
+          removedAt: component.removedAt ? new Date(component.removedAt) : null,
+          serviceDistanceMeters: component.serviceDistanceMeters
+        })
+        if (created) totals.componentsCreated += 1
+        else totals.failed += 1
+      }
+    }
+
+    for (const match of matches) {
+      if (match.outcome.kind !== 'matched') continue
+      const gearId = gearIdByName.get(normalizeGearName(match.gearName))
+      if (!gearId) {
+        totals.failed += 1
+        continue
+      }
+
+      if (input.overwrite) {
+        const updated = await database.setFitnessFileGear({
+          fitnessFileId: match.outcome.fileId,
+          actorId: actor.id,
+          gearId
+        })
+        if (updated) totals.assigned += 1
+        else totals.failed += 1
+        continue
+      }
+
+      const assigned = await database.assignFitnessFileGearIfUnset({
+        fitnessFileId: match.outcome.fileId,
+        actorId: actor.id,
+        gearId
+      })
+      if (assigned) totals.assigned += 1
+      else totals.alreadyAssigned += 1
+    }
+
+    for (const assignment of windowAssignments) {
+      const gearId = gearIdByName.get(normalizeGearName(assignment.gearName))
+      if (!gearId) {
+        totals.failed += 1
+        continue
+      }
+      // Windows never overwrite, even with --overwrite: they describe a period,
+      // not the specific ride the owner may have corrected by hand.
+      const assigned = await database.assignFitnessFileGearIfUnset({
+        fitnessFileId: assignment.fileId,
+        actorId: actor.id,
+        gearId
+      })
+      if (assigned) totals.windowAssigned += 1
+      else totals.alreadyAssigned += 1
+    }
+
+    console.log(
+      `\nDone: ${totals.gearsCreated} gear created, ${totals.gearsReused} reused, ` +
+        `${totals.retiredChanged} retirement change(s), ${totals.componentsCreated} components added.\n` +
+        `Activities: ${totals.assigned} assigned, ${totals.windowAssigned} by window, ` +
+        `${totals.alreadyAssigned} already had gear, ${unmatched.length} unmatched, ` +
+        `${ambiguous.length + conflicts.length} skipped, ${totals.failed} error(s).`
+    )
+
+    return totals.failed > 0 ? 1 : 0
+  } finally {
+    await database.destroy()
+  }
+}
+
+if (require.main === module) {
+  importFitnessGearScript()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Script failed:', error)
+      process.exit(1)
+    })
+}
+
+export { importFitnessGearScript }

--- a/scripts/fitness/importFitnessGear.ts
+++ b/scripts/fitness/importFitnessGear.ts
@@ -181,7 +181,8 @@ const loadActorFitnessFiles = async (
         fileName: file.fileName,
         activityStartTime: file.activityStartTime,
         activityType: file.activityType,
-        gearId: file.gearId
+        gearId: file.gearId,
+        processingStatus: file.processingStatus
       })
     }
 
@@ -265,9 +266,13 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
     }
 
     // A default sport belongs to one gear at a time, so creating gear that
-    // claims one silently takes it from whoever holds it now.
+    // claims one silently takes it from whoever holds it now. Only gear this
+    // run actually creates can steal: `defaultSports` is passed to
+    // `createFitnessGear` and nowhere else, so warning about a reused entry
+    // would describe a change that never happens.
     const claimedSports = new Map<SportKey, string>()
-    for (const { entry } of resolved) {
+    for (const { entry, existing } of resolved) {
+      if (existing) continue
       for (const sportKey of entry.defaultSports ?? []) {
         claimedSports.set(sportKey, entry.name)
       }
@@ -291,6 +296,22 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
       }
     }
 
+    // Two entries pointing at one database row would each diff their components
+    // against the same pre-write snapshot, so both would insert and the gear
+    // would end up with the history twice over.
+    const resolvedById = new Map<string, string>()
+    for (const { entry, existing } of resolved) {
+      if (!existing) continue
+      const owner = resolvedById.get(existing.id)
+      if (owner) {
+        errors.push(
+          `entries "${owner}" and "${entry.name}" both resolve to the existing gear "${existing.name}"`
+        )
+        continue
+      }
+      resolvedById.set(existing.id, entry.name)
+    }
+
     if (errors.length > 0) {
       console.error('Error: import cannot proceed:')
       for (const error of errors) console.error(`  - ${error}`)
@@ -299,12 +320,24 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
 
     const files = await loadActorFitnessFiles(database, actor.id)
 
+    // An actor with no activities at all cannot be the one these assignments
+    // describe. Creating the gear anyway would leave rows on the wrong actor —
+    // and `stealDefaultSports` would quietly strip sports off their real gear —
+    // so stop while that is still just a typo in `--actor-id`.
+    if (files.length === 0 && file.assignments.length > 0) {
+      console.error(
+        `Error: ${actor.id} has no activities, but the file has ${file.assignments.length} assignments.\n` +
+          '  Check --actor-id and the database shown above before re-running.'
+      )
+      return 1
+    }
+
     const gearKindByName = new Map<string, FitnessGearKind>(
       file.gears.map((gear) => [normalizeGearName(gear.name), gear.kind])
     )
 
     // --- Plan phase -------------------------------------------------------
-    const { matches, claimedFileIds, timestamplessFileCount } =
+    const { matches, reservedFileIds, timestamplessFileCount } =
       matchAssignmentsToFiles({
         assignments: file.assignments,
         files,
@@ -315,7 +348,7 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
     const windowAssignments = applyWindows({
       gears: file.gears,
       files,
-      claimedFileIds
+      reservedFileIds
     })
 
     const componentPlan = new Map<
@@ -366,7 +399,11 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
       const key = normalizeGearName(entry.name)
       const components = componentPlan.get(key) ?? []
       const parts = [
-        existing ? 'reuse' : 'create',
+        // Reuse adds the missing components and reconciles `retired`, but never
+        // rewrites the gear's own fields — an import must not overwrite what the
+        // owner may have corrected in the UI. Say so, or a re-run after editing
+        // brand/notes/defaultSports in the file looks like it applied them.
+        existing ? 'reuse (existing gear fields left as they are)' : 'create',
         `${components.length}/${entry.components.length} components to add`,
         `${matchedByGear.get(key) ?? 0} matched`,
         `${windowsByGear.get(key) ?? 0} by window`
@@ -379,6 +416,17 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
         `  ${entry.name} [${entry.kind}]: ${parts.join(', ')}${retiredChange}`
       )
     }
+
+    // Gear totals only count 'completed' activities, so a matched file that is
+    // still processing (or failed) gets its gearId but stays out of the numbers
+    // until it finishes — worth saying, since the totals are what an operator
+    // compares against Strava.
+    const filesById = new Map(files.map((entry) => [entry.id, entry]))
+    const notCompletedCount = matches.filter(
+      (match) =>
+        match.outcome.kind === 'matched' &&
+        filesById.get(match.outcome.fileId)?.processingStatus !== 'completed'
+    ).length
 
     const unmatched = matches.filter(
       (match) => match.outcome.kind === 'unmatched'
@@ -423,9 +471,33 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
     }
 
     if (kindMismatches.length > 0) {
+      // Assigned anyway on purpose: the import file knows which gear was used,
+      // while the local sport is guessed from free-form `activityType`. But this
+      // is the only skipped-or-warned category that still writes, so it gets the
+      // same detail as the others — and grouping by gear surfaces the case that
+      // matters, a gear whose every activity mismatches, which means its `kind`
+      // is wrong in the file and cannot be changed after the gear is created.
       console.log(
-        `\n! ${kindMismatches.length} assignments put a bike sport on shoes (or the reverse) — assigned anyway.`
+        `\n! Sport/kind mismatches (${kindMismatches.length}, assigned anyway):`
       )
+      const mismatchByGear = new Map<string, number>()
+      for (const match of kindMismatches) {
+        const key = normalizeGearName(match.gearName)
+        mismatchByGear.set(key, (mismatchByGear.get(key) ?? 0) + 1)
+      }
+      for (const [key, count] of mismatchByGear) {
+        const entry = file.gears.find(
+          (gear) => normalizeGearName(gear.name) === key
+        )
+        const total = matchedByGear.get(key) ?? 0
+        const allOfThem =
+          count === total && total > 1
+            ? ` — every one of them, so "kind": "${entry?.kind}" is probably wrong in the file`
+            : ''
+        console.log(
+          `  ${entry?.name ?? key} [${entry?.kind}]: ${count} of ${total}${allOfThem}`
+        )
+      }
     }
 
     if (input.dryRun) {
@@ -449,110 +521,202 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
     }
 
     const gearIdByName = new Map<string, string>()
-
-    for (const { entry, existing } of resolved) {
-      const key = normalizeGearName(entry.name)
-      let gear = existing
-
-      if (gear) {
-        totals.gearsReused += 1
-      } else {
-        gear = await database.createFitnessGear({
-          actorId: actor.id,
-          kind: entry.kind,
-          name: entry.name,
-          brand: entry.brand,
-          model: entry.model,
-          bikeType: entry.bikeType,
-          weightKilograms: entry.weightKilograms,
-          defaultSports: entry.defaultSports ?? [],
-          alertDistanceMeters: entry.alertDistanceMeters,
-          notes: entry.notes,
-          stravaGearId: entry.stravaGearId
-        })
-        totals.gearsCreated += 1
-        console.log(`  Created gear ${entry.name}`)
-      }
-
-      gearIdByName.set(key, gear.id)
-
-      if (Boolean(gear.retiredAt) !== entry.retired) {
-        await database.setFitnessGearRetired({
-          id: gear.id,
-          actorId: actor.id,
-          retired: entry.retired
-        })
-        totals.retiredChanged += 1
-      }
-
-      for (const component of componentPlan.get(key) ?? []) {
-        const created = await database.createFitnessGearComponent({
-          gearId: gear.id,
-          actorId: actor.id,
-          componentType: component.type,
-          brand: component.brand,
-          model: component.model,
-          addedAt: component.addedAt ? new Date(component.addedAt) : null,
-          removedAt: component.removedAt ? new Date(component.removedAt) : null,
-          serviceDistanceMeters: component.serviceDistanceMeters
-        })
-        if (created) totals.componentsCreated += 1
-        else totals.failed += 1
+    const printSummary = () => {
+      console.log(
+        `\nDone: ${totals.gearsCreated} gear created, ${totals.gearsReused} reused, ` +
+          `${totals.retiredChanged} retirement change(s), ${totals.componentsCreated} components added.\n` +
+          `Activities: ${totals.assigned} assigned, ${totals.windowAssigned} by window, ` +
+          `${totals.alreadyAssigned} already had gear, ${unmatched.length} unmatched, ` +
+          `${ambiguous.length + conflicts.length} skipped, ${totals.failed} error(s).`
+      )
+      if (notCompletedCount > 0) {
+        console.log(
+          `  ${notCompletedCount} of the matched activities are not 'completed' yet, so they ` +
+            'will not count toward gear totals until their processing finishes.'
+        )
       }
     }
 
-    for (const match of matches) {
-      if (match.outcome.kind !== 'matched') continue
-      const gearId = gearIdByName.get(normalizeGearName(match.gearName))
-      if (!gearId) {
-        totals.failed += 1
-        continue
+    // A throw here (a dropped connection, a statement timeout) would otherwise
+    // take the counters with it, leaving no way to tell whether the run wrote
+    // nothing or nearly everything.
+    let inFlight = 'the gear'
+    try {
+      for (const { entry, existing } of resolved) {
+        inFlight = `gear "${entry.name}"`
+        const key = normalizeGearName(entry.name)
+        let gear = existing
+
+        if (gear) {
+          totals.gearsReused += 1
+        } else {
+          gear = await database.createFitnessGear({
+            actorId: actor.id,
+            kind: entry.kind,
+            name: entry.name,
+            brand: entry.brand,
+            model: entry.model,
+            bikeType: entry.bikeType,
+            weightKilograms: entry.weightKilograms,
+            defaultSports: entry.defaultSports ?? [],
+            alertDistanceMeters: entry.alertDistanceMeters,
+            notes: entry.notes,
+            stravaGearId: entry.stravaGearId
+          })
+          totals.gearsCreated += 1
+          console.log(`  Created gear ${entry.name}`)
+        }
+
+        gearIdByName.set(key, gear.id)
+
+        if (Boolean(gear.retiredAt) !== entry.retired) {
+          const retired = await database.setFitnessGearRetired({
+            id: gear.id,
+            actorId: actor.id,
+            retired: entry.retired
+          })
+          if (retired) totals.retiredChanged += 1
+          else {
+            totals.failed += 1
+            console.error(
+              `  ! could not ${entry.retired ? 'retire' : 'unretire'} "${entry.name}" (${gear.id}) — the gear is no longer readable`
+            )
+          }
+        }
+
+        const planned = componentPlan.get(key) ?? []
+        for (const [position, component] of planned.entries()) {
+          const created = await database.createFitnessGearComponent({
+            gearId: gear.id,
+            actorId: actor.id,
+            componentType: component.type,
+            brand: component.brand,
+            model: component.model,
+            addedAt: component.addedAt ? new Date(component.addedAt) : null,
+            removedAt: component.removedAt
+              ? new Date(component.removedAt)
+              : null,
+            serviceDistanceMeters: component.serviceDistanceMeters
+          })
+          if (created) {
+            totals.componentsCreated += 1
+            continue
+          }
+          // Null means the gear itself is gone or not ours, which is fatal for
+          // every remaining component of this gear — looping on would just
+          // count the same failure once per part.
+          const remaining = planned.length - position
+          totals.failed += remaining
+          console.error(
+            `  ! gear "${entry.name}" (${gear.id}) is no longer readable — ` +
+              `skipped ${remaining} of its ${planned.length} new components, starting at "${component.type}"`
+          )
+          break
+        }
       }
 
-      if (input.overwrite) {
-        const updated = await database.setFitnessFileGear({
+      for (const match of matches) {
+        if (match.outcome.kind !== 'matched') continue
+        inFlight = `assignment ${match.index} (${describeAssignmentSource(match)} → ${match.gearName})`
+        const gearId = gearIdByName.get(normalizeGearName(match.gearName))
+        if (!gearId) {
+          totals.failed += 1
+          console.error(
+            `  ! ${describeAssignmentSource(match)} → ${match.gearName}: gear was never created`
+          )
+          continue
+        }
+
+        if (input.overwrite) {
+          const updated = await database.setFitnessFileGear({
+            fitnessFileId: match.outcome.fileId,
+            actorId: actor.id,
+            gearId
+          })
+          if (updated) totals.assigned += 1
+          else {
+            totals.failed += 1
+            console.error(
+              `  ! ${describeAssignmentSource(match)} → ${match.gearName}: activity ${match.outcome.fileName} could not be updated`
+            )
+          }
+          continue
+        }
+
+        const assigned = await database.assignFitnessFileGearIfUnset({
           fitnessFileId: match.outcome.fileId,
           actorId: actor.id,
           gearId
         })
-        if (updated) totals.assigned += 1
-        else totals.failed += 1
-        continue
+        if (assigned) {
+          totals.assigned += 1
+        } else if (match.outcome.alreadyAssigned) {
+          // Expected: the activity carried gear when the plan was read, and this
+          // run is not allowed to overwrite it.
+          totals.alreadyAssigned += 1
+        } else {
+          // The guarded UPDATE matched nothing even though the activity had no
+          // gear moments ago — the row (or the gear) changed underneath us.
+          totals.failed += 1
+          console.error(
+            `  ! ${describeAssignmentSource(match)} → ${match.gearName}: activity ${match.outcome.fileName} ` +
+              'had no gear when planned but the write was rejected; it or the gear changed during the run'
+          )
+        }
       }
 
-      const assigned = await database.assignFitnessFileGearIfUnset({
-        fitnessFileId: match.outcome.fileId,
-        actorId: actor.id,
-        gearId
-      })
-      if (assigned) totals.assigned += 1
-      else totals.alreadyAssigned += 1
-    }
-
-    for (const assignment of windowAssignments) {
-      const gearId = gearIdByName.get(normalizeGearName(assignment.gearName))
-      if (!gearId) {
-        totals.failed += 1
-        continue
+      for (const assignment of windowAssignments) {
+        inFlight = `window assignment for ${assignment.gearName}`
+        const gearId = gearIdByName.get(normalizeGearName(assignment.gearName))
+        if (!gearId) {
+          totals.failed += 1
+          console.error(
+            `  ! window assignment for ${assignment.gearName}: gear was never created`
+          )
+          continue
+        }
+        // Windows never overwrite, even with --overwrite: they describe a period,
+        // not the specific ride the owner may have corrected by hand.
+        const assigned = await database.assignFitnessFileGearIfUnset({
+          fitnessFileId: assignment.fileId,
+          actorId: actor.id,
+          gearId
+        })
+        if (assigned) {
+          totals.windowAssigned += 1
+        } else {
+          // `applyWindows` only ever offers activities whose gear was null, so
+          // unlike the matched loop there is no benign reading of a false here.
+          totals.failed += 1
+          console.error(
+            `  ! window assignment for ${assignment.gearName}: activity ${assignment.fileName} ` +
+              'had no gear when planned but the write was rejected; it changed during the run'
+          )
+        }
       }
-      // Windows never overwrite, even with --overwrite: they describe a period,
-      // not the specific ride the owner may have corrected by hand.
-      const assigned = await database.assignFitnessFileGearIfUnset({
-        fitnessFileId: assignment.fileId,
-        actorId: actor.id,
-        gearId
-      })
-      if (assigned) totals.windowAssigned += 1
-      else totals.alreadyAssigned += 1
+    } catch (error) {
+      console.error(`\nAborted while processing ${inFlight}.`)
+      printSummary()
+      console.error(
+        'Every step is idempotent — re-run to continue where it stopped.'
+      )
+      throw error
     }
 
-    console.log(
-      `\nDone: ${totals.gearsCreated} gear created, ${totals.gearsReused} reused, ` +
-        `${totals.retiredChanged} retirement change(s), ${totals.componentsCreated} components added.\n` +
-        `Activities: ${totals.assigned} assigned, ${totals.windowAssigned} by window, ` +
-        `${totals.alreadyAssigned} already had gear, ${unmatched.length} unmatched, ` +
-        `${ambiguous.length + conflicts.length} skipped, ${totals.failed} error(s).`
-    )
+    printSummary()
+
+    // A run that wrote no attribution at all did not do its job, whatever the
+    // per-item counters say. `alreadyAssigned` keeps a genuine re-run green.
+    if (
+      file.assignments.length > 0 &&
+      totals.assigned + totals.windowAssigned + totals.alreadyAssigned === 0
+    ) {
+      console.error(
+        `\nError: none of the ${file.assignments.length} assignments reached an activity. ` +
+          'Check --actor-id, the database above, and the unmatched deltas.'
+      )
+      return 1
+    }
 
     return totals.failed > 0 ? 1 : 0
   } finally {

--- a/scripts/fitness/importFitnessGear.ts
+++ b/scripts/fitness/importFitnessGear.ts
@@ -609,7 +609,7 @@ async function importFitnessGearScript(args = process.argv.slice(2)) {
           totals.failed += remaining
           console.error(
             `  ! gear "${entry.name}" (${gear.id}) is no longer readable — ` +
-              `skipped ${remaining} of its ${planned.length} new components, starting at "${component.type}"`
+              `${remaining} of its ${planned.length} new components were not created, starting at "${component.type}"`
           )
           break
         }


### PR DESCRIPTION
## Why

Gear tracking (#1402) arrived after most activities did, so anything imported before it carries no gear at all. Re-importing would duplicate the posts, and the Strava import paths only attribute activities they import themselves — which leaves no way to backfill years of history.

## What

**`scripts/fitness/importFitnessGear.ts`** — creates gear and its component history from a JSON file, then attributes existing activities by matching each entry's timestamp against `activityStartTime`.

- **Assignments** are the precise instrument (one `{time, gear}` entry per activity); **per-gear date windows** are the blunt one, applied afterwards to whatever is still unassigned. Windows are half-open `[from, to)` so back-to-back periods share a boundary date without both claiming the activity that starts on it.
- An entry that matches nothing, ties between two activities, or lands on one another entry already claimed is **reported and skipped, never guessed at**. The dry-run report includes how far the nearest activity was for each unmatched entry, so a systematic clock problem shows up as a uniform offset before anything is written.
- Activities that already carry gear are left alone unless `--overwrite` is given, so re-running is free and never undoes a manual correction. Gear is found by name then Strava id, and components are diffed on `(type, brand, model, addedAt)` — a bike carries several identical chains over its life, distinguished only by when they went on.
- Dates are a `YYYY-MM-DD` day (UTC midnight) or a datetime with an explicit `Z`/offset. A bare local datetime is **rejected**: JavaScript would read it in the running machine's zone and shift every activity by hours, which mostly manifests as a sea of unmatched entries with no obvious cause.

**`scripts/fitness/convertStravaExportToGearImport.ts`** — builds the assignments from a Strava export. `activities.csv` is the only record of which gear each historical activity used, and its `Activity Date` column is UTC (it matches the exported GPX `<time>` to the second). Component install dates exist only on Strava's gear pages, so the gear description stays hand-authored and is merged in.

Parsed in arrays mode because the CSV repeats five header names — the second `Distance` is the one in meters, and it is the only column that reproduces the totals Strava shows, which makes it the checksum for the whole conversion.

**`scripts/fitness/gearImportPlan.ts`** — the schema, matcher, window pass and component diff as pure functions, following the `storedImportPlan.ts` pattern so the interesting decisions are testable without a database.

## Verification

- `yarn lint` (0 errors), `yarn build`, `yarn test` — **8,824 tests pass**, 70 of them new.
- Ran end-to-end against a local SQLite database seeded with **real timestamps from a 1,745-row Strava export**: 40/41 activities matched (the 41st has no start time and is reported), re-run was fully idempotent (0 written, 40 already assigned), `--overwrite` corrected 40 deliberately wrong assignments, a duplicate-timestamp twin was correctly flagged ambiguous, and a windows-only file claimed exactly the 21 post-2018 bike rides.
- The converter reproduced every per-gear total from the Strava gear page (Moots 35,670.2 km, Brompton S6R 4,228.3 km, Rental bike 518.2 km).
- Browser: gear page shows derived distances and retired grouping; component install windows render with correctly apportioned distance (two chains sharing an Apr 1 2020 boundary, 431.4 km vs 0.0 km, no double-counting).

## Notes

- No schema change, no runtime change — scripts and docs only, hence `none:`.
- The import does not evaluate service reminders, so backfilling years of activities sends no alerts.
- `defaultSports` takes a sport from whatever gear holds it now; the script warns before doing so. A purely historical import should leave it empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)