### PR TITLE
none: correct the stale Better Auth signing comment in authorizeQuery

### DIFF
--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -98,7 +98,10 @@ describe('OAuth authorize query helpers', () => {
     expect(shouldDelegateToBetterAuth(signedParams)).toBe(false)
   })
 
-  it('serializes signed consent queries in Better Auth signature order', () => {
+  // Order is not signature-relevant (Better Auth canonicalizes by sorting
+  // before signing); this pins the stable, readable serialization the helper
+  // produces — request params first, signature envelope last.
+  it('serializes query params in a stable order with the signature envelope last', () => {
     const signedParams: SearchParams = {
       ...unsignedParams,
       prompt: 'consent',

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -1,12 +1,27 @@
 import { SearchParams } from './types'
 
-// Better Auth 1.6.9 signs serializeAuthorizationQuery(ctx.query).toString()
-// before appending sig in @better-auth/oauth-provider/dist/index.mjs. Its
-// signParams helper sets exp with Math.floor(Date.now() / 1e3) + codeExpiresIn
-// in the same file. Keep both the order and seconds-based exp units in sync
-// when upgrading Better Auth or consent signature verification can fail even
-// when the query values are unchanged.
-const BetterAuthAuthorizationParamOrder = [
+// A stable, readable serialization order. NOT a signature-relevant one.
+//
+// @better-auth/oauth-provider (a direct dependency) signs its consent query in
+// `signParams`: it appends `exp`, an issued-at `ba_iat`, and one repeated
+// `ba_param` entry per signed parameter name, then hashes
+// `canonicalizeOAuthQueryParams(params).toString()` — which SORTS the entries
+// by key, then value, before hashing. Verification re-canonicalizes the same
+// way, so the order a query is serialized in cannot change the signature.
+//
+// Nothing here reproduces a signed query anyway. `SearchParams` (types.ts) is a
+// plain `z.object`, so it strips the `ba_*` envelope Better Auth signed over,
+// and every caller either drops `sig`/`exp` outright
+// (`buildBetterAuthAuthorizeUrl`, and `resolveSignInRedirect`, which drops
+// `ba_*` too) or — in `AuthorizeCard` — prefers `window.location.search`, the
+// raw signed query Better Auth actually put in the address bar, falling back
+// here only when there is no window.
+//
+// So this array does one thing: it fixes the order the known params come out
+// in — the request params as RFC 6749 §4.1.1 lists them, signature envelope
+// last — with anything unlisted appended after. It filters nothing; the second
+// loop in `buildOAuthQuery` passes unknown params through.
+const OAuthQueryParamOrder = [
   'response_type',
   'client_id',
   'redirect_uri',
@@ -21,9 +36,7 @@ const BetterAuthAuthorizationParamOrder = [
   'sig'
 ]
 
-const BetterAuthAuthorizationParamSet = new Set(
-  BetterAuthAuthorizationParamOrder
-)
+const OrderedOAuthQueryParams = new Set(OAuthQueryParamOrder)
 
 const shouldIncludeOAuthParam = (
   key: string,
@@ -38,17 +51,17 @@ export const buildOAuthQuery = (params: SearchParams): string => {
   // input as the string record this helper actually forwards. The `unknown`
   // bridge is required because `boolean` no longer overlaps the string record.
   const values = params as unknown as Record<string, string | null | undefined>
-  for (const key of BetterAuthAuthorizationParamOrder) {
+  for (const key of OAuthQueryParamOrder) {
     const value = values[key]
     if (shouldIncludeOAuthParam(key, value)) oauthQuery.set(key, value)
   }
-  // Preserve future/raw caller params after the signature-sensitive keys. The
-  // page currently passes parsed SearchParams, but keeping extras here makes
-  // the helper safe if a route later forwards raw URLSearchParams-shaped data.
+  // Preserve future/raw caller params after the ordered keys. The page
+  // currently passes parsed SearchParams, but keeping extras here makes the
+  // helper safe if a route later forwards raw URLSearchParams-shaped data.
   for (const [key, value] of Object.entries(values)) {
     if (
       shouldIncludeOAuthParam(key, value) &&
-      !BetterAuthAuthorizationParamSet.has(key)
+      !OrderedOAuthQueryParams.has(key)
     ) {
       oauthQuery.set(key, value)
     }
@@ -71,6 +84,12 @@ export const buildBetterAuthAuthorizeUrl = (
   return url.toString()
 }
 
+// `exp` is epoch SECONDS — Better Auth's signParams sets it to
+// `Math.floor(Date.now() / 1e3) + codeExpiresIn`. Keep the units in sync when
+// upgrading @better-auth/oauth-provider: read them as milliseconds and every
+// signature looks live forever, so an expired one reaches the consent POST and
+// comes back `invalid_signature`; read milliseconds as seconds and every live
+// signature looks long expired, re-delegating to Better Auth on every load.
 const hasExpiredBetterAuthSignature = (exp: string): boolean => {
   const expiresAt = Number(exp)
   return !Number.isFinite(expiresAt) || Date.now() / 1000 > expiresAt


### PR DESCRIPTION
## Summary

The header comment on `app/(nosidebar)/oauth/authorize/authorizeQuery.ts` was stale and actively misleading. It claimed Better Auth signs `serializeAuthorizationQuery(ctx.query).toString()` and instructed the reader to keep the local `BetterAuthAuthorizationParamOrder` array "in sync" with that order.

That has not been true for several releases. `signParams` now hashes `canonicalizeOAuthQueryParams(params).toString()`, which **sorts** the entries by key then value, and verification re-canonicalizes the same way. It also appends an issued-at `ba_iat` and one repeated `ba_param` entry per signed parameter name.

This predates #1415 (`main` already ran a version with the new scheme), which is why it was deliberately left out of that dependency refresh.

## Is the ordering array still needed?

It is **not signature-relevant, and could not be** — for two independent reasons, both verified against a running server rather than inferred from reading:

1. **Order doesn't matter.** Signing and verification both canonicalize by sorting first.
2. **`buildOAuthQuery` cannot produce a signed query at all.** `SearchParams` in `types.ts` is a plain `z.object`, so it strips the `ba_*` envelope Better Auth signed over before the helper ever sees it. Every caller is unsigned anyway: `buildBetterAuthAuthorizeUrl` and `resolveSignInRedirect` drop `sig`/`exp` deliberately, and `AuthorizeCard` prefers the raw `window.location.search`, falling back to the helper only when there is no window.

So the array survives purely as a **display/reconstruction ordering**. It is kept — a stable, readable serialization is still worth having, and it keeps the output independent of the input object's key order — but renamed and re-documented to say what it actually does.

## Changes

- Rewrote the header comment to describe the current signing scheme: canonicalized sort, the `ba_param` allow-list, and `ba_iat`. No hardcoded version number, following the "exact-pinned" phrasing style of `lib/services/oauth/matchRedirectUri.ts`.
- Renamed `BetterAuthAuthorizationParamOrder` → `OAuthQueryParamOrder` (and its set to `OrderedOAuthQueryParams`). Both are module-private; no external references.
- Moved the `exp` epoch-seconds note down to `hasExpiredBetterAuthSignature`, the code that actually reads it, and spelled out both failure directions if the units drift.
- Renamed the test `serializes signed consent queries in Better Auth signature order`, which repeated the same false claim.

No runtime behavior change: the exact-string serialization test passes unchanged, which is the proof that `buildOAuthQuery`'s output is byte-identical.

## Verification

**Full OAuth authorize/consent flow, end to end** against `yarn start` on local SQLite: registered a client → `/oauth/authorize` 307s to Better Auth carrying the helper's ordering → Better Auth signs and redirects back with `exp` (10-digit seconds), `ba_iat` (13-digit ms), sorted repeated `ba_param` entries and `sig` → consent page renders 200 → `POST /api/auth/oauth2/consent` returns an authorization code → exchanged successfully for an access token.

Two targeted probes confirm the claims the new comment makes:

| Probe | Result |
| --- | --- |
| Signed consent query replayed with parameters **fully reversed** (`sig` first, `response_type` last) | verifies, issues a code — order is not signature-relevant |
| Same query with **only** the `ba_*` envelope removed (exactly what the Zod `z.object` does) | `invalid_signature` — the envelope is what is load-bearing |

Definition of Done gate, in order:

- `yarn run prettier --write .` — no changes
- `yarn lint` — 0 errors (31 warnings, all pre-existing in unrelated files)
- `yarn build` — exit 0
- `yarn test` — **782 files, 8842 tests, all passing**
- `app/(nosidebar)/oauth/authorize/*` specifically — 3 files, 52 tests passing

## Notes

- No UI change, so no screenshots.
- `package.json` pins `@better-auth/oauth-provider` as `^1.6.27` — a caret range, unlike the exact pins on `better-auth`/`@better-auth/core` — so the comment says "a direct dependency" rather than copying "exact-pinned" verbatim.
- `none:` prefix: comments plus a module-private rename, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
