### PR TITLE
none: stage the pyramid claim race instead of relying on pool timing

### DIFF
--- a/lib/database/sql/fitnessRouteHeatmapTile.test.ts
+++ b/lib/database/sql/fitnessRouteHeatmapTile.test.ts
@@ -558,41 +558,80 @@ describe('FitnessRouteHeatmapTileDatabase', () => {
           seedCursor: true
         }
       ])(
-        'lets exactly one of two concurrent claimers win over $description',
+        'refuses a claim whose build was taken over between its read and its write, over $description',
         async ({ seedCursor }) => {
-          // The compare-and-swap itself. Both claimers read before either
-          // writes, so only the guard can separate them; the resumable row is
-          // the case that used to hand BOTH workers the build, because a resume
-          // leaves `version` untouched.
-          const actorId = await createActor(database)
-          if (seedCursor) {
-            const seeding = await database.claimFitnessRouteHeatmapPyramidBuild(
-              {
-                actorId,
-                requestedAt: Date.now(),
-                staleBefore: Date.now() - 120_000
-              }
-            )
-            await database.updateFitnessRouteHeatmapPyramid({
-              actorId,
-              claimSeq: seeding.pyramid.claimSeq,
-              cursor: { createdAt: 1_700_000_000_000, id: 'activity-9' }
-            })
-          }
+          // The compare-and-swap itself: a claimer that decided on one state
+          // and writes against another must lose.
+          //
+          // Staged with a listener rather than by racing two real claims
+          // through `Promise.all`. That only produces the read-read-write-write
+          // interleaving on SQLite's single-connection pool; on PostgreSQL the
+          // first claim routinely finishes before the second one reads, and
+          // there a second winner is CORRECT — a far-future `staleBefore` makes
+          // the just-claimed build look abandoned, so taking it over is the
+          // documented behaviour, not a bug. Asserting exactly-one-winner
+          // against that was flaky (~2/5 on pg) and only ever passed on SQLite
+          // by pool timing.
+          //
+          // The resumable row is the case that used to hand BOTH workers the
+          // build, because a resume leaves `version` untouched — which is why
+          // the fence is `claimSeq` and why it is worth pinning per shape.
+          const { database: isolated, instance } =
+            getTestSQLDatabaseWithInstance()
+          await isolated.migrate()
 
-          const contest = () =>
-            database.claimFitnessRouteHeatmapPyramidBuild({
+          try {
+            const actorId = await createActor(isolated)
+            if (seedCursor) {
+              const seeding =
+                await isolated.claimFitnessRouteHeatmapPyramidBuild({
+                  actorId,
+                  requestedAt: Date.now(),
+                  staleBefore: Date.now() - 120_000
+                })
+              await isolated.updateFitnessRouteHeatmapPyramid({
+                actorId,
+                claimSeq: seeding.pyramid.claimSeq,
+                cursor: { createdAt: 1_700_000_000_000, id: 'activity-9' }
+              })
+            }
+
+            // Attached only now, so the seeding claim above does not trip it.
+            // Fires once, on the claim's read — the exact window the guard
+            // exists for — and bumps the token the way a competing worker
+            // winning the race would.
+            let stolen = false
+            const stealOnFirstRead = async ({ sql }: { sql: string }) => {
+              if (
+                stolen ||
+                !sql.trimStart().toLowerCase().startsWith('select') ||
+                !sql.includes('fitness_route_heatmap_pyramids')
+              ) {
+                return
+              }
+              stolen = true
+              await instance('fitness_route_heatmap_pyramids')
+                .where('actorId', actorId)
+                .increment('claimSeq', 1)
+            }
+            instance.on('query-response', (_response, query) => {
+              void stealOnFirstRead(query)
+            })
+
+            const claim = await isolated.claimFitnessRouteHeatmapPyramidBuild({
               actorId,
               requestedAt: Date.now(),
-              // Far future, so an existing build always looks abandoned and
-              // neither claimer is turned away as 'build-in-progress'.
+              // Far future, so the row never reads as a live build and only
+              // the token can turn this claim away.
               staleBefore: Date.now() + 60_000
             })
-          const [a, b] = await Promise.all([contest(), contest()])
 
-          expect([a.claimed, b.claimed].filter(Boolean)).toHaveLength(1)
-          const loser = a.claimed ? b : a
-          expect(loser.reason).toBe('lost-race')
+            expect(stolen).toBe(true)
+            expect(claim.claimed).toBe(false)
+            expect(claim.reason).toBe('lost-race')
+          } finally {
+            await isolated.destroy()
+          }
         }
       )
 


### PR DESCRIPTION
## Summary

Test-only. Found while reviewing #1454 — flagged there rather than fixed, because it predates that PR and is unrelated to it.

`lets exactly one of two concurrent claimers win` (added in #1452, on `main`) races two real claims through `Promise.all` and asserts exactly one wins. That premise only holds if **both claimers read before either writes**, and nothing guarantees it: SQLite's single-connection pool happens to interleave them that way, but on PostgreSQL the first claim routinely finishes before the second one reads. It failed roughly **2 runs in 5** against a real PG cluster.

**The second winner there is not a bug.** The test hands both claimers a `staleBefore` an hour in the future, which makes the just-claimed build look abandoned — and taking over an abandoned build is precisely what the claim is documented to do. So the assertion was wrong about the code, not the other way round. CI never saw it because `ci.yml` pins `TEST_DATABASE_TYPE: sqlite`.

## What changed

The interleaving is now stated directly instead of hoped for: a knex `query-response` listener bumps the ownership token between the claim's read and its write, and the claim must answer `lost-race`. That is the property the compare-and-swap exists for, and it holds regardless of connection pooling.

This is the same staging technique three other tests in the file already use (`carries the claim decision into the compare-and-swap itself`, `recreates the build row when a clear removes it mid-claim`), including their use of an isolated `getTestSQLDatabaseWithInstance()` for raw query events.

Both shapes are kept in the `it.each`. The resumable one matters most: it is the case that used to hand *both* workers the same build, because a resume leaves `version` untouched — which is why the fence is `claimSeq`.

## Verification

- **Deterministic:** 12 consecutive runs, 0 failures (the old one was ~2/5 on pg).
- **Still has teeth:** removing the `.where('claimSeq', …)` guard from the CAS fails both parametrised cases (plus the sibling structural test) — mutation-verified.
- Full suite green: 812 files / 9511 tests; lint clean.

No production code changed, so `none:` — no release.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, and `yarn test` all pass locally
- [x] Docs updated: n/a — no command, env var, route, script or convention changed
- [x] If migrations changed: none in this PR
- [x] `version` in `package.json` is untouched
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELw2T3kDEwCRZjdoveDefw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELw2T3kDEwCRZjdoveDefw)_