### PR TITLE
none: correct the Bun install rationale and bound its retries

### DIFF
--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -171,13 +171,14 @@ jobs:
           # look. Never let this check fail the install it is annotating.
           #
           # awk deliberately reads to EOF instead of `exit`ing on the first
-          # match. Leaving early closes the pipe under the writer, and with
-          # `pipefail` that turns a successful extraction into a failed
-          # pipeline the moment the response outgrows the pipe buffer — either
-          # silently discarding the version via the `||` below, or, with the
-          # writer inside its own substitution, killing this step outright on
-          # SIGPIPE (141) after the install had already succeeded. The file is
-          # a few KB; reading all of it costs nothing and removes the class.
+          # match, which sits ~200 lines into a 23KB response. Leaving early
+          # closes the pipe while curl is still writing, curl exits 23, and
+          # `pipefail` then hands the `||` below a failed pipeline — so the
+          # version it just extracted is thrown away. This is a race on how
+          # much curl has flushed, not a size threshold, and it already loses
+          # most of the time: 20 real fetches gave 6 extractions and 14
+          # discards, against 20/20 reading to EOF. Left as `exit` the check
+          # would have looked fine and simply never warned.
           action_bun_version="$(
             curl --fail --location --silent --show-error --max-time 30 \
               'https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml' |

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -169,10 +169,19 @@ jobs:
 
           # Best effort: a mismatch is not fatal, it just means someone should
           # look. Never let this check fail the install it is annotating.
+          #
+          # awk deliberately reads to EOF instead of `exit`ing on the first
+          # match. Leaving early closes the pipe under the writer, and with
+          # `pipefail` that turns a successful extraction into a failed
+          # pipeline the moment the response outgrows the pipe buffer — either
+          # silently discarding the version via the `||` below, or, with the
+          # writer inside its own substitution, killing this step outright on
+          # SIGPIPE (141) after the install had already succeeded. The file is
+          # a few KB; reading all of it costs nothing and removes the class.
           action_bun_version="$(
             curl --fail --location --silent --show-error --max-time 30 \
               'https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml' |
-              awk '/^[[:space:]]*bun-version:/ { print $2; exit }'
+              awk '/^[[:space:]]*bun-version:/ && !found { print $2; found = 1 }'
           )" || action_bun_version=''
 
           if [ -n "${action_bun_version}" ] &&

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -96,12 +96,16 @@ jobs:
       # anthropics/claude-code-action runs on Bun and installs it itself, through
       # a bundled `oven-sh/setup-bun` step that pulls the binary off the GitHub
       # release CDN. Two syncs on 2026-08-12 (runs 31638242964 and 31639748162)
-      # died right there with `socket hang up`: `@actions/tool-cache` gave up
-      # after three attempts in ~37s, every later step of the composite action
-      # was skipped, and its `Post buffered inline comments` step — which is an
-      # ordinary step carrying `if: always()`, not a post-step — then ran `bun`
-      # and hit `command not found`. That is the exit code 127 those runs report;
-      # the failed download is the cause. (The other `Install Bun` entry, logged
+      # died right there: `@actions/tool-cache` gave up after three attempts,
+      # in ~37s and ~31s respectively — the first run failed all three with
+      # `socket hang up`, the second mixed in an `Unexpected HTTP response:
+      # 503`, so this is CDN flakiness generally rather than one error. Every
+      # substantive step of the composite action was then skipped, and its
+      # `Post buffered inline comments` step — which still ran, being an
+      # ordinary step carrying `if: always()`, not a post-step — invoked `bun`
+      # and hit `command not found`. That is the exit code 127 those runs
+      # report; the failed download is the cause. (The other `Install Bun`
+      # entry, logged
       # `outcome=skipped` under `Post job cleanup`, is setup-bun's cache-save
       # post-step. It is declared `post-if: success()`, so it skipped only
       # because the job had already failed — it is not the step that failed.)
@@ -126,9 +130,12 @@ jobs:
       # neither caps the loop: `--retry-max-time` is what stops curl starting
       # further attempts, and `timeout-minutes` is the backstop. Without them a
       # CDN that accepts the connection and then stalls — a different failure
