### PR TITLE
Bump version to v1.125.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.125.1",
+  "version": "1.125.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.125.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.125.1`
- Base main SHA: `402220ce98366dc1ee2b0b62d32fd4d891b6c6be`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
