### PR TITLE
fix: harden the version bump merge gate after review

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -492,8 +492,12 @@ jobs:
               while IFS= read -r required_check; do
                 [ -n "$required_check" ] || continue
 
-                status=$(printf '%s\n' "$states" | awk -F"$TAB" -v name="$required_check" '$1 == name { print $2 }')
-                conclusion=$(printf '%s\n' "$states" | awk -F"$TAB" -v name="$required_check" '$1 == name { print $3 }')
+                # Pass the name through the environment, not `awk -v`: -v runs
+                # the value through escape processing, so a check name
+                # containing a backslash would never match itself and would sit
+                # "pending" until the gate timed out.
+                status=$(printf '%s\n' "$states" | name="$required_check" awk -F"$TAB" '$1 == ENVIRON["name"] { print $2 }')
+                conclusion=$(printf '%s\n' "$states" | name="$required_check" awk -F"$TAB" '$1 == ENVIRON["name"] { print $3 }')
 
                 if [ -n "$status" ]; then
                   registered=$((registered + 1))
@@ -501,13 +505,16 @@ jobs:
 
                 case "${status}/${conclusion}" in
                   completed/success) ;;
-                  completed/cancelled | completed/skipped | completed/neutral)
+                  completed/cancelled | completed/skipped | completed/neutral | completed/)
                     # Not terminal. CI cancels superseded runs, so a cancelled
                     # check run means "a newer run is coming", and branch
