### PR TITLE
fix: federate Strava webhook fitness imports once their content is complete

### DIFF
--- a/app/api/v1/webhooks/strava/[webhookToken]/route.test.ts
+++ b/app/api/v1/webhooks/strava/[webhookToken]/route.test.ts
@@ -106,7 +106,8 @@ describe('Strava Webhook API', () => {
           // The webhook is the only entry point that opts into the import
           // email. Asserted explicitly so the feature cannot be switched off
           // by dropping this one field with a green build.
-          notifyOnComplete: true
+          notifyOnComplete: true,
+          publishSendNote: true
         }
       })
     )
@@ -148,7 +149,8 @@ describe('Strava Webhook API', () => {
           actorId: 'actor-1',
           stravaActivityId: '13579',
           visibility: 'private',
-          notifyOnComplete: true
+          notifyOnComplete: true,
+          publishSendNote: true
         }
       })
     )
@@ -199,7 +201,8 @@ describe('Strava Webhook API', () => {
           actorId: 'actor-1',
           stravaActivityId: '24680',
           visibility: 'private',
-          notifyOnComplete: true
+          notifyOnComplete: true,
+          publishSendNote: true
         }
       })
     )

--- a/app/api/v1/webhooks/strava/[webhookToken]/route.ts
+++ b/app/api/v1/webhooks/strava/[webhookToken]/route.ts
@@ -189,7 +189,12 @@ export const POST = traceApiRoute(
           // unattended, which is the whole reason to tell the user. Retry-all
           // and the scripts/fitness recovery tools drive the same job in bulk
           // and deliberately leave this off.
-          notifyOnComplete: true
+          notifyOnComplete: true,
+          // Same entry point, same reason: this is a ride the user just
+          // finished and expects their followers to see. The bulk recovery
+          // paths leave it off so a sweep never re-delivers a timeline's worth
+          // of activities.
+          publishSendNote: true
         }
       })
 

--- a/lib/jobs/importFitnessFilesJob.test.ts
+++ b/lib/jobs/importFitnessFilesJob.test.ts
@@ -1,5 +1,8 @@
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
-import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
+import {
+  importFitnessFiles,
+  importFitnessFilesJob
+} from '@/lib/jobs/importFitnessFilesJob'
 import {
   IMPORT_FITNESS_FILES_JOB_NAME,
   PROCESS_FITNESS_FILE_JOB_NAME
@@ -878,6 +881,130 @@ describe('importFitnessFilesJob', () => {
         .map(([message]) => message)
         .find((message) => message.name === PROCESS_FITNESS_FILE_JOB_NAME)
       expect(publish?.data.notifyOnComplete).toBe(true)
+    })
+  })
+
+  describe('federation opt-in', () => {
+    const createFile = async (name: string) => {
+      const file = await database.createFitnessFile({
+        actorId: actor.id,
+        path: `fitness/${name}.fit`,
+        fileName: `${name}.fit`,
+        fileType: 'fit',
+        mimeType: 'application/vnd.ant.fit',
+        bytes: 1_024,
+        importBatchId: 'batch-federation-optin'
+      })
+      return file!.id
+    }
+
+    const stubParse = (startDay: number) => {
+      mockParseFitnessFile.mockResolvedValueOnce({
+        coordinates: [],
+        trackPoints: [],
+        totalDistanceMeters: 9_000,
+        totalDurationSeconds: 2_400,
+        startTime: new Date(Date.UTC(2026, 2, startDay))
+      })
+    }
+
+    const getProcessJobs = () =>
+      (getQueue().publish as jest.Mock).mock.calls
+        .map(([message]) => message)
+        .filter((message) => message.name === PROCESS_FITNESS_FILE_JOB_NAME)
+
+    it.each([
+      {
+        description: 'stays local when the publisher did not opt in',
+        requested: undefined,
+        expected: false
+      },
+      {
+        description: 'federates when the publisher opted in',
+        requested: true,
+        expected: true
+      }
+    ])('$description', async ({ requested, expected }) => {
+      const fitnessFileIds = [await createFile(`optin-${String(requested)}`)]
+      stubParse(expected ? 3 : 4)
+
+      await importFitnessFilesJob(database, {
+        id: `job-federation-${String(requested)}`,
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          batchId: 'batch-federation-optin',
+          fitnessFileIds,
+          ...(requested === undefined ? {} : { publishSendNote: requested })
+        }
+      })
+
+      const publish = getProcessJobs().at(-1)
+      expect(publish?.data.publishSendNote).toBe(expected)
+    })
+
+    it('does not federate again when the import re-runs over an existing status', async () => {
+      // Retries and the recovery scripts re-drive this job over statuses that
+      // are already live. Their Create has been delivered, so a second one
+      // would post the same ride to every follower twice.
+      const fitnessFileIds = [await createFile('rerun')]
+      stubParse(6)
+
+      await importFitnessFilesJob(database, {
+        id: 'job-federation-first',
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          batchId: 'batch-federation-optin',
+          fitnessFileIds,
+          publishSendNote: true
+        }
+      })
+      expect(getProcessJobs().at(-1)?.data.publishSendNote).toBe(true)
+
+      stubParse(6)
+      await importFitnessFilesJob(database, {
+        id: 'job-federation-rerun',
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          batchId: 'batch-federation-optin',
+          fitnessFileIds,
+          publishSendNote: true
+        }
+      })
+
+      expect(getProcessJobs().at(-1)?.data.publishSendNote).toBe(false)
+    })
+
+    it('returns the process job instead of publishing it when deferred', async () => {
+      const fitnessFileIds = [await createFile('deferred')]
+      stubParse(8)
+
+      const groups = await importFitnessFiles(
+        database,
+        {
+          actorId: actor.id,
+          batchId: 'batch-federation-optin',
+          fitnessFileIds,
+          publishSendNote: true
+        },
+        { deferProcessJobPublishes: true }
+      )
+
+      expect(getProcessJobs()).toHaveLength(0)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].statusCreated).toBe(true)
+      expect(groups[0].processJob).toEqual(
+        expect.objectContaining({
+          name: PROCESS_FITNESS_FILE_JOB_NAME,
+          data: expect.objectContaining({
+            statusId: groups[0].statusId,
+            fitnessFileId: fitnessFileIds[0],
+            publishSendNote: true
+          })
+        })
+      )
     })
   })
 

