### PR TITLE
Bump version to v1.135.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.134.0",
+  "version": "1.135.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.135.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.134.0`
- Base main SHA: `addda8232683a95ec6cbf795dc9dad490dbaa5cb`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