-      # from the `socket hang up` seen here — would burn ~31 minutes of the
-      # job's 45-minute budget and leave the merge step to be killed mid-run,
-      # turning a fast, clear failure into a slow, confusing one.
+      # from the ones seen here — could spend ~31 minutes of the job's
+      # 45-minute budget on this step alone. Whichever way that lands is worse
+      # than failing fast: exhaust the attempts and the sync has burnt the
+      # window to report what the old code reported in ~37s, or succeed on a
+      # late attempt and the merge step inherits too little of the budget to
+      # finish, dying on the job cap rather than its own.
       #
       # BUN_VERSION tracks the `bun-version` that claude-code-action pins in its
       # own action.yml; the drift check below warns when they diverge, because

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -175,10 +175,11 @@ jobs:
           # closes the pipe while curl is still writing, curl exits 23, and
           # `pipefail` then hands the `||` below a failed pipeline — so the
           # version it just extracted is thrown away. This is a race on how
-          # much curl has flushed, not a size threshold, and it already loses
-          # most of the time: 20 real fetches gave 6 extractions and 14
-          # discards, against 20/20 reading to EOF. Left as `exit` the check
-          # would have looked fine and simply never warned.
+          # much curl has flushed, not a size threshold, so it fails at a rate
+          # that varies run to run rather than never or always: three samples
+          # of 20 real fetches discarded 14, 9 and 12 of them, where reading to
+          # EOF gave 20/20 every time. Left as `exit` the check would have
+          # looked healthy and simply gone quiet for whole runs at a time.
           action_bun_version="$(
             curl --fail --location --silent --show-error --max-time 30 \
               'https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml' |

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -93,32 +93,55 @@ jobs:
           echo "git merge failed before conflict resolution" >&2
           exit 1
 
-      # anthropics/claude-code-action runs on Bun and installs it itself, in a
-      # bundled `Install Bun` step that pulls the binary straight off the GitHub
-      # release CDN with three closely-spaced retries and no fallback. Two syncs
-      # on 2026-08-12 (runs 31638242964 and 31639748162) died right there with
-      # `socket hang up`: the download gave up after ~37s, every later step of
-      # the composite action was skipped, and the action's always-run post-step
-      # then hit `bun: command not found` and reported exit code 127. That 127 is
-      # the reported failure but not the cause — the cause is the failed
-      # download, and the `Install Bun` entry showing `outcome=skipped` in those
-      # logs is setup-bun's *post*-job step, which always skips.
+      # anthropics/claude-code-action runs on Bun and installs it itself, through
+      # a bundled `oven-sh/setup-bun` step that pulls the binary off the GitHub
+      # release CDN. Two syncs on 2026-08-12 (runs 31638242964 and 31639748162)
+      # died right there with `socket hang up`: `@actions/tool-cache` gave up
+      # after three attempts in ~37s, every later step of the composite action
+      # was skipped, and its `Post buffered inline comments` step — which is an
+      # ordinary step carrying `if: always()`, not a post-step — then ran `bun`
+      # and hit `command not found`. That is the exit code 127 those runs report;
+      # the failed download is the cause. (The other `Install Bun` entry, logged
+      # `outcome=skipped` under `Post job cleanup`, is setup-bun's cache-save
+      # post-step. It is declared `post-if: success()`, so it skipped only
+      # because the job had already failed — it is not the step that failed.)
       #
-      # Installing Bun here instead and handing the action the path via
-      # `path_to_bun_executable` disables its internal install outright (that
-      # step carries `if: inputs.path_to_bun_executable == ''`) and puts the
-      # download on a retry budget we control. `--retry-all-errors` is the part
-      # that matters: a mid-transfer reset is not one of curl's default
-      # retryable errors.
+      # Installing Bun here and passing the path via `path_to_bun_executable`
+      # disables the action's internal install outright, since that step carries
+      # `if: inputs.path_to_bun_executable == ''`, and puts the download on a
+      # retry budget we control. A bare `oven-sh/setup-bun` pre-step would also
+      # have avoided a second download — setup-bun reuses an existing
+      # `~/.bun/bin/bun` of a matching version before it consults its cache, so
+      # `no-cache: true` does not force a re-download — but it would have run
+      # the same untunable `@actions/tool-cache` retry policy that failed here,
+      # relocating the flake rather than removing it.
+      #
+      # `--retry-all-errors` is the flag that matters: a mid-transfer reset is
+      # CURLE_RECV_ERROR/CURLE_PARTIAL_FILE, outside curl's default set of
+      # retryable errors, so without it the extra attempts never fire for this
+      # exact failure.
+      #
+      # Both time bounds are deliberate. curl resets `--max-time` on every retry
+      # and a server's `Retry-After` can push a wait past `--retry-delay`, so
+      # neither caps the loop: `--retry-max-time` is what stops curl starting
+      # further attempts, and `timeout-minutes` is the backstop. Without them a
+      # CDN that accepts the connection and then stalls — a different failure
+      # from the `socket hang up` seen here — would burn ~31 minutes of the
+      # job's 45-minute budget and leave the merge step to be killed mid-run,
+      # turning a fast, clear failure into a slow, confusing one.
       #
       # BUN_VERSION tracks the `bun-version` that claude-code-action pins in its
