### PR TITLE
Bump version to v1.130.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.129.1",
+  "version": "1.130.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.130.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.129.1`
- Base main SHA: `8491e84ce802fba5001e6c5c66a176379cb6c763`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
