### PR TITLE
Bump version to v1.125.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.125.0",
+  "version": "1.125.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.125.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.125.0`
- Base main SHA: `ab6210094b3f43da4eef76dc1fb618a0ca80a618`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
