### PR TITLE
Bump version to v1.129.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.128.1",
+  "version": "1.129.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.129.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.128.1`
- Base main SHA: `65b6b6ddb178b74c6b79c3448d78e045a0e03234`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