--- a/lib/jobs/importFitnessFilesJob.test.ts
+++ b/lib/jobs/importFitnessFilesJob.test.ts
@@ -915,18 +915,18 @@ describe('importFitnessFilesJob', () => {
 
     it.each([
       {
-        description: 'stays local when the publisher did not opt in',
+        description: 'stays local without an opt-in',
         requested: undefined,
         expected: false
       },
       {
-        description: 'federates when the publisher opted in',
+        description: 'federates on opt-in',
         requested: true,
         expected: true
       }
     ])('$description', async ({ requested, expected }) => {
       const fitnessFileIds = [await createFile(`optin-${String(requested)}`)]
-      stubParse(expected ? 3 : 4)
+      stubParse(3)
 
       await importFitnessFilesJob(database, {
         id: `job-federation-${String(requested)}`,

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -26,6 +26,7 @@ import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { logger } from '@/lib/utils/logger'
 import { generatePublicId } from '@/lib/utils/publicId'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 import { createJobHandle } from './createJobHandle'
 import { IMPORT_FITNESS_FILES_JOB_NAME } from './names'
@@ -560,7 +561,8 @@ export const importFitnessFiles = async (
         actorId,
         batchId,
         fitnessFileIds: targetFitnessFileIds,
-        error: errorMessage
+        error: errorMessage,
+        err: toLoggableError(error)
       })
 
       await Promise.all(
@@ -573,13 +575,12 @@ export const importFitnessFiles = async (
         try {
           await database.deleteStatus({ statusId: createdStatusId })
         } catch (cleanupError) {
-          const nodeCleanupError = cleanupError as Error
           logger.error({
             message: 'Failed to cleanup local status after import failure',
             actorId,
             batchId,
             statusId: createdStatusId,
-            error: nodeCleanupError.message
+            err: toLoggableError(cleanupError)
           })
         }
       }

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -266,9 +266,11 @@ export interface ImportFitnessFilesOptions {
   deferProcessJobPublishes?: boolean
 }
 
+export type ImportFitnessFilesData = z.input<typeof JobData>
+
 export const importFitnessFiles = async (
   database: Database,
-  data: unknown,
+  data: ImportFitnessFilesData,
   options: ImportFitnessFilesOptions = {}
 ): Promise<ImportedFitnessGroup[]> => {
   const {
@@ -590,6 +592,8 @@ export const importFitnessFiles = async (
 export const importFitnessFilesJob = createJobHandle(
   IMPORT_FITNESS_FILES_JOB_NAME,
   async (database, message) => {
-    await importFitnessFiles(database, message.data)
+    // JobData.parse inside still validates the shape; the cast only restores
+    // compile-time checking for the direct caller, which passes a literal.
+    await importFitnessFiles(database, message.data as ImportFitnessFilesData)
   }
 )

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/services/fitness-files/parseFitnessFile'
 import { linkFitnessFileDeviceGear } from '@/lib/services/fitness-gears/resolveDeviceGear'
 import { getQueue } from '@/lib/services/queue'
+import { JobMessage } from '@/lib/services/queue/type'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Mention } from '@/lib/types/activitypub'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
@@ -50,7 +51,18 @@ const JobData = z.object({
   // Only an unattended, single-activity import sets it: the Strava webhook.
   // Defaulting to false means a new caller is silent until it opts in, which is
   // the safe direction to be wrong in.
-  notifyOnComplete: z.boolean().optional().default(false)
+  notifyOnComplete: z.boolean().optional().default(false),
+  // Whether a status newly created here should federate its Create.
+  //
+  // Same reasoning as notifyOnComplete, and set by the same single caller: this
+  // job funnels every bulk import, so inferring the flag from "a status was
+  // created" would deliver one Create per activity — a 500-ride archive import
+  // would flood every follower's timeline. Only the Strava webhook, which
+  // carries exactly one freshly recorded activity, opts in.
+  //
+  // An import that reuses an existing status never federates regardless of this
+  // flag: see the publishSendNote expression on the process job below.
+  publishSendNote: z.boolean().optional().default(false)
 })
 
 const ACTOR_NOT_FOUND_IMPORT_ERROR = 'Actor not found for fitness import'
@@ -233,250 +245,275 @@ const createLocalOnlyFitnessStatus = async ({
   return createdStatus
 }
 
-export const importFitnessFilesJob = createJobHandle(
-  IMPORT_FITNESS_FILES_JOB_NAME,
-  async (database, message) => {
-    const {
-      actorId,
-      batchId,
-      fitnessFileIds,
-      overlapFitnessFileIds,
-      visibility,
-      notifyOnComplete
-    } = JobData.parse(message.data)
+export interface ImportedFitnessGroup {
+  statusId: string
+  statusCreated: boolean
+  primaryFitnessFileId: string
+  // The PROCESS_FITNESS_FILE_JOB message this group needs, with
+  // publishSendNote/notifyOnComplete already resolved against the existing
+  // status. Null when the group's primary file is not among this run's targets
+  // — a merge into a sibling's post, which must not reprocess it.
+  processJob: JobMessage | null
+}
 
-    const actor = await database.getActorFromId({ id: actorId })
-    if (!actor) {
-      logger.error({
-        message: ACTOR_NOT_FOUND_IMPORT_ERROR,
+export interface ImportFitnessFilesOptions {
+  // Return each group's PROCESS_FITNESS_FILE_JOB instead of publishing it, so
+  // the caller can publish once the status content is complete.
+  //
+  // Deliberately an option of this function rather than a JobData field: a
+  // queued caller never sees the return value, so deferring there would drop
+  // the process job entirely. Only the inline Strava caller sets it.
+  deferProcessJobPublishes?: boolean
+}
+
+export const importFitnessFiles = async (
+  database: Database,
+  data: unknown,
+  options: ImportFitnessFilesOptions = {}
+): Promise<ImportedFitnessGroup[]> => {
+  const {
+    actorId,
+    batchId,
+    fitnessFileIds,
+    overlapFitnessFileIds,
+    visibility,
+    notifyOnComplete,
+    publishSendNote
+  } = JobData.parse(data)
+
+  const importedGroups: ImportedFitnessGroup[] = []
+
+  const actor = await database.getActorFromId({ id: actorId })
+  if (!actor) {
+    logger.error({
+      message: ACTOR_NOT_FOUND_IMPORT_ERROR,
+      actorId,
+      batchId
+    })
+
+    await Promise.all([
+      database.updateFitnessFilesImportStatus({
+        fitnessFileIds,
+        importStatus: 'failed',
+        importError: ACTOR_NOT_FOUND_IMPORT_ERROR
+      }),
+      database.updateFitnessFilesProcessingStatus({
+        fitnessFileIds,
+        processingStatus: 'failed'
+      })
+    ])
+
+    return importedGroups
+  }
+
+  const parsedFiles: ParsedImportFile[] = []
+  const targetFitnessFileIdSet = new Set(fitnessFileIds)
+  const allFitnessFileIds = Array.from(
+    new Set([...fitnessFileIds, ...overlapFitnessFileIds])
+  )
+  const fitnessFiles = await database.getFitnessFilesByIds({
+    fitnessFileIds: allFitnessFileIds
+  })
+  const fitnessFileById = new Map(
+    fitnessFiles.map((fitnessFile) => [fitnessFile.id, fitnessFile])
+  )
+
+  for (const fitnessFileId of allFitnessFileIds) {
+    const fitnessFile = fitnessFileById.get(fitnessFileId)
+    const isTargetFile = targetFitnessFileIdSet.has(fitnessFileId)
+
+    if (!fitnessFile) {
+      logger.warn({
+        message: MISSING_FITNESS_FILE_IMPORT_ERROR,
+        fitnessFileId,
         actorId,
         batchId
       })
 
-      await Promise.all([
-        database.updateFitnessFilesImportStatus({
-          fitnessFileIds,
-          importStatus: 'failed',
-          importError: ACTOR_NOT_FOUND_IMPORT_ERROR
-        }),
-        database.updateFitnessFilesProcessingStatus({
-          fitnessFileIds,
-          processingStatus: 'failed'
-        })
-      ])
+      if (isTargetFile) {
+        await markImportFileFailed(
+          database,
+          fitnessFileId,
+          MISSING_FITNESS_FILE_IMPORT_ERROR
+        )
+      }
 
-      return
+      continue
     }
 
-    const parsedFiles: ParsedImportFile[] = []
-    const targetFitnessFileIdSet = new Set(fitnessFileIds)
-    const allFitnessFileIds = Array.from(
-      new Set([...fitnessFileIds, ...overlapFitnessFileIds])
-    )
-    const fitnessFiles = await database.getFitnessFilesByIds({
-      fitnessFileIds: allFitnessFileIds
-    })
-    const fitnessFileById = new Map(
-      fitnessFiles.map((fitnessFile) => [fitnessFile.id, fitnessFile])
-    )
-
-    for (const fitnessFileId of allFitnessFileIds) {
-      const fitnessFile = fitnessFileById.get(fitnessFileId)
-      const isTargetFile = targetFitnessFileIdSet.has(fitnessFileId)
-
-      if (!fitnessFile) {
-        logger.warn({
-          message: MISSING_FITNESS_FILE_IMPORT_ERROR,
-          fitnessFileId,
-          actorId,
-          batchId
-        })
-
-        if (isTargetFile) {
-          await markImportFileFailed(
-            database,
-            fitnessFileId,
-            MISSING_FITNESS_FILE_IMPORT_ERROR
-          )
-        }
-
-        continue
-      }
-
-      if (fitnessFile.actorId !== actorId) {
-        if (isTargetFile) {
-          await markImportFileFailed(
-            database,
-            fitnessFile.id,
-            'Fitness file does not belong to actor'
-          )
-        }
-        continue
-      }
-
-      if (!isTargetFile) {
-        const parsedFromStoredActivity = buildParsedFileFromStoredActivity({
-          fitnessFile,
-          source: 'overlap'
-        })
-
-        if (parsedFromStoredActivity) {
-          parsedFiles.push(parsedFromStoredActivity)
-        }
-
-        continue
-      }
-
-      try {
-        const buffer = await getFitnessFileBuffer(
+    if (fitnessFile.actorId !== actorId) {
+      if (isTargetFile) {
+        await markImportFileFailed(
           database,
           fitnessFile.id,
-          fitnessFile
+          'Fitness file does not belong to actor'
         )
-        if (!isParseableFitnessFileType(fitnessFile.fileType)) {
-          throw new Error(
-            `Unsupported fitness file type for activity parsing: ${fitnessFile.fileType}`
-          )
-        }
-        const activityData = await parseFitnessFile({
-          fileType: fitnessFile.fileType,
-          buffer
-        })
-
-        // Same reason as processFitnessFileJob: the reset below de-references
-        // any copy stored for an earlier import of this row, and a file that
-        // ends up non-primary never reaches processFitnessFileJob to rewrite it.
-        await deleteEmailMapImage({
-          database,
-          fitnessFileId: fitnessFile.id,
-          mapImageEmailPath: fitnessFile.mapImageEmailPath
-        })
-
-        await database.updateFitnessFileActivityData(fitnessFile.id, {
-          totalDistanceMeters: activityData.totalDistanceMeters,
-          totalDurationSeconds: activityData.totalDurationSeconds,
-          movingTimeSeconds: activityData.movingTimeSeconds ?? null,
-          elevationGainMeters: activityData.elevationGainMeters,
-          activityType: activityData.activityType,
-          activityStartTime: activityData.startTime ?? null,
-          hasMapData: false,
-          mapImagePath: null,
-          mapImageEmailPath: null,
-          // The map is being redone from scratch, so a reason recorded for the
-          // previous one is stale. Left behind it would keep the status looking
-          // retriable forever — including on a file that ends up non-primary
-          // and is never supposed to own a map at all.
-          mapError: null,
-          ...(activityData.deviceManufacturer !== undefined
-            ? { deviceManufacturer: activityData.deviceManufacturer }
-            : {}),
-          ...(activityData.deviceName !== undefined
-            ? { deviceName: activityData.deviceName }
-            : {})
-        })
-
-        await linkFitnessFileDeviceGear({
-          database,
-          actorId,
-          fitnessFileId: fitnessFile.id,
-          deviceName: activityData.deviceName ?? fitnessFile.deviceName,
-          deviceManufacturer:
-            activityData.deviceManufacturer ?? fitnessFile.deviceManufacturer
-        })
-
-        parsedFiles.push({
-          fitnessFile,
-          totalDurationSeconds: activityData.totalDurationSeconds,
-          source: 'target',
-          hasCoordinates: activityData.coordinates.length >= 2,
-          ...(activityData.startTime
-            ? { startTimeMs: activityData.startTime.getTime() }
-            : null)
-        })
-      } catch (error) {
-        const errorMessage = toImportErrorMessage(error)
-
-        logger.warn({
-          message: 'Failed to parse fitness file during import',
-          fitnessFileId,
-          actorId,
-          batchId,
-          error: errorMessage
-        })
-
-        await markImportFileFailed(database, fitnessFile.id, errorMessage)
       }
+      continue
     }
 
-    if (!parsedFiles.some((item) => item.source === 'target')) {
-      return
-    }
+    if (!isTargetFile) {
+      const parsedFromStoredActivity = buildParsedFileFromStoredActivity({
+        fitnessFile,
+        source: 'overlap'
+      })
 
-    const groups = groupFilesByOverlap(parsedFiles)
-
-    for (const group of groups) {
-      const orderedGroup = sortFilesByActivityStart(group)
-      const orderedTargetGroup = sortFilesByActivityStart(
-        group.filter((item) => item.source === 'target')
-      )
-
-      if (orderedTargetGroup.length === 0) {
-        continue
+      if (parsedFromStoredActivity) {
+        parsedFiles.push(parsedFromStoredActivity)
       }
 
-      const targetFitnessFileIds = orderedTargetGroup.map(
-        (item) => item.fitnessFile.id
+      continue
+    }
+
+    try {
+      const buffer = await getFitnessFileBuffer(
+        database,
+        fitnessFile.id,
+        fitnessFile
       )
-      const primaryTargetFile = selectPrimaryTargetFile(orderedTargetGroup)
-      const earliestTargetFile = orderedTargetGroup[0]
-      const createdAt =
-        earliestTargetFile.startTimeMs ??
-        earliestTargetFile.fitnessFile.createdAt
-      let createdStatusId: string | null = null
+      if (!isParseableFitnessFileType(fitnessFile.fileType)) {
+        throw new Error(
+          `Unsupported fitness file type for activity parsing: ${fitnessFile.fileType}`
+        )
+      }
+      const activityData = await parseFitnessFile({
+        fileType: fitnessFile.fileType,
+        buffer
+      })
 
-      try {
-        const existingStatusId =
-          orderedGroup.find((item) => item.fitnessFile.statusId)?.fitnessFile
-            .statusId ?? null
+      // Same reason as processFitnessFileJob: the reset below de-references
+      // any copy stored for an earlier import of this row, and a file that
+      // ends up non-primary never reaches processFitnessFileJob to rewrite it.
+      await deleteEmailMapImage({
+        database,
+        fitnessFileId: fitnessFile.id,
+        mapImageEmailPath: fitnessFile.mapImageEmailPath
+      })
 
-        const existingStatus = existingStatusId
-          ? await database.getStatus({
-              statusId: existingStatusId,
-              withReplies: false
-            })
-          : null
+      await database.updateFitnessFileActivityData(fitnessFile.id, {
+        totalDistanceMeters: activityData.totalDistanceMeters,
+        totalDurationSeconds: activityData.totalDurationSeconds,
+        movingTimeSeconds: activityData.movingTimeSeconds ?? null,
+        elevationGainMeters: activityData.elevationGainMeters,
+        activityType: activityData.activityType,
+        activityStartTime: activityData.startTime ?? null,
+        hasMapData: false,
+        mapImagePath: null,
+        mapImageEmailPath: null,
+        // The map is being redone from scratch, so a reason recorded for the
+        // previous one is stale. Left behind it would keep the status looking
+        // retriable forever — including on a file that ends up non-primary
+        // and is never supposed to own a map at all.
+        mapError: null,
+        ...(activityData.deviceManufacturer !== undefined
+          ? { deviceManufacturer: activityData.deviceManufacturer }
+          : {}),
+        ...(activityData.deviceName !== undefined
+          ? { deviceName: activityData.deviceName }
+          : {})
+      })
 
-        const existingPrimaryFileId =
-          existingStatus &&
-          orderedGroup.find(
-            (item) =>
-              item.fitnessFile.statusId === existingStatus.id &&
-              item.fitnessFile.isPrimary
-          )?.fitnessFile.id
+      await linkFitnessFileDeviceGear({
+        database,
+        actorId,
+        fitnessFileId: fitnessFile.id,
+        deviceName: activityData.deviceName ?? fitnessFile.deviceName,
+        deviceManufacturer:
+          activityData.deviceManufacturer ?? fitnessFile.deviceManufacturer
+      })
 
-        const status =
-          existingStatus ??
-          (await createLocalOnlyFitnessStatus({
-            actor,
-            createdAt,
-            visibility,
-            database
-          }))
-        if (!existingStatus) {
-          createdStatusId = status.id
-        }
+      parsedFiles.push({
+        fitnessFile,
+        totalDurationSeconds: activityData.totalDurationSeconds,
+        source: 'target',
+        hasCoordinates: activityData.coordinates.length >= 2,
+        ...(activityData.startTime
+          ? { startTimeMs: activityData.startTime.getTime() }
+          : null)
+      })
+    } catch (error) {
+      const errorMessage = toImportErrorMessage(error)
 
-        const primaryFitnessFileId =
-          existingPrimaryFileId ?? primaryTargetFile.fitnessFile.id
+      logger.warn({
+        message: 'Failed to parse fitness file during import',
+        fitnessFileId,
+        actorId,
+        batchId,
+        error: errorMessage
+      })
 
-        await database.assignFitnessFilesToImportedStatus({
-          fitnessFileIds: targetFitnessFileIds,
-          primaryFitnessFileId,
-          statusId: status.id
-        })
+      await markImportFileFailed(database, fitnessFile.id, errorMessage)
+    }
+  }
 
-        if (targetFitnessFileIds.includes(primaryFitnessFileId)) {
-          await getQueue().publish({
+  if (!parsedFiles.some((item) => item.source === 'target')) {
+    return importedGroups
+  }
+
+  const groups = groupFilesByOverlap(parsedFiles)
+
+  for (const group of groups) {
+    const orderedGroup = sortFilesByActivityStart(group)
+    const orderedTargetGroup = sortFilesByActivityStart(
+      group.filter((item) => item.source === 'target')
+    )
+
+    if (orderedTargetGroup.length === 0) {
+      continue
+    }
+
+    const targetFitnessFileIds = orderedTargetGroup.map(
+      (item) => item.fitnessFile.id
+    )
+    const primaryTargetFile = selectPrimaryTargetFile(orderedTargetGroup)
+    const earliestTargetFile = orderedTargetGroup[0]
+    const createdAt =
+      earliestTargetFile.startTimeMs ?? earliestTargetFile.fitnessFile.createdAt
+    let createdStatusId: string | null = null
+
+    try {
+      const existingStatusId =
+        orderedGroup.find((item) => item.fitnessFile.statusId)?.fitnessFile
+          .statusId ?? null
+
+      const existingStatus = existingStatusId
+        ? await database.getStatus({
+            statusId: existingStatusId,
+            withReplies: false
+          })
+        : null
+
+      const existingPrimaryFileId =
+        existingStatus &&
+        orderedGroup.find(
+          (item) =>
+            item.fitnessFile.statusId === existingStatus.id &&
+            item.fitnessFile.isPrimary
+        )?.fitnessFile.id
+
+      const status =
+        existingStatus ??
+        (await createLocalOnlyFitnessStatus({
+          actor,
+          createdAt,
+          visibility,
+          database
+        }))
+      if (!existingStatus) {
+        createdStatusId = status.id
+      }
+
+      const primaryFitnessFileId =
+        existingPrimaryFileId ?? primaryTargetFile.fitnessFile.id
+
+      await database.assignFitnessFilesToImportedStatus({
+        fitnessFileIds: targetFitnessFileIds,
+        primaryFitnessFileId,
+        statusId: status.id
+      })
+
+      const processJob = targetFitnessFileIds.includes(primaryFitnessFileId)
+        ? {
             id: getHashFromString(
               `${status.id}:${primaryFitnessFileId}:process-fitness`
             ),
@@ -485,50 +522,74 @@ export const importFitnessFilesJob = createJobHandle(
               actorId,
               statusId: status.id,
               fitnessFileId: primaryFitnessFileId,
-              publishSendNote: false,
+              // Both conditions, for the same reason as notifyOnComplete
+              // below: the Create has to go out exactly once, and only for a
+              // status this run created. Retries and the recovery scripts
+              // re-run over statuses that are already live, whose Create (if
+              // there was one) has already been delivered.
+              publishSendNote: publishSendNote && !existingStatus,
               // Both conditions: the caller has to be one that emails at all,
               // AND this has to be a genuine first import rather than a
               // reprocess of a status that already exists.
               notifyOnComplete: notifyOnComplete && !existingStatus
             }
-          })
-        }
-      } catch (error) {
-        // Must not be `(error as Error).message`: this block covers the queue
-        // publish, and a non-Error rejection would make the reason `undefined`,
-        // which updateFitnessFileImportStatus writes as NULL — wiping any prior
-        // reason and leaving the file `failed` with no explanation.
-        const errorMessage = toImportErrorMessage(error)
-
-        logger.error({
-          message: 'Failed to create local status for imported fitness files',
-          actorId,
-          batchId,
-          fitnessFileIds: targetFitnessFileIds,
-          error: errorMessage
-        })
-
-        await Promise.all(
-          orderedTargetGroup.map((item) =>
-            markImportFileFailed(database, item.fitnessFile.id, errorMessage)
-          )
-        )
-
-        if (createdStatusId) {
-          try {
-            await database.deleteStatus({ statusId: createdStatusId })
-          } catch (cleanupError) {
-            const nodeCleanupError = cleanupError as Error
-            logger.error({
-              message: 'Failed to cleanup local status after import failure',
-              actorId,
-              batchId,
-              statusId: createdStatusId,
-              error: nodeCleanupError.message
-            })
           }
+        : null
+
+      if (processJob && !options.deferProcessJobPublishes) {
+        await getQueue().publish(processJob)
+      }
+
+      importedGroups.push({
+        statusId: status.id,
+        statusCreated: !existingStatus,
+        primaryFitnessFileId,
+        processJob
+      })
+    } catch (error) {
+      // Must not be `(error as Error).message`: this block covers the queue
+      // publish, and a non-Error rejection would make the reason `undefined`,
+      // which updateFitnessFileImportStatus writes as NULL — wiping any prior
+      // reason and leaving the file `failed` with no explanation.
+      const errorMessage = toImportErrorMessage(error)
+
+      logger.error({
+        message: 'Failed to create local status for imported fitness files',
+        actorId,
+        batchId,
+        fitnessFileIds: targetFitnessFileIds,
+        error: errorMessage
+      })
+
+      await Promise.all(
+        orderedTargetGroup.map((item) =>
+          markImportFileFailed(database, item.fitnessFile.id, errorMessage)
+        )
+      )
+
+      if (createdStatusId) {
+        try {
+          await database.deleteStatus({ statusId: createdStatusId })
+        } catch (cleanupError) {
+          const nodeCleanupError = cleanupError as Error
+          logger.error({
+            message: 'Failed to cleanup local status after import failure',
+            actorId,
+            batchId,
+            statusId: createdStatusId,
+            error: nodeCleanupError.message
+          })
         }
       }
     }
+  }
+
+  return importedGroups
+}
+
+export const importFitnessFilesJob = createJobHandle(
+  IMPORT_FITNESS_FILES_JOB_NAME,
+  async (database, message) => {
+    await importFitnessFiles(database, message.data)
   }
 )

--- a/lib/jobs/importStravaActivityJob.federation.test.ts
+++ b/lib/jobs/importStravaActivityJob.federation.test.ts
@@ -309,6 +309,11 @@ describe('importStravaActivityJob federation', () => {
   it('does not federate an import that did not opt in', async () => {
     await importActivity('2002', 2)
 
+    // Proves the pipeline actually ran for THIS ride. Without it the test
+    // passes for the wrong reason the moment its start day collides with
+    // another test's: the ride merges into that status, no process job is
+    // published at all, and "no Create" becomes vacuously true.
+    expect(mockGenerateMapImage).toHaveBeenCalled()
     expect(hoisted.sendNoteSnapshots).toHaveLength(0)
   })
 

--- a/lib/jobs/importStravaActivityJob.federation.test.ts
+++ b/lib/jobs/importStravaActivityJob.federation.test.ts
@@ -1,0 +1,342 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { importStravaActivityJob } from '@/lib/jobs/importStravaActivityJob'
+import {
+  IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+  SEND_NOTE_JOB_NAME
+} from '@/lib/jobs/names'
+import {
+  getFitnessFileBuffer,
+  saveFitnessFile
+} from '@/lib/services/fitness-files'
+import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
+import { parseFitnessFile } from '@/lib/services/fitness-files/parseFitnessFile'
+import { saveMedia } from '@/lib/services/medias'
+import {
+  buildGpxFromStravaStreams,
+  buildTcxFromStravaStreams,
+  getStravaActivity,
+  getStravaActivityPhotos,
+  getStravaActivityStreams,
+  getValidStravaAccessToken
+} from '@/lib/services/strava/activity'
+import { getStravaActivityBatchId } from '@/lib/services/strava/activityBatch'
+import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { Actor } from '@/lib/types/domain/actor'
+
+// Runs published jobs inline against the SAME in-memory test database, so the
+// whole import -> process -> federate path executes end-to-end, and records
+// what the status looked like AT THE MOMENT the Create was queued. That last
+// part is the point of this file: publishing the process job is what federates,
+// and under NoQueue it runs inline, so a status still missing its caption or
+// map when SEND_NOTE is queued is exactly the bug this guards.
+//
+// SEND_NOTE itself is captured rather than dispatched — delivery is
+// sendNoteJob's own concern and needs no network here.
+const hoisted = vi.hoisted(() => ({
+  database: null as unknown,
+  sendNoteSnapshots: [] as {
+    statusId: string
+    text: string
+    attachmentNames: string[]
+  }[]
+}))
+
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: () => ({
+    publish: async (message: {
+      name: string
+      data?: { statusId?: string }
+    }) => {
+      const database = hoisted.database as Database | null
+      if (!database) return
+
+      if (message.name === SEND_NOTE_JOB_NAME) {
+        const statusId = message.data?.statusId as string
+        const status = await database.getStatus({
+          statusId,
+          withReplies: false
+        })
+        hoisted.sendNoteSnapshots.push({
+          statusId,
+          text: status && 'text' in status ? status.text : '',
+          attachmentNames:
+            status && 'attachments' in status
+              ? status.attachments.map((attachment) => attachment.name ?? '')
+              : []
+        })
+        return
+      }
+
+      const { JOBS } = await import('@/lib/jobs')
+      const job = (JOBS as Record<string, unknown>)[message.name] as
+        ((db: unknown, msg: unknown) => Promise<void>) | undefined
+      if (job) {
+        await job(database, message)
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/services/fitness-files', async () => {
+  const actual = await vi.importActual('@/lib/services/fitness-files')
+  return {
+    ...actual,
+    saveFitnessFile: vi.fn(),
+    getFitnessFileBuffer: vi.fn()
+  }
+})
+
+vi.mock('@/lib/services/fitness-files/parseFitnessFile', async () => {
+  const actual = await vi.importActual(
+    '@/lib/services/fitness-files/parseFitnessFile'
+  )
+  return { ...actual, parseFitnessFile: vi.fn() }
+})
+
+vi.mock('@/lib/services/fitness-files/generateMapImage', () => ({
+  generateMapImage: vi.fn()
+}))
+
+vi.mock('@/lib/services/medias', async () => {
+  const actual = await vi.importActual('@/lib/services/medias')
+  return { ...actual, saveMedia: vi.fn() }
+})
+
+vi.mock('@/lib/services/strava/activity', async () => {
+  const actual = await vi.importActual('@/lib/services/strava/activity')
+  return {
+    ...actual,
+    getStravaActivity: vi.fn(),
+    getStravaActivityStreams: vi.fn(),
+    getStravaActivityPhotos: vi.fn(),
+    getValidStravaAccessToken: vi.fn(),
+    buildTcxFromStravaStreams: vi.fn(),
+    buildGpxFromStravaStreams: vi.fn()
+  }
+})
+
+const mockSaveFitnessFile = saveFitnessFile as jest.MockedFunction<
+  typeof saveFitnessFile
+>
+const mockGetFitnessFileBuffer = getFitnessFileBuffer as jest.MockedFunction<
+  typeof getFitnessFileBuffer
+>
+const mockParseFitnessFile = parseFitnessFile as jest.MockedFunction<
+  typeof parseFitnessFile
+>
+const mockGenerateMapImage = generateMapImage as jest.MockedFunction<
+  typeof generateMapImage
+>
+const mockSaveMedia = saveMedia as jest.MockedFunction<typeof saveMedia>
+const mockGetStravaActivity = getStravaActivity as jest.MockedFunction<
+  typeof getStravaActivity
+>
+const mockGetStravaActivityStreams =
+  getStravaActivityStreams as jest.MockedFunction<
+    typeof getStravaActivityStreams
+  >
+const mockGetStravaActivityPhotos =
+  getStravaActivityPhotos as jest.MockedFunction<typeof getStravaActivityPhotos>
+const mockGetValidStravaAccessToken =
+  getValidStravaAccessToken as jest.MockedFunction<
+    typeof getValidStravaAccessToken
+  >
+const mockBuildTcx = buildTcxFromStravaStreams as jest.MockedFunction<
+  typeof buildTcxFromStravaStreams
+>
+const mockBuildGpx = buildGpxFromStravaStreams as jest.MockedFunction<
+  typeof buildGpxFromStravaStreams
+>
+
+// Every test in this file shares one in-memory database, and the importer
+// merges activities that overlap in time — so each test needs its own start or
+// its ride would join the previous test's post and be treated as a re-import.
+const rideStart = (dayOfMonth: number) =>
+  `2026-04-${String(dayOfMonth).padStart(2, '0')}T08:00:00.000Z`
+const ACTIVITY_NAME = 'Morning Ride'
+
+describe('importStravaActivityJob federation', () => {
+  const database = getTestSQLDatabase()
+  let actor: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    actor = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    hoisted.database = database
+    await database.createFitnessSettings({
+      actorId: actor.id,
+      serviceType: 'strava',
+      accessToken: 'access-token'
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.sendNoteSnapshots = []
+
+    mockGetValidStravaAccessToken.mockResolvedValue('access-token')
+    mockGetStravaActivityStreams.mockResolvedValue({
+      latlng: {
+        type: 'latlng',
+        data: [
+          [37.77, -122.41],
+          [37.78, -122.42]
+        ]
+      },
+      time: { type: 'time', data: [0, 3600] }
+    })
+    mockBuildTcx.mockReturnValue(null)
+    mockBuildGpx.mockReturnValue('<?xml version="1.0"?><gpx>...</gpx>')
+    mockGetStravaActivityPhotos.mockResolvedValue([])
+
+    mockSaveFitnessFile.mockImplementation(async (db, fileActor, options) => {
+      const created = await db.createFitnessFile({
+        actorId: fileActor.id,
+        path: `fitness/${options.file.name}`,
+        fileName: options.file.name,
+        fileType: 'gpx',
+        mimeType: 'application/gpx+xml',
+        bytes: 64,
+        importBatchId: options.importBatchId,
+        sourceUrl: options.sourceUrl
+      })
+      return {
+        id: created!.id,
+        type: 'fitness',
+        file_type: 'gpx',
+        mime_type: 'application/gpx+xml',
+        url: `http://llun.test/api/v1/fitness-files/${created!.id}`,
+        fileName: options.file.name,
+        size: 64
+      } as never
+    })
+
+    mockGetFitnessFileBuffer.mockResolvedValue(Buffer.from('gpx-bytes'))
+
+    mockParseFitnessFile.mockResolvedValue({
+      coordinates: [
+        { lat: 37.77, lng: -122.41 },
+        { lat: 37.78, lng: -122.42 }
+      ],
+      trackPoints: [
+        { lat: 37.77, lng: -122.41 },
+        { lat: 37.78, lng: -122.42 }
+      ],
+      totalDistanceMeters: 20_000,
+      totalDurationSeconds: 3_600,
+      elevationGainMeters: 50,
+      activityType: 'cycling'
+    } as never)
+
+    mockGenerateMapImage.mockResolvedValue(Buffer.from('map-image'))
+    let mediaCounter = 0
+    mockSaveMedia.mockImplementation(async () => {
+      mediaCounter += 1
+      return {
+        id: `map-media-${mediaCounter}`,
+        type: 'image',
+        mime_type: 'image/webp',
+        url: `https://llun.test/api/v1/files/medias/route-map-${mediaCounter}.webp`,
+        preview_url: null,
+        text_url: null,
+        remote_url: null,
+        meta: { original: { width: 800, height: 600 } },
+        description: 'Route map'
+      } as never
+    })
+  })
+
+  const importActivity = async (
+    stravaActivityId: string,
+    startDay: number,
+    data: Record<string, unknown> = {}
+  ) => {
+    const startDate = rideStart(startDay)
+    mockParseFitnessFile.mockResolvedValue({
+      coordinates: [
+        { lat: 37.77, lng: -122.41 },
+        { lat: 37.78, lng: -122.42 }
+      ],
+      trackPoints: [
+        { lat: 37.77, lng: -122.41 },
+        { lat: 37.78, lng: -122.42 }
+      ],
+      totalDistanceMeters: 20_000,
+      totalDurationSeconds: 3_600,
+      elevationGainMeters: 50,
+      activityType: 'cycling',
+      startTime: new Date(startDate)
+    } as never)
+    mockGetStravaActivity.mockResolvedValueOnce({
+      id: Number(stravaActivityId),
+      name: ACTIVITY_NAME,
+      distance: 20_000,
+      elapsed_time: 3_600,
+      total_elevation_gain: 50,
+      start_date: startDate,
+      sport_type: 'Ride',
+      visibility: 'everyone'
+    } as never)
+
+    await importStravaActivityJob(database, {
+      id: `job-${stravaActivityId}`,
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: { actorId: actor.id, stravaActivityId, ...data }
+    })
+  }
+
+  it('federates a webhook import once its caption and route map are on the status', async () => {
+    await importActivity('2001', 1, { publishSendNote: true })
+
+    expect(hoisted.sendNoteSnapshots).toHaveLength(1)
+    const [snapshot] = hoisted.sendNoteSnapshots
+    // Both were written before the Create was queued. Federating first would
+    // deliver an empty note that no later job re-sends.
+    expect(snapshot.text).toContain(ACTIVITY_NAME)
+    expect(snapshot.attachmentNames).toContain('Activity route map')
+  })
+
+  it('does not federate an import that did not opt in', async () => {
+    await importActivity('2002', 2)
+
+    expect(hoisted.sendNoteSnapshots).toHaveLength(0)
+  })
+
+  it('does not federate again when the same activity is imported a second time', async () => {
+    await importActivity('2003', 3, { publishSendNote: true })
+    expect(hoisted.sendNoteSnapshots).toHaveLength(1)
+
+    hoisted.sendNoteSnapshots = []
+    await importActivity('2003', 3, { publishSendNote: true })
+
+    expect(hoisted.sendNoteSnapshots).toHaveLength(0)
+  })
+
+  it('federates one Create for a ride merged from two device webhooks', async () => {
+    // A single ride recorded on two devices arrives as two Strava activities.
+    // They collapse into one post, so exactly one Create describes the ride.
+    await importActivity('2004', 4, { publishSendNote: true })
+    await importActivity('2005', 4, { publishSendNote: true })
+
+    const [fileA] = await database.getFitnessFilesByBatchId({
+      batchId: getStravaActivityBatchId('2004')
+    })
+    const [fileB] = await database.getFitnessFilesByBatchId({
+      batchId: getStravaActivityBatchId('2005')
+    })
+    expect(fileB.statusId).toBe(fileA.statusId)
+
+    expect(hoisted.sendNoteSnapshots).toHaveLength(1)
+    expect(hoisted.sendNoteSnapshots[0].statusId).toBe(fileA.statusId)
+  })
+})

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -1,11 +1,11 @@
 import { lookup } from 'node:dns/promises'
 
 import { Database } from '@/lib/database/types'
-import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
+import { importFitnessFiles } from '@/lib/jobs/importFitnessFilesJob'
 import { importStravaActivityJob } from '@/lib/jobs/importStravaActivityJob'
 import {
-  IMPORT_FITNESS_FILES_JOB_NAME,
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+  PROCESS_FITNESS_FILE_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
   SEND_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
@@ -36,7 +36,7 @@ vi.mock('@/lib/services/medias/index', async () => ({
 }))
 
 vi.mock('@/lib/jobs/importFitnessFilesJob', async () => ({
-  importFitnessFilesJob: vi.fn()
+  importFitnessFiles: vi.fn()
 }))
 
 vi.mock('@/lib/services/strava/activity', async () => {
@@ -72,8 +72,8 @@ vi.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
     mockSendNotificationAlerts(...args)
 }))
 
-const mockImportFitnessFilesJob = importFitnessFilesJob as jest.MockedFunction<
-  typeof importFitnessFilesJob
+const mockImportFitnessFiles = importFitnessFiles as jest.MockedFunction<
+  typeof importFitnessFiles
 >
 const mockGetStravaActivity = getStravaActivity as jest.MockedFunction<
   typeof getStravaActivity
@@ -271,7 +271,7 @@ describe('importStravaActivityJob', () => {
       fileName: 'strava-123.gpx',
       size: 42
     })
-    mockImportFitnessFilesJob.mockResolvedValue(undefined)
+    mockImportFitnessFiles.mockResolvedValue([])
     mockGetStravaActivityPhotos.mockResolvedValue([])
     mockGetQueue.mockReturnValue({
       publish: vi.fn().mockResolvedValue(undefined)
@@ -299,18 +299,16 @@ describe('importStravaActivityJob', () => {
         sourceUrl: 'https://www.strava.com/activities/123'
       })
     )
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledTimes(1)
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+    expect(mockImportFitnessFiles).toHaveBeenCalledTimes(1)
+    expect(mockImportFitnessFiles).toHaveBeenCalledWith(
       database,
       expect.objectContaining({
-        name: IMPORT_FITNESS_FILES_JOB_NAME,
-        data: expect.objectContaining({
-          actorId: 'actor-1',
-          fitnessFileIds: ['new-file'],
-          overlapFitnessFileIds: ['overlap-file'],
-          visibility: 'public'
-        })
-      })
+        actorId: 'actor-1',
+        fitnessFileIds: ['new-file'],
+        overlapFitnessFileIds: ['overlap-file'],
+        visibility: 'public'
+      }),
+      { deferProcessJobPublishes: true }
     )
     expect(database.updateNote).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -336,7 +334,7 @@ describe('importStravaActivityJob', () => {
       expect.objectContaining({ token: 'lock-token' })
     )
     // The merge-deciding work runs inside the lock.
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledTimes(1)
+    expect(mockImportFitnessFiles).toHaveBeenCalledTimes(1)
   })
 
   it('does not acquire the import lock when the activity already has a status', async () => {
@@ -370,7 +368,7 @@ describe('importStravaActivityJob', () => {
     })
 
     expect(database.acquireImportLock).not.toHaveBeenCalled()
-    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(mockImportFitnessFiles).not.toHaveBeenCalled()
   })
 
   it('seeds activity start time and duration at import so later same-ride imports can merge before processing', async () => {
@@ -500,14 +498,12 @@ describe('importStravaActivityJob', () => {
       }
     })
 
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+    expect(mockImportFitnessFiles).toHaveBeenCalledWith(
       database,
       expect.objectContaining({
-        name: IMPORT_FITNESS_FILES_JOB_NAME,
-        data: expect.objectContaining({
-          visibility: 'direct'
-        })
-      })
+        visibility: 'direct'
+      }),
+      { deferProcessJobPublishes: true }
     )
   })
 
@@ -533,14 +529,12 @@ describe('importStravaActivityJob', () => {
       }
     })
 
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+    expect(mockImportFitnessFiles).toHaveBeenCalledWith(
       database,
       expect.objectContaining({
-        name: IMPORT_FITNESS_FILES_JOB_NAME,
-        data: expect.objectContaining({
-          visibility: 'private'
-        })
-      })
+        visibility: 'private'
+      }),
+      { deferProcessJobPublishes: true }
     )
   })
 
@@ -585,7 +579,7 @@ describe('importStravaActivityJob', () => {
         file: expect.objectContaining({ name: 'strava-125.tcx' })
       })
     )
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledTimes(1)
+    expect(mockImportFitnessFiles).toHaveBeenCalledTimes(1)
     expect(database.createNote).not.toHaveBeenCalled()
   })
 
@@ -623,7 +617,7 @@ describe('importStravaActivityJob', () => {
       expect.objectContaining({ time: expect.anything() })
     )
     expect(mockSaveFitnessFile).not.toHaveBeenCalled()
-    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(mockImportFitnessFiles).not.toHaveBeenCalled()
     expect(database.createNote).toHaveBeenCalledWith(
       expect.objectContaining({
         actorId: 'actor-1',
@@ -881,7 +875,7 @@ describe('importStravaActivityJob', () => {
         file: expect.objectContaining({ name: 'strava-125.gpx' })
       })
     )
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledTimes(1)
+    expect(mockImportFitnessFiles).toHaveBeenCalledTimes(1)
     expect(database.createNote).not.toHaveBeenCalled()
   })
 
@@ -914,7 +908,7 @@ describe('importStravaActivityJob', () => {
     })
 
     expect(mockSaveFitnessFile).not.toHaveBeenCalled()
-    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(mockImportFitnessFiles).not.toHaveBeenCalled()
   })
 
   it('queues map regeneration when existing activity has no map', async () => {
@@ -1026,11 +1020,10 @@ describe('importStravaActivityJob', () => {
       data: { actorId: 'actor-1', stravaActivityId: '123' }
     })
 
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+    expect(mockImportFitnessFiles).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        data: expect.objectContaining({ notifyOnComplete: false })
-      })
+      expect.objectContaining({ notifyOnComplete: false }),
+      expect.anything()
     )
   })
 
@@ -1047,12 +1040,144 @@ describe('importStravaActivityJob', () => {
       }
     })
 
-    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+    expect(mockImportFitnessFiles).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        data: expect.objectContaining({ notifyOnComplete: true })
-      })
+      expect.objectContaining({ notifyOnComplete: true }),
+      expect.anything()
     )
+  })
+
+  describe('federation opt-in', () => {
+    const PROCESS_JOB = {
+      id: 'process-job-id',
+      name: PROCESS_FITNESS_FILE_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        statusId: 'status-1',
+        fitnessFileId: 'new-file',
+        publishSendNote: true,
+        notifyOnComplete: false
+      }
+    }
+
+    const deferOneProcessJob = () => {
+      mockImportFitnessFiles.mockResolvedValue([
+        {
+          statusId: 'status-1',
+          statusCreated: true,
+          primaryFitnessFileId: 'new-file',
+          processJob: PROCESS_JOB
+        }
+      ])
+    }
+
+    const getProcessPublishes = () =>
+      (mockGetQueue().publish as jest.Mock).mock.calls
+        .map(([message]) => message)
+        .filter((message) => message.name === PROCESS_FITNESS_FILE_JOB_NAME)
+
+    it.each([
+      { description: 'withholds federation by default', requested: {} },
+      {
+        description: 'forwards the federation opt-in from the webhook',
+        requested: { publishSendNote: true }
+      }
+    ])('$description', async ({ requested }) => {
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-forward',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          ...requested
+        }
+      })
+
+      expect(mockImportFitnessFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          publishSendNote: 'publishSendNote' in requested
+        }),
+        { deferProcessJobPublishes: true }
+      )
+    })
+
+    it('publishes the deferred process job only after the caption and photos are on the status', async () => {
+      // Under NoQueue publishing the process job runs it inline, and it is what
+      // federates the Create. Published before these writes it would deliver an
+      // empty, photoless note — deterministically in local dev, and as a race
+      // under QStash.
+      deferOneProcessJob()
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-order',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      const publishes = getProcessPublishes()
+      expect(publishes).toHaveLength(1)
+      expect(publishes[0]).toEqual(PROCESS_JOB)
+
+      const publishOrder = (mockGetQueue().publish as jest.Mock).mock
+        .invocationCallOrder[0]
+      expect(database.updateNote.mock.invocationCallOrder[0]).toBeLessThan(
+        publishOrder
+      )
+      expect(
+        mockGetStravaActivityPhotos.mock.invocationCallOrder[0]
+      ).toBeLessThan(publishOrder)
+    })
+
+    it('still publishes the deferred process job when the Strava photos fail', async () => {
+      // Otherwise a photo-service hiccup strands the file mid-pipeline with no
+      // map and no post — a worse outcome than a post without its photos.
+      deferOneProcessJob()
+      mockGetStravaActivityPhotos.mockRejectedValueOnce(
+        new Error('strava photos unavailable')
+      )
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-photo-failure',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      expect(getProcessPublishes()).toHaveLength(1)
+    })
+
+    it('publishes no process job when the import merged the file into an existing post', async () => {
+      // The sibling of a two-device ride: its files join the primary's status,
+      // which already owns the single process job and the single Create.
+      mockImportFitnessFiles.mockResolvedValue([
+        {
+          statusId: 'status-1',
+          statusCreated: false,
+          primaryFitnessFileId: 'sibling-file',
+          processJob: null
+        }
+      ])
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-merged',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      expect(getProcessPublishes()).toHaveLength(0)
+    })
   })
 
   it('defers the activity_import notification on the normal path', async () => {
@@ -1433,7 +1558,7 @@ describe('importStravaActivityJob', () => {
       })
 
       expect(mockSaveFitnessFile).toHaveBeenCalled()
-      expect(mockImportFitnessFilesJob).toHaveBeenCalled()
+      expect(mockImportFitnessFiles).toHaveBeenCalled()
     })
   })
 })

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -7,7 +7,8 @@ import {
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
   PROCESS_FITNESS_FILE_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
-  SEND_NOTE_JOB_NAME
+  SEND_NOTE_JOB_NAME,
+  SEND_UPDATE_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
 import { saveFitnessFile } from '@/lib/services/fitness-files'
 import { saveMedia } from '@/lib/services/medias/index'
@@ -609,7 +610,8 @@ describe('importStravaActivityJob', () => {
       name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
       data: {
         actorId: 'actor-1',
-        stravaActivityId: '125'
+        stravaActivityId: '125',
+        publishSendNote: true
       }
     })
 
@@ -632,7 +634,39 @@ describe('importStravaActivityJob', () => {
       })
     )
     expect(mockAddStatusToTimelines).toHaveBeenCalledTimes(1)
