### PR TITLE
Bump version to v1.133.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.132.0",
+  "version": "1.133.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.133.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.132.0`
- Base main SHA: `7445b75588960a0acea3df9da041b65fdd4d2399`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
