### PR TITLE
Bump version to v1.131.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.130.0",
+  "version": "1.131.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.131.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.130.0`
- Base main SHA: `0361f35de115092590d7e1e5169423ab512a88ca`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
