### PR TITLE
Bump version to v1.134.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.133.1",
+  "version": "1.134.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.134.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.133.1`
- Base main SHA: `750cfa080316d35ca2e1c420bac6bf2bda4ba255`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
