### PR TITLE
Bump version to v1.127.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.127.1",
+  "version": "1.127.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.127.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.127.1`
- Base main SHA: `1b7a66bd9c7fc16d5be581e98a811197008dadd8`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
