### PR TITLE
Bump version to v1.128.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.128.0",
+  "version": "1.128.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.128.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.128.0`
- Base main SHA: `9fe04225a8cdde180699407665fdf4bb14b6f967`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
