### PR TITLE
minor: add Mastodon-style remote follow in both directions

### DIFF
--- a/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.test.tsx
+++ b/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ActorProfile } from '@/lib/types/domain/actor'
+
+import { AuthorizeInteractionCard } from './AuthorizeInteractionCard'
+
+vi.mock('@/lib/components/follow-action/follow-action', () => ({
+  FollowAction: ({ targetActorId }: { targetActorId: string }) => (
+    <div data-testid="follow-action">{targetActorId}</div>
+  )
+}))
+
+const actor = {
+  id: 'https://remote.test/users/someone',
+  username: 'someone',
+  domain: 'remote.test',
+  name: 'Someone Remote',
+  iconUrl: 'https://remote.test/avatar.png'
+} as ActorProfile
+
+describe('AuthorizeInteractionCard', () => {
+  it('shows the account and a follow action', () => {
+    render(<AuthorizeInteractionCard actor={actor} isSelf={false} />)
+
+    expect(screen.getByText('Someone Remote')).toBeInTheDocument()
+    expect(screen.getByText('@someone@remote.test')).toBeInTheDocument()
+    expect(screen.getByTestId('follow-action')).toHaveTextContent(
+      'https://remote.test/users/someone'
+    )
+  })
+
+  it('passes the raw activitypub id to the follow action', () => {
+    render(<AuthorizeInteractionCard actor={actor} isSelf={false} />)
+
+    // The client encodes ids itself; pre-encoding here would corrupt them.
+    expect(screen.getByTestId('follow-action')).toHaveTextContent(
+      'https://remote.test/users/someone'
+    )
+  })
+
+  it('links to the profile page', () => {
+    render(<AuthorizeInteractionCard actor={actor} isSelf={false} />)
+
+    expect(screen.getByRole('link', { name: 'View profile' })).toHaveAttribute(
+      'href',
+      '/@someone@remote.test'
+    )
+  })
+
+  it('hides the follow action for the viewer own account', () => {
+    render(<AuthorizeInteractionCard actor={actor} isSelf />)
+
+    expect(screen.queryByTestId('follow-action')).not.toBeInTheDocument()
+    expect(screen.getByText('This is you')).toBeInTheDocument()
+  })
+
+  it('omits the profile link for the headless instance actor', () => {
+    render(
+      <AuthorizeInteractionCard
+        actor={{ ...actor, type: 'Service' }}
+        isSelf={false}
+      />
+    )
+
+    expect(screen.queryByRole('link', { name: 'View profile' })).toBeNull()
+    expect(screen.getByTestId('follow-action')).toBeInTheDocument()
+  })
+
+  it('falls back to the username when the account has no display name', () => {
+    render(
+      <AuthorizeInteractionCard
+        actor={{ ...actor, name: undefined }}
+        isSelf={false}
+      />
+    )
+
+    expect(screen.getByText('@someone@remote.test')).toBeInTheDocument()
+    expect(screen.queryByText('Someone Remote')).toBeNull()
+  })
+})

--- a/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
+++ b/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { FollowAction } from '@/lib/components/follow-action/follow-action'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from '@/lib/components/ui/card'
+import { ActorProfile } from '@/lib/types/domain/actor'
+
+const getInitials = (name: string, fallback: string) =>
+  (name || fallback)
+    .trim()
+    .split(/\s+/)
+    .map((part) => Array.from(part)[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+interface AuthorizeInteractionCardProps {
+  actor: Pick<
+    ActorProfile,
+    'id' | 'username' | 'domain' | 'name' | 'iconUrl' | 'type'
+  >
+  isSelf: boolean
+}
+
+export const AuthorizeInteractionCard: FC<AuthorizeInteractionCardProps> = ({
+  actor,
+  isSelf
+}) => {
+  const handle = `@${actor.username}@${actor.domain}`
+  // The headless instance actor has no profile page (it is excluded from the
+  // WebFinger profile-page link for the same reason), so do not offer a link
+  // that only ever 404s.
+  const profileUrl = actor.type === 'Service' ? null : `/${handle}`
+
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">
+          {isSelf ? 'This is you' : 'Follow this account'}
+        </CardTitle>
+        <CardDescription>
+          {isSelf
+            ? 'You are signed in as this account.'
+            : 'You are about to follow this account from your account on this server.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-3">
+        <Avatar className="h-16 w-16">
+          <AvatarImage src={actor.iconUrl || undefined} />
+          <AvatarFallback>
+            {getInitials(actor.name || '', actor.username)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="text-center">
+          {actor.name ? (
+            <p className="text-lg font-semibold">{actor.name}</p>
+          ) : null}
+          <p className="text-muted-foreground">{handle}</p>
+        </div>
+      </CardContent>
+      <CardFooter className="flex justify-center gap-2">
+        {isSelf ? null : <FollowAction targetActorId={actor.id} isLoggedIn />}
+        {profileUrl ? (
+          <Button variant="outline" asChild>
+            <Link href={profileUrl}>View profile</Link>
+          </Button>
+        ) : null}
+      </CardFooter>
+    </Card>
+  )
+}

--- a/app/(nosidebar)/authorize_interaction/AuthorizeInteractionError.tsx
+++ b/app/(nosidebar)/authorize_interaction/AuthorizeInteractionError.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from '@/lib/components/ui/card'
+
+interface AuthorizeInteractionErrorProps {
+  title: string
+  description: string
+  uri?: string
+}
+
+export const AuthorizeInteractionError: FC<AuthorizeInteractionErrorProps> = ({
+  title,
+  description,
+  uri
+}) => (
+  <Card>
+    <CardHeader className="text-center">
+      <CardTitle className="text-2xl">{title}</CardTitle>
+      <CardDescription>{description}</CardDescription>
+    </CardHeader>
+    {uri ? (
+      <CardContent>
+        {/* The value is whatever a remote server put in the query string, so it
+            is rendered as inert text — never as a link. */}
+        <code className="block wrap-anywhere rounded-md bg-muted p-3 text-sm">
+          {uri}
+        </code>
+      </CardContent>
+    ) : null}
+    <CardFooter className="flex justify-center">
+      <Button variant="outline" asChild>
+        <Link href="/">Back to home</Link>
+      </Button>
+    </CardFooter>
+  </Card>
+)

--- a/app/(nosidebar)/authorize_interaction/page.test.tsx
+++ b/app/(nosidebar)/authorize_interaction/page.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { redirect } from 'next/navigation'
+
+import { resolveAccountTarget } from '@/lib/services/actors/resolveAccountTarget'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { Actor } from '@/lib/types/domain/actor'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+
+const mockDatabase = {}
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn()
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue(new Headers({ host: 'llun.test' }))
+}))
+
+vi.mock('@/lib/services/guards/headerHost', () => ({
+  headerHost: () => 'llun.test'
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/actors/resolveAccountTarget', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/services/actors/resolveAccountTarget')
+  >('@/lib/services/actors/resolveAccountTarget')
+  return {
+    ACCOUNT_TARGET_MAX_LENGTH: actual.ACCOUNT_TARGET_MAX_LENGTH,
+    resolveAccountTarget: vi.fn()
+  }
+})
+
+vi.mock('./AuthorizeInteractionCard', () => ({
+  AuthorizeInteractionCard: ({
+    actor,
+    isSelf
+  }: {
+    actor: { id: string }
+    isSelf: boolean
+  }) => (
+    <div data-testid="card" data-self={String(isSelf)}>
+      {actor.id}
+    </div>
+  )
+}))
+
+const currentActor = {
+  id: 'https://llun.test/users/viewer',
+  username: 'viewer',
+  domain: 'llun.test'
+} as Actor
+
+const remoteActor = {
+  id: 'https://remote.test/users/someone',
+  username: 'someone',
+  domain: 'remote.test'
+} as Actor
+
+const renderPage = async (searchParams: Record<string, string | string[]>) => {
+  const element = await Page({ searchParams: Promise.resolve(searchParams) })
+  return render(element)
+}
+
+describe('authorize_interaction page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+    vi.mocked(getActorFromSession).mockResolvedValue(currentActor)
+    vi.mocked(resolveAccountTarget).mockResolvedValue({
+      type: 'resolved',
+      actor: remoteActor
+    })
+  })
+
+  it('renders the confirmation card for a resolved account', async () => {
+    await renderPage({ uri: 'someone@remote.test' })
+
+    expect(screen.getByTestId('card')).toHaveTextContent(
+      'https://remote.test/users/someone'
+    )
+    expect(screen.getByTestId('card')).toHaveAttribute('data-self', 'false')
+  })
+
+  it('marks the card as self when the target is the viewer', async () => {
+    vi.mocked(resolveAccountTarget).mockResolvedValue({
+      type: 'resolved',
+      actor: currentActor
+    })
+
+    await renderPage({ uri: 'viewer@llun.test' })
+
+    expect(screen.getByTestId('card')).toHaveAttribute('data-self', 'true')
+  })
+
+  it('redirects a signed out visitor to sign in and back', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue(null)
+
+    await renderPage({ uri: 'someone@remote.test' })
+
+    expect(redirect).toHaveBeenCalledTimes(1)
+    const target = new URL(vi.mocked(redirect).mock.calls[0][0])
+    expect(target.origin).toEqual('https://llun.test')
+    expect(target.pathname).toEqual('/auth/signin')
+    // searchParams.get decodes once, leaving the path the sign-in page will
+    // redirect to; Next decodes the inner uri once more when this page re-reads
+    // its search params.
+    expect(target.searchParams.get('redirectBack')).toEqual(
+      '/authorize_interaction?uri=someone%40remote.test'
+    )
+    expect(resolveAccountTarget).not.toHaveBeenCalled()
+  })
+
+  it('keeps an ampersand in the uri intact through the sign in round trip', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue(null)
+
+    await renderPage({ uri: 'https://remote.test/users/a?b=1&c=2' })
+
+    const target = new URL(vi.mocked(redirect).mock.calls[0][0])
+    const redirectBack = target.searchParams.get('redirectBack') as string
+    const resumed = new URL(redirectBack, 'https://llun.test')
+    expect(resumed.searchParams.get('uri')).toEqual(
+      'https://remote.test/users/a?b=1&c=2'
+    )
+  })
+
+  it.each([
+    {
+      description: 'renders the not found state',
+      result: { type: 'not-found' as const },
+      text: 'Account not found'
+    },
+    {
+      description: 'renders the forbidden state',
+      result: { type: 'forbidden' as const },
+      text: "Can't reach that server"
+    },
+    {
+      description: 'renders the invalid state',
+      result: { type: 'invalid' as const },
+      text: "That doesn't look like an account"
+    }
+  ])('$description', async ({ result, text }) => {
+    vi.mocked(resolveAccountTarget).mockResolvedValue(result)
+
+    await renderPage({ uri: 'whatever' })
+
+    expect(screen.getByText(text)).toBeInTheDocument()
+    // The value came from a remote server, so it is shown as inert text.
+    expect(screen.queryByRole('link', { name: 'whatever' })).toBeNull()
+  })
+
+  it('renders the empty state without resolving when uri is missing', async () => {
+    await renderPage({})
+
+    expect(screen.getByText('Nothing to follow')).toBeInTheDocument()
+    expect(resolveAccountTarget).not.toHaveBeenCalled()
+    expect(redirect).not.toHaveBeenCalled()
+  })
+
+  it('uses the first value when uri repeats', async () => {
+    await renderPage({ uri: ['someone@remote.test', 'other@remote.test'] })
+
+    expect(resolveAccountTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ input: 'someone@remote.test' })
+    )
+  })
+
+  it('rejects an over long uri without resolving it', async () => {
+    await renderPage({ uri: `user@${'a'.repeat(4000)}.test` })
+
+    expect(screen.getByText('Nothing to follow')).toBeInTheDocument()
+    expect(resolveAccountTarget).not.toHaveBeenCalled()
+  })
+})