-      # own action.yml — check it after an upstream bump, since the action pins
-      # deliberately to dodge Bun regressions. BUN_SHA256 is that release's
-      # `bun-linux-x64.zip` entry from its SHASUMS256.txt and must be updated
-      # together with the version. linux-x64 is hardcoded to match `runs-on`.
+      # own action.yml; the drift check below warns when they diverge, because
+      # `@v1` moves and the action pins deliberately to dodge Bun regressions.
+      # BUN_SHA256 is that release's `bun-linux-x64.zip` entry from its
+      # SHASUMS256.txt and must be updated together with the version. The
+      # artifact is hardcoded to the non-baseline linux-x64 build to match
+      # `runs-on: ubuntu-latest`; a runner without AVX2, or an arm64 one, needs
+      # a different archive (`-baseline`, `-aarch64`) and its own checksum.
       - name: Install Bun
         id: bun
         if: steps.synced.outputs.skip == 'false'
+        timeout-minutes: 6
         shell: bash
         env:
           BUN_VERSION: '1.3.14'
@@ -130,7 +153,7 @@ jobs:
           curl \
             --fail --location --silent --show-error \
             --retry 5 --retry-delay 10 --retry-all-errors \
-            --connect-timeout 15 --max-time 300 \
+            --retry-max-time 120 --connect-timeout 15 --max-time 120 \
             --output "${bun_root}/bun.zip" \
             "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip"
 
@@ -143,6 +166,22 @@ jobs:
           "${bun_bin}" --version
 
           echo "path=${bun_bin}" >> "${GITHUB_OUTPUT}"
+
+          # Best effort: a mismatch is not fatal, it just means someone should
+          # look. Never let this check fail the install it is annotating.
+          action_bun_version="$(
+            curl --fail --location --silent --show-error --max-time 30 \
+              'https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml' |
+              awk '/^[[:space:]]*bun-version:/ { print $2; exit }'
+          )" || action_bun_version=''
+
+          if [ -n "${action_bun_version}" ] &&
+            [ "${action_bun_version}" != "${BUN_VERSION}" ]; then
+            echo "::warning::claude-code-action@v1 now pins Bun" \
+              "${action_bun_version}, but this workflow installs" \
+              "${BUN_VERSION}. Update BUN_VERSION and BUN_SHA256 in" \
+              ".github/workflows/sync-main-to-oltp.yml."
+          fi
 
       - name: Resolve and validate merge with Claude
         if: steps.synced.outputs.skip == 'false'


### PR DESCRIPTION
Follow-up to #1426. That PR was squash-merged carrying only its first commit, so the review fixes below never reached `main` — `main` today still has the three factual errors in the comment, `--max-time 300` with no bound, and no drift check.

This PR carries those fixes plus one more found afterwards. No behaviour change to the happy path: the Bun install, checksum, and `path_to_bun_executable` wiring that #1426 shipped are untouched.

## 1. Three factual errors in the comment and commit message

All verified against upstream source. The comment exists to help the next person read the failing run's log, so naming the wrong entries defeats its purpose.

- **A plain `oven-sh/setup-bun` pre-step *would* have avoided the second download.** #1426 claimed `no-cache: true` makes the action re-download unconditionally. Wrong — in setup-bun `src/action.ts` @ `0c5077e5`, `noCache` is consumed only by `isCacheEnabled()`, which gates `restoreCache`/`saveCache`. An existing `~/.bun/bin/bun` of a matching version short-circuits *before* that, unconditioned on `noCache`:

  ```js
  if (!options.customUrl && existsSync(bunPath)) {
    const existingRevision = await getRevision(bunPath);
    if (existingRevision && isVersionMatch(existingRevision, options.version)) {
      cacheHit = true; // Treat as cache hit to avoid unnecessary network requests
  ```

  The conclusion still holds, but the reason is different: a pre-step reuses the same untunable `@actions/tool-cache` retry policy that failed here, relocating the flake instead of removing it.
- **`Post buffered inline comments` is not a post-step.** It is an ordinary composite step carrying `if: always() && inputs.classify_inline_comments != 'false'` (action.yml L432), logged *before* `Post job cleanup`.
- **setup-bun's post-step does not "always skip".** Its `action.yml` declares `post: dist/cache-save/index.js` with **`post-if: success()`** — it skipped in those runs only because the job had already failed.

