### PR TITLE
Bump version to v1.132.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.131.0",
+  "version": "1.132.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.132.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.131.0`
- Base main SHA: `5901d2fefe3bd07cc46ffb3b9e8191a85ba4f644`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