--- a/app/(nosidebar)/authorize_interaction/page.tsx
+++ b/app/(nosidebar)/authorize_interaction/page.tsx
@@ -1,0 +1,112 @@
+import { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { FC } from 'react'
+
+import { getBaseURL } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import {
+  ACCOUNT_TARGET_MAX_LENGTH,
+  resolveAccountTarget
+} from '@/lib/services/actors/resolveAccountTarget'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { AuthorizeInteractionCard } from './AuthorizeInteractionCard'
+import { AuthorizeInteractionError } from './AuthorizeInteractionError'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Follow',
+  // The URL carries text a remote server chose; there is nothing here worth
+  // indexing and every rendering of it is per-visitor.
+  robots: { index: false, follow: false }
+}
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+/**
+ * Mastodon-compatible remote-follow landing page. Other servers send a visitor
+ * here (via the `http://ostatus.org/schema/1.0/subscribe` WebFinger template,
+ * or by guessing this path) with the account they want to follow in `uri`.
+ */
+const Page: FC<Props> = async ({ searchParams }) => {
+  const database = getDatabase()
+  if (!database) throw new Error('Database is not available')
+
+  const rawUri = (await searchParams).uri
+  const uri = (Array.isArray(rawUri) ? rawUri[0] : rawUri)?.trim() ?? ''
+
+  if (!uri || uri.length > ACCOUNT_TARGET_MAX_LENGTH) {
+    return (
+      <AuthorizeInteractionError
+        title="Nothing to follow"
+        description="This link is missing the account to follow. Open it again from the other server, or search for the account here."
+      />
+    )
+  }
+
+  const session = await getServerAuthSession()
+  const currentActor = await getActorFromSession(database, session)
+
+  // Bounce before resolving anything, so an anonymous visitor can never drive
+  // an outbound fetch through this page.
+  if (!currentActor) {
+    // Keep the sign-in redirect on the host the request arrived on so a login
+    // started on a trusted alias domain is not bounced to ACTIVITIES_HOST;
+    // inherit only the scheme from getBaseURL(). Same rule as /oauth/authorize.
+    const requestHost = headerHost(await headers())
+    const { protocol } = new URL(getBaseURL())
+    const url = new URL('/auth/signin', `${protocol}//${requestHost}`)
+    // Encode the uri into redirectBack's value first: searchParams.append
+    // encodes the value once more, and the sign-in page decodes exactly once
+    // (searchParams.get), so a uri containing `&` survives the round trip.
+    url.searchParams.append(
+      'redirectBack',
+      `/authorize_interaction?uri=${encodeURIComponent(uri)}`
+    )
+    return redirect(url.toString())
+  }
+
+  const result = await resolveAccountTarget({ database, input: uri })
+
+  switch (result.type) {
+    case 'resolved':
+      return (
+        <AuthorizeInteractionCard
+          actor={result.actor}
+          isSelf={result.actor.id === currentActor.id}
+        />
+      )
+    case 'forbidden':
+      return (
+        <AuthorizeInteractionError
+          title="Can't reach that server"
+          description="This server does not federate with the server that account is on."
+          uri={uri}
+        />
+      )
+    case 'not-found':
+      return (
+        <AuthorizeInteractionError
+          title="Account not found"
+          description="We couldn't find that account. Only accounts can be opened from this page — a link to a single post won't work."
+          uri={uri}
+        />
+      )
+    default:
+      return (
+        <AuthorizeInteractionError
+          title="That doesn't look like an account"
+          description="Expected an address like username@example.com or a link to a profile."
+          uri={uri}
+        />
+      )
+  }
+}
+
+export default Page

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
@@ -29,6 +29,12 @@ vi.mock('@/lib/components/mute-action/mute-action', () => ({
   )
 }))
 