+    // Gated on the same opt-in as the file-backed path: this test drives the
+    // webhook shape, so the fallback note federates.
     expect(mockGetQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({ name: SEND_NOTE_JOB_NAME })
+    )
+  })
+
+  it('does not federate a fallback note for a caller that did not opt in', async () => {
+    // A retry-all sweep or a scripts/fitness recovery run drives this same
+    // branch over every streamless activity an actor has.
+    mockGetStravaActivity.mockResolvedValueOnce({
+      id: 125,
+      name: 'Morning Run',
+      distance: 5_000,
+      elapsed_time: 1_500,
+      total_elevation_gain: 120,
+      start_date: '2026-01-01T00:00:00.000Z',
+      sport_type: 'Run',
+      visibility: 'everyone'
+    } as never)
+    mockGetStravaActivityStreams.mockResolvedValueOnce(null)
+
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-no-upload-no-optin',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        stravaActivityId: '125'
+      }
+    })
+
+    expect(database.createNote).toHaveBeenCalled()
+    expect(mockGetQueue().publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ name: SEND_NOTE_JOB_NAME })
     )
   })
@@ -720,7 +754,8 @@ describe('importStravaActivityJob', () => {
       name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
       data: {
         actorId: 'actor-1',
-        stravaActivityId: '125'
+        stravaActivityId: '125',
+        publishSendNote: true
       }
     })
 
