### PR TITLE
Bump version to v1.127.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.126.0",
+  "version": "1.127.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.127.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.126.0`
- Base main SHA: `83aeba04ed5b5dedebcc6476c372691c9e5899ad`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
