### PR TITLE
Bump version to v1.126.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.125.2",
+  "version": "1.126.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.126.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.125.2`
- Base main SHA: `a5ec306ec9d162406d2d43a8a8154ae25a539aaa`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
