### PR TITLE
Bump version to v1.133.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.133.0",
+  "version": "1.133.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.133.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.133.0`
- Base main SHA: `fa534081b9f0af59f268bcda423fd45f7fe47065`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