@@ -1239,6 +1274,102 @@ describe('importStravaActivityJob', () => {
         'failed',
         'queue exploded'
       )
+    })
+
+    it('never federates an activity the athlete marked only me on Strava', async () => {
+      // The webhook always sends an explicit visibility, so the only_me ->
+      // direct mapping never applies here and the ride would otherwise be
+      // pushed at whatever the account default happens to be.
+      mockGetStravaActivity.mockReset()
+      mockGetStravaActivity.mockResolvedValue({
+        id: 123,
+        name: 'Secret Ride',
+        distance: 5_000,
+        elapsed_time: 1_500,
+        total_elevation_gain: 20,
+        start_date: '2026-01-01T00:00:00.000Z',
+        sport_type: 'Ride',
+        visibility: 'only_me'
+      } as never)
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-only-me',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          visibility: 'public',
+          publishSendNote: true
+        }
+      })
+
+      expect(mockImportFitnessFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ publishSendNote: false }),
+        expect.anything()
+      )
+    })
+
+    it('sends an update when Strava photos land after the create', async () => {
+      // The process job is published before the photos, so under NoQueue the
+      // Create has already gone out by now; without this the remote copy keeps
+      // the photoless version forever. A merged sibling brings its own photos
+      // to an already-federated post for the same reason.
+      deferOneProcessJob()
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValueOnce([
+        { id: 'photo-1', url: 'https://images.example.com/photo-1.jpg' }
+      ] as never)
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(Buffer.from('jpg'), {
+          headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+        })
+      )
+
+      try {
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-federation-photo-update',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+      } finally {
+        fetchSpy.mockRestore()
+      }
+
+      expect(database.createAttachment).toHaveBeenCalledTimes(1)
+      const updates = (mockGetQueue().publish as jest.Mock).mock.calls
+        .map(([message]) => message)
+        .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+      expect(updates).toHaveLength(1)
+      expect(updates[0].data).toEqual({
+        actorId: 'actor-1',
+        statusId: 'status-1'
+      })
+    })
+
+    it('sends no update when the activity had no photos to attach', async () => {
+      deferOneProcessJob()
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-no-photo-update',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      expect(
+        (mockGetQueue().publish as jest.Mock).mock.calls
+          .map(([message]) => message)
+          .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+      ).toHaveLength(0)
     })
 
     it('publishes no process job when the import merged the file into an existing post', async () => {

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -1387,6 +1387,89 @@ describe('importStravaActivityJob', () => {
       )
     })
 
+    it('sends no photo update when the process job could not be published', async () => {
+      // That job is what sends the Create, so an Update would be the only
+      // thing reaching the network — federating a ride just marked failed,
+      // whose retry path never sends a Create of its own.
+      deferOneProcessJob()
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValueOnce([
+        { id: 'photo-1', url: 'https://images.example.com/photo-1.jpg' }
+      ] as never)
+      ;(mockGetQueue().publish as jest.Mock).mockRejectedValueOnce(
+        'queue exploded'
+      )
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(Buffer.from('jpg'), {
+          headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+        })
+      )
+
+      try {
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-federation-photo-update-after-publish-failure',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+      } finally {
+        fetchSpy.mockRestore()
+      }
+
+      expect(database.createAttachment).toHaveBeenCalledTimes(1)
+      expect(mockGetQueue().publish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: SEND_UPDATE_NOTE_JOB_NAME })
+      )
+    })
+
+    it('still reports photos as attached when the update cannot be queued', async () => {
+      // The photos are on the status either way; what was lost is the Update,
+      // so it must not be logged as a photo failure.
+      deferOneProcessJob()
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValueOnce([
+        { id: 'photo-1', url: 'https://images.example.com/photo-1.jpg' }
+      ] as never)
+      const publishMock = mockGetQueue().publish as jest.Mock
+      publishMock.mockImplementation(async (message: { name: string }) => {
+        if (message.name === SEND_UPDATE_NOTE_JOB_NAME) {
+          throw new Error('queue exploded')
+        }
+      })
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(Buffer.from('jpg'), {
+          headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+        })
+      )
+
+      try {
+        await expect(
+          importStravaActivityJob(database as unknown as Database, {
+            id: 'job-federation-update-publish-failure',
+            name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+            data: {
+              actorId: 'actor-1',
+              stravaActivityId: '123',
+              publishSendNote: true
+            }
+          })
+        ).resolves.toBeUndefined()
+      } finally {
+        fetchSpy.mockRestore()
+        publishMock.mockReset()
+        publishMock.mockResolvedValue(undefined)
+      }
+
+      expect(database.createAttachment).toHaveBeenCalledTimes(1)
+      // The import is not demoted over a lost Update.
+      expect(database.updateFitnessFileProcessingStatus).not.toHaveBeenCalled()
+    })
+
     it('sends no update when the activity had no photos to attach', async () => {
       deferOneProcessJob()
 

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -1352,6 +1352,41 @@ describe('importStravaActivityJob', () => {
       })
     })
 