+vi.mock('@/lib/components/remote-follow/remote-follow-dialog', () => ({
+  RemoteFollowDialog: ({ targetHandle }: { targetHandle: string }) => (
+    <div data-testid="remote-follow-dialog">{targetHandle}</div>
+  )
+}))
+
 const relationship = (
   overrides: Partial<MastodonRelationship> = {}
 ): MastodonRelationship => ({
@@ -51,10 +57,43 @@ const relationship = (
 })
 
 describe('ProfileRelationshipActions', () => {
+  it('offers the remote follow dialog to a logged out visitor', () => {
+    render(
+      <ProfileRelationshipActions
+        targetActorId="https://llun.test/users/local"
+        targetHandle="local@llun.test"
+        isLoggedIn={false}
+        relationship={null}
+      />
+    )
+
+    expect(screen.getByTestId('remote-follow-dialog')).toHaveTextContent(
+      'local@llun.test'
+    )
+    expect(screen.queryByTestId('follow-action')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mute-action')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('block-action')).not.toBeInTheDocument()
+  })
+
+  it('does not offer the remote follow dialog to a signed in viewer', () => {
+    render(
+      <ProfileRelationshipActions
+        targetActorId="https://remote.test/users/open"
+        targetHandle="open@remote.test"
+        isLoggedIn
+        relationship={relationship()}
+      />
+    )
+
+    expect(screen.queryByTestId('remote-follow-dialog')).not.toBeInTheDocument()
+    expect(screen.getByTestId('follow-action')).toBeInTheDocument()
+  })
+
   it('hides the follow action when the current actor is blocking the profile actor', () => {
     render(
       <ProfileRelationshipActions
         targetActorId="https://remote.test/users/blocked"
+        targetHandle="blocked@remote.test"
         isLoggedIn
         relationship={relationship({ blocking: true })}
       />
@@ -71,6 +110,7 @@ describe('ProfileRelationshipActions', () => {
     render(
       <ProfileRelationshipActions
         targetActorId="https://remote.test/users/open"
+        targetHandle="open@remote.test"
         isLoggedIn
         relationship={relationship()}
       />

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
@@ -3,10 +3,12 @@ import { FC } from 'react'
 import { BlockAction } from '@/lib/components/block-action/block-action'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { MuteAction } from '@/lib/components/mute-action/mute-action'
+import { RemoteFollowDialog } from '@/lib/components/remote-follow/remote-follow-dialog'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 
 interface ProfileRelationshipActionsProps {
   targetActorId: string
+  targetHandle: string
   isLoggedIn: boolean
   relationship: MastodonRelationship | null
 }
@@ -17,28 +19,41 @@ export const isBlockedRelationship = (
 
 export const ProfileRelationshipActions: FC<
   ProfileRelationshipActionsProps
-> = ({ targetActorId, isLoggedIn, relationship }) => (
-  <div className="flex flex-wrap gap-2">
-    {!isBlockedRelationship(relationship) ? (
-      <>
-        <FollowAction
-          key={`follow-${targetActorId}`}
-          targetActorId={targetActorId}
-          isLoggedIn={isLoggedIn}
-        />
-        <MuteAction
-          key={`mute-${targetActorId}`}
-          targetActorId={targetActorId}
-          isLoggedIn={isLoggedIn}
-          initialRelationship={relationship}
-        />
-      </>
-    ) : null}
-    <BlockAction
-      key={`block-${targetActorId}`}
-      targetActorId={targetActorId}
-      isLoggedIn={isLoggedIn}
-      initialRelationship={relationship}
-    />
-  </div>
-)
+> = ({ targetActorId, targetHandle, isLoggedIn, relationship }) => {
+  // Every action below renders nothing without a session. A logged-out visitor
+  // gets the remote-follow dialog instead, so they can follow from their own
+  // server the way Mastodon offers.
+  if (!isLoggedIn) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <RemoteFollowDialog targetHandle={targetHandle} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {!isBlockedRelationship(relationship) ? (
+        <>
+          <FollowAction
+            key={`follow-${targetActorId}`}
+            targetActorId={targetActorId}
+            isLoggedIn={isLoggedIn}
+          />
+          <MuteAction
+            key={`mute-${targetActorId}`}
+            targetActorId={targetActorId}
+            isLoggedIn={isLoggedIn}
+            initialRelationship={relationship}
+          />
+        </>
+      ) : null}
+      <BlockAction
+        key={`block-${targetActorId}`}
+        targetActorId={targetActorId}
+        isLoggedIn={isLoggedIn}
+        initialRelationship={relationship}
+      />
+    </div>
+  )
+}

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -170,6 +170,7 @@ const Page: FC<Props> = async ({ params }) => {
             ) : (
               <ProfileRelationshipActions
                 targetActorId={person.id}
+                targetHandle={`${person.preferredUsername}@${actorDomain}`}
                 isLoggedIn={isLoggedIn}
                 relationship={relationship}
               />

--- a/app/api/v1/remote-follow/route.test.ts
+++ b/app/api/v1/remote-follow/route.test.ts
@@ -214,6 +214,21 @@ describe('GET /api/v1/remote-follow', () => {
     expect(getWebfingerSubscribeTemplate).not.toHaveBeenCalled()
   })
 
+  it('punycodes an internationalized domain before looking it up', async () => {
+    const response = await callRoute({
+      account: 'visitor@bücher.test',
+      target: 'local@llun.test'
+    })
+
+    expect(response.status).toEqual(200)
+    expect(getWebfingerSubscribeTemplate).toHaveBeenCalledWith({
+      account: 'visitor@xn--bcher-kva.test'
+    })
+    expect(await response.json()).toEqual({
+      url: 'https://xn--bcher-kva.test/authorize_interaction?uri=local%40llun.test'
+    })
+  })
+
   it('returns forbidden for a domain the instance does not federate with', async () => {
     vi.mocked(canFederateWithDomain).mockResolvedValue(false)
 

--- a/app/api/v1/remote-follow/route.test.ts
+++ b/app/api/v1/remote-follow/route.test.ts
@@ -1,0 +1,244 @@
+import { NextRequest } from 'next/server'
+
+import { Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+interface MockDatabase {
+  getActorFromUsername: ReturnType<typeof vi.fn>
+}
+
+let mockDatabase: MockDatabase | null = null
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('@/lib/activities/getWebfingerDocument', () => ({
+  getWebfingerSubscribeTemplate: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: vi.fn()
+}))
+
+const { getWebfingerSubscribeTemplate } = await vi.importMock<
+  typeof import('@/lib/activities/getWebfingerDocument')
+>('@/lib/activities/getWebfingerDocument')
+const { canFederateWithDomain } = await vi.importMock<
+  typeof import('@/lib/services/federation/domainPolicy')
+>('@/lib/services/federation/domainPolicy')
+
+const localActor = {
+  id: 'https://llun.test/users/local',
+  username: 'local',
+  domain: 'llun.test',
+  privateKey: 'private-key'
+} as Actor
+
+const callRoute = (params: Record<string, string>) => {
+  const url = new URL('https://llun.test/api/v1/remote-follow')
+  Object.entries(params).forEach(([key, value]) =>
+    url.searchParams.set(key, value)
+  )
+  return GET(new NextRequest(url), { params: Promise.resolve({}) })
+}
+
+describe('GET /api/v1/remote-follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase = {
+      getActorFromUsername: vi.fn().mockResolvedValue(localActor)
+    }
+    vi.mocked(canFederateWithDomain).mockResolvedValue(true)
+    vi.mocked(getWebfingerSubscribeTemplate).mockResolvedValue(null)
+  })
+
+  it('substitutes the local account into the advertised template', async () => {
+    vi.mocked(getWebfingerSubscribeTemplate).mockResolvedValue(
+      'https://remote.test/authorize_interaction?uri={uri}'
+    )
+
+    const response = await callRoute({
+      account: 'visitor@remote.test',
+      target: 'local@llun.test'
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({
+      url: 'https://remote.test/authorize_interaction?uri=local%40llun.test'
+    })
+    expect(getWebfingerSubscribeTemplate).toHaveBeenCalledWith({
+      account: 'visitor@remote.test'
+    })
+  })
+
+  it('substitutes into a template with a different path and extra params', async () => {
+    vi.mocked(getWebfingerSubscribeTemplate).mockResolvedValue(
+      'https://remote.test/ostatus_subscribe?acct={uri}&source=web'
+    )
+
+    const response = await callRoute({
+      account: 'visitor@remote.test',
+      target: 'local@llun.test'
+    })
+
+    expect(await response.json()).toEqual({
+      url: 'https://remote.test/ostatus_subscribe?acct=local%40llun.test&source=web'
+    })
+  })
+
+  it.each([
+    {
+      description: 'falls back when the server advertises no template',
+      template: null
+    },
+    {
+      description: 'falls back when the template has no uri placeholder',
+      template: 'https://remote.test/authorize_interaction'
+    },
+    {
+      description: 'falls back when the template is not https',
+      template: 'javascript:alert({uri})'
+    },
+    {
+      description: 'falls back when the template carries credentials',
+      template: 'https://user:pass@remote.test/authorize?uri={uri}'
+    }
+  ])('$description', async ({ template }) => {
+    vi.mocked(getWebfingerSubscribeTemplate).mockResolvedValue(template)
+
+    const response = await callRoute({
+      account: 'visitor@remote.test',
+      target: 'local@llun.test'
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({
+      url: 'https://remote.test/authorize_interaction?uri=local%40llun.test'
+    })
+  })
+
+  it('skips the webfinger lookup for a bare domain', async () => {
+    const response = await callRoute({
+      account: 'remote.test',
+      target: 'local@llun.test'
+    })
+
+    expect(await response.json()).toEqual({
+      url: 'https://remote.test/authorize_interaction?uri=local%40llun.test'
+    })
+    expect(getWebfingerSubscribeTemplate).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'accepts a leading at sign',
+      account: '@visitor@remote.test'
+    },
+    { description: 'accepts an acct uri', account: 'acct:visitor@remote.test' }
+  ])('$description', async ({ account }) => {
+    const response = await callRoute({ account, target: 'local@llun.test' })
+
+    expect(response.status).toEqual(200)
+    expect(getWebfingerSubscribeTemplate).toHaveBeenCalledWith({
+      account: 'visitor@remote.test'
+    })
+  })
+
+  it.each([
+    {
+      description: 'rejects a missing account',
+      params: { target: 'local@llun.test' }
+    },
+    {
+      description: 'rejects a missing target',
+      params: { account: 'visitor@remote.test' }
+    },
+    {
+      description: 'rejects an empty account',
+      params: { account: '   ', target: 'local@llun.test' }
+    },
+    {
+      description: 'rejects an over long account',
+      params: {
+        account: `visitor@${'a'.repeat(400)}.test`,
+        target: 'local@llun.test'
+      }
+    },
+    {
+      description: 'rejects a domain carrying a path',
+      params: { account: 'remote.test/evil', target: 'local@llun.test' }
+    },
+    {
+      description: 'rejects a domain carrying credentials',
+      params: { account: 'user:pass@remote.test', target: 'local@llun.test' }
+    },
+    {
+      description: 'rejects a single label domain',
+      params: { account: 'localhost', target: 'local@llun.test' }
+    },
+    {
+      description: 'rejects a malformed target',
+      params: { account: 'visitor@remote.test', target: 'not-a-handle' }
+    }
+  ])('$description', async ({ params }) => {
+    const response = await callRoute(params as Record<string, string>)
+
+    expect(response.status).toEqual(400)
+  })
+
+  it('returns not found when the target is not hosted here', async () => {
+    mockDatabase?.getActorFromUsername.mockResolvedValue(null)
+
+    const response = await callRoute({
+      account: 'visitor@remote.test',
+      target: 'someone@elsewhere.test'
+    })
+
+    expect(response.status).toEqual(404)
+  })
+
+  it('returns not found when the target is a remote actor cached here', async () => {
+    mockDatabase?.getActorFromUsername.mockResolvedValue({
+      ...localActor,
+      privateKey: undefined
+    })
+
+    const response = await callRoute({
+      account: 'visitor@remote.test',
+      target: 'someone@remote.test'
+    })
+
+    expect(response.status).toEqual(404)
+    expect(getWebfingerSubscribeTemplate).not.toHaveBeenCalled()
+  })
+
+  it('returns forbidden for a domain the instance does not federate with', async () => {
+    vi.mocked(canFederateWithDomain).mockResolvedValue(false)
+
+    const response = await callRoute({
+      account: 'visitor@blocked.test',
+      target: 'local@llun.test'
+    })
+
+    expect(response.status).toEqual(403)
+    expect(getWebfingerSubscribeTemplate).not.toHaveBeenCalled()
+  })
+
+  it('uses the stored actor casing for the substituted account', async () => {
+    mockDatabase?.getActorFromUsername.mockResolvedValue({
+      ...localActor,
+      username: 'Local'
+    })
+
+    const response = await callRoute({
+      account: 'remote.test',
+      target: 'local@llun.test'
+    })
+
+    expect(await response.json()).toEqual({
+      url: 'https://remote.test/authorize_interaction?uri=Local%40llun.test'
+    })
+  })
+})

--- a/app/api/v1/remote-follow/route.ts
+++ b/app/api/v1/remote-follow/route.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod'
+
+import { getWebfingerSubscribeTemplate } from '@/lib/activities/getWebfingerDocument'
+import { getDatabase } from '@/lib/database'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { parseAccountHandle, stripAcctPrefix } from '@/lib/utils/accountHandle'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const ALLOWED_METHODS = [HttpMethod.enum.GET]
+
+// Longest sensible address; also the cap on the URL this route hands back.
+const MAX_ACCOUNT_LENGTH = 320
+const MAX_RESULT_URL_LENGTH = 2048
+
+const RemoteFollowQuery = z.object({
+  // The visitor's own account: `user@domain`, `@user@domain`, `acct:user@domain`
+  // or a bare `domain`.
+  account: z.string().trim().min(1).max(MAX_ACCOUNT_LENGTH),
+  // The local account they want to follow, as `user@domain`.
+  target: z.string().trim().min(1).max(MAX_ACCOUNT_LENGTH)
+})
+
+// Conservative superset of what fediverse software allows in a local
+// username. The visitor's username goes straight into an outbound `acct:`
+// resource, so anything outside this set (`user:pass`, a slash, a control
+// character) is rejected rather than looked up.
+const USERNAME_PATTERN = /^[a-zA-Z0-9._-]+$/
+
+const buildFallbackTemplate = (domain: string) =>
+  `https://${domain}/authorize_interaction?uri={uri}`
+
+// Accepts a bare hostname only — no credentials, path, query or fragment — so
+// the domain that ends up in the redirect cannot smuggle anything else in.
+const parseBareDomain = (value: string): string | null => {
+  try {
+    const url = new URL(`https://${value}`)
+    if (
+      url.username ||
+      url.password ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash ||
+      !url.hostname.includes('.')
+    ) {
+      return null
+    }
+    return url.host
+  } catch {
+    return null
+  }
+}
+
+const isUsableRedirectUrl = (value: string) => {
+  if (value.length > MAX_RESULT_URL_LENGTH) return false
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && !url.username && !url.password
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolves where to send a logged-out visitor so they can follow a local
+ * account from their own server — the outbound half of the fediverse
+ * remote-follow handshake.
+ *
+ * Deliberately unauthenticated: the whole feature exists for visitors with no
+ * account here. It is a read-only GET that changes no state, and the abuse
+ * surface (one outbound WebFinger request to a user-supplied domain) is bounded
+ * by strict syntax validation, the instance's federation policy, the
+ * retry-disabled request helper's timeouts and body cap, and the requirement
+ * that `target` name an actor this server actually hosts — so it cannot be
+ * repurposed into a general-purpose URL builder or redirector for third
+ * parties. This instance has no inbound rate-limit layer; operators should
+ * rate-limit at the reverse proxy.
+ */
+export const GET = traceApiRoute('remoteFollow', async (req) => {
+  const database = getDatabase()
+  if (!database) return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+
+  const query = RemoteFollowQuery.safeParse(
+    Object.fromEntries(new URL(req.url).searchParams)
+  )
+  if (!query.success) return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+
+  // The followed account must be one of ours. This is what keeps the endpoint
+  // from building arbitrary third-party URLs.
+  const targetHandle = parseAccountHandle(stripAcctPrefix(query.data.target))
+  if (!targetHandle) return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+
+  const targetActor = await database.getActorFromUsername({
+    username: targetHandle.username,
+    domain: targetHandle.domain
+  })
+  if (!targetActor?.privateKey) return apiErrorResponse(HTTP_STATUS.NOT_FOUND)
+
+  const account = stripAcctPrefix(query.data.account)
+  const visitorHandle = account.includes('@')
+    ? parseAccountHandle(account)
+    : null
+  if (visitorHandle && !USERNAME_PATTERN.test(visitorHandle.username)) {
+    return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const visitorDomain = visitorHandle
+    ? visitorHandle.domain
+    : parseBareDomain(account)
+  if (!visitorDomain) return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+
+  // A handle's domain has not been through the URL parser, so hold it to the
+  // same bare-hostname rule as the domain-only form.
+  if (
+    visitorHandle &&
+    parseBareDomain(visitorHandle.domain) !== visitorDomain
+  ) {
+    return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+  }
+
+  if (!(await canFederateWithDomain(database, visitorDomain))) {
+    return apiErrorResponse(HTTP_STATUS.FORBIDDEN)
+  }
+
+  // A bare domain has no account to look up, so go straight to the
+  // conventional path. Any lookup failure degrades to the same fallback rather
+  // than failing the request — Mastodon behaves identically.
+  const advertisedTemplate = visitorHandle
+    ? await getWebfingerSubscribeTemplate({
+        account: `${visitorHandle.username}@${visitorHandle.domain}`
+      })
+    : null
+
+  const fallbackTemplate = buildFallbackTemplate(visitorDomain)
+  const template =
+    advertisedTemplate && advertisedTemplate.includes('{uri}')
+      ? advertisedTemplate
+      : fallbackTemplate
+
+  // Substitute the bare acct rather than a profile URL: it is what the
+  // receiving server WebFingers, so it resolves regardless of that server's
+  // content negotiation or which alias domain served this page.
+  const targetAcct = `${targetActor.username}@${targetActor.domain}`
+  const url = template.replace('{uri}', encodeURIComponent(targetAcct))
+
+  return apiResponse({
+    req,
+    allowedMethods: ALLOWED_METHODS,
+    data: {
+      url: isUsableRedirectUrl(url)
+        ? url
+        : fallbackTemplate.replace('{uri}', encodeURIComponent(targetAcct))
+    }
+  })
+})

--- a/app/api/v1/remote-follow/route.ts
+++ b/app/api/v1/remote-follow/route.ts
@@ -109,19 +109,16 @@ export const GET = traceApiRoute('remoteFollow', async (req) => {
     return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
   }
 
-  const visitorDomain = visitorHandle
-    ? visitorHandle.domain
-    : parseBareDomain(account)
+  // Both forms go through parseBareDomain, so a handle's domain is held to the
+  // same bare-hostname rule as the domain-only form — and both come back in the
+  // parser's normalized form, which is what makes an internationalized domain
+  // usable: the URL parser punycodes `bücher.test` to `xn--bcher-kva.test`,
+  // matching what the remote server actually serves and what its `acct:`
+  // resource is spelled with.
+  const visitorDomain = parseBareDomain(
+    visitorHandle ? visitorHandle.domain : account
+  )
   if (!visitorDomain) return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
-
-  // A handle's domain has not been through the URL parser, so hold it to the
-  // same bare-hostname rule as the domain-only form.
-  if (
-    visitorHandle &&
-    parseBareDomain(visitorHandle.domain) !== visitorDomain
-  ) {
-    return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
-  }
 
   if (!(await canFederateWithDomain(database, visitorDomain))) {
     return apiErrorResponse(HTTP_STATUS.FORBIDDEN)
@@ -132,7 +129,7 @@ export const GET = traceApiRoute('remoteFollow', async (req) => {
   // than failing the request — Mastodon behaves identically.
   const advertisedTemplate = visitorHandle
     ? await getWebfingerSubscribeTemplate({
-        account: `${visitorHandle.username}@${visitorHandle.domain}`
+        account: `${visitorHandle.username}@${visitorDomain}`
       })
     : null
 

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -28,7 +28,10 @@ import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
-import { parseAccountHandle } from '@/lib/utils/accountHandle'
+import {
+  parseAccountHandle,
+  parseProfileUrlAccountHandle
+} from '@/lib/utils/accountHandle'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -151,22 +154,6 @@ const normalizeStatusLookupId = async (
   value?: string | null
 ) => (await resolveSearchStatusId(database, value)) ?? ''
 
-const getProfileUrlAccountHandle = (query: string) => {
-  try {
-    const url = new URL(query)
-    const match = /^\/@([^/]+)\/?$/.exec(url.pathname)
-    if (!match) return null
-
-    const profileHandle = decodeURIComponent(match[1])
-    const handle = profileHandle.includes('@')
-      ? `@${profileHandle.replace(/^@/, '')}`
-      : `@${profileHandle}@${url.hostname}`
-    return parseAccountHandle(handle)
-  } catch {
-    return null
-  }
-}
-
 const getCanonicalAccountActorId = async ({
   query,
   signingActor
@@ -174,7 +161,7 @@ const getCanonicalAccountActorId = async ({
   query: string
   signingActor?: Actor
 }) => {
-  const handle = getProfileUrlAccountHandle(query)
+  const handle = parseProfileUrlAccountHandle(query)
   if (!handle) {
     const person = await getActorPerson({
       actorId: query,

--- a/app/api/well-known/webfinger/route.test.ts
+++ b/app/api/well-known/webfinger/route.test.ts
@@ -47,6 +47,12 @@ describe('GET /api/well-known/webfinger', () => {
       subject: 'acct:test@example.com',
       aliases: ['https://example.com/@test', 'https://example.com/users/test']
     })
+    expect(data.links).toContainEqual(
+      expect.objectContaining({
+        rel: 'http://ostatus.org/schema/1.0/subscribe',
+        template: 'https://test.llun.dev/authorize_interaction?uri={uri}'
+      })
+    )
   })
 
   it('returns WebFinger JRD for the headless instance actor without a profile page link', async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,8 @@ The server implements the [ActivityPub](https://www.w3.org/TR/activitypub/) prot
 
 - **Inbox** (`/api/inbox`, `/api/users/:username/inbox`) — Receives activities from remote servers
 - **Outbox** (`/api/users/:username/outbox`) — Lists activities by a local actor
-- **WebFinger** (`/.well-known/webfinger`) — Actor discovery
+- **WebFinger** (`/.well-known/webfinger`) — Actor discovery, including the `http://ostatus.org/schema/1.0/subscribe` template that points remote-follow visitors at `/authorize_interaction`
+- **Remote follow** (`/authorize_interaction?uri=…`) — Mastodon-compatible landing page where a signed-in local user confirms following an account another server sent them to; the outbound half (a logged-out visitor following a local account from their own server) resolves through `GET /api/v1/remote-follow`
 - **NodeInfo** (`/.well-known/nodeinfo`) — Instance metadata
 - **HTTP Signatures** — All outgoing requests are signed; incoming requests are verified
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -89,7 +89,8 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Trends** — local trending hashtags via `GET /api/v1/trends/tags` (plus deprecated `GET /api/v1/trends`) and trending statuses via `GET /api/v1/trends/statuses`, both computed live from the last seven days of public local activity; `GET /api/v1/trends/links` intentionally stays an empty list (no preview-card storage)
 - ✅ **Followed hashtags** — Follow and unfollow hashtags and view a followed-tags timeline
 - ✅ **Mutes** — Mute and unmute accounts
-- ✅ **WebFinger** — Actor discovery via `/.well-known/webfinger`
+- ✅ **WebFinger** — Actor discovery via `/.well-known/webfinger`, including the `http://ostatus.org/schema/1.0/subscribe` remote-follow template
+- ✅ **Remote follow** — Both directions of the fediverse remote-follow handshake: `/authorize_interaction?uri=…` lets a signed-in local user follow an account another server sent them to, and a logged-out visitor viewing a local profile can enter their own handle to be redirected to their home server's follow page (resolved server-side via `GET /api/v1/remote-follow`)
 - ✅ **NodeInfo** — Instance metadata at `/.well-known/nodeinfo`
 - ✅ **OAuth Authorization Server metadata** — At `/.well-known/oauth-authorization-server`
 - ✅ **Instance legal documents** — Admin-configured plain-text pages via `GET /api/v1/instance/privacy_policy` and `GET /api/v1/instance/terms_of_service` (plus `GET /api/v1/instance/terms_of_service/:date`), backed by the optional `ACTIVITIES_PRIVACY_POLICY` / `ACTIVITIES_TERMS_OF_SERVICE` config keys; each returns 404 when its document is unset

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -253,6 +253,17 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
 - **Presigned / direct-to-storage media** — `/api/v1/medias/presigned` (and the
   Strava archive presigned upload) provide an asynchronous upload path that
   offloads bytes directly to object storage.
+- **Remote-follow resolution** — `GET /api/v1/remote-follow?account=…&target=…`
+  resolves where to send a logged-out visitor so they can follow a local account
+  (`target`, a local `user@domain`) from their own server (`account`, their
+  handle or bare domain). It answers `{ "url": "…" }` built from the remote
+  server's advertised `http://ostatus.org/schema/1.0/subscribe` template,
+  falling back to Mastodon's conventional `/authorize_interaction?uri={uri}`
+  path when that server advertises none. Deliberately unauthenticated — the
+  feature exists for visitors with no account here — and read-only; `target`
+  must name an actor this instance hosts. The inbound half is the
+  Mastodon-compatible `/authorize_interaction` **page** (not an API endpoint),
+  which this instance advertises in its own WebFinger document.
 - **Curated collections** — `/api/v1/collections/*`, `/api/v1/accounts/:id/collections`,
   `/api/v1/accounts/:id/in_collections`, and `/api/v1/timelines/collection/:id`
   back the shareable public-feed feature, which federates as FEP-7aa9

--- a/lib/activities/getWebfingerDocument.test.ts
+++ b/lib/activities/getWebfingerDocument.test.ts
@@ -1,0 +1,135 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { mockRequests } from '@/lib/stub/activities'
+import { MockWebfinger } from '@/lib/stub/webfinger'
+
+import {
+  getWebfingerDocument,
+  getWebfingerSubscribeTemplate
+} from './getWebfingerDocument'
+
+enableFetchMocks()
+
+describe('getWebfingerDocument', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockRequests(fetchMock)
+  })
+
+  it('returns the whole document including links', async () => {
+    const document = await getWebfingerDocument({ account: 'test1@llun.test' })
+
+    expect(document?.subject).toEqual('acct:test1@llun.test')
+    expect(document?.links).toContainEqual(
+      expect.objectContaining({
+        rel: 'self',
+        href: 'https://llun.test/users/test1'
+      })
+    )
+  })
+
+  it('requests a JRD response using an encoded acct resource', async () => {
+    await getWebfingerDocument({ account: 'test1@llun.test' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://llun.test/.well-known/webfinger?resource=acct%3Atest1%40llun.test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/jrd+json, application/json'
+        })
+      })
+    )
+  })
+
+  it('returns null for a not found account', async () => {
+    expect(
+      await getWebfingerDocument({ account: 'notexist@llun.test' })
+    ).toBeNull()
+  })
+
+  it('returns null for malformed json', async () => {
+    fetchMock.resetMocks()
+    fetchMock.mockResponseOnce('not json at all')
+
+    expect(
+      await getWebfingerDocument({ account: 'user@remote.test' })
+    ).toBeNull()
+  })
+
+  it('returns null when the document does not match the schema', async () => {
+    fetchMock.resetMocks()
+    fetchMock.mockResponseOnce(JSON.stringify({ unexpected: true }))
+
+    expect(
+      await getWebfingerDocument({ account: 'user@remote.test' })
+    ).toBeNull()
+  })
+
+  it('does not request malformed account names', async () => {
+    const document = await getWebfingerDocument({
+      account: 'user@example.com@evil.test'
+    })
+
+    expect(document).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getWebfingerSubscribeTemplate', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('returns the advertised subscribe template', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        MockWebfinger({
+          account: 'user@remote.test',
+          includeSubscribeLink: true
+        })
+      )
+    )
+
+    expect(
+      await getWebfingerSubscribeTemplate({ account: 'user@remote.test' })
+    ).toEqual('https://remote.test/authorize_interaction?uri={uri}')
+  })
+
+  it('returns null when the server advertises no subscribe rel', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify(MockWebfinger({ account: 'user@remote.test' }))
+    )
+
+    expect(
+      await getWebfingerSubscribeTemplate({ account: 'user@remote.test' })
+    ).toBeNull()
+  })
+
+  it('returns null when the subscribe link carries no template', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        MockWebfinger({
+          account: 'user@remote.test',
+          links: [
+            {
+              rel: 'http://ostatus.org/schema/1.0/subscribe',
+              href: 'https://remote.test/authorize_interaction'
+            }
+          ]
+        })
+      )
+    )
+
+    expect(
+      await getWebfingerSubscribeTemplate({ account: 'user@remote.test' })
+    ).toBeNull()
+  })
+
+  it('returns null when the lookup fails', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 })
+
+    expect(
+      await getWebfingerSubscribeTemplate({ account: 'user@remote.test' })
+    ).toBeNull()
+  })
+})

--- a/lib/activities/getWebfingerDocument.ts
+++ b/lib/activities/getWebfingerDocument.ts
@@ -1,0 +1,77 @@
+import { WebFinger } from '@/lib/types/activitypub/webfinger'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+import { getTracer } from '@/lib/utils/trace'
+
+// Standard OStatus rel carrying the URL template a server wants remote-follow
+// visitors sent to. Mirrors REMOTE_FOLLOW_SUBSCRIBE_REL on the serving side.
+export const SUBSCRIBE_REL = 'http://ostatus.org/schema/1.0/subscribe'
+
+/**
+ * Fetches a remote WebFinger document whole, unlike `getWebfingerSelf` which
+ * keeps only the `self` link. Retries are disabled: the caller is an
+ * unauthenticated interactive endpoint, so a slow or dead remote must cost one
+ * bounded request rather than several.
+ */
+export const getWebfingerDocument = async ({
+  account
+}: {
+  account: string
+}): Promise<WebFinger | null> =>
+  getTracer().startActiveSpan(
+    'activities.getWebfingerDocument',
+    { attributes: { account } },
+    async (span) => {
+      const [user, domain, ...rest] = account.split('@')
+      if (!user || !domain || rest.length > 0) {
+        span.end()
+        return null
+      }
+
+      try {
+        const url = new URL(`https://${domain}/.well-known/webfinger`)
+        url.searchParams.set('resource', `acct:${account}`)
+
+        const { statusCode, body } = await request({
+          url: url.toString(),
+          headers: {
+            Accept: 'application/jrd+json, application/json'
+          },
+          numberOfRetry: 0
+        })
+        if (statusCode !== 200) return null
+
+        const parsed = WebFinger.safeParse(JSON.parse(body))
+        return parsed.success ? parsed.data : null
+      } catch (error) {
+        span.recordException(error as Error)
+        logger.warn({
+          message: 'Failed to fetch webfinger document',
+          account,
+          err: toLoggableError(error)
+        })
+        return null
+      } finally {
+        span.end()
+      }
+    }
+  )
+
+/**
+ * Reads the remote-follow URL template a server advertises, or null when it
+ * advertises none (callers fall back to Mastodon's conventional path).
+ */
+export const getWebfingerSubscribeTemplate = async ({
+  account
+}: {
+  account: string
+}): Promise<string | null> => {
+  const document = await getWebfingerDocument({ account })
+  if (!document) return null
+
+  const link = document.links.find(
+    (item) => item.rel === SUBSCRIBE_REL && 'template' in item
+  )
+  return link && 'template' in link ? link.template : null
+}

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -4778,3 +4778,34 @@ export const assignAdminReportToSelf = adminReportAction('assign_to_self')
 export const unassignAdminReport = adminReportAction('unassign')
 export const resolveAdminReport = adminReportAction('resolve')
 export const reopenAdminReport = adminReportAction('reopen')
+
+/**
+ * Resolves where to send a logged-out visitor so they can follow a local
+ * account from their own fediverse server. The lookup runs server-side (the
+ * visitor's WebFinger document is not readable from the browser), and the
+ * returned URL is always absolute and https.
+ */
+export const getRemoteFollowUrl = async ({
+  account,
+  target
+}: {
+  account: string
+  target: string
+}): Promise<string> => {
+  const params = new URLSearchParams({ account, target })
+  const response = await fetch(`/api/v1/remote-follow?${params.toString()}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) {
+    await throwApiError(response, 'Unable to reach that server')
+  }
+
+  const data = await response.json()
+  if (typeof data?.url !== 'string') {
+    throw new Error('Unable to reach that server')
+  }
+  return data.url
+}

--- a/lib/components/remote-follow/remote-follow-dialog.test.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.test.tsx
@@ -179,6 +179,118 @@ describe('RemoteFollowDialog', () => {
     expect(screen.getByRole('button', { name: 'Go' })).toBeEnabled()
   })
 
+  it('does not navigate when a dismissed lookup settles after the dialog is reopened', async () => {
+    // Reopening to retry is the natural next move after giving up, and it must
+    // not revive the lookup that was walked away from.
+    let resolveLookup: (url: string) => void = () => undefined
+    getRemoteFollowUrlMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveLookup = resolve
+      })
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    openDialog()
+    await screen.findByLabelText('Your address')
+
+    await act(async () => {
+      resolveLookup('https://abandoned.test/authorize_interaction?uri=x')
+    })
+
+    expect(assign).not.toHaveBeenCalled()
+    expect(
+      window.localStorage.getItem('activities.remote-follow-account')
+    ).toBeNull()
+  })
+
+  it('sends the visitor to the retried address, not the abandoned one', async () => {
+    const settle: Record<string, (url: string) => void> = {}
+    getRemoteFollowUrlMock.mockImplementation(
+      ({ account }: { account: string }) =>
+        new Promise<string>((resolve) => {
+          settle[account] = resolve
+        })
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('typo@wrong.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    openDialog()
+    await typeAddress('visitor@correct.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+
+    // The abandoned lookup finishes first and must lose.
+    await act(async () => {
+      settle['typo@wrong.test'](
+        'https://wrong.test/authorize_interaction?uri=x'
+      )
+    })
+    expect(assign).not.toHaveBeenCalled()
+
+    await act(async () => {
+      settle['visitor@correct.test'](
+        'https://correct.test/authorize_interaction?uri=x'
+      )
+    })
+    expect(assign).toHaveBeenCalledExactlyOnceWith(
+      'https://correct.test/authorize_interaction?uri=x'
+    )
+    expect(
+      window.localStorage.getItem('activities.remote-follow-account')
+    ).toEqual('visitor@correct.test')
+  })
+
+  it('does not show an error from a superseded lookup', async () => {
+    const settle: Record<string, (error: Error) => void> = {}
+    getRemoteFollowUrlMock.mockImplementation(
+      ({ account }: { account: string }) =>
+        new Promise<string>((_resolve, reject) => {
+          settle[account] = reject
+        })
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('typo@wrong.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    openDialog()
+    await typeAddress('visitor@correct.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+
+    await act(async () => {
+      settle['typo@wrong.test'](new Error('Unable to reach that server'))
+    })
+
+    expect(screen.queryByText('Unable to reach that server')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Redirecting...' })
+    ).toBeDisabled()
+  })
+
   it('prefills a remembered address', async () => {
     window.localStorage.setItem(
       'activities.remote-follow-account',

--- a/lib/components/remote-follow/remote-follow-dialog.test.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { getRemoteFollowUrl } from '@/lib/client'
 
@@ -122,6 +122,61 @@ describe('RemoteFollowDialog', () => {
         window.localStorage.getItem('activities.remote-follow-account')
       ).toEqual('visitor@remote.test')
     })
+  })
+
+  it('does not navigate when the dialog is dismissed while the lookup is in flight', async () => {
+    let resolveLookup: (url: string) => void = () => undefined
+    getRemoteFollowUrlMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveLookup = resolve
+      })
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+
+    // Escape is reachable even while Cancel is disabled, and the lookup
+    // resolves to a URL even when the remote server never answers.
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveLookup('https://remote.test/authorize_interaction?uri=x')
+    })
+
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('leaves the form usable after a dismissed lookup resolves', async () => {
+    let resolveLookup: (url: string) => void = () => undefined
+    getRemoteFollowUrlMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveLookup = resolve
+      })
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    await act(async () => {
+      resolveLookup('https://remote.test/authorize_interaction?uri=x')
+    })
+
+    openDialog()
+
+    expect(await screen.findByLabelText('Your address')).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Go' })).toBeEnabled()
   })
 
   it('prefills a remembered address', async () => {

--- a/lib/components/remote-follow/remote-follow-dialog.test.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { getRemoteFollowUrl } from '@/lib/client'
+
+import { RemoteFollowDialog } from './remote-follow-dialog'
+
+vi.mock('@/lib/client', () => ({
+  getRemoteFollowUrl: vi.fn()
+}))
+
+const assign = vi.fn()
+
+beforeAll(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, assign }
+  })
+})
+
+const openDialog = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Follow' }))
+
+const typeAddress = async (value: string) => {
+  const input = await screen.findByLabelText('Your address')
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: 'Go' }))
+
+describe('RemoteFollowDialog', () => {
+  const getRemoteFollowUrlMock = getRemoteFollowUrl as jest.Mock
+
+  beforeEach(() => {
+    getRemoteFollowUrlMock.mockReset()
+    assign.mockReset()
+    window.localStorage.clear()
+    getRemoteFollowUrlMock.mockResolvedValue(
+      'https://remote.test/authorize_interaction?uri=local%40llun.test'
+    )
+  })
+
+  it('sends the visitor to the url the server resolves', async () => {
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+
+    await waitFor(() => {
+      expect(getRemoteFollowUrlMock).toHaveBeenCalledWith({
+        account: 'visitor@remote.test',
+        target: 'local@llun.test'
+      })
+    })
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith(
+        'https://remote.test/authorize_interaction?uri=local%40llun.test'
+      )
+    })
+  })
+
+  it('trims the typed address before sending it', async () => {
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('  visitor@remote.test  ')
+    submit()
+
+    await waitFor(() => {
+      expect(getRemoteFollowUrlMock).toHaveBeenCalledWith({
+        account: 'visitor@remote.test',
+        target: 'local@llun.test'
+      })
+    })
+  })
+
+  it('shows the failure message and stays put when the lookup fails', async () => {
+    getRemoteFollowUrlMock.mockRejectedValue(
+      new Error('Unable to reach that server')
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+
+    expect(
+      await screen.findByText('Unable to reach that server')
+    ).toBeInTheDocument()
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('rejects an address containing whitespace without calling the server', async () => {
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor name@remote.test')
+    submit()
+
+    expect(
+      await screen.findByText(
+        'Enter your address, for example username@mastodon.social'
+      )
+    ).toBeInTheDocument()
+    expect(getRemoteFollowUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('remembers the address for the next visit', async () => {
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem('activities.remote-follow-account')
+      ).toEqual('visitor@remote.test')
+    })
+  })
+
+  it('prefills a remembered address', async () => {
+    window.localStorage.setItem(
+      'activities.remote-follow-account',
+      'visitor@remote.test'
+    )
+    render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    expect(await screen.findByLabelText('Your address')).toHaveValue(
+      'visitor@remote.test'
+    )
+  })
+})

--- a/lib/components/remote-follow/remote-follow-dialog.test.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.test.tsx
@@ -291,6 +291,30 @@ describe('RemoteFollowDialog', () => {
     ).toBeDisabled()
   })
 
+  it('does not navigate when the page is left while the lookup is in flight', async () => {
+    // Radix pushes no history entry, so a browser or Android system Back
+    // unmounts this without ever closing the dialog.
+    let resolveLookup: (url: string) => void = () => undefined
+    getRemoteFollowUrlMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveLookup = resolve
+      })
+    )
+    const view = render(<RemoteFollowDialog targetHandle="local@llun.test" />)
+    openDialog()
+
+    await typeAddress('visitor@remote.test')
+    submit()
+    await screen.findByRole('button', { name: 'Redirecting...' })
+
+    view.unmount()
+    await act(async () => {
+      resolveLookup('https://abandoned.test/authorize_interaction?uri=x')
+    })
+
+    expect(assign).not.toHaveBeenCalled()
+  })
+
   it('prefills a remembered address', async () => {
     window.localStorage.setItem(
       'activities.remote-follow-account',

--- a/lib/components/remote-follow/remote-follow-dialog.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { FC, FormEvent, useState } from 'react'
+
+import { getRemoteFollowUrl } from '@/lib/client'
+import { Button } from '@/lib/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/lib/components/ui/dialog'
+import { Input } from '@/lib/components/ui/input'
+import { Label } from '@/lib/components/ui/label'
+
+const REMOTE_FOLLOW_ACCOUNT_KEY = 'activities.remote-follow-account'
+const MAX_ACCOUNT_LENGTH = 320
+
+const readRememberedAccount = () => {
+  if (typeof window === 'undefined') return ''
+  try {
+    return window.localStorage.getItem(REMOTE_FOLLOW_ACCOUNT_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+const rememberAccount = (account: string) => {
+  try {
+    window.localStorage.setItem(REMOTE_FOLLOW_ACCOUNT_KEY, account)
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies); remembering
+    // the handle is a convenience, never a requirement.
+  }
+}
+
+interface RemoteFollowDialogProps {
+  targetHandle: string
+}
+
+/**
+ * The logged-out Follow affordance: a visitor with an account on another
+ * fediverse server types their own handle, and we send them to their home
+ * server's remote-follow page with this account pre-filled.
+ */
+export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
+  targetHandle
+}) => {
+  const [open, setOpen] = useState(false)
+  const [account, setAccount] = useState(readRememberedAccount)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setError(null)
+    setOpen(nextOpen)
+  }
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedAccount = account.trim()
+    if (!trimmedAccount || /\s/.test(trimmedAccount)) {
+      setError('Enter your address, for example username@mastodon.social')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const url = await getRemoteFollowUrl({
+        account: trimmedAccount,
+        target: targetHandle
+      })
+      rememberAccount(trimmedAccount)
+      window.location.assign(url)
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : 'Unable to reach that server'
+      )
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="flex-shrink-0">
+        <Button type="button" onClick={() => handleOpenChange(true)}>
+          Follow
+        </Button>
+      </div>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Follow @{targetHandle}</DialogTitle>
+            <DialogDescription>
+              To follow this account, sign in to your account on whatever
+              fediverse server you use. Enter your address and we&apos;ll send
+              you there.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-2 py-4">
+              <Label htmlFor="remote-follow-account">Your address</Label>
+              <Input
+                id="remote-follow-account"
+                autoFocus
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                maxLength={MAX_ACCOUNT_LENGTH}
+                placeholder="E.g. username@mastodon.social"
+                value={account}
+                disabled={isLoading}
+                onChange={(event) => setAccount(event.target.value)}
+              />
+              {error ? (
+                <p className="text-sm text-destructive">{error}</p>
+              ) : null}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isLoading || !account.trim()}>
+                {isLoading ? 'Redirecting...' : 'Go'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/lib/components/remote-follow/remote-follow-dialog.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, FormEvent, useRef, useState } from 'react'
+import { FC, FormEvent, useEffect, useRef, useState } from 'react'
 
 import { getRemoteFollowUrl } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
@@ -64,6 +64,17 @@ export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
   // on open is un-set by the visitor simply reopening the dialog to retry,
   // which put the abandoned navigation right back.
   const attemptRef = useRef(0)
+
+  // Leaving the page abandons the lookup too. Radix does not push a history
+  // entry, so a browser or Android system Back unmounts this without ever
+  // closing the dialog — an abandonment the visitor means exactly as much as
+  // Escape, and the only one that could still navigate them.
+  useEffect(
+    () => () => {
+      attemptRef.current += 1
+    },
+    []
+  )
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {

--- a/lib/components/remote-follow/remote-follow-dialog.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.tsx
@@ -52,16 +52,22 @@ export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
   const [account, setAccount] = useState(readRememberedAccount)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  // Closing the dialog abandons whatever lookup is in flight. The lookup can
-  // take as long as the outbound WebFinger request's timeout, and it resolves
-  // to a URL even when that request fails (the route degrades to the
-  // conventional path), so without this a visitor who gave up and dismissed
-  // the dialog was navigated off the page seconds later anyway.
-  const abandonedRef = useRef(false)
+  // Identifies the one lookup whose result still matters. Closing the dialog
+  // or starting another lookup bumps it, and a settling request compares the
+  // token it captured before acting — so a result the visitor walked away from
+  // can neither navigate them nor write an error into the dialog.
+  //
+  // This has to be a token rather than a boolean flag: the lookup can run for
+  // as long as the outbound WebFinger timeout and it RESOLVES even when that
+  // request fails (the route degrades to the conventional path), so an
+  // abandoned attempt always settles into a usable URL later. A flag cleared
+  // on open is un-set by the visitor simply reopening the dialog to retry,
+  // which put the abandoned navigation right back.
+  const attemptRef = useRef(0)
 
   const handleOpenChange = (nextOpen: boolean) => {
-    abandonedRef.current = !nextOpen
     if (!nextOpen) {
+      attemptRef.current += 1
       setError(null)
       setIsLoading(false)
     }
@@ -78,18 +84,18 @@ export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
       return
     }
 
-    abandonedRef.current = false
+    const attempt = ++attemptRef.current
     setIsLoading(true)
     try {
       const url = await getRemoteFollowUrl({
         account: trimmedAccount,
         target: targetHandle
       })
-      if (abandonedRef.current) return
+      if (attempt !== attemptRef.current) return
       rememberAccount(trimmedAccount)
       window.location.assign(url)
     } catch (submitError) {
-      if (abandonedRef.current) return
+      if (attempt !== attemptRef.current) return
       setError(
         submitError instanceof Error
           ? submitError.message

--- a/lib/components/remote-follow/remote-follow-dialog.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, FormEvent, useState } from 'react'
+import { FC, FormEvent, useRef, useState } from 'react'
 
 import { getRemoteFollowUrl } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
@@ -52,9 +52,19 @@ export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
   const [account, setAccount] = useState(readRememberedAccount)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Closing the dialog abandons whatever lookup is in flight. The lookup can
+  // take as long as the outbound WebFinger request's timeout, and it resolves
+  // to a URL even when that request fails (the route degrades to the
+  // conventional path), so without this a visitor who gave up and dismissed
+  // the dialog was navigated off the page seconds later anyway.
+  const abandonedRef = useRef(false)
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) setError(null)
+    abandonedRef.current = !nextOpen
+    if (!nextOpen) {
+      setError(null)
+      setIsLoading(false)
+    }
     setOpen(nextOpen)
   }
 
@@ -68,15 +78,18 @@ export const RemoteFollowDialog: FC<RemoteFollowDialogProps> = ({
       return
     }
 
+    abandonedRef.current = false
     setIsLoading(true)
     try {
       const url = await getRemoteFollowUrl({
         account: trimmedAccount,
         target: targetHandle
       })
+      if (abandonedRef.current) return
       rememberAccount(trimmedAccount)
       window.location.assign(url)
     } catch (submitError) {
+      if (abandonedRef.current) return
       setError(
         submitError instanceof Error
           ? submitError.message

--- a/lib/services/actors/resolveAccountTarget.test.ts
+++ b/lib/services/actors/resolveAccountTarget.test.ts
@@ -1,0 +1,348 @@
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+
+import {
+  ACCOUNT_TARGET_MAX_LENGTH,
+  parseAccountTarget,
+  resolveAccountTarget
+} from './resolveAccountTarget'
+
+vi.mock('@/lib/activities/getWebfingerSelf', () => ({
+  getWebfingerSelf: vi.fn()
+}))
+
+vi.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: vi.fn(),
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActorSafe: vi.fn()
+}))
+
+vi.mock('./refreshRemoteActor', () => ({
+  recordRemoteActorBestEffort: vi.fn()
+}))
+
+const { getWebfingerSelf } = await vi.importMock<
+  typeof import('@/lib/activities/getWebfingerSelf')
+>('@/lib/activities/getWebfingerSelf')
+const { getActorPerson } = await vi.importMock<
+  typeof import('@/lib/activities/getActorPerson')
+>('@/lib/activities/getActorPerson')
+const { canFederateWithDomain, isLocalFederationDomain } = await vi.importMock<
+  typeof import('@/lib/services/federation/domainPolicy')
+>('@/lib/services/federation/domainPolicy')
+const { getFederationSigningActorSafe } = await vi.importMock<
+  typeof import('@/lib/services/federation/getFederationSigningActor')
+>('@/lib/services/federation/getFederationSigningActor')
+const { recordRemoteActorBestEffort } = await vi.importMock<
+  typeof import('./refreshRemoteActor')
+>('./refreshRemoteActor')
+
+const remoteActor = {
+  id: 'https://remote.test/users/someone',
+  username: 'someone',
+  domain: 'remote.test'
+} as Actor
+
+const localActor = {
+  id: 'https://llun.test/users/local',
+  username: 'local',
+  domain: 'llun.test',
+  privateKey: 'private-key'
+} as Actor
+
+const mockDatabase = {
+  getActorFromUsername: vi.fn(),
+  getActorFromId: vi.fn()
+}
+
+const database = mockDatabase as unknown as Database
+
+describe('parseAccountTarget', () => {
+  it.each([
+    {
+      description: 'accepts a bare handle',
+      input: 'user@remote.test',
+      expected: {
+        type: 'handle',
+        username: 'user',
+        domain: 'remote.test',
+        acct: 'user@remote.test'
+      }
+    },
+    {
+      description: 'accepts a handle with a leading at sign',
+      input: '@user@remote.test',
+      expected: {
+        type: 'handle',
+        username: 'user',
+        domain: 'remote.test',
+        acct: 'user@remote.test'
+      }
+    },
+    {
+      description: 'accepts an acct uri',
+      input: 'acct:user@remote.test',
+      expected: {
+        type: 'handle',
+        username: 'user',
+        domain: 'remote.test',
+        acct: 'user@remote.test'
+      }
+    },
+    {
+      description: 'lowercases the handle domain',
+      input: 'user@Remote.TEST',
+      expected: {
+        type: 'handle',
+        username: 'user',
+        domain: 'remote.test',
+        acct: 'user@remote.test'
+      }
+    },
+    {
+      description: 'accepts a profile url',
+      input: 'https://remote.test/@user',
+      expected: { type: 'url', url: 'https://remote.test/@user' }
+    },
+    {
+      description: 'accepts an activitypub actor uri',
+      input: 'https://remote.test/users/user',
+      expected: { type: 'url', url: 'https://remote.test/users/user' }
+    },
+    {
+      description: 'accepts a status url for later rejection at resolution',
+      input: 'https://remote.test/@user/12345',
+      expected: { type: 'url', url: 'https://remote.test/@user/12345' }
+    },
+    {
+      description: 'accepts an http url for local development',
+      input: 'http://localhost:3000/users/user',
+      expected: { type: 'url', url: 'http://localhost:3000/users/user' }
+    },
+    {
+      description: 'rejects a bare domain',
+      input: 'remote.test',
+      expected: null
+    },
+    { description: 'rejects an empty value', input: '', expected: null },
+    { description: 'rejects whitespace only', input: '   ', expected: null },
+    {
+      description: 'rejects a handle with two domains',
+      input: 'user@remote.test@evil.test',
+      expected: null
+    },
+    {
+      description: 'rejects a javascript url',
+      input: 'javascript:alert(1)',
+      expected: null
+    },
+    {
+      description: 'rejects a data url',
+      input: 'data:text/html,<script>alert(1)</script>',
+      expected: null
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(parseAccountTarget(input)).toEqual(expected)
+  })
+
+  it('rejects input longer than the maximum length', () => {
+    const longDomain = `${'a'.repeat(ACCOUNT_TARGET_MAX_LENGTH)}.test`
+    expect(parseAccountTarget(`user@${longDomain}`)).toBeNull()
+  })
+})
+
+describe('resolveAccountTarget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getActorFromUsername.mockResolvedValue(null)
+    mockDatabase.getActorFromId.mockResolvedValue(null)
+    vi.mocked(canFederateWithDomain).mockResolvedValue(true)
+    vi.mocked(isLocalFederationDomain).mockResolvedValue(false)
+    vi.mocked(getFederationSigningActorSafe).mockResolvedValue(undefined)
+    vi.mocked(getWebfingerSelf).mockResolvedValue(null)
+    vi.mocked(getActorPerson).mockResolvedValue(null)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(null)
+  })
+
+  it('returns invalid for an unparseable target', async () => {
+    const result = await resolveAccountTarget({ database, input: 'banana' })
+
+    expect(result).toEqual({ type: 'invalid' })
+    expect(canFederateWithDomain).not.toHaveBeenCalled()
+  })
+
+  it('returns forbidden when the instance cannot federate with the domain', async () => {
+    vi.mocked(canFederateWithDomain).mockResolvedValue(false)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'user@blocked.test'
+    })
+
+    expect(result).toEqual({ type: 'forbidden' })
+    expect(getWebfingerSelf).not.toHaveBeenCalled()
+  })
+
+  it('resolves a known handle without any outbound request', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue(localActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: '@local@llun.test'
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: localActor })
+    expect(getWebfingerSelf).not.toHaveBeenCalled()
+  })
+
+  it('does not webfinger its own domain for an unknown local handle', async () => {
+    vi.mocked(isLocalFederationDomain).mockResolvedValue(true)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'ghost@llun.test'
+    })
+
+    expect(result).toEqual({ type: 'not-found' })
+    expect(getWebfingerSelf).not.toHaveBeenCalled()
+  })
+
+  it('resolves an unknown remote handle through webfinger', async () => {
+    vi.mocked(getWebfingerSelf).mockResolvedValue(remoteActor.id)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(remoteActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'someone@remote.test'
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: remoteActor })
+    expect(getWebfingerSelf).toHaveBeenCalledWith({
+      account: 'someone@remote.test'
+    })
+  })
+
+  it('returns not found when webfinger has no such account', async () => {
+    vi.mocked(getWebfingerSelf).mockResolvedValue(null)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'ghost@remote.test'
+    })
+
+    expect(result).toEqual({ type: 'not-found' })
+    expect(recordRemoteActorBestEffort).not.toHaveBeenCalled()
+  })
+
+  it('re-checks federation policy against the actor id webfinger returns', async () => {
+    vi.mocked(getWebfingerSelf).mockResolvedValue(
+      'https://elsewhere.test/users/someone'
+    )
+    vi.mocked(canFederateWithDomain).mockImplementation(
+      async (_db, value) => !value.includes('elsewhere.test')
+    )
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'someone@remote.test'
+    })
+
+    expect(result).toEqual({ type: 'forbidden' })
+    expect(recordRemoteActorBestEffort).not.toHaveBeenCalled()
+  })
+
+  it('returns not found when the remote actor cannot be recorded', async () => {
+    vi.mocked(getWebfingerSelf).mockResolvedValue(remoteActor.id)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(null)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'someone@remote.test'
+    })
+
+    expect(result).toEqual({ type: 'not-found' })
+  })
+
+  it('resolves a stored actor uri without any outbound request', async () => {
+    mockDatabase.getActorFromId.mockResolvedValue(remoteActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: remoteActor.id
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: remoteActor })
+    expect(getActorPerson).not.toHaveBeenCalled()
+  })
+
+  it('resolves a profile url through the handle path', async () => {
+    vi.mocked(getWebfingerSelf).mockResolvedValue(remoteActor.id)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(remoteActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'https://remote.test/@someone'
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: remoteActor })
+    expect(getWebfingerSelf).toHaveBeenCalledWith({
+      account: 'someone@remote.test'
+    })
+    expect(getActorPerson).not.toHaveBeenCalled()
+  })
+
+  it('resolves an unknown actor uri by fetching the person document', async () => {
+    vi.mocked(getActorPerson).mockResolvedValue({
+      id: remoteActor.id
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(remoteActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: remoteActor.id
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: remoteActor })
+    expect(recordRemoteActorBestEffort).toHaveBeenCalledWith(
+      expect.objectContaining({ actorId: remoteActor.id })
+    )
+  })
+
+  it('returns not found for a status url that is not an actor', async () => {
+    vi.mocked(getActorPerson).mockResolvedValue(null)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'https://remote.test/users/someone/statuses/12345'
+    })
+
+    expect(result).toEqual({ type: 'not-found' })
+    expect(recordRemoteActorBestEffort).not.toHaveBeenCalled()
+  })
+
+  it('re-checks federation policy against the canonical actor id', async () => {
+    vi.mocked(getActorPerson).mockResolvedValue({
+      id: 'https://elsewhere.test/users/someone'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    vi.mocked(canFederateWithDomain).mockImplementation(
+      async (_db, value) => !value.includes('elsewhere.test')
+    )
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'https://remote.test/users/someone'
+    })
+
+    expect(result).toEqual({ type: 'forbidden' })
+    expect(recordRemoteActorBestEffort).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/actors/resolveAccountTarget.test.ts
+++ b/lib/services/actors/resolveAccountTarget.test.ts
@@ -64,6 +64,23 @@ const mockDatabase = {
 
 const database = mockDatabase as unknown as Database
 
+// The real canFederateWithDomain resolves the value to a HOST before deciding,
+// so a mock matching on the raw string is a trap: `https://a.test/@u@b.test`
+// contains "b.test" as a substring and would answer as though b.test had been
+// gated, hiding exactly the bug these tests exist to catch.
+const blockDomains =
+  (...blocked: string[]) =>
+  async (_database: Database, value: string) => {
+    const host = (() => {
+      try {
+        return new URL(value).hostname
+      } catch {
+        return value.split('/')[0] ?? value
+      }
+    })()
+    return !blocked.includes(host.toLowerCase())
+  }
+
 describe('parseAccountTarget', () => {
   it.each([
     {
@@ -241,12 +258,62 @@ describe('resolveAccountTarget', () => {
     expect(recordRemoteActorBestEffort).not.toHaveBeenCalled()
   })
 
+  it('refuses a profile url carrying a handle on a domain it cannot federate with', async () => {
+    // The wrapper host is allowed and the embedded domain is not; gating only
+    // the URL's own host let the blocked domain through, while the same
+    // account written as a bare handle was correctly refused.
+    vi.mocked(canFederateWithDomain).mockImplementation(
+      blockDomains('blocked.test')
+    )
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'https://mastodon.social/@spammer@blocked.test'
+    })
+
+    expect(result).toEqual({ type: 'forbidden' })
+    expect(mockDatabase.getActorFromUsername).not.toHaveBeenCalled()
+    expect(getWebfingerSelf).not.toHaveBeenCalled()
+  })
+
+  it('refuses both spellings of an account on a domain it cannot federate with', async () => {
+    vi.mocked(canFederateWithDomain).mockImplementation(
+      blockDomains('blocked.test')
+    )
+
+    const asHandle = await resolveAccountTarget({
+      database,
+      input: 'spammer@blocked.test'
+    })
+    const asWrappedProfileUrl = await resolveAccountTarget({
+      database,
+      input: 'https://mastodon.social/@spammer@blocked.test'
+    })
+
+    expect(asWrappedProfileUrl).toEqual(asHandle)
+  })
+
+  it('still resolves a profile url whose embedded domain is allowed', async () => {
+    vi.mocked(canFederateWithDomain).mockImplementation(
+      blockDomains('blocked.test')
+    )
+    vi.mocked(getWebfingerSelf).mockResolvedValue(remoteActor.id)
+    vi.mocked(recordRemoteActorBestEffort).mockResolvedValue(remoteActor)
+
+    const result = await resolveAccountTarget({
+      database,
+      input: 'https://mastodon.social/@someone@remote.test'
+    })
+
+    expect(result).toEqual({ type: 'resolved', actor: remoteActor })
+  })
+
   it('re-checks federation policy against the actor id webfinger returns', async () => {
     vi.mocked(getWebfingerSelf).mockResolvedValue(
       'https://elsewhere.test/users/someone'
     )
     vi.mocked(canFederateWithDomain).mockImplementation(
-      async (_db, value) => !value.includes('elsewhere.test')
+      blockDomains('elsewhere.test')
     )
 
     const result = await resolveAccountTarget({
@@ -334,7 +401,7 @@ describe('resolveAccountTarget', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
     vi.mocked(canFederateWithDomain).mockImplementation(
-      async (_db, value) => !value.includes('elsewhere.test')
+      blockDomains('elsewhere.test')
     )
 
     const result = await resolveAccountTarget({

--- a/lib/services/actors/resolveAccountTarget.ts
+++ b/lib/services/actors/resolveAccountTarget.ts
@@ -1,0 +1,185 @@
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
+import { Database } from '@/lib/database/types'
+import {
+  canFederateWithDomain,
+  isLocalFederationDomain
+} from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { Actor } from '@/lib/types/domain/actor'
+import {
+  parseAccountHandle,
+  parseProfileUrlAccountHandle,
+  stripAcctPrefix
+} from '@/lib/utils/accountHandle'
+import { normalizeActorId } from '@/lib/utils/activitypub'
+
+import { recordRemoteActorBestEffort } from './refreshRemoteActor'
+
+// Anything longer than this is not an account address. The cap runs before any
+// parsing so a hostile `uri` cannot push work into the URL parser or a log
+// line; it is generous enough for the longest realistic actor URI.
+export const ACCOUNT_TARGET_MAX_LENGTH = 2048
+
+export type AccountTarget =
+  | { type: 'handle'; username: string; domain: string; acct: string }
+  | { type: 'url'; url: string }
+
+export type ResolveAccountTargetResult =
+  | { type: 'resolved'; actor: Actor }
+  | { type: 'invalid' }
+  | { type: 'forbidden' }
+  | { type: 'not-found' }
+
+/**
+ * Normalizes every form a remote server may hand to `/authorize_interaction`
+ * into either an account handle or an http(s) URL. Accepts `user@domain`,
+ * `@user@domain`, `acct:user@domain`, a profile page URL and a bare
+ * ActivityPub actor URI; rejects everything else (bare domains, non-http
+ * schemes, over-long input) rather than guessing.
+ */
+export const parseAccountTarget = (input: string): AccountTarget | null => {
+  const trimmed = input.trim()
+  if (!trimmed || trimmed.length > ACCOUNT_TARGET_MAX_LENGTH) return null
+
+  const withoutAcct = stripAcctPrefix(trimmed)
+  if (!withoutAcct) return null
+
+  // URL-ness is decided FIRST. A profile URL carries exactly one `@`
+  // (`https://d/@user`), which `parseAccountHandle` would otherwise split into
+  // the nonsense handle `https://d/` @ `user` — silently sending the most
+  // common Mastodon input form to WebFinger as garbage. Anything that parses
+  // as a URL is therefore never reconsidered as a handle; a non-http scheme is
+  // rejected outright rather than falling through.
+  try {
+    const url = new URL(withoutAcct)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+    return { type: 'url', url: withoutAcct }
+  } catch {
+    // Not a URL — fall through to handle parsing.
+  }
+
+  const handle = parseAccountHandle(withoutAcct)
+  if (!handle) return null
+
+  return {
+    type: 'handle',
+    username: handle.username,
+    domain: handle.domain,
+    acct: `${handle.username}@${handle.domain}`
+  }
+}
+
+const resolveHandle = async ({
+  database,
+  username,
+  domain,
+  acct,
+  signingActor
+}: {
+  database: Database
+  username: string
+  domain: string
+  acct: string
+  signingActor?: Actor
+}): Promise<ResolveAccountTargetResult> => {
+  const persistedActor = await database.getActorFromUsername({
+    username,
+    domain
+  })
+  if (persistedActor) return { type: 'resolved', actor: persistedActor }
+
+  // Never WebFinger ourselves: an unknown username on a domain this instance
+  // serves is simply not an account here.
+  if (await isLocalFederationDomain(database, domain)) {
+    return { type: 'not-found' }
+  }
+
+  const actorId = await getWebfingerSelf({ account: acct })
+  if (!actorId) return { type: 'not-found' }
+
+  // WebFinger can point at a different host than the handle's, so the actor id
+  // it returns is re-gated rather than inheriting the handle's decision.
+  if (!(await canFederateWithDomain(database, actorId))) {
+    return { type: 'forbidden' }
+  }
+
+  const actor = await recordRemoteActorBestEffort({
+    actorId,
+    database,
+    signingActor
+  })
+  return actor ? { type: 'resolved', actor } : { type: 'not-found' }
+}
+
+/**
+ * Resolves the `uri` an inbound remote-follow hands us to a persisted actor.
+ *
+ * The result is a closed set of outcomes so the page can render distinct copy
+ * for "that is not an address", "we cannot talk to that server" and "no such
+ * account" instead of collapsing them into one failure. Non-actor documents
+ * (Mastodon also sends status permalinks for reply/boost intents) fall out as
+ * `not-found`: getActorPerson's schema rejects them.
+ */
+export const resolveAccountTarget = async ({
+  database,
+  input
+}: {
+  database: Database
+  input: string
+}): Promise<ResolveAccountTargetResult> => {
+  const target = parseAccountTarget(input)
+  if (!target) return { type: 'invalid' }
+
+  const gateValue = target.type === 'handle' ? target.domain : target.url
+  if (!(await canFederateWithDomain(database, gateValue))) {
+    return { type: 'forbidden' }
+  }
+
+  const signingActor = await getFederationSigningActorSafe(
+    database,
+    'for authorize interaction resolution'
+  )
+
+  if (target.type === 'handle') {
+    return resolveHandle({
+      database,
+      username: target.username,
+      domain: target.domain,
+      acct: target.acct,
+      signingActor
+    })
+  }
+
+  // A known id (local actors included) resolves with no outbound request.
+  const knownActor = await database.getActorFromId({ id: target.url })
+  if (knownActor) return { type: 'resolved', actor: knownActor }
+
+  const profileHandle = parseProfileUrlAccountHandle(target.url)
+  if (profileHandle) {
+    return resolveHandle({
+      database,
+      username: profileHandle.username,
+      domain: profileHandle.domain,
+      acct: `${profileHandle.username}@${profileHandle.domain}`,
+      signingActor
+    })
+  }
+
+  const person = await getActorPerson({ actorId: target.url, signingActor })
+  if (!person) return { type: 'not-found' }
+
+  const canonicalActorId = normalizeActorId(person.id)
+  if (!canonicalActorId) return { type: 'not-found' }
+
+  if (!(await canFederateWithDomain(database, canonicalActorId))) {
+    return { type: 'forbidden' }
+  }
+
+  const actor = await recordRemoteActorBestEffort({
+    actorId: canonicalActorId,
+    database,
+    signingActor
+  })
+  return actor ? { type: 'resolved', actor } : { type: 'not-found' }
+}

--- a/lib/services/actors/resolveAccountTarget.ts
+++ b/lib/services/actors/resolveAccountTarget.ts
@@ -83,6 +83,15 @@ const resolveHandle = async ({
   acct: string
   signingActor?: Actor
 }): Promise<ResolveAccountTargetResult> => {
+  // Gated here rather than at the call sites so the check always covers the
+  // domain actually being resolved. A profile URL can carry a handle on a
+  // DIFFERENT domain than its own host (`https://a.test/@user@b.test`), so
+  // gating only the caller's value let `b.test` through whenever `a.test` was
+  // allowed — the same account was correctly refused as a bare handle.
+  if (!(await canFederateWithDomain(database, domain))) {
+    return { type: 'forbidden' }
+  }
+
   const persistedActor = await database.getActorFromUsername({
     username,
     domain
@@ -131,8 +140,14 @@ export const resolveAccountTarget = async ({
   const target = parseAccountTarget(input)
   if (!target) return { type: 'invalid' }
 
-  const gateValue = target.type === 'handle' ? target.domain : target.url
-  if (!(await canFederateWithDomain(database, gateValue))) {
+  // A URL is gated on its own host before anything is fetched from it. Handle
+  // inputs are gated inside resolveHandle instead — including the handle a
+  // profile URL can carry on another domain entirely — so the check always
+  // lands on the domain being resolved rather than on whatever named it.
+  if (
+    target.type === 'url' &&
+    !(await canFederateWithDomain(database, target.url))
+  ) {
     return { type: 'forbidden' }
   }
 

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -357,9 +357,59 @@ describe('getWebFingerResponse', () => {
           rel: 'self',
           type: 'application/activity+json',
           href: 'https://example.com/users/test'
+        }),
+        expect.objectContaining({
+          rel: 'http://ostatus.org/schema/1.0/subscribe',
+          template: 'https://test.example.com/authorize_interaction?uri={uri}'
         })
       ])
     })
+  })
+
+  it('advertises the remote follow template from the instance base url', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://example.com/users/test',
+      username: 'test',
+      domain: 'example.com',
+      privateKey: 'private-key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'acct:test@example.com'
+    })
+
+    const subscribeLink = result?.links.find(
+      (link) => link.rel === 'http://ostatus.org/schema/1.0/subscribe'
+    )
+    // The placeholder must stay literal: consumers substitute it with a plain
+    // string replace, so a percent-encoded `%7Buri%7D` would never match.
+    expect(subscribeLink?.template).toEqual(
+      'https://test.example.com/authorize_interaction?uri={uri}'
+    )
+    expect(subscribeLink?.template).toContain('{uri}')
+  })
+
+  it('advertises the remote follow template for the service instance actor', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://example.com/users/instance',
+      username: 'instance',
+      domain: 'example.com',
+      privateKey: 'private-key',
+      type: 'Service'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'acct:instance@example.com'
+    })
+
+    expect(result?.links).toContainEqual(
+      expect.objectContaining({
+        rel: 'http://ostatus.org/schema/1.0/subscribe',
+        template: 'https://test.example.com/authorize_interaction?uri={uri}'
+      })
+    )
   })
 
   it('handles acct: prefix correctly', async () => {

--- a/lib/services/wellknown/webfinger.ts
+++ b/lib/services/wellknown/webfinger.ts
@@ -1,4 +1,12 @@
+import { getBaseURL } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+
+// Standard OStatus rel other servers look for to discover where to send a
+// visitor who typed their handle into a remote "follow from your server"
+// dialog. Mastodon guesses `/authorize_interaction` when it is absent, but
+// other implementations do not, so advertise it.
+export const REMOTE_FOLLOW_SUBSCRIBE_REL =
+  'http://ostatus.org/schema/1.0/subscribe'
 
 export interface WebFingerLink {
   rel: string
@@ -88,6 +96,17 @@ export const getWebFingerResponse = async ({
         rel: 'self',
         type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
         href: actor.id
+      },
+      // The template is instance-level rather than per-account, so it is built
+      // from getBaseURL() (which honours ACTIVITIES_INSECURE_AUTH) instead of
+      // this file's older hardcoded `https://${actor.domain}` profile URLs: the
+      // consumer is a browser that has to end up signed in on THIS instance,
+      // and sessions are anchored to the configured host. Concatenate rather
+      // than building with URL/URLSearchParams — those percent-encode `{uri}`
+      // to `%7Buri%7D` and break consumers doing a literal `.replace('{uri}')`.
+      {
+        rel: REMOTE_FOLLOW_SUBSCRIBE_REL,
+        template: `${getBaseURL()}/authorize_interaction?uri={uri}`
       }
     ]
   }

--- a/lib/stub/webfinger.ts
+++ b/lib/stub/webfinger.ts
@@ -4,11 +4,13 @@ interface Params {
   aliases?: string[]
   links?: {
     rel: string
-    type: string
-    href: string
+    type?: string
+    href?: string
+    template?: string
   }[]
   includeProfileLink?: boolean
   includeSelfLink?: boolean
+  includeSubscribeLink?: boolean
 }
 export const MockWebfinger = ({
   account,
@@ -16,7 +18,8 @@ export const MockWebfinger = ({
   aliases,
   links,
   includeProfileLink = true,
-  includeSelfLink = true
+  includeSelfLink = true,
+  includeSubscribeLink = false
 }: Params) => {
   const [user, domain] = account.split('@')
   const profilePage = `https://${domain}/@${user}`
@@ -36,6 +39,14 @@ export const MockWebfinger = ({
             rel: 'self',
             type: 'application/activity+json',
             href: userUrl ?? `https://${domain}/users/${user}`
+          }
+        ]
+      : []),
+    ...(includeSubscribeLink
+      ? [
+          {
+            rel: 'http://ostatus.org/schema/1.0/subscribe',
+            template: `https://${domain}/authorize_interaction?uri={uri}`
           }
         ]
       : [])

--- a/lib/utils/accountHandle.test.ts
+++ b/lib/utils/accountHandle.test.ts
@@ -1,0 +1,123 @@
+import {
+  parseAccountHandle,
+  parseProfileUrlAccountHandle,
+  stripAcctPrefix
+} from './accountHandle'
+
+describe('parseAccountHandle', () => {
+  it.each([
+    {
+      description: 'parses a bare handle',
+      input: 'user@example.com',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'strips a leading at sign',
+      input: '@user@example.com',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'lowercases the domain',
+      input: 'user@Example.COM',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'trims surrounding whitespace',
+      input: '  user@example.com  ',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'rejects an extra domain part',
+      input: 'user@example.com@evil.test',
+      expected: null
+    },
+    { description: 'rejects a bare username', input: 'user', expected: null },
+    {
+      description: 'rejects a missing username',
+      input: '@example.com',
+      expected: null
+    },
+    { description: 'rejects an empty value', input: '', expected: null }
+  ])('$description', ({ input, expected }) => {
+    expect(parseAccountHandle(input)).toEqual(expected)
+  })
+})
+
+describe('stripAcctPrefix', () => {
+  it.each([
+    {
+      description: 'removes a lowercase acct prefix',
+      input: 'acct:user@example.com',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'removes an uppercase acct prefix',
+      input: 'ACCT:user@example.com',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'removes a mixed case acct prefix',
+      input: 'Acct:user@example.com',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'leaves a value without the prefix alone',
+      input: 'user@example.com',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'trims surrounding whitespace',
+      input: '  acct:user@example.com ',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'does not strip acct inside a username',
+      input: 'acctuser@example.com',
+      expected: 'acctuser@example.com'
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(stripAcctPrefix(input)).toEqual(expected)
+  })
+})
+
+describe('parseProfileUrlAccountHandle', () => {
+  it.each([
+    {
+      description: 'qualifies a bare profile handle with the url host',
+      input: 'https://example.com/@user',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'keeps a fully qualified profile handle',
+      input: 'https://example.com/@user@other.test',
+      expected: { username: 'user', domain: 'other.test' }
+    },
+    {
+      description: 'accepts a trailing slash',
+      input: 'https://example.com/@user/',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'decodes a percent encoded segment',
+      input: 'https://example.com/@user%40other.test',
+      expected: { username: 'user', domain: 'other.test' }
+    },
+    {
+      description: 'rejects a status permalink',
+      input: 'https://example.com/@user/12345',
+      expected: null
+    },
+    {
+      description: 'rejects an actor uri without the profile path shape',
+      input: 'https://example.com/users/user',
+      expected: null
+    },
+    {
+      description: 'rejects a non url value',
+      input: 'user@example.com',
+      expected: null
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(parseProfileUrlAccountHandle(input)).toEqual(expected)
+  })
+})

--- a/lib/utils/accountHandle.ts
+++ b/lib/utils/accountHandle.ts
@@ -4,3 +4,37 @@ export const parseAccountHandle = (value: string) => {
   if (!username || !domain || rest.length > 0) return null
   return { username, domain: domain.toLowerCase() }
 }
+
+/**
+ * Drops a case-insensitive `acct:` URI scheme prefix. WebFinger resources and
+ * the `uri` other servers hand to `/authorize_interaction` both arrive in that
+ * form, and `parseAccountHandle` splits on `@`, so `acct:user@domain` would
+ * otherwise parse with `acct:user` as the username.
+ */
+export const stripAcctPrefix = (value: string) => {
+  const trimmed = value.trim()
+  return trimmed.toLowerCase().startsWith('acct:')
+    ? trimmed.slice('acct:'.length)
+    : trimmed
+}
+
+/**
+ * Reads the account handle out of a profile page URL (`https://d/@user` or
+ * `https://d/@user@other`), qualifying a bare `@user` with the URL's own host.
+ * Returns null for any other URL shape, including status permalinks.
+ */
+export const parseProfileUrlAccountHandle = (value: string) => {
+  try {
+    const url = new URL(value)
+    const match = /^\/@([^/]+)\/?$/.exec(url.pathname)
+    if (!match) return null
+
+    const profileHandle = decodeURIComponent(match[1])
+    const handle = profileHandle.includes('@')
+      ? `@${profileHandle.replace(/^@/, '')}`
+      : `@${profileHandle}@${url.hostname}`
+    return parseAccountHandle(handle)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Following an account on this instance from another server dead-ended on a 404. Entering a local handle in Mastodon's "Sign in to continue" box redirects the browser to `https://your-instance/authorize_interaction?uri=…`, which this server did not serve — and neither half of the fediverse remote-follow handshake existed here.

Three changes, one per direction plus discovery:

**Inbound — `/authorize_interaction` (fixes the 404).** A new page at `app/(nosidebar)/authorize_interaction/` resolves the `uri` another server sends and renders a confirmation card with the shared `FollowAction`. It accepts every form senders use: `user@domain`, `@user@domain`, `acct:user@domain`, a profile URL, or a bare ActivityPub actor URI. Signed-out visitors bounce through `/auth/signin` and back — **before** any resolution runs, so an anonymous visitor can never drive an outbound fetch through the page. Resolution lives in a framework-free service (`lib/services/actors/resolveAccountTarget.ts`) that reuses the existing primitives (`getWebfingerSelf`, `getActorPerson`, `recordRemoteActorBestEffort`, `canFederateWithDomain`, the headless signing actor) and returns a closed set of outcomes, so the page renders distinct copy for "that isn't an address", "we can't reach that server" and "no such account" instead of one generic failure. A local target short-circuits with no network call; a status permalink (Mastodon also sends those for reply/boost intents) falls out as not-found because `getActorPerson`'s schema rejects it.

**Discovery — WebFinger.** The document now advertises the standard `http://ostatus.org/schema/1.0/subscribe` template. Mastodon guesses the path when it's absent; other implementations don't. Built from `getBaseURL()` (instance host, scheme-aware) by plain concatenation — `new URL`/`URLSearchParams` would percent-encode `{uri}` to `%7Buri%7D` and break consumers doing a literal `.replace('{uri}', …)`.

**Outbound — logged-out Follow.** A logged-out visitor on a local profile previously saw no Follow affordance at all (`FollowAction` returns `null` without a session). They now get a Follow button opening a dialog for their own handle, mirroring Mastodon's. `GET /api/v1/remote-follow` resolves their home server's subscribe template server-side — WebFinger isn't readable from the browser — and falls back to Mastodon's conventional `/authorize_interaction?uri={uri}` when that server advertises none.

### Notes for review

- **A profile URL carries exactly one `@`.** `parseAccountTarget` therefore decides URL-ness *before* handle parsing: otherwise `parseAccountHandle` splits `https://d/@user` into the nonsense handle `https://d/` @ `user` and silently sends the most common Mastodon input form to WebFinger as garbage. This was caught by a test, and the ordering is commented at the call site.
- **`GET /api/v1/remote-follow` is deliberately unauthenticated** — the whole feature exists for visitors with no account here — and read-only. The abuse surface is one outbound WebFinger GET to a user-supplied domain, the same primitive search already exposes, bounded by: strict handle/domain syntax validation (username charset, bare-hostname rule rejecting credentials/paths), the instance's federation policy, retry-disabled requests with the shared helper's timeouts and body cap, an https-only check on the constructed URL, and the requirement that `target` name an actor this server actually hosts — so it can't be repurposed into a general-purpose URL builder or redirector. The shared `request` helper delegates to `safeRemoteFetch`, which rejects private/loopback/link-local addresses (v4 and v6), pins the resolved address, and is HTTPS-only outside development — verified empirically. The repo has no inbound rate-limit layer; operators should rate-limit at the reverse proxy. Flagging the unauthenticated decision for an explicit second opinion.
- `getProfileUrlAccountHandle` moved out of `app/api/v2/search/route.ts` into `lib/utils/accountHandle.ts` as `parseProfileUrlAccountHandle` (verbatim, now shared and tested). The rest of the search route's resolution was deliberately left alone — it's interleaved with search-only concerns and reshaping it would risk a hot endpoint for little gain.

## Review

Five rounds of adversarial sub-agent review, ending clean. **Sixteen findings raised, four real, twelve refuted with evidence.** Full round-by-round detail is in the review threads and the summary comment below; the four fixes were:

1. The federation gate ran on a profile URL's own host rather than the handle's domain it actually resolved, so `https://allowed.test/@user@blocked.test` slipped past a check that correctly refused the same account written as a bare handle.
2. Dismissing the follow dialog mid-lookup still navigated the visitor off-site seconds later.
3. That guard was reopen-unsafe — a shared boolean cleared on open, so retrying revived the abandoned lookup.
4. The replacement per-attempt token missed unmount, i.e. browser and Android system Back.

Every fix carries a regression test **verified to fail against the unfixed code**, which mattered here: two of my tests initially passed against the very bugs they were written for (a mock matching `blocked.test` as a substring of the whole URL, and a dialog test that reopened only after resolving). Reverting the source and re-running is the only thing that established either was worth keeping.

## Screenshots

Verified in Chromium against a local SQLite instance with mock users. Transcribed here since they were produced by an automated run rather than uploaded through the web UI.

**Logged-out profile → follow dialog (new).** The profile now shows a **Follow** button where a logged-out visitor previously saw nothing. It opens a dialog titled *"Follow @testuser@localhost:3000"* with the body *"To follow this account, sign in to your account on whatever fediverse server you use. Enter your address and we'll send you there."*, a **Your address** field placeheld `E.g. username@mastodon.social`, and **Cancel** / **Go** — the same shape as the Mastodon box in the report. Typing `visitor@example.com` and clicking **Go** navigated the browser to:

```
https://example.com/authorize_interaction?uri=testuser%40localhost%3A3000
```

**`/authorize_interaction` confirmation card.** For another account it renders *"Follow this account | You are about to follow this account from your account on this server"* above the avatar, `@seconduser@localhost:3000`, a **Follow** button and **View profile**. For your own account it renders *"This is you | You are signed in as this account"* with the Follow button suppressed.

Error states all render at HTTP 200 with the offending `uri` shown as inert text, never a link:

| `uri` | Rendered |
| --- | --- |
| `banana` | "That doesn't look like an account" |
| `ghost@localhost:3000` | "Account not found … a link to a single post won't work" |
| `https://remote.invalid/@user/12345` | same not-found copy (status permalinks are out of scope for v1) |
| *(absent)* | "Nothing to follow" |

### Manual verification performed

```
# WebFinger advertises the template (http:// here proves getBaseURL() honours
# ACTIVITIES_INSECURE_AUTH, unlike the file's older hardcoded https:// links)
$ curl -s '.../.well-known/webfinger?resource=acct:testuser@localhost:3000' | jq '.links[-1]'
{ "rel": "http://ostatus.org/schema/1.0/subscribe",
  "template": "http://localhost:3000/authorize_interaction?uri={uri}" }

# remote-follow: fallback path, and the guards
$ curl -s '.../api/v1/remote-follow?account=example.com&target=testuser@localhost:3000'
{"url":"https://example.com/authorize_interaction?uri=testuser%40localhost%3A3000"}
$ ...?account=user:pass@evil.test&...   -> 400
$ ...?target=ghost@localhost:3000       -> 404

# signed-out bounce preserves an ampersand-bearing uri through the round trip
$ curl -s -o /dev/null -w '%{redirect_url}' '.../authorize_interaction?uri=https%3A%2F%2Fremote.test%2Fusers%2Fa%3Fb%3D1%26c%3D2'
.../auth/signin?redirectBack=%2Fauthorize_interaction%3Furi%3Dhttps%253A%252F%252F...%253Fb%253D1%2526c%253D2
```

Also driven in a browser with a lookup held open to imitate a dead instance: dismissing mid-flight leaves the visitor on the profile, and the reopened form is usable rather than stuck.

One honest gap: clicking **Follow** on the card returned 404 in local dev. That is **pre-existing and unrelated** — the ordinary profile page's own Follow button returns the identical 404 for the same local target, because the follow route fetches `https://localhost:3000/users/…` over HTTPS, which an http dev server can't serve. The card wires the same shared component, so it behaves identically to every other surface. Following a genuinely remote account needs outbound network and was not exercised here.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order — lint 0 errors, build compiled with `/authorize_interaction` and `/api/v1/remote-follow` both registered, **807 test files / 9373 tests passing**
- [x] Docs updated: `docs/features.md`, `docs/architecture.md`, and `docs/mastodon-api-compatibility.md` (Extensions); grepped `*.md` and `docs/` for the new route names
- [x] If migrations changed: n/a — no schema change, so no dump regeneration
- [x] `version` in `package.json` is untouched
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166m459D8LVfVEz8N7m4HLY