### PR TITLE
Bump version to v1.127.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.127.0",
+  "version": "1.127.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.127.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.127.0`
- Base main SHA: `00a534451fe89b295d8a9a0498e896f65c22f575`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