+    it('sends no photo update for an import that did not opt into federation', async () => {
+      // sendUpdateNoteJob consults no opt-in of its own, and Mastodon
+      // synthesises a Create for an unseen object younger than about a day —
+      // so an ungated Update publishes a status that deliberately stayed
+      // local, an only_me activity included, just because it had a photo.
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValueOnce([
+        { id: 'photo-1', url: 'https://images.example.com/photo-1.jpg' }
+      ] as never)
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(Buffer.from('jpg'), {
+          headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+        })
+      )
+
+      try {
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-federation-photo-update-no-optin',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123'
+          }
+        })
+      } finally {
+        fetchSpy.mockRestore()
+      }
+
+      expect(database.createAttachment).toHaveBeenCalledTimes(1)
+      expect(mockGetQueue().publish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: SEND_UPDATE_NOTE_JOB_NAME })
+      )
+    })
+
     it('sends no update when the activity had no photos to attach', async () => {
       deferOneProcessJob()
 

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -123,6 +123,8 @@ type MockDatabase = Pick<
   | 'createFitnessGear'
   | 'assignFitnessFileGearIfUnset'
   | 'findFitnessGearByDeviceKey'
+  | 'updateFitnessFileImportStatus'
+  | 'updateFitnessFileProcessingStatus'
 >
 
 describe('importStravaActivityJob', () => {
@@ -149,7 +151,9 @@ describe('importStravaActivityJob', () => {
     releaseImportLock: vi.fn().mockResolvedValue(true),
     createFitnessGear: vi.fn(),
     assignFitnessFileGearIfUnset: vi.fn(),
-    findFitnessGearByDeviceKey: vi.fn()
+    findFitnessGearByDeviceKey: vi.fn(),
+    updateFitnessFileImportStatus: vi.fn(),
+    updateFitnessFileProcessingStatus: vi.fn()
   }
 
   beforeEach(() => {
@@ -1076,10 +1080,20 @@ describe('importStravaActivityJob', () => {
         .map(([message]) => message)
         .filter((message) => message.name === PROCESS_FITNESS_FILE_JOB_NAME)
 
+    // Derived from the process job rather than invocationCallOrder[0], which is
+    // whichever job happened to be published first.
+    const getProcessPublishOrder = () => {
+      const publish = mockGetQueue().publish as jest.Mock
+      const index = publish.mock.calls.findIndex(
+        ([message]) => message.name === PROCESS_FITNESS_FILE_JOB_NAME
+      )
+      return publish.mock.invocationCallOrder[index]
+    }
+
     it.each([
-      { description: 'withholds federation by default', requested: {} },
+      { description: 'withholds by default', requested: {} },
       {
-        description: 'forwards the federation opt-in from the webhook',
+        description: 'forwards the webhook opt-in',
         requested: { publishSendNote: true }
       }
     ])('$description', async ({ requested }) => {
@@ -1102,11 +1116,10 @@ describe('importStravaActivityJob', () => {
       )
     })
 
-    it('publishes the deferred process job only after the caption and photos are on the status', async () => {
+    it('publishes the deferred process job only after the caption is on the status', async () => {
       // Under NoQueue publishing the process job runs it inline, and it is what
-      // federates the Create. Published before these writes it would deliver an
-      // empty, photoless note — deterministically in local dev, and as a race
-      // under QStash.
+      // federates the Create. Published before the caption write it would
+      // deliver an empty note that nothing ever re-sends.
       deferOneProcessJob()
 
       await importStravaActivityJob(database as unknown as Database, {
@@ -1123,19 +1136,36 @@ describe('importStravaActivityJob', () => {
       expect(publishes).toHaveLength(1)
       expect(publishes[0]).toEqual(PROCESS_JOB)
 
-      const publishOrder = (mockGetQueue().publish as jest.Mock).mock
-        .invocationCallOrder[0]
-      expect(database.updateNote.mock.invocationCallOrder[0]).toBeLessThan(
-        publishOrder
+      expect(database.updateNote.mock.invocationCallOrder.at(-1)).toBeLessThan(
+        getProcessPublishOrder()
       )
-      expect(
-        mockGetStravaActivityPhotos.mock.invocationCallOrder[0]
-      ).toBeLessThan(publishOrder)
     })
 
-    it('still publishes the deferred process job when the Strava photos fail', async () => {
-      // Otherwise a photo-service hiccup strands the file mid-pipeline with no
-      // map and no post — a worse outcome than a post without its photos.
+    it('publishes the deferred process job before downloading the Strava photos', async () => {
+      // The photo downloads are four HTTP fetches plus transcodes against a 30s
+      // job cap with no retries, and by this point the file sits at import
+      // 'completed' / processing 'pending' — a state no retry predicate
+      // matches. A worker killed mid-download after the publish only loses the
+      // photos; before it, the ride is stranded unprocessed forever.
+      deferOneProcessJob()
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-publish-before-photos',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      expect(getProcessPublishOrder()).toBeLessThan(
+        mockGetStravaActivityPhotos.mock.invocationCallOrder[0]
+      )
+    })
+
+    it('still writes the caption when the Strava photos fail', async () => {
+      // Separate containment: one failure must not swallow the other's work.
       deferOneProcessJob()
       mockGetStravaActivityPhotos.mockRejectedValueOnce(
         new Error('strava photos unavailable')
@@ -1152,6 +1182,63 @@ describe('importStravaActivityJob', () => {
       })
 
       expect(getProcessPublishes()).toHaveLength(1)
+      expect(database.updateNote).toHaveBeenCalledWith(
+        expect.objectContaining({ statusId: 'status-1' })
+      )
+    })
+
+    it('publishes the process job even when the caption write fails', async () => {
+      // processFitnessFileJob backfills the generated summary for an empty
+      // note, so a lost caption degrades the post; a lost process job loses
+      // the map, the stats and the Create with no way back.
+      deferOneProcessJob()
+      database.updateNote.mockRejectedValueOnce(new Error('write conflict'))
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-caption-failure',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      expect(getProcessPublishes()).toHaveLength(1)
+      expect(mockGetStravaActivityPhotos).toHaveBeenCalled()
+    })
+
+    it('marks the file failed when the deferred process job cannot be published', async () => {
+      // Without this the import is stranded: the status exists and the file
+      // sits at processing 'pending', which no retry predicate matches, so
+      // nothing would ever offer to finish the activity.
+      deferOneProcessJob()
+      ;(mockGetQueue().publish as jest.Mock).mockRejectedValueOnce(
+        'queue exploded'
+      )
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-publish-failure',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          publishSendNote: true
+        }
+      })
+
+      // A non-Error rejection on purpose: toImportErrorMessage exists so the
+      // reason can never land as NULL and wipe the explanation.
+      expect(database.updateFitnessFileImportStatus).toHaveBeenCalledWith(
+        'new-file',
+        'failed',
+        'queue exploded'
+      )
+      expect(database.updateFitnessFileProcessingStatus).toHaveBeenCalledWith(
+        'new-file',
+        'failed',
+        'queue exploded'
+      )
     })
 
     it('publishes no process job when the import merged the file into an existing post', async () => {

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@/lib/services/strava/activity'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
 
 vi.mock('node:dns/promises', async () => ({
   lookup: vi.fn()
@@ -61,6 +62,14 @@ vi.mock('@/lib/services/queue', async () => ({
 
 vi.mock('@/lib/services/timelines', async () => ({
   addStatusToTimelines: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
 }))
 
 const mockSaveFitnessFile = saveFitnessFile as jest.MockedFunction<
@@ -1502,6 +1511,65 @@ describe('importStravaActivityJob', () => {
       expect(database.createAttachment).toHaveBeenCalledTimes(1)
       // The import is not demoted over a lost Update.
       expect(database.updateFitnessFileProcessingStatus).not.toHaveBeenCalled()
+      // What distinguishes this from the Update publish living inside the photo
+      // try/catch, which also neither threw nor demoted: there the failure was
+      // reported as a photo failure, and the photos are on the status.
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to attach Strava photos to imported status'
+        })
+      )
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to queue the update for late Strava photos'
+        })
+      )
+    })
+
+    it('sends an update for a merged sibling that brings its own photos', async () => {
+      // The case the Update mainly exists for: the second device's webhook adds
+      // its photos to a post whose Create went out with the primary's, so it
+      // owns no process job of its own and the Update is the only thing that
+      // can carry them across.
+      mockImportFitnessFiles.mockResolvedValue([
+        {
+          statusId: 'status-1',
+          statusCreated: false,
+          primaryFitnessFileId: 'sibling-file',
+          processJob: null
+        }
+      ])
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValueOnce([
+        { id: 'photo-2', url: 'https://images.example.com/photo-2.jpg' }
+      ] as never)
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(Buffer.from('jpg'), {
+          headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+        })
+      )
+
+      try {
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-federation-merged-photos',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+      } finally {
+        fetchSpy.mockRestore()
+      }
+
+      expect(getProcessPublishes()).toHaveLength(0)
+      expect(
+        (mockGetQueue().publish as jest.Mock).mock.calls
+          .map(([message]) => message)
+          .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+      ).toHaveLength(1)
     })
 
     it('sends no update when the activity had no photos to attach', async () => {

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -1264,16 +1264,17 @@ describe('importStravaActivityJob', () => {
 
       // A non-Error rejection on purpose: toImportErrorMessage exists so the
       // reason can never land as NULL and wipe the explanation.
-      expect(database.updateFitnessFileImportStatus).toHaveBeenCalledWith(
-        'new-file',
-        'failed',
-        'queue exploded'
-      )
       expect(database.updateFitnessFileProcessingStatus).toHaveBeenCalledWith(
         'new-file',
         'failed',
         'queue exploded'
       )
+      // The IMPORT column stays completed. retryFitnessImportBatch resets a
+      // failed import to 'pending', but re-running this job then short-circuits
+      // past the importer because a statusId already exists, and nothing writes
+      // importStatus back — the file would show as pending forever and stop
+      // being retriable at all.
+      expect(database.updateFitnessFileImportStatus).not.toHaveBeenCalled()
     })
 
     it('never federates an activity the athlete marked only me on Strava', async () => {
@@ -1294,6 +1295,39 @@ describe('importStravaActivityJob', () => {
 
       await importStravaActivityJob(database as unknown as Database, {
         id: 'job-federation-only-me',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '123',
+          visibility: 'public',
+          publishSendNote: true
+        }
+      })
+
+      expect(mockImportFitnessFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ publishSendNote: false }),
+        expect.anything()
+      )
+    })
+
+    it('does not federate when Strava reports no visibility for the activity', async () => {
+      // The field is optional, so a denylist would federate an unknown at the
+      // account default — which can be public. mapStravaVisibilityToMastodon
+      // resolves the same unknown to private.
+      mockGetStravaActivity.mockReset()
+      mockGetStravaActivity.mockResolvedValue({
+        id: 123,
+        name: 'Unlabelled Ride',
+        distance: 5_000,
+        elapsed_time: 1_500,
+        total_elevation_gain: 20,
+        start_date: '2026-01-01T00:00:00.000Z',
+        sport_type: 'Ride'
+      } as never)
+
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-federation-unknown-visibility',
         name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
         data: {
           actorId: 'actor-1',

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -861,10 +861,13 @@ export const importStravaActivityJob = createJobHandle(
     // the route map before it queues SEND_NOTE, and sendNoteJob re-reads the
     // status at delivery. Under NoQueue the whole chain runs inline right here,
     // so a dev-mode Create carries the caption and map but not the photos.
+    let processJobPublishFailed = false
     for (const processJob of deferredProcessJobs) {
       try {
         await getQueue().publish(processJob)
       } catch (error) {
+        processJobPublishFailed = true
+
         // Same protection the non-deferred path gives itself, minus the status
         // cleanup: by now the status is written, timelined and carries the
         // Strava caption, so deleting it would destroy real content. Leave the
@@ -898,8 +901,9 @@ export const importStravaActivityJob = createJobHandle(
     // Separately contained from the caption: a photo failure must not skip the
     // caption, and neither may take down the import now that the file is past
     // the point where a retry could find it.
+    let attachedPhotoCount = 0
     try {
-      const attachedPhotoCount = await attachStravaPhotosToStatus({
+      attachedPhotoCount = await attachStravaPhotosToStatus({
         database,
         actor,
         actorId,
@@ -908,33 +912,6 @@ export const importStravaActivityJob = createJobHandle(
         accessToken,
         activity
       })
-
-      // A photo attached after the Create needs an Update or the remote copy
-      // keeps the version without it, forever. Two cases land here: the process
-      // job published above already federated (always under NoQueue, a race
-      // under QStash), and a merged sibling, which brings its OWN Strava photos
-      // to a post whose Create went out with the primary's.
-      //
-      // Gated on the same opt-in as the Create, and that gate is load-bearing
-      // rather than tidiness: sendUpdateNoteJob delivers to every federated
-      // inbox without consulting any opt-in of its own, and Mastodon's Update
-      // handler SYNTHESISES a Create for an object it has not seen that is
-      // younger than about a day. Ungated, a recovery sweep — or an only_me
-      // activity, which reaches here having deliberately skipped its Create —
-      // would publish a status precisely because it had a photo.
-      //
-      // The id carries the Strava activity so a merged sibling's photos get
-      // their own Update rather than being deduplicated against the primary's,
-      // while a redelivery of the same webhook still collapses.
-      if (shouldFederateImport && attachedPhotoCount > 0) {
-        await getQueue().publish({
-          id: getHashFromString(
-            `${importedFitnessFile.statusId}:${stravaActivityId}:strava-photos:send-update-note`
-          ),
-          name: SEND_UPDATE_NOTE_JOB_NAME,
-          data: { actorId, statusId: importedFitnessFile.statusId }
-        })
-      }
     } catch (error) {
       logger.warn({
         message: 'Failed to attach Strava photos to imported status',
@@ -943,6 +920,56 @@ export const importStravaActivityJob = createJobHandle(
         statusId: importedFitnessFile.statusId,
         err: toLoggableError(error)
       })
+    }
+
+    // A photo attached after the Create needs an Update or the remote copy
+    // keeps the version without it, forever. Two cases land here: the process
+    // job published above already federated (always under NoQueue, a race under
+    // QStash), and a merged sibling, which brings its OWN Strava photos to a
+    // post whose Create went out with the primary's.
+    //
+    // Gated on the same opt-in as the Create, and that gate is load-bearing
+    // rather than tidiness: sendUpdateNoteJob delivers to every federated inbox
+    // without consulting any opt-in of its own, and Mastodon's Update handler
+    // SYNTHESISES a Create for an object it has not seen that is younger than
+    // about a day. Ungated, a recovery sweep — or an only_me activity, which
+    // reaches here having deliberately skipped its Create — would publish a
+    // status precisely because it had a photo. For the same reason it is also
+    // gated on the process job having been queued: that job is what sends the
+    // Create, so after it failed to publish an Update is the only thing that
+    // would reach the network, federating a ride we just marked failed and
+    // whose retry (through retryImports, which does not opt in) never sends a
+    // Create of its own.
+    //
+    // The id carries the Strava activity so a merged sibling's photos get their
+    // own Update rather than being deduplicated against the primary's, while a
+    // redelivery of the same webhook still collapses.
+    //
+    // Kept out of the photo try/catch above so a failure here is not reported
+    // as a photo failure — the photos are on the status either way, and what
+    // was lost is the Update.
+    if (
+      shouldFederateImport &&
+      attachedPhotoCount > 0 &&
+      !processJobPublishFailed
+    ) {
+      try {
+        await getQueue().publish({
+          id: getHashFromString(
+            `${importedFitnessFile.statusId}:${stravaActivityId}:strava-photos:send-update-note`
+          ),
+          name: SEND_UPDATE_NOTE_JOB_NAME,
+          data: { actorId, statusId: importedFitnessFile.statusId }
+        })
+      } catch (error) {
+        logger.error({
+          message: 'Failed to queue the update for late Strava photos',
+          actorId,
+          stravaActivityId,
+          statusId: importedFitnessFile.statusId,
+          err: toLoggableError(error)
+        })
+      }
     }
 
     // The notification for this path now fires at the end of

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -323,12 +323,11 @@ const attachStravaPhotosToStatus = async ({
       attachmentNames.add(attachmentName)
       attachedCount += 1
     } catch (error) {
-      const nodeError = error as Error
       logger.warn({
         message: 'Failed to store Strava photo as attachment',
         actorId,
         stravaActivityId,
-        error: nodeError.message
+        err: toLoggableError(error)
       })
     }
   }

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -910,19 +910,26 @@ export const importStravaActivityJob = createJobHandle(
       })
 
       // A photo attached after the Create needs an Update or the remote copy
-      // keeps the version without it, forever. Three cases land here: the
-      // process job published above already federated (always under NoQueue,
-      // a race under QStash); and a merged sibling, which brings its OWN
-      // Strava photos to a post whose Create went out with the primary's.
+      // keeps the version without it, forever. Two cases land here: the process
+      // job published above already federated (always under NoQueue, a race
+      // under QStash), and a merged sibling, which brings its OWN Strava photos
+      // to a post whose Create went out with the primary's.
       //
-      // Cheap when there is nothing to say — no photos, no Update — and safe
-      // when the Create was never sent at all, since a receiver that does not
-      // know the object either ignores the Update or synthesises the Create
-      // from it, which is the outcome we wanted anyway.
-      if (attachedPhotoCount > 0) {
+      // Gated on the same opt-in as the Create, and that gate is load-bearing
+      // rather than tidiness: sendUpdateNoteJob delivers to every federated
+      // inbox without consulting any opt-in of its own, and Mastodon's Update
+      // handler SYNTHESISES a Create for an object it has not seen that is
+      // younger than about a day. Ungated, a recovery sweep — or an only_me
+      // activity, which reaches here having deliberately skipped its Create —
+      // would publish a status precisely because it had a photo.
+      //
+      // The id carries the Strava activity so a merged sibling's photos get
+      // their own Update rather than being deduplicated against the primary's,
+      // while a redelivery of the same webhook still collapses.
+      if (shouldFederateImport && attachedPhotoCount > 0) {
         await getQueue().publish({
           id: getHashFromString(
-            `${importedFitnessFile.statusId}:strava-photos:send-update-note`
+            `${importedFitnessFile.statusId}:${stravaActivityId}:strava-photos:send-update-note`
           ),
           name: SEND_UPDATE_NOTE_JOB_NAME,
           data: { actorId, statusId: importedFitnessFile.statusId }

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -457,8 +457,8 @@ export const importStravaActivityJob = createJobHandle(
       visibility ?? mapStravaVisibilityToMastodon(activity.visibility)
     const batchId = getStravaActivityBatchId(stravaActivityId)
 
-    // An activity the athlete marked "Only me" on Strava never gets pushed to
-    // anyone, whatever the account default says.
+    // Only an activity Strava says is shared gets pushed anywhere, whatever the
+    // account default says.
     //
     // The webhook always sends an explicit `visibility` (the actor's Strava
     // default), so the `only_me` -> `direct` arm of mapStravaVisibilityToMastodon
@@ -466,8 +466,15 @@ export const importStravaActivityJob = createJobHandle(
     // import was local-only — the post existed at the account default and went
     // nowhere. Now that imports federate it would be a leak, and the account
     // default is the one setting a user would never think to check for it.
-    const shouldFederateImport =
-      publishSendNote && activity.visibility !== 'only_me'
+    //
+    // An allowlist rather than `!== 'only_me'` because the field is optional:
+    // absent, a denylist federates at the account default, which can be public.
+    // mapStravaVisibilityToMastodon resolves the same unknown to `private`, so
+    // failing closed here is the answer this codebase already gives.
+    const isStravaSharedActivity =
+      activity.visibility === 'everyone' ||
+      activity.visibility === 'followers_only'
+    const shouldFederateImport = publishSendNote && isStravaSharedActivity
 
     // Nothing here reads `activity.gear_id`, and that is deliberate: gear is
     // attributed downstream by `processFitnessFileJob`, from the gear whose
@@ -868,10 +875,17 @@ export const importStravaActivityJob = createJobHandle(
       } catch (error) {
         processJobPublishFailed = true
 
-        // Same protection the non-deferred path gives itself, minus the status
-        // cleanup: by now the status is written, timelined and carries the
-        // Strava caption, so deleting it would destroy real content. Leave the
-        // file failed with a reason so the fitness UI offers its retry.
+        // Only the PROCESSING column, unlike the non-deferred path's
+        // markImportFileFailed. The import itself succeeded — the status is
+        // written, timelined and carries the caption — and what failed is the
+        // work after it, so deleting the status would destroy real content and
+        // failing the import would strand the file: retryFitnessImportBatch
+        // resets a failed import to `pending`, but re-running this job then
+        // short-circuits past the importer because a statusId already exists,
+        // and nothing else ever writes importStatus back to `completed`. Its
+        // own docstring calls that out. Leaving it `completed` keeps the file
+        // retriable through the processing predicate, and
+        // buildProcessingStatusUpdate still persists the reason.
         const errorMessage = toImportErrorMessage(error)
 
         logger.error({
@@ -883,18 +897,11 @@ export const importStravaActivityJob = createJobHandle(
           err: toLoggableError(error)
         })
 
-        await Promise.all([
-          database.updateFitnessFileImportStatus(
-            targetFitnessFile.id,
-            'failed',
-            errorMessage
-          ),
-          database.updateFitnessFileProcessingStatus(
-            targetFitnessFile.id,
-            'failed',
-            errorMessage
-          )
-        ])
+        await database.updateFitnessFileProcessingStatus(
+          targetFitnessFile.id,
+          'failed',
+          errorMessage
+        )
       }
     }
 
@@ -929,12 +936,14 @@ export const importStravaActivityJob = createJobHandle(
     // post whose Create went out with the primary's.
     //
     // Gated on the same opt-in as the Create, and that gate is load-bearing
-    // rather than tidiness: sendUpdateNoteJob delivers to every federated inbox
-    // without consulting any opt-in of its own, and Mastodon's Update handler
-    // SYNTHESISES a Create for an object it has not seen that is younger than
-    // about a day. Ungated, a recovery sweep — or an only_me activity, which
-    // reaches here having deliberately skipped its Create — would publish a
-    // status precisely because it had a photo. For the same reason it is also
+    // rather than tidiness: sendUpdateNoteJob consults no opt-in of its own —
+    // it delivers to every follower inbox, plus every accepted relay for a
+    // public audience — and an Update embeds the whole note, so the content
+    // leaves the instance whatever the receiver decides to do with it. Some
+    // implementations additionally treat an Update for an object they have
+    // never seen as a Create. Ungated, a recovery sweep — or an only_me
+    // activity, which reaches here having deliberately skipped its Create —
+    // would ship a status precisely because it had a photo. For the same reason
     // gated on the process job having been queued: that job is what sends the
     // Create, so after it failed to publish an Update is the only thing that
     // would reach the network, federating a ride we just marked failed and

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -787,12 +787,11 @@ export const importStravaActivityJob = createJobHandle(
       withReplies: false
     })
 
-    // Best effort, and deliberately not fatal: the deferred process job below
-    // is what finishes the import and federates it, so letting a Strava photo
-    // download take the whole job down would strand the file mid-pipeline with
-    // no map and no post content. Degrading here is benign — with no caption
-    // processFitnessFileJob backfills the generated activity summary, so the
-    // Create still describes exactly what the post shows locally.
+    // Best effort, and deliberately not fatal: the process job below is what
+    // finishes the import, so letting a caption write take the whole job down
+    // would strand the file mid-pipeline with no map at all. Degrading here is
+    // benign — processFitnessFileJob backfills the generated activity summary
+    // whenever the text is still empty.
     try {
       if (
         status?.type === StatusType.enum.Note &&
@@ -804,19 +803,9 @@ export const importStravaActivityJob = createJobHandle(
           summary: null
         })
       }
-
-      await attachStravaPhotosToStatus({
-        database,
-        actor,
-        actorId,
-        statusId: importedFitnessFile.statusId,
-        stravaActivityId,
-        accessToken,
-        activity
-      })
     } catch (error) {
       logger.warn({
-        message: 'Failed to attach Strava caption or photos to imported status',
+        message: 'Failed to write the Strava caption to the imported status',
         actorId,
         stravaActivityId,
         statusId: importedFitnessFile.statusId,
@@ -824,8 +813,28 @@ export const importStravaActivityJob = createJobHandle(
       })
     }
 
-    // Held back until the status carries its caption and photos: publishing
-    // this is what triggers processing and, for the webhook, the Create.
+    // Published here, between the caption and the photos, because the two
+    // hazards pull in opposite directions.
+    //
+    // Publishing it inside importFitnessFiles (where the non-deferred callers
+    // still do) is too early: under NoQueue `publish` runs the job inline, so
+    // it would federate the note before the caption above exists — an empty
+    // note that nothing ever re-sends.
+    //
+    // Publishing it after the photos is too late: by now
+    // assignFitnessFilesToImportedStatus has already set the primary file to
+    // importStatus 'completed' / processingStatus 'pending', which NO retry
+    // predicate matches (isFitnessProcessingStuck wants 'processing',
+    // isFitnessImportStuck wants an import-'pending' file with no status). A
+    // worker killed during the photo downloads — four HTTP fetches plus
+    // transcodes, against QStash's 30s cap and zero retries — would leave the
+    // ride permanently unprocessed and unreachable by every retry path.
+    //
+    // The cost is that a photo attached after this point may miss the Create.
+    // Under QStash it almost never does: the process job still has to generate
+    // the route map before it queues SEND_NOTE, and sendNoteJob re-reads the
+    // status at delivery. Under NoQueue the whole chain runs inline right here,
+    // so a dev-mode Create carries the caption and map but not the photos.
     for (const processJob of deferredProcessJobs) {
       try {
         await getQueue().publish(processJob)
@@ -858,6 +867,29 @@ export const importStravaActivityJob = createJobHandle(
           )
         ])
       }
+    }
+
+    // Separately contained from the caption: a photo failure must not skip the
+    // caption, and neither may take down the import now that the file is past
+    // the point where a retry could find it.
+    try {
+      await attachStravaPhotosToStatus({
+        database,
+        actor,
+        actorId,
+        statusId: importedFitnessFile.statusId,
+        stravaActivityId,
+        accessToken,
+        activity
+      })
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to attach Strava photos to imported status',
+        actorId,
+        stravaActivityId,
+        statusId: importedFitnessFile.statusId,
+        err: toLoggableError(error)
+      })
     }
 
     // The notification for this path now fires at the end of

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -12,15 +12,15 @@ import {
   OVERLAP_CONTEXT_SCAN_LIMIT,
   getOverlapContextFitnessFileIds
 } from '@/lib/jobs/fitnessImportOverlap'
-import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
+import { importFitnessFiles } from '@/lib/jobs/importFitnessFilesJob'
 import {
-  IMPORT_FITNESS_FILES_JOB_NAME,
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
   SEND_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
 import { buildActivityImportEmail } from '@/lib/services/email/templates/activityImport'
 import { saveFitnessFile } from '@/lib/services/fitness-files'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import { withImportLock } from '@/lib/services/fitness-files/importLock'
 import { linkFitnessFileDeviceGear } from '@/lib/services/fitness-gears/resolveDeviceGear'
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
@@ -29,6 +29,7 @@ import { getActivityImportGroupKey } from '@/lib/services/notifications/activity
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { getQueue } from '@/lib/services/queue'
+import { JobMessage } from '@/lib/services/queue/type'
 import {
   StravaActivity,
   buildGpxFromStravaStreams,
@@ -56,6 +57,7 @@ import {
   SAFE_DOWNLOAD_MAX_BYTES,
   readResponseArrayBufferWithLimit
 } from '@/lib/utils/streamLimit'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 import { createJobHandle } from './createJobHandle'
 
@@ -82,7 +84,17 @@ const JobData = z.object({
   // would mail once per recovered activity.
   //
   // Defaults to false so a caller is silent until it opts in.
-  notifyOnComplete: z.boolean().optional().default(false)
+  notifyOnComplete: z.boolean().optional().default(false),
+  // Whether a status newly created by this import should federate its Create.
+  //
+  // Set by the same single caller as notifyOnComplete and for the same reason:
+  // the webhook carries one freshly recorded activity the user expects their
+  // followers to see, while retry-all and the recovery scripts sweep every
+  // failed batch for an actor — opting those in would deliver a Create per
+  // recovered activity.
+  //
+  // Defaults to false so a caller is silent until it opts in.
+  publishSendNote: z.boolean().optional().default(false)
 })
 
 const MAX_STRAVA_PHOTOS_TO_ATTACH = 4
@@ -388,7 +400,8 @@ export const importStravaActivityJob = createJobHandle(
       stravaActivityId,
       stravaAuth,
       visibility,
-      notifyOnComplete
+      notifyOnComplete,
+      publishSendNote
     } = JobData.parse(message.data)
 
     const actor = await database.getActorFromId({ id: actorId })
@@ -699,6 +712,7 @@ export const importStravaActivityJob = createJobHandle(
     }
 
     const isNewImport = !targetFitnessFile.statusId
+    let deferredProcessJobs: JobMessage[] = []
     if (isNewImport) {
       // Serialize the post-creation critical section per actor. Strava delivers
       // one webhook per activity, so a single ride recorded on two devices
@@ -707,36 +721,52 @@ export const importStravaActivityJob = createJobHandle(
       // either has assigned a status, so each creates its own post (duplicate
       // same-ride posts). Holding the lock means the sibling's import has
       // already assigned its status by the time this one scans, so the overlap
-      // merge in importFitnessFilesJob finds it and collapses both files into a
+      // merge in importFitnessFiles finds it and collapses both files into a
       // single post.
-      await withImportLock(database, `strava-import:${actorId}`, async () => {
-        const actorFitnessFiles = await database.getFitnessFilesByActor({
-          actorId,
-          limit: OVERLAP_CONTEXT_SCAN_LIMIT
-        })
-        const overlapFitnessFileIds = getOverlapContextFitnessFileIds({
-          actorId,
-          fitnessFileId: targetFitnessFile.id,
-          activityStartTime: getStravaActivityStartTimeMs(activity),
-          activityDurationSeconds: getStravaActivityDurationSeconds(activity),
-          files: actorFitnessFiles
-        })
-
-        await importFitnessFilesJob(database, {
-          id: getHashFromString(`${actorId}:strava-import:${stravaActivityId}`),
-          name: IMPORT_FITNESS_FILES_JOB_NAME,
-          data: {
+      const importedGroups = await withImportLock(
+        database,
+        `strava-import:${actorId}`,
+        async () => {
+          const actorFitnessFiles = await database.getFitnessFilesByActor({
             actorId,
-            batchId,
-            fitnessFileIds: [targetFitnessFile.id],
-            overlapFitnessFileIds,
-            visibility: resolvedVisibility,
-            // Forwarded from this job's own caller, so only the webhook — one
-            // activity, arriving while the user is elsewhere — emails.
-            notifyOnComplete
-          }
-        })
-      })
+            limit: OVERLAP_CONTEXT_SCAN_LIMIT
+          })
+          const overlapFitnessFileIds = getOverlapContextFitnessFileIds({
+            actorId,
+            fitnessFileId: targetFitnessFile.id,
+            activityStartTime: getStravaActivityStartTimeMs(activity),
+            activityDurationSeconds: getStravaActivityDurationSeconds(activity),
+            files: actorFitnessFiles
+          })
+
+          return importFitnessFiles(
+            database,
+            {
+              actorId,
+              batchId,
+              fitnessFileIds: [targetFitnessFile.id],
+              overlapFitnessFileIds,
+              visibility: resolvedVisibility,
+              // Forwarded from this job's own caller, so only the webhook — one
+              // activity, arriving while the user is elsewhere — emails.
+              notifyOnComplete,
+              // Same: only the webhook federates. A merged sibling reuses the
+              // existing status, so importFitnessFiles resolves this to false
+              // for it and the ride's Create still goes out exactly once.
+              publishSendNote
+            },
+            // The process job is the pipeline's federation trigger, and under
+            // NoQueue publishing it runs it inline — before the Strava caption
+            // and photos below exist. Publishing after those writes keeps the
+            // Create describing the finished post in both queue modes.
+            { deferProcessJobPublishes: true }
+          )
+        }
+      )
+
+      deferredProcessJobs = importedGroups
+        .map((group) => group.processJob)
+        .filter((processJob): processJob is JobMessage => processJob !== null)
     }
 
     const importedFitnessFile = await database.getFitnessFile({
@@ -757,32 +787,84 @@ export const importStravaActivityJob = createJobHandle(
       withReplies: false
     })
 
-    if (
-      status?.type === StatusType.enum.Note &&
-      status.text.trim().length === 0
-    ) {
-      await database.updateNote({
-        statusId: status.id,
-        text: buildStravaActivitySummary(activity),
-        summary: null
+    // Best effort, and deliberately not fatal: the deferred process job below
+    // is what finishes the import and federates it, so letting a Strava photo
+    // download take the whole job down would strand the file mid-pipeline with
+    // no map and no post content. Degrading here is benign — with no caption
+    // processFitnessFileJob backfills the generated activity summary, so the
+    // Create still describes exactly what the post shows locally.
+    try {
+      if (
+        status?.type === StatusType.enum.Note &&
+        status.text.trim().length === 0
+      ) {
+        await database.updateNote({
+          statusId: status.id,
+          text: buildStravaActivitySummary(activity),
+          summary: null
+        })
+      }
+
+      await attachStravaPhotosToStatus({
+        database,
+        actor,
+        actorId,
+        statusId: importedFitnessFile.statusId,
+        stravaActivityId,
+        accessToken,
+        activity
+      })
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to attach Strava caption or photos to imported status',
+        actorId,
+        stravaActivityId,
+        statusId: importedFitnessFile.statusId,
+        err: toLoggableError(error)
       })
     }
 
-    await attachStravaPhotosToStatus({
-      database,
-      actor,
-      actorId,
-      statusId: importedFitnessFile.statusId,
-      stravaActivityId,
-      accessToken,
-      activity
-    })
+    // Held back until the status carries its caption and photos: publishing
+    // this is what triggers processing and, for the webhook, the Create.
+    for (const processJob of deferredProcessJobs) {
+      try {
+        await getQueue().publish(processJob)
+      } catch (error) {
+        // Same protection the non-deferred path gives itself, minus the status
+        // cleanup: by now the status is written, timelined and carries the
+        // Strava caption, so deleting it would destroy real content. Leave the
+        // file failed with a reason so the fitness UI offers its retry.
+        const errorMessage = toImportErrorMessage(error)
+
+        logger.error({
+          message: 'Failed to publish fitness processing job after import',
+          actorId,
+          stravaActivityId,
+          statusId: importedFitnessFile.statusId,
+          fitnessFileId: targetFitnessFile.id,
+          err: toLoggableError(error)
+        })
+
+        await Promise.all([
+          database.updateFitnessFileImportStatus(
+            targetFitnessFile.id,
+            'failed',
+            errorMessage
+          ),
+          database.updateFitnessFileProcessingStatus(
+            targetFitnessFile.id,
+            'failed',
+            errorMessage
+          )
+        ])
+      }
+    }
 
     // The notification for this path now fires at the end of
     // processFitnessFileJob instead. Creating it here was premature: under
     // QStash that job is only enqueued at this point, so the route map and the
     // parsed stats do not exist yet and the email would arrive empty.
-    // importFitnessFilesJob sets notifyOnComplete for a first import.
+    // importFitnessFiles sets notifyOnComplete for a first import.
 
     // Only fall back to a regenerate-map job for a re-imported PRIMARY file
     // that still lacks a map. On a fresh import the primary is already handed

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -16,7 +16,8 @@ import { importFitnessFiles } from '@/lib/jobs/importFitnessFilesJob'
 import {
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
-  SEND_NOTE_JOB_NAME
+  SEND_NOTE_JOB_NAME,
+  SEND_UPDATE_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
 import { buildActivityImportEmail } from '@/lib/services/email/templates/activityImport'
 import { saveFitnessFile } from '@/lib/services/fitness-files'
@@ -215,7 +216,8 @@ const attachStravaPhotosToStatus = async ({
   stravaActivityId: string
   accessToken: string
   activity: StravaActivity
-}) => {
+}): Promise<number> => {
+  let attachedCount = 0
   const existingAttachments = await database.getAttachments({ statusId })
   const attachmentNames = new Set(
     existingAttachments
@@ -228,7 +230,7 @@ const attachStravaPhotosToStatus = async ({
   )
 
   if (remainingAttachmentSlots <= 0) {
-    return
+    return attachedCount
   }
 
   const photos = await getStravaActivityPhotos({
@@ -319,6 +321,7 @@ const attachStravaPhotosToStatus = async ({
         mediaId: storedMedia.id
       })
       attachmentNames.add(attachmentName)
+      attachedCount += 1
     } catch (error) {
       const nodeError = error as Error
       logger.warn({
@@ -329,6 +332,8 @@ const attachStravaPhotosToStatus = async ({
       })
     }
   }
+
+  return attachedCount
 }
 
 const getOrCreateStravaFallbackNote = async ({
@@ -452,6 +457,18 @@ export const importStravaActivityJob = createJobHandle(
       visibility ?? mapStravaVisibilityToMastodon(activity.visibility)
     const batchId = getStravaActivityBatchId(stravaActivityId)
 
+    // An activity the athlete marked "Only me" on Strava never gets pushed to
+    // anyone, whatever the account default says.
+    //
+    // The webhook always sends an explicit `visibility` (the actor's Strava
+    // default), so the `only_me` -> `direct` arm of mapStravaVisibilityToMastodon
+    // never gets a chance to apply on that path. That was harmless while every
+    // import was local-only — the post existed at the account default and went
+    // nowhere. Now that imports federate it would be a leak, and the account
+    // default is the one setting a user would never think to check for it.
+    const shouldFederateImport =
+      publishSendNote && activity.visibility !== 'only_me'
+
     // Nothing here reads `activity.gear_id`, and that is deliberate: gear is
     // attributed downstream by `processFitnessFileJob`, from the gear whose
     // `defaultSports` claims the parsed sport — the athlete's own shed, which
@@ -523,11 +540,20 @@ export const importStravaActivityJob = createJobHandle(
           activity
         })
 
-        await getQueue().publish({
-          id: getHashFromString(`${actorId}:strava-note:${stravaActivityId}`),
-          name: SEND_NOTE_JOB_NAME,
-          data: { actorId, statusId: createdNote.id }
-        })
+        // Gated like the file-backed path above. This branch used to federate
+        // unconditionally, which is the asymmetry that hid the missing Create
+        // on the main path: a degenerate, streamless activity was the only
+        // Strava import that ever reached a follower. Ungated it also means a
+        // retry-all sweep or a scripts/fitness recovery run still delivers one
+        // Create per streamless activity — exactly what the flag exists to
+        // prevent — so it answers to the same opt-in.
+        if (shouldFederateImport) {
+          await getQueue().publish({
+            id: getHashFromString(`${actorId}:strava-note:${stravaActivityId}`),
+            name: SEND_NOTE_JOB_NAME,
+            data: { actorId, statusId: createdNote.id }
+          })
+        }
 
         // Gated on notifyOnComplete as a whole, not just on the email. This
         // path never creates a fitness file — the activity had no exportable
@@ -753,7 +779,7 @@ export const importStravaActivityJob = createJobHandle(
               // Same: only the webhook federates. A merged sibling reuses the
               // existing status, so importFitnessFiles resolves this to false
               // for it and the ride's Create still goes out exactly once.
-              publishSendNote
+              publishSendNote: shouldFederateImport
             },
             // The process job is the pipeline's federation trigger, and under
             // NoQueue publishing it runs it inline — before the Strava caption
@@ -873,7 +899,7 @@ export const importStravaActivityJob = createJobHandle(
     // caption, and neither may take down the import now that the file is past
     // the point where a retry could find it.
     try {
-      await attachStravaPhotosToStatus({
+      const attachedPhotoCount = await attachStravaPhotosToStatus({
         database,
         actor,
         actorId,
@@ -882,6 +908,26 @@ export const importStravaActivityJob = createJobHandle(
         accessToken,
         activity
       })
+
+      // A photo attached after the Create needs an Update or the remote copy
+      // keeps the version without it, forever. Three cases land here: the
+      // process job published above already federated (always under NoQueue,
+      // a race under QStash); and a merged sibling, which brings its OWN
+      // Strava photos to a post whose Create went out with the primary's.
+      //
+      // Cheap when there is nothing to say — no photos, no Update — and safe
+      // when the Create was never sent at all, since a receiver that does not
+      // know the object either ignores the Update or synthesises the Create
+      // from it, which is the outcome we wanted anyway.
+      if (attachedPhotoCount > 0) {
+        await getQueue().publish({
+          id: getHashFromString(
+            `${importedFitnessFile.statusId}:strava-photos:send-update-note`
+          ),
+          name: SEND_UPDATE_NOTE_JOB_NAME,
+          data: { actorId, statusId: importedFitnessFile.statusId }
+        })
+      }
     } catch (error) {
       logger.warn({
         message: 'Failed to attach Strava photos to imported status',

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -476,6 +476,25 @@ export const importStravaActivityJob = createJobHandle(
       activity.visibility === 'followers_only'
     const shouldFederateImport = publishSendNote && isStravaSharedActivity
 
+    // Logged rather than left silent: the visibility type is open-ended, so a
+    // value Strava adds later — or stops sending — would suppress federation
+    // for every import, and the symptom ("my rides stopped appearing on other
+    // servers") looks identical to the bug this opt-in exists to fix. Only for
+    // a caller that asked to federate, and never for only_me, which is a
+    // decision rather than a surprise.
+    if (
+      publishSendNote &&
+      !isStravaSharedActivity &&
+      activity.visibility !== 'only_me'
+    ) {
+      logger.warn({
+        message: 'Not federating an import with an unrecognised visibility',
+        actorId,
+        stravaActivityId,
+        stravaVisibility: activity.visibility ?? null
+      })
+    }
+
     // Nothing here reads `activity.gear_id`, and that is deliberate: gear is
     // attributed downstream by `processFitnessFileJob`, from the gear whose
     // `defaultSports` claims the parsed sport — the athlete's own shed, which

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -294,13 +294,12 @@ describe('importStravaArchiveJob', () => {
       })
     )
     // An archive import walks years of activities: opting it into federation
-    // would deliver a Create per ride to every follower.
-    expect(mockQueuePublish).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: IMPORT_FITNESS_FILES_JOB_NAME,
-        data: expect.objectContaining({ publishSendNote: true })
-      })
-    )
+    // would deliver a Create per ride to every follower. Asserted as an absent
+    // key rather than a non-true value, which any typo would also satisfy.
+    const importJob = mockQueuePublish.mock.calls
+      .map(([message]) => message)
+      .find((message) => message.name === IMPORT_FITNESS_FILES_JOB_NAME)
+    expect(importJob.data).not.toHaveProperty('publishSendNote')
     expect(mockSaveMedia).toHaveBeenCalledTimes(1)
     expect(database.createAttachment).toHaveBeenCalledTimes(1)
     expect(mockDeleteFitnessFile).toHaveBeenCalledWith(

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -293,6 +293,14 @@ describe('importStravaArchiveJob', () => {
         })
       })
     )
+    // An archive import walks years of activities: opting it into federation
+    // would deliver a Create per ride to every follower.
+    expect(mockQueuePublish).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: expect.objectContaining({ publishSendNote: true })
+      })
+    )
     expect(mockSaveMedia).toHaveBeenCalledTimes(1)
     expect(database.createAttachment).toHaveBeenCalledTimes(1)
     expect(mockDeleteFitnessFile).toHaveBeenCalledWith(

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -199,6 +199,12 @@ describe('processFitnessFileJob', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    // clearAllMocks resets call history but KEEPS implementations, and
+    // publishSendNote defaults to true — so a test that makes this throw would
+    // otherwise leave every later test quietly running its federation publish
+    // down the failure path.
+    ;(getQueue().publish as jest.Mock).mockImplementation(async () => undefined)
+
     mockGetFitnessFileBuffer.mockResolvedValue(
       Buffer.from('fitness-file-bytes')
     )

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -1071,6 +1071,41 @@ describe('processFitnessFileJob', () => {
     expect(retriedFitnessFile?.importError).toBeUndefined()
   })
 
+  it('keeps the activity completed when the federation publish fails', async () => {
+    // The publish sits after processingStatus 'completed' is persisted, so an
+    // uncontained queue failure rewrote a fully processed ride to 'failed' —
+    // hiding it from the detail dashboard, the stat grid and every rollup
+    // because its Create could not be queued.
+    const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
+      text: ''
+    })
+    ;(getQueue().publish as jest.Mock).mockImplementation(
+      async (message: { name: string }) => {
+        if (message.name === SEND_NOTE_JOB_NAME) {
+          throw new Error('queue exploded')
+        }
+      }
+    )
+
+    await expect(
+      processFitnessFileJob(database, {
+        id: 'job-id-send-note-publish-failure',
+        name: PROCESS_FITNESS_FILE_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          statusId,
+          fitnessFileId,
+          publishSendNote: true
+        }
+      })
+    ).resolves.toBeUndefined()
+
+    const updatedFitnessFile = await database.getFitnessFile({
+      id: fitnessFileId
+    })
+    expect(updatedFitnessFile?.processingStatus).toBe('completed')
+  })
+
   it('skips federation publish when publishSendNote is false', async () => {
     const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
       text: ''

--- a/lib/jobs/processFitnessFileJob.ts
+++ b/lib/jobs/processFitnessFileJob.ts
@@ -795,15 +795,32 @@ export const processFitnessFileJob = createJobHandle(
         })
       }
 
+      // Contained like notifyActivityImported above, and for a sharper reason:
+      // the activity is fully processed and already persisted as `completed` by
+      // this point, so letting a federation failure reach the outer catch would
+      // rewrite it to `failed` — hiding a perfectly good ride from the detail
+      // dashboard, the stat grid, the overview and every rollup because the
+      // Create could not be queued. Under NoQueue this publish runs sendNoteJob
+      // inline, so it covers delivery errors too.
       if (publishSendNote) {
-        await getQueue().publish({
-          id: getHashFromString(`${statusId}:send-note`),
-          name: SEND_NOTE_JOB_NAME,
-          data: {
+        try {
+          await getQueue().publish({
+            id: getHashFromString(`${statusId}:send-note`),
+            name: SEND_NOTE_JOB_NAME,
+            data: {
+              actorId,
+              statusId
+            }
+          })
+        } catch (error) {
+          logger.error({
+            message: 'Failed to queue the Create for a processed fitness file',
             actorId,
-            statusId
-          }
-        })
+            statusId,
+            fitnessFileId,
+            err: toLoggableError(error)
+          })
+        }
       }
 
       // A replaced map is deliberately NOT federated from here. Whether the

--- a/lib/services/fitness-files/retryImports.test.ts
+++ b/lib/services/fitness-files/retryImports.test.ts
@@ -173,6 +173,9 @@ describe('retryFitnessImportBatch', () => {
     // Strava retries re-derive visibility server-side, so it must be omitted.
     const job = (getQueue().publish as jest.Mock).mock.calls[0][0]
     expect(job.data).not.toHaveProperty('visibility')
+    // A retry sweep runs over every failed batch an actor has. Opting it into
+    // federation would deliver a Create per recovered activity.
+    expect(job.data).not.toHaveProperty('publishSendNote')
   })
 
   it('requeues the file importer with completed overlap context for non-Strava batches', async () => {
@@ -211,6 +214,9 @@ describe('retryFitnessImportBatch', () => {
         })
       })
     )
+    // Same as the Strava branch: a recovery sweep must stay local-only.
+    const job = (getQueue().publish as jest.Mock).mock.calls[0][0]
+    expect(job.data).not.toHaveProperty('publishSendNote')
   })
 
   it('retries a stuck-processing file by resetting it to pending', async () => {


### PR DESCRIPTION
## Context

Started from "why does `mastodon.social/@ride@llun.social` end on 11 July while `llun.social` has 11 more posts?"

The presenting symptom turned out **not** to be a delivery bug: `@ride` has no followers on any remote instance, so `getFederatedStatusDeliveryInboxes` yields no external inbox and nothing was ever sent. The two posts mastodon.social holds arrived via a boost, and its "1740 posts" counter is copied from our outbox `totalItems`.

Verifying that surfaced a real latent bug underneath, which this PR fixes: **even after a remote user follows `@ride`, imported activities still would not federate.**

## The bug

`lib/jobs/importFitnessFilesJob.ts` hardcoded `publishSendNote: false` on the `PROCESS_FITNESS_FILE_JOB` it queues, and that flag is the pipeline's **only** federation trigger. Every GPS-bearing Strava import — including the single-activity webhook — created a local-only status that `createLocalOnlyFitnessStatus` gives a full `to`/`cc` audience, so it looked federated everywhere except on the wire. Inverted asymmetry: the **degenerate** no-GPS fallback *did* send a Create; the good import did not.

The flag was introduced for bulk archive imports (avoid one Create per ride over years of history). The design gap is that the same importer is also the funnel for the single-activity webhook.

## The fix

The webhook opts in; bulk paths stay local-only. The subtleties, each found by review and each pinned by a test verified to fail when its production line is reverted:

**Gated on the status being new** — `publishSendNote && !existingStatus`, mirroring the existing `notifyOnComplete` gate. Retries, `retryImports`, the recovery scripts and a merged second-device sibling never re-deliver a ride. A two-device ride federates **exactly one** Create: the first webhook creates the status and owns the single process job; the sibling merges into `existingStatus` and its group carries `processJob: null`.

**Published between the caption and the photos.** Publishing the process job is what federates, and under NoQueue `publish` runs the job inline. Inside `importFitnessFiles` it would federate before the caption exists — an empty note nothing re-sends. After the photo downloads it would sit behind four HTTP fetches plus transcodes, against QStash's 30s cap and zero retries, while the file is already at import `completed` / processing `pending` — a state **no retry predicate matches**, so a killed worker stranded the ride permanently. Between the two, both hazards are closed.

**Photos landing after the Create get an `Update`** — gated on the same opt-in, because `sendUpdateNoteJob` consults none of its own and an Update ships the whole note to every follower and relay. Its id carries the Strava activity id so a merged sibling's photos aren't deduplicated against the primary's, and it is suppressed when the process-job publish failed, since the Update would then be the only thing reaching the network for a ride just marked failed.

**Only activities Strava reports as shared federate.** The webhook always sends an explicit visibility, so `mapStravaVisibilityToMastodon`'s `only_me → direct` arm never applied there — harmless while imports were local-only, a leak once they aren't. An allowlist rather than a denylist because the field is optional and the type open-ended; a suppression by an *unrecognised* value is warned about, so the feature can't silently switch itself off.

**The no-GPS fallback is gated too** — it published `SEND_NOTE` unconditionally, so a retry-all sweep still delivered one Create per streamless activity.

To make the ordering possible the job body moves into an exported `importFitnessFiles()` that can return each group's ready-to-publish process job (`createJobHandle` discards handler return values); `importFitnessFilesJob` stays a thin wrapper. Also contained `processFitnessFileJob`'s `SEND_NOTE` publish — it sits after `processingStatus: 'completed'` is persisted, so a queue failure reaching the outer catch rewrote a fully processed ride to `failed` and hid it from every rollup. And the deferred-publish failure marks only the *processing* column: failing the import column on a file that already has a `statusId` is the combination `retryFitnessImportBatch`'s own docstring warns strands a file forever.

Unchanged and still local-only: archive walker, browser bulk upload, `retry-fitness`, `retryImports`, `scripts/fitness/*`. No schema changes.

## Tests

`yarn lint`, `yarn build` and the full `yarn test` (809 files / 9416 tests) pass. Beyond unit coverage of each gate, `importStravaActivityJob.federation.test.ts` runs the pipeline end-to-end with jobs dispatched inline against one test DB, snapshotting the status **at the moment** `SEND_NOTE` is queued: one Create carrying caption + route map, none without opt-in, none on re-import, and exactly one for a two-webhook merged ride. Its non-opt-in case asserts the pipeline actually ran, so a start-day collision can't make it pass vacuously.

## Known gaps (deliberately not fixed here)

- **A backdated Create lands where it was recorded.** Mastodon derives the snowflake id from `published` for inbox-delivered Creates, so a manually-uploaded old activity is filed at its start time and trimmed out of an 800-item home feed. Correct locally, invisible remotely. A recency guard on the opt-in would fix it.
- **Every federated fitness Create carries `updated`.** `updateNote` always records a `status_history` row, so the caption write makes `hasStatusBeenEdited` true and the note arrives flagged "Edited" with no history.
- **Map-regeneration Updates don't advance `updated`** — attachment changes don't bump `statuses.updatedAt`, so successive Updates repeat a timestamp.
- **`withImportLock` proceeds after a 15s wait timeout**, so two simultaneous same-ride webhooks that both blow the budget can now produce two *remote* posts rather than two local ones.
- **The Strava visibility gate covers delivery, not local visibility.** The webhook always supplies its own visibility (the account's Strava default), so `resolvedVisibility` ignores the activity's own — an `only_me` ride is still created as a public local post when that default is `public`, and a `followers_only` ride is still *upgraded* to public and federated as such. This PR suppresses the `only_me` Create, so it is no worse than `main` here, but capping `resolvedVisibility` at `mapStravaVisibilityToMastodon(activity.visibility)` would close both and is worth deciding separately, since it changes how imports look on the local timeline.
- **A batch retry recovers a ride without its stats.** A file left `processingStatus: 'failed'` is picked up by the batch retry, which re-runs the Strava job; that short-circuits past the importer (a statusId exists) and falls through to regenerate-maps, which writes only map fields before marking it `completed` — so the ride ends up complete but with no distance or activity type. Pre-existing for any parse failure, unchanged here; the per-status "retry" on the post does a full reprocess.
- **A webhook import that fails and is retried through the UI stays local-only** — the retry path never sets the opt-in, and there is no later affordance to send the Create.

## Follow-ups from the same investigation

1. `getPersonFromActor` never emits `manuallyApprovesFollowers`. Confirmed live: `@ride` is locked on llun.social but mastodon.social caches `locked: false`, so a remote follow looks instant while parking as `Requested`.
2. Outbound delivery failures are invisible: `postActivityToInbox` returns a status code every status-delivery caller discards, never logs non-2xx, and swallows throws — which also makes the follower-rejection `catch` in `sendNoteJob`/`sendUpdateNoteJob` unreachable. With `MAX_JOB_RETRIES = 0` there is no retry either. Now that unattended imports are the main producer of Creates, a rejected delivery leaves no log, no metric and no trace — the original "why does it stop at 11 July" question would still be unanswerable from logs.
3. Outbox pagination ignores `min_id`/`max_id` and emits no `next`/`prev`, so `last` returns the first page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