## 2. The retry budget was not actually bounded

curl **resets `--max-time` on every retry** — man page: *"If you enable retrying the transfer (--retry) then the maximum time counter is reset each time the transfer is retried."* Reproduced against a stalling local server: `--retry 2 --retry-delay 1 --max-time 3` took **11s**, not 3s. A `Retry-After` response header can also push a wait *above* `--retry-delay`.

Worst case was 6 × 300s + 5 × 10s ≈ **31 minutes** of the job's 45-minute budget, which would leave `Resolve and validate merge with Claude` (`timeout-minutes: 30`) to be killed by the *job* timeout mid-merge — turning the fast, clear failure this PR series is about into a slow, confusing one.

Fixed with `--retry-max-time 120` (verified to bound it: 22s vs ~86s against a stalling server, exiting as a clean curl error 28 rather than a hard step kill), `--max-time 120`, and `timeout-minutes: 6` as the backstop. Worst case is now ~240s, inside the step timeout.

## 3. Bun version drift had no signal

`BUN_VERSION`/`BUN_SHA256` are pinned by hand against `@v1`, a moving tag. If upstream bumps its `bun-version`, nothing here says so — and per #1426's own notes a failed sync is silent unless someone reads the Actions tab, so the observable effect is that oltp sync quietly stops working.

Added a best-effort check that reads `bun-version` from `claude-code-action@v1`'s `action.yml` and emits `::warning::` on mismatch. It can never fail the install it annotates.

## 4. …and that check discarded its own result (found reviewing the fix)

The check as first written piped curl into an `awk` that `exit`s on the first match — which sits ~200 lines into a 23,689-byte response. Leaving early closes the pipe while curl is still writing, curl exits 23, and `pipefail` hands the `||` fallback a failed pipeline, so the version it just extracted is thrown away.

This is **not** a "large file" edge case and it is not hypothetical. It is a race on how much curl has flushed before awk leaves, so it fails at a rate that varies run to run rather than never or always — three samples of 20 real fetches each:

| form | sample 1 | sample 2 | sample 3 |
| --- | --- | --- | --- |
| `awk '… { print $2; exit }'` | 6 kept / **14 discarded** | 11 kept / **9 discarded** | 8 kept / **12 discarded** |
| `awk '… && !found { print $2; found = 1 }'` | 20 kept / 0 | 20 kept / 0 | 20 kept / 0 |

Left as-is, the drift check would have shipped looking perfectly healthy and simply never warned — the exact silent-failure mode this PR series exists to remove.

Splitting fetch from parse turned out to be **worse**: the writer moves inside its own command substitution with no `||` of its own, so the same SIGPIPE aborts the step with **141** under `-e`, after the install had already succeeded. That arrangement was tried and discarded.

The fix is to have awk read to EOF. The file is 23KB, so reading all of it costs nothing and removes the class entirely.

## Verification

Every path executed verbatim (step body extracted from the YAML) under GitHub's exact shell flags, `bash --noprofile --norc -e -o pipefail`:

| Path | Result |
| --- | --- |
| Happy path | download + checksum + unzip + `bun-linux-x64/bun` layout, exit 0 |
| Bad checksum | exit 1 before `unzip` — binary can never be executed or handed to the action |
| Unusable binary | exit 126, `GITHUB_OUTPUT` never written |
| Drift check, real fetch | returns `1.3.14` (matching today, no warning), exit 0 |
| Drift check, 60 real fetches | 20/20 extracted `1.3.14` in all three samples (old form: 6, 11, 8 of 20) |
| Drift check, 9.5MB stream | extracts **and keeps** the value, exit 0 |
| Drift check, unreachable host | empty, step survives, exit 0 |
| `--max-time` per-attempt | 11s for 3 attempts at `--max-time 3` — confirms the reset |
| `--retry-max-time` bound | 22s vs ~86s unbounded, clean curl exit 28 |

Local gate green: `prettier:check` clean, `yarn lint` 0 errors, `yarn build` passed, `yarn test` **788 files / 8992 tests passed**.

## Notes

- No version bump: `.github/`-only change, both commits `none:`.
- The hardcoded `bun-linux-x64.zip` is the non-baseline AVX2 build. Today's runner fleet resolves to it (visible in the failing run's own log) and a mismatch would fail loudly at the `bun --version` probe, but the comment now names the baseline dimension so a future runner migration is one lookup rather than a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