-                    # protection counts skipped and neutral as passing. Waiting
-                    # is what keeps a cancelled sibling from abandoning a PR
-                    # whose live run is still green.
-                    pending="${pending:+${pending}, }${required_check} (${conclusion})"
+                    # protection counts skipped and neutral as passing. An empty
+                    # conclusion on a completed run is GitHub briefly reporting a
+                    # run it has not finalized — treating that as a failure would
+                    # abandon the PR on the first poll with no second look, since
+                    # the failure branch below is the one terminal decision here
+                    # that never retries. Waiting covers all four.
+                    pending="${pending:+${pending}, }${required_check} (${conclusion:-not concluded})"
                     ;;
                   completed/*)
                     failed="${failed:+${failed}, }${required_check} (${conclusion:-unknown})"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -438,6 +438,7 @@ jobs:
             local conclusion
             local current_sha
             local failed
+            local head_mismatches=0
             local kicked=0
             local pending
             local registered
@@ -452,9 +453,28 @@ jobs:
               current_sha=$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
 
               if [ -n "$current_sha" ] && [ "$current_sha" != "$head_sha" ]; then
-                echo "::warning::${pr_url} head moved from ${head_sha} to ${current_sha}; a newer version-bump run owns this PR."
-                return 1
+                head_mismatches=$((head_mismatches + 1))
+
+                # Believe a handover only after two consecutive reads. The PR
+                # head is eventually consistent right after the force-push
+                # above, so a single stale read still reports the *previous*
+                # bump commit, and bailing on that would abandon a PR this run
+                # does own.
+                if [ "$head_mismatches" -ge 2 ]; then
+                  echo "::warning::${pr_url} head moved from ${head_sha} to ${current_sha}; a newer version-bump run owns this PR."
+                  return 1
+                fi
+
+                # Do not judge this commit's checks while the PR may already
+                # point somewhere else — re-read before deciding anything. Left
+                # to fall through, a green result on the stale commit would
+                # return success for a head we no longer own.
+                echo "${pr_url} head read as ${current_sha}, expected ${head_sha}; re-reading before judging checks."
+                sleep "$CHECK_INTERVAL_SECONDS"
+                continue
               fi
+
+              head_mismatches=0
 
               if states=$(latest_check_run_states "$head_sha" 2> "$CHECKS_ERROR"); then
                 states_ok=1
@@ -479,11 +499,23 @@ jobs:
                   registered=$((registered + 1))
                 fi
 
-                if [ "$status" != "completed" ]; then
-                  pending="${pending:+${pending}, }${required_check}"
-                elif [ "$conclusion" != "success" ]; then
-                  failed="${failed:+${failed}, }${required_check} (${conclusion:-unknown})"
-                fi
+                case "${status}/${conclusion}" in
+                  completed/success) ;;
+                  completed/cancelled | completed/skipped | completed/neutral)
+                    # Not terminal. CI cancels superseded runs, so a cancelled
+                    # check run means "a newer run is coming", and branch
+                    # protection counts skipped and neutral as passing. Waiting
+                    # is what keeps a cancelled sibling from abandoning a PR
+                    # whose live run is still green.
+                    pending="${pending:+${pending}, }${required_check} (${conclusion})"
+                    ;;
+                  completed/*)
+                    failed="${failed:+${failed}, }${required_check} (${conclusion:-unknown})"
+                    ;;
+                  *)
+                    pending="${pending:+${pending}, }${required_check}"
+                    ;;
+                esac
               done <<< "$required_check_names"
 
               if [ -n "$failed" ]; then
@@ -498,11 +530,16 @@ jobs:
 
               # Self-heal: a bot force-push that updates the bump PR head
               # sometimes fails to trigger the pull_request CI workflows, so no
-              # check run is ever created and the PR stays blocked forever. Only
-              # an empty required-check set proves that. A partially reported set
-              # just means the remaining jobs have not been queued yet, and
-              # reopening then would cancel the healthy run in flight.
-              if [ "$kicked" -eq 0 ] && [ "$states_ok" -eq 1 ] && [ "$registered" -eq 0 ] && [ "$attempt" -ge "$CHECK_KICK_ATTEMPT" ]; then
+              # check run is ever created and the PR stays blocked forever.
+              #
+              # Reopening cancels whatever run is in flight, so only reopen on
+              # unambiguous evidence that nothing fired: the commit must carry no
+              # check runs *at all*, not merely none whose name we recognise. A
+              # partially reported set means the remaining jobs have not been
+              # queued yet, and a set of only unrecognised names means CI ran
+              # under names this gate does not expect — reopening either one
+              # would kill a healthy run and leave its cancelled jobs behind.
+              if [ "$kicked" -eq 0 ] && [ "$states_ok" -eq 1 ] && [ "$registered" -eq 0 ] && [ -z "$states" ] && [ "$attempt" -ge "$CHECK_KICK_ATTEMPT" ]; then
                 echo "No required check runs on ${head_sha} after ${attempt} attempts; reopening ${pr_url} to re-trigger CI."
 
                 if gh pr close "$pr_url"; then
@@ -539,6 +576,25 @@ jobs:
             return 1
           }
 
+          # Hand the PR to GitHub instead of dropping it whenever this run gives
+          # up. Every abandon path used to exit having armed nothing, so the
+          # bump then waited for an entirely new run — which only happens on the
+          # next push to main, i.e. hours on a quiet day. Arming is safe even
+          # for a bump whose version may be stale, because branch protection is
+          # `strict`: an armed PR can merge only while it is both green *and*
+          # up to date with main, and a stale bump goes BEHIND the moment main
+          # moves, staying blocked until the next run force-pushes the
+          # recomputed version onto it.
+          arm_auto_merge() {
+            local pr_url="$1"
+
+            if gh pr merge --auto --squash --delete-branch "$pr_url"; then
+              echo "Armed auto-merge on ${pr_url}; GitHub will merge it once branch protection is satisfied."
+            else
+              echo "::warning::Could not arm auto-merge on ${pr_url}."
+            fi
+          }
+
           CHECKS_ERROR=$(mktemp)
           trap 'rm -f "$CHECKS_ERROR"' EXIT
 
@@ -557,6 +613,7 @@ jobs:
 
             if ! wait_for_required_checks "$PR_URL" "$HEAD_SHA" "$BRANCH_PROTECTION_CHECK_NAMES"; then
               echo "::warning::Required PR checks did not pass; leaving $PR_URL open."
+              arm_auto_merge "$PR_URL"
               exit 0
             fi
           fi
@@ -566,17 +623,45 @@ jobs:
 
           if [ "$LATEST_MAIN_SHA" != "$BASE_SHA" ]; then
             echo "Leaving $PR_URL open: main moved from $BASE_SHA to $LATEST_MAIN_SHA while checks were running."
+            arm_auto_merge "$PR_URL"
             exit 0
           fi
 
-          # Auto-merge can only be *enabled* while the PR is still blocked. By
-          # now the required checks have usually all passed, so GitHub rejects
-          # the request with "Pull request is in clean status" — merge directly
-          # in that case instead of leaving a green bump PR sitting open.
           if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
             echo "Enabled auto-merge for $PR_URL"
-          else
-            echo "Could not enable auto-merge for $PR_URL; merging it directly."
+            exit 0
+          fi
+
+          # Auto-merge can only be *enabled* while the PR is still blocked, and
+          # by now the required checks have usually all passed, so GitHub
+          # rejects the request with "Pull request is in clean status". Merging
+          # directly is the right answer for that case only — never for an
+          # arbitrary --auto failure. PAT_TOKEN belongs to a repo admin and
+          # `enforce_admins` is false on main, so a blind direct merge here
+          # could push a bump past required checks this gate never verified
+          # (most sharply on the "could not read branch protection" path above,
+          # which does no local gating at all). Re-read the merge state and
+          # merge only what GitHub itself already considers CLEAN.
+          MERGE_STATE=""
+
+          for merge_state_attempt in 1 2 3; do
+            MERGE_STATE=$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || true)
+
+            # UNKNOWN means GitHub has not finished computing mergeability yet,
+            # not that the PR is unmergeable; the read itself kicks that off.
+            if [ -n "$MERGE_STATE" ] && [ "$MERGE_STATE" != "UNKNOWN" ]; then
+              break
+            fi
+
+            if [ "$merge_state_attempt" -lt 3 ]; then
+              sleep 5
+            fi
+          done
+
+          if [ "$MERGE_STATE" = "CLEAN" ]; then
+            echo "Auto-merge was refused and $PR_URL is CLEAN; merging it directly."
             gh pr merge --squash --delete-branch "$PR_URL"
             echo "Merged $PR_URL"
+          else
+            echo "::warning::Could not enable auto-merge for $PR_URL and its merge state is ${MERGE_STATE:-unreadable}; leaving it open."
           fi


### PR DESCRIPTION
Follow-up to [#1420](https://github.com/llun/activities.next/pull/1420), which fixed the version-bump PRs that sat open for hours. That change made the gate work; this one makes its failure modes safe. Every item below came out of the sub-agent review rounds on #1420 and is verified against real data or a targeted experiment, not reasoning alone.

## 1. Never hard-merge on an arbitrary `--auto` failure (highest severity)

#1420 added a direct-merge fallback for when `gh pr merge --auto` is refused because the PR already went green. But the `else` caught **every** non-zero exit — transient GraphQL 5xx, auto-merge disabled repo-wide, permission errors — and then ran an unconditional `gh pr merge --squash`.

That is a real bypass, not a theoretical one:

```
$ gh api repos/llun/activities.next/branches/main/protection --jq '.enforce_admins.enabled'
false
$ gh api user --jq .login          → llun
$ gh api repos/llun/activities.next --jq .permissions.admin  → true
```

`PAT_TOKEN` is an admin token and `enforce_admins` is off, so branch protection does not constrain it. The sharpest path is the "could not read branch protection" branch, which does no local gating at all: a transient `--auto` failure there would merge a bump whose CI is still running or already red. The preceding `origin/main == BASE_SHA` guard does not help — it proves the *base* is fresh, not that the *head* is tested.

Now the fallback re-reads `mergeStateStatus` (retrying past `UNKNOWN`, which means "not computed yet", not "unmergeable") and merges directly only when GitHub itself already reports `CLEAN`.

## 2. Arm auto-merge on the abandon paths

Every abandon path exited having armed nothing, so a bump PR that turned green later still waited for an entirely new workflow run — which only happens on the next push to `main`. That is the same "open for hours" symptom #1420 set out to fix, just reached by a different route.

Arming is safe even for a bump whose version may be stale, because branch protection is `strict: true`: an armed PR can merge only while it is both green **and** up to date with main. A stale bump goes `BEHIND` the moment main moves and stays blocked until the next run force-pushes the recomputed version onto it.

## 3. `cancelled` / `skipped` / `neutral` / unconcluded are pending, not failures

- CI uses `cancel-in-progress`, so a `cancelled` check run means "a newer run is coming" — treating it as terminal is how a superseded sibling abandons a PR whose live run is green. This was the residual of #1420's own bug: whenever the reopen *does* fire legitimately, it cancels the run in flight and the old failure reproduces.
- Branch protection counts `skipped` and `neutral` as passing, so the gate must not be stricter than the thing it is predicting.
- **`completed` with a null conclusion** — the brief window while GitHub finalizes a run — fell into the failure arm. That arm is the one terminal decision in the gate with no retry behind it, so a single unlucky poll abandoned the PR for a check that was about to report `success`.

## 4. Reopen only on unambiguous evidence that nothing fired

The kick now additionally requires the commit to carry **no check runs at all**, not merely none whose name we recognise. A set of only unrecognised names means CI ran under names this gate does not expect; reopening would kill a healthy run and leave its cancelled jobs behind — exactly the failure #1420 fixed.

## 5. Head-moved guard needs two consecutive reads

`HEAD_SHA` is the just-force-pushed local commit and the PR head is eventually consistent, so a single stale read reports the *previous* bump commit and the guard fires backwards — abandoning a PR this run does own. It now needs two consecutive mismatches, and it skips check evaluation while a mismatch is outstanding: left to fall through, a green result on the stale commit would return success for a head we no longer own. (Caught by the test matrix below — the first attempt at this fix had exactly that hole.)

## 6. Look check names up via the environment, not `awk -v`

`awk -v` runs its value through escape processing, so a required check whose name contains a backslash never matches itself:

```
check name: [All\Tests] (9 chars)
old  (awk -v)   -> []
new  (ENVIRON)  -> [completed]
```

Both status and conclusion came back empty on every poll, the check stayed "pending" forever, and the gate burned its full 30-minute budget. Names with spaces (`Lint and Prettier`) and `$` were re-verified as still matching.

## Verification

The gate functions were extracted from the workflow and driven against fixtures built from the **real** check-run payload of `232ff2bc` (the commit #1418 was stuck on, which still carries both the cancelled and the healthy run):

| Scenario | Result |
| --- | --- |
| Poisoned `232ff2bc` (duplicate names, older = failed/cancelled) | all three `success` → merge |
| One stale head read, then correct | survives → merge |
| Head genuinely moved (persistent mismatch) | bails, newer run owns the PR |
| Newest `All Tests` = `cancelled` | pending, not abandoned |
| Newest `All Tests` = `skipped` | pending, not abandoned |
| Newest `All Tests` = `completed` / null conclusion | pending, not abandoned |
| Newest `All Tests` genuinely `failure` | fails, PR left open |
| Commit has zero check runs | reopens once |
| Only unrelated checks (CodeQL etc.) present | no reopen |
| Fan-in `All Tests` not created yet | pending, no reopen |

Also verified empirically rather than assumed: `sort -t<TAB> -k1,1 -k2,2nr` keeps the primary key ascending while taking the highest id per name (including under `LC_ALL=en_US.UTF-8`, where names that collate equal still dedupe, because `awk`'s `!seen[$1]++` keys on the exact string); a failing `gh` propagates out of the `gh | sort | awk` pipeline under `pipefail` while a legitimately empty result exits 0 with `states=""`; and the herestring loop is not a subshell, so `registered`/`pending`/`failed` mutations survive.

Locally: `prettier --check` clean, `yarn lint` 0 errors (31 pre-existing warnings), `yarn build` and `yarn test` exit 0, `bash -n` clean on the extracted step.

## Not changed

- `join_check_names` rewrites commas inside a check name (`Build, Lint` → `Build,  Lint`). Pre-existing, and it feeds log lines only.
- `read_branch_protection_required_checks` re-arms `errexit` inside a caller that disabled it. Pre-existing; the only unguarded command on that path is a `cat`, and aborting there yields the same non-zero result the caller already checks.
- A required check published as a legacy **commit status** rather than a check run would be invisible to `/commits/{sha}/check-runs` and would time out. Not a defect today — all three required contexts are Actions check runs pinned to `app_id 15368` — and with item 2 above the timeout now leaves the PR armed for GitHub to merge, so the failure mode is benign.
- Out of scope: `ci.yml`'s own comment recommends marking `CI Success` as *the* required check, but branch protection requires `All Tests`/`Build`/`Lint and Prettier` instead. Worth reconciling separately.

No version bump: `.github/`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
