### PR TITLE
Bump version to v1.128.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.127.2",
+  "version": "1.128.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.128.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.127.2`
- Base main SHA: `6c1f0b2dd279200213d2ff84ca96120815b1851e`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
