### PR TITLE
minor: add the route heatmap tiler — zoom-independent precision, as pure functions

### DIFF
--- a/lib/services/fitness-files/heatmapTiles/constants.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/constants.test.ts
@@ -1,0 +1,193 @@
+import {
+  HEAT_COUNT_SATURATION,
+  HEAT_HIDDEN_BASE_OPACITY,
+  HEAT_VISIBLE_BASE_OPACITY,
+  TILE_EXTENT,
+  TILE_LADDER_ZOOMS,
+  TILE_MAX_ZOOM,
+  TILE_MIN_ZOOM,
+  TILE_SIMPLIFY_TOLERANCE_PX,
+  heatOpacityForCount,
+  metersPerPixelAtZoom,
+  tileToleranceMeters
+} from '@/lib/services/fitness-files/heatmapTiles/constants'
+import { TILE_SIZE } from '@/lib/utils/webMercator'
+
+describe('metersPerPixelAtZoom', () => {
+  // Measured ground resolution, the figure the whole ladder is chosen from.
+  it.each([
+    {
+      description: 'z4 at the equator',
+      zoom: 4,
+      latitude: 0,
+      expected: 9783.94
+    },
+    { description: 'z8 at the equator', zoom: 8, latitude: 0, expected: 611.5 },
+    {
+      description: 'z12 at the equator',
+      zoom: 12,
+      latitude: 0,
+      expected: 38.22
+    },
+    {
+      description: 'z16 at the equator',
+      zoom: 16,
+      latitude: 0,
+      expected: 2.39
+    },
+    // cos(60) is exactly 0.5, so this pins the latitude scaling itself.
+    {
+      description: 'z16 at 60N, half the equator figure',
+      zoom: 16,
+      latitude: 60,
+      expected: 1.19
+    }
+  ])('reports $description', ({ zoom, latitude, expected }) => {
+    expect(metersPerPixelAtZoom(zoom, latitude)).toBeCloseTo(expected, 2)
+  })
+
+  it('halves for every zoom level gained', () => {
+    for (let zoom = 1; zoom <= 18; zoom += 1) {
+      expect(metersPerPixelAtZoom(zoom, 0)).toBeCloseTo(
+        metersPerPixelAtZoom(zoom - 1, 0) / 2,
+        6
+      )
+    }
+  })
+})
+
+describe('tileToleranceMeters', () => {
+  it.each([
+    { description: 'z8 at the equator', zoom: 8, latitude: 0, expected: 611.5 },
+    {
+      description: 'z12 at the equator',
+      zoom: 12,
+      latitude: 0,
+      expected: 38.22
+    },
+    { description: 'z16 at the equator', zoom: 16, latitude: 0, expected: 2.39 }
+  ])(
+    'passes $description through, being above the floor',
+    ({ zoom, latitude, expected }) => {
+      expect(tileToleranceMeters(zoom, latitude, 1)).toBeCloseTo(expected, 2)
+    }
+  )
+
+  it('clamps to the floor where a pixel is finer than GPS noise', () => {
+    // z16 at 80N is 0.41m/px — below the 1m floor, so simplifying to it would
+    // preserve jitter as though it were shape.
+    expect(metersPerPixelAtZoom(16, 80)).toBeLessThan(1)
+    expect(tileToleranceMeters(16, 80, 1)).toBe(1)
+  })
+
+  it('is the per-pixel figure times the pixel tolerance, not a fixed table', () => {
+    // Pinned as the relation rather than copied numbers: change the pixel
+    // tolerance and every level must move with it.
+    for (const zoom of TILE_LADDER_ZOOMS) {
+      expect(tileToleranceMeters(zoom, 0, 0)).toBeCloseTo(
+        metersPerPixelAtZoom(zoom, 0) * TILE_SIMPLIFY_TOLERANCE_PX,
+        6
+      )
+    }
+  })
+
+  it('never returns less than the floor at any ladder zoom or latitude', () => {
+    for (const zoom of TILE_LADDER_ZOOMS) {
+      for (const latitude of [0, 45, 60, 80, 85]) {
+        expect(tileToleranceMeters(zoom, latitude, 1)).toBeGreaterThanOrEqual(1)
+      }
+    }
+  })
+})
+
+describe('heatOpacityForCount', () => {
+  it.each([
+    { count: 1, expected: 0.55 },
+    { count: 2, expected: 0.7975 },
+    { count: 3, expected: 0.908875 },
+    { count: 4, expected: 0.95899375 }
+  ])(
+    'stacks $count visits the way overdrawing $count translucent lines did',
+    ({ count, expected }) => {
+      expect(heatOpacityForCount(count, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+        expected,
+        8
+      )
+    }
+  )
+
+  it('reproduces the additive-alpha formula exactly, at both bases', () => {
+    // The compatibility-bearing part: computed from the formula rather than
+    // compared against copied literals, so the two can never drift.
+    for (const base of [HEAT_VISIBLE_BASE_OPACITY, HEAT_HIDDEN_BASE_OPACITY]) {
+      for (let count = 1; count <= HEAT_COUNT_SATURATION; count += 1) {
+        expect(heatOpacityForCount(count, base)).toBeCloseTo(
+          1 - (1 - base) ** count,
+          10
+        )
+      }
+    }
+  })
+
+  it('saturates past the clamp instead of climbing forever', () => {
+    const saturated = heatOpacityForCount(
+      HEAT_COUNT_SATURATION,
+      HEAT_VISIBLE_BASE_OPACITY
+    )
+    for (const count of [HEAT_COUNT_SATURATION + 1, 50, 10_000]) {
+      expect(heatOpacityForCount(count, HEAT_VISIBLE_BASE_OPACITY)).toBe(
+        saturated
+      )
+    }
+  })
+
+  it.each([
+    { description: 'zero', count: 0 },
+    { description: 'a negative count', count: -3 }
+  ])('floors $description at a single visit', ({ count }) => {
+    expect(heatOpacityForCount(count, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+      HEAT_VISIBLE_BASE_OPACITY,
+      10
+    )
+  })
+
+  it('never leaves the drawable range', () => {
+    for (const base of [HEAT_VISIBLE_BASE_OPACITY, HEAT_HIDDEN_BASE_OPACITY]) {
+      for (const count of [0, 1, 3, 6, 99]) {
+        const opacity = heatOpacityForCount(count, base)
+        expect(opacity).toBeGreaterThan(0)
+        expect(opacity).toBeLessThanOrEqual(1)
+      }
+    }
+  })
+})
+
+describe('format invariants', () => {
+  it('keeps one stored unit equal to one screen pixel', () => {
+    // The identity the whole design rests on: quantizing to this collapses GPS
+    // jitter onto shared edges instead of near-miss polylines.
+    expect(TILE_EXTENT).toBe(TILE_SIZE)
+  })
+
+  it('stops the ladder at the GPS-noise floor', () => {
+    // Finer than ~2.4m/px would encode jitter rather than road.
+    expect(metersPerPixelAtZoom(TILE_MAX_ZOOM, 0)).toBeCloseTo(2.39, 2)
+    expect(metersPerPixelAtZoom(TILE_MAX_ZOOM + 2, 0)).toBeLessThan(1)
+  })
+
+  it('is ascending, unique, and spans its own min and max', () => {
+    expect([...TILE_LADDER_ZOOMS]).toEqual(
+      [...TILE_LADDER_ZOOMS].sort((a, b) => a - b)
+    )
+    expect(new Set(TILE_LADDER_ZOOMS).size).toBe(TILE_LADDER_ZOOMS.length)
+    expect(TILE_MIN_ZOOM).toBe(Math.min(...TILE_LADDER_ZOOMS))
+    expect(TILE_MAX_ZOOM).toBe(Math.max(...TILE_LADDER_ZOOMS))
+  })
+
+  it('steps evenly, so each level costs a quarter of the one below', () => {
+    const steps = TILE_LADDER_ZOOMS.slice(1).map(
+      (zoom, index) => zoom - TILE_LADDER_ZOOMS[index]
+    )
+    expect(new Set(steps)).toEqual(new Set([2]))
+  })
+})

--- a/lib/services/fitness-files/heatmapTiles/constants.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/constants.test.ts
@@ -129,6 +129,48 @@ describe('heatOpacityForCount', () => {
     }
   })
 
+  it('pins the saturation point itself, not just its own consequences', () => {
+    // Every other assertion here derives from the constant, so they hold for
+    // any value it takes. Six is the point where the ramp reaches 0.99 and
+    // further visits stop being visible.
+    expect(HEAT_COUNT_SATURATION).toBe(6)
+    expect(heatOpacityForCount(7, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+      1 - 0.45 ** 6,
+      10
+    )
+    expect(heatOpacityForCount(5, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+      1 - 0.45 ** 5,
+      10
+    )
+  })
+
+  it('starts the privacy-trimmed class at the opacity the untiled map draws', () => {
+    // Its whole reason for existing is matching what the map already renders.
+    expect(HEAT_HIDDEN_BASE_OPACITY).toBe(0.4)
+    expect(heatOpacityForCount(1, HEAT_HIDDEN_BASE_OPACITY)).toBeCloseTo(
+      0.4,
+      10
+    )
+    expect(heatOpacityForCount(2, HEAT_HIDDEN_BASE_OPACITY)).toBeCloseTo(
+      0.64,
+      10
+    )
+  })
+
+  it('rounds a fractional count rather than raising to a fractional power', () => {
+    // Counts are whole visits; a fraction can only arrive from corrupt data,
+    // and the ramp should answer the nearest real count rather than something
+    // between two of them.
+    expect(heatOpacityForCount(2.6, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+      heatOpacityForCount(3, HEAT_VISIBLE_BASE_OPACITY),
+      10
+    )
+    expect(heatOpacityForCount(2.4, HEAT_VISIBLE_BASE_OPACITY)).toBeCloseTo(
+      heatOpacityForCount(2, HEAT_VISIBLE_BASE_OPACITY),
+      10
+    )
+  })
+
   it('saturates past the clamp instead of climbing forever', () => {
     const saturated = heatOpacityForCount(
       HEAT_COUNT_SATURATION,

--- a/lib/services/fitness-files/heatmapTiles/constants.ts
+++ b/lib/services/fitness-files/heatmapTiles/constants.ts
@@ -1,0 +1,129 @@
+/**
+ * Format and density constants for the route heatmap's zoom-tiled pyramid.
+ *
+ * This module is deliberately dependency-free and carries no `'use client'`
+ * directive: the generation job, the serving routes and the map components all
+ * import it, and a server module reading a value out of a client module gets
+ * nothing (see AGENTS.md → Server/Client Module Boundary). It also reads no
+ * environment: the one tunable it consumes, the simplification floor, is passed
+ * in as a plain number by whichever server caller resolved it from config.
+ */
+
+/**
+ * The zoom levels the pyramid stores, coarsest first.
+ *
+ * Stops at 16 because a z16 pixel is 2.39 m at the equator, which is already at
+ * the GPS-noise floor — a finer level would encode jitter rather than road, and
+ * every repeat ride would land on slightly different pixels instead of stacking
+ * onto shared ones. Steps by 2 rather than 1 because each level costs about a
+ * quarter of the one below it, so the whole seven-level ladder is ~1.4x the
+ * finest level alone; a step of 1 would nearly double that for detail no
+ * viewport asks for (the client rounds a view up to the next stored level).
+ */
+export const TILE_LADDER_ZOOMS = [4, 6, 8, 10, 12, 14, 16] as const
+
+export const TILE_MIN_ZOOM = TILE_LADDER_ZOOMS[0]
+export const TILE_MAX_ZOOM = TILE_LADDER_ZOOMS[TILE_LADDER_ZOOMS.length - 1]
+
+/**
+ * Tile-local coordinate space, matching `TILE_SIZE` in `lib/utils/webMercator`
+ * so one stored unit is exactly one screen pixel at that zoom. That identity is
+ * what makes the whole design work: quantizing to it collapses GPS jitter onto
+ * shared edges, so a street ridden fifty times stores one edge with a count of
+ * fifty rather than fifty near-miss polylines.
+ *
+ * Note the space is INCLUSIVE of both ends — a coordinate runs 0..256, which is
+ * 257 distinct values, because a point exactly on a tile's far boundary belongs
+ * to both that tile (at 256) and its neighbour (at 0). Anything packing a
+ * vertex into a single integer must therefore use a base of at least 257; base
+ * 256 collides (1,0) with (0,256).
+ *
+ * There is deliberately NO maximum-points constant anywhere in the tiled path.
+ * Tile size is bounded by physical density — a 1-pixel simplification tolerance
+ * plus quantized-edge dedup means a tile can only hold as much as the road
+ * network inside it — not by an arbitrary budget, so zooming in keeps revealing
+ * detail instead of hitting a ceiling.
+ */
+export const TILE_EXTENT = 256
+
+/**
+ * Ramer-Douglas-Peucker tolerance, in pixels at the zoom being built. One pixel
+ * is the smallest tolerance that can still change what is drawn: anything finer
+ * survives simplification only to be quantized onto the same pixel anyway, so
+ * it costs storage and buys nothing.
+ */
+export const TILE_SIMPLIFY_TOLERANCE_PX = 1
+
+/**
+ * How many tiles one serving request may ask for. A bound on request batching
+ * only — a viewport needing more tiles issues more requests, and never receives
+ * fewer points per tile. Sized so a normal view (~64 tiles when the ladder
+ * rounds a zoom up) fits in a single round trip with headroom.
+ */
+export const MAX_TILES_PER_REQUEST = 128
+
+/**
+ * Ground resolution in meters per pixel at a given zoom and latitude — the
+ * standard Web Mercator figure: the equatorial circumference (40,075,016.686 m)
+ * divided by the 256-pixel world at zoom 0, scaled by cos(latitude) because
+ * Mercator stretches east-west away from the equator.
+ */
+export const EQUATOR_METERS_PER_PIXEL_AT_ZOOM_0 = 156_543.03392
+
+export const metersPerPixelAtZoom = (zoom: number, latitude: number) =>
+  (EQUATOR_METERS_PER_PIXEL_AT_ZOOM_0 * Math.cos((latitude * Math.PI) / 180)) /
+  2 ** zoom
+
+/**
+ * The simplification tolerance to build a zoom at, in meters.
+ *
+ * Derived from the zoom rather than fixed, which is the whole point of the
+ * pyramid: every level is simplified to its own pixel, so precision per screen
+ * pixel is constant and no longer falls off as an actor's coverage grows. At
+ * the equator that is 9.8 km at z4, 611 m at z8, 38 m at z12 and 2.39 m at z16.
+ *
+ * `floorMeters` is a floor, not a target — near the poles, or at the finest
+ * levels, the per-pixel figure drops below the GPS-noise floor (z16 at 80°N is
+ * 0.41 m), and simplifying that finely would preserve jitter as if it were
+ * shape.
+ */
+export const tileToleranceMeters = (
+  zoom: number,
+  latitude: number,
+  floorMeters: number
+) =>
+  Math.max(
+    floorMeters,
+    metersPerPixelAtZoom(zoom, latitude) * TILE_SIMPLIFY_TOLERANCE_PX
+  )
+
+/**
+ * Opacity of a visible route line at a visit count of one. Matches what the
+ * untiled heatmap has always drawn, so a regenerated map does not suddenly
+ * change tone.
+ */
+export const HEAT_VISIBLE_BASE_OPACITY = 0.55
+
+/** The same, for the privacy-trimmed class the owner sees in blue. */
+export const HEAT_HIDDEN_BASE_OPACITY = 0.4
+
+/**
+ * Visit count at which the ramp stops getting hotter. Six passes reach 0.99
+ * opacity, so past it the difference is invisible while the numbers keep
+ * growing — clamping keeps a commuter's daily street from flattening every
+ * other road on the map to nothing.
+ */
+export const HEAT_COUNT_SATURATION = 6
+
+/**
+ * Opacity for a line visited `count` times.
+ *
+ * `1 - (1 - base)^n` is exactly what stacking n translucent lines at `base`
+ * used to produce when the untiled heatmap drew one polyline per activity, so
+ * the ramp reproduces the look people already have rather than inventing one —
+ * the difference is that the tiled path computes it once from a stored count
+ * instead of paying to overdraw n times.
+ */
+export const heatOpacityForCount = (count: number, base: number) =>
+  1 -
+  (1 - base) ** Math.min(Math.max(Math.round(count), 1), HEAT_COUNT_SATURATION)

--- a/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
@@ -1,0 +1,422 @@
+import { TILE_EXTENT } from '@/lib/services/fitness-files/heatmapTiles/constants'
+import {
+  VERTEX_PACK_BASE,
+  assembleEdgesToSegments,
+  edgeKey,
+  explodeTileToEdges,
+  mergeTileDelta,
+  packVertex,
+  unpackVertex
+} from '@/lib/services/fitness-files/heatmapTiles/edgeMerge'
+import type { TileEdgeMap } from '@/lib/services/fitness-files/heatmapTiles/edgeMerge'
+import type { TileSegment } from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+
+/** The edge multiset a tile stands for, order-independent, counts included. */
+const edgeMultiset = (segments: TileSegment[]) =>
+  [...explodeTileToEdges(segments).entries()]
+    .map(([key, edge]) => `${key}=${edge.count}`)
+    .sort()
+
+const buildEdges = (
+  entries: Array<{
+    a: [number, number]
+    b: [number, number]
+    count: number
+    hidden?: boolean
+  }>
+): TileEdgeMap => {
+  const edges: TileEdgeMap = new Map()
+  for (const entry of entries) {
+    const a = packVertex(entry.a[0], entry.a[1])
+    const b = packVertex(entry.b[0], entry.b[1])
+    const hidden = Boolean(entry.hidden)
+    edges.set(edgeKey(a, b, hidden), {
+      a: Math.min(a, b),
+      b: Math.max(a, b),
+      hidden,
+      count: entry.count
+    })
+  }
+  return edges
+}
+
+describe('packVertex', () => {
+  it('round trips every corner of the coordinate space', () => {
+    for (const x of [0, 1, 128, TILE_EXTENT]) {
+      for (const y of [0, 1, 128, TILE_EXTENT]) {
+        expect(unpackVertex(packVertex(x, y))).toEqual({ x, y })
+      }
+    }
+  })
+
+  it('does not collide across the inclusive edge', () => {
+    // The reason the base is 257 and not 256: the space runs 0..256, so a
+    // point on a tile's far boundary is 256 here and 0 in the neighbour.
+    // Base 256 makes (1,0) and (0,256) the same integer, welding two
+    // unrelated streets together.
+    expect(packVertex(1, 0)).not.toBe(packVertex(0, TILE_EXTENT))
+    expect(VERTEX_PACK_BASE).toBe(TILE_EXTENT + 1)
+  })
+
+  it('is injective over the whole space', () => {
+    const seen = new Set<number>()
+    for (let x = 0; x <= TILE_EXTENT; x += 1) {
+      for (let y = 0; y <= TILE_EXTENT; y += 1) {
+        seen.add(packVertex(x, y))
+      }
+    }
+    expect(seen.size).toBe((TILE_EXTENT + 1) ** 2)
+  })
+})
+
+describe('edgeKey', () => {
+  it('normalizes direction, so an out-and-back is one edge', () => {
+    const a = packVertex(1, 1)
+    const b = packVertex(2, 2)
+    expect(edgeKey(a, b, false)).toBe(edgeKey(b, a, false))
+  })
+
+  it('keeps hidden and visible geometry apart', () => {
+    const a = packVertex(1, 1)
+    const b = packVertex(2, 2)
+    expect(edgeKey(a, b, true)).not.toBe(edgeKey(a, b, false))
+  })
+})
+
+describe('explodeTileToEdges', () => {
+  it('breaks a polyline into its edges', () => {
+    const edges = explodeTileToEdges([{ count: 2, points: [0, 0, 1, 1, 2, 2] }])
+    expect(edges.size).toBe(2)
+    expect([...edges.values()].every((edge) => edge.count === 2)).toBe(true)
+  })
+
+  it('sums an edge that appears in more than one run', () => {
+    const edges = explodeTileToEdges([
+      { count: 2, points: [0, 0, 1, 1] },
+      { count: 3, points: [1, 1, 0, 0] }
+    ])
+    expect(edges.size).toBe(1)
+    expect([...edges.values()][0].count).toBe(5)
+  })
+
+  it('drops a self-loop rather than storing geometry with no length', () => {
+    expect(explodeTileToEdges([{ count: 1, points: [4, 4, 4, 4] }]).size).toBe(
+      0
+    )
+  })
+
+  it('is empty for a run too short to have an edge', () => {
+    expect(explodeTileToEdges([{ count: 1, points: [4, 4] }]).size).toBe(0)
+  })
+})
+
+describe('assembleEdgesToSegments', () => {
+  it('joins a chain into one polyline', () => {
+    const segments = assembleEdgesToSegments(
+      buildEdges([
+        { a: [0, 0], b: [1, 1], count: 1 },
+        { a: [1, 1], b: [2, 2], count: 1 },
+        { a: [2, 2], b: [3, 3], count: 1 }
+      ])
+    )
+    expect(segments).toHaveLength(1)
+    expect(segments[0].points).toHaveLength(8)
+    expect(segments[0].count).toBe(1)
+  })
+
+  it('never merges edges of different counts into one run', () => {
+    // A stored run carries ONE count for all its points, so putting a
+    // twice-ridden edge in the same run as a once-ridden one would have to
+    // pick a count — and whichever it picked would be wrong for the other.
+    const segments = assembleEdgesToSegments(
+      buildEdges([
+        { a: [0, 0], b: [1, 1], count: 1 },
+        { a: [1, 1], b: [2, 2], count: 2 }
+      ])
+    )
+    expect(segments).toHaveLength(2)
+    expect(segments.map((segment) => segment.count).sort()).toEqual([1, 2])
+  })
+
+  it('never merges hidden geometry into a visible run', () => {
+    const segments = assembleEdgesToSegments(
+      buildEdges([
+        { a: [0, 0], b: [1, 1], count: 1 },
+        { a: [1, 1], b: [2, 2], count: 1, hidden: true }
+      ])
+    )
+    expect(segments).toHaveLength(2)
+    expect(segments.filter((segment) => segment.hidden)).toHaveLength(1)
+  })
+
+  it('keeps a closed loop, which has no odd-degree vertex to start from', () => {
+    // The classic drop: a roundabout or a lap is all-even-degree, so a walk
+    // that only starts at odd-degree vertices never enters it and every edge
+    // in it vanishes.
+    const loop = buildEdges([
+      { a: [0, 0], b: [4, 0], count: 1 },
+      { a: [4, 0], b: [4, 4], count: 1 },
+      { a: [4, 4], b: [0, 4], count: 1 },
+      { a: [0, 4], b: [0, 0], count: 1 }
+    ])
+    const segments = assembleEdgesToSegments(loop)
+
+    expect(edgeMultiset(segments)).toEqual(
+      [...loop.entries()].map(([key, edge]) => `${key}=${edge.count}`).sort()
+    )
+  })
+
+  it.each([
+    {
+      description: 'a simple chain',
+      entries: [
+        {
+          a: [0, 0] as [number, number],
+          b: [1, 1] as [number, number],
+          count: 1
+        },
+        {
+          a: [1, 1] as [number, number],
+          b: [2, 2] as [number, number],
+          count: 1
+        }
+      ]
+    },
+    {
+      description: 'a junction of degree three',
+      entries: [
+        {
+          a: [5, 5] as [number, number],
+          b: [0, 5] as [number, number],
+          count: 1
+        },
+        {
+          a: [5, 5] as [number, number],
+          b: [10, 5] as [number, number],
+          count: 1
+        },
+        {
+          a: [5, 5] as [number, number],
+          b: [5, 10] as [number, number],
+          count: 1
+        }
+      ]
+    },
+    {
+      description: 'a figure eight sharing one degree-four vertex',
+      entries: [
+        {
+          a: [5, 5] as [number, number],
+          b: [0, 0] as [number, number],
+          count: 1
+        },
+        {
+          a: [0, 0] as [number, number],
+          b: [0, 5] as [number, number],
+          count: 1
+        },
+        {
+          a: [0, 5] as [number, number],
+          b: [5, 5] as [number, number],
+          count: 1
+        },
+        {
+          a: [5, 5] as [number, number],
+          b: [10, 10] as [number, number],
+          count: 1
+        },
+        {
+          a: [10, 10] as [number, number],
+          b: [10, 5] as [number, number],
+          count: 1
+        },
+        {
+          a: [10, 5] as [number, number],
+          b: [5, 5] as [number, number],
+          count: 1
+        }
+      ]
+    },
+    {
+      description: 'two runs meeting at one vertex with mixed counts',
+      entries: [
+        {
+          a: [0, 0] as [number, number],
+          b: [1, 1] as [number, number],
+          count: 3
+        },
+        {
+          a: [1, 1] as [number, number],
+          b: [2, 2] as [number, number],
+          count: 1
+        },
+        {
+          a: [1, 1] as [number, number],
+          b: [3, 3] as [number, number],
+          count: 3
+        }
+      ]
+    },
+    {
+      description: 'a loop with a tail',
+      entries: [
+        {
+          a: [0, 0] as [number, number],
+          b: [4, 0] as [number, number],
+          count: 2
+        },
+        {
+          a: [4, 0] as [number, number],
+          b: [4, 4] as [number, number],
+          count: 2
+        },
+        {
+          a: [4, 4] as [number, number],
+          b: [0, 0] as [number, number],
+          count: 2
+        },
+        {
+          a: [0, 0] as [number, number],
+          b: [-0 + 8, 8] as [number, number],
+          count: 2
+        }
+      ]
+    }
+  ])('preserves the edge multiset of $description', ({ entries }) => {
+    const edges = buildEdges(entries)
+    const expected = [...edges.entries()]
+      .map(([key, edge]) => `${key}=${edge.count}`)
+      .sort()
+
+    expect(edgeMultiset(assembleEdgesToSegments(edges))).toEqual(expected)
+  })
+
+  it('is empty for an empty edge set', () => {
+    expect(assembleEdgesToSegments(new Map())).toEqual([])
+  })
+
+  it('assembles a dense tile whole, with no cap and no quadratic blowup', () => {
+    // There is deliberately no per-tile maximum, so the assembler has to stay
+    // linear: a downtown tile crossed by thousands of activities is the
+    // ordinary case, not the adversarial one.
+    const entries = Array.from({ length: 4_000 }, (_value, index) => ({
+      a: [index % 200, Math.floor(index / 200)] as [number, number],
+      b: [(index % 200) + 1, Math.floor(index / 200)] as [number, number],
+      count: (index % 3) + 1
+    }))
+    const edges = buildEdges(entries)
+
+    const startedAt = process.hrtime.bigint()
+    const segments = assembleEdgesToSegments(edges)
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
+
+    expect(edgeMultiset(segments)).toEqual(
+      [...edges.entries()].map(([key, edge]) => `${key}=${edge.count}`).sort()
+    )
+    // Generous, but a quadratic assembler over 4,000 edges does not finish here.
+    expect(elapsedMs).toBeLessThan(2_000)
+  })
+})
+
+describe('explode and assemble round trip', () => {
+  it.each([
+    {
+      description: 'a single run',
+      segments: [{ count: 1, points: [0, 0, 1, 1, 2, 2] }]
+    },
+    {
+      description: 'mixed counts and privacy classes',
+      segments: [
+        { count: 2, points: [0, 0, 1, 1] },
+        { count: 5, points: [1, 1, 2, 2] },
+        { count: 1, hidden: true, points: [2, 2, 3, 3] }
+      ]
+    },
+    {
+      description: 'coordinates at both ends of the space',
+      segments: [
+        { count: 1, points: [0, 0, TILE_EXTENT, TILE_EXTENT] },
+        { count: 1, points: [0, TILE_EXTENT, TILE_EXTENT, 0] }
+      ]
+    }
+  ])('preserves $description exactly', ({ segments }) => {
+    const before = edgeMultiset(segments)
+    const after = edgeMultiset(
+      assembleEdgesToSegments(explodeTileToEdges(segments))
+    )
+    expect(after).toEqual(before)
+  })
+})
+
+describe('mergeTileDelta', () => {
+  const existing: TileSegment[] = [{ count: 1, points: [0, 0, 1, 1] }]
+
+  it('adds to a tile this same build already wrote', () => {
+    const merged = mergeTileDelta({
+      existingSegments: existing,
+      existingVersion: 7,
+      buildVersion: 7,
+      delta: buildEdges([{ a: [0, 0], b: [1, 1], count: 1 }])
+    })
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].count).toBe(2)
+  })
+
+  it('replaces a tile an older build wrote, rather than double counting it', () => {
+    // The previous generation already counted every activity once. Adding to
+    // it would count them twice, and no later sweep could undo that.
+    const merged = mergeTileDelta({
+      existingSegments: existing,
+      existingVersion: 6,
+      buildVersion: 7,
+      delta: buildEdges([{ a: [0, 0], b: [1, 1], count: 1 }])
+    })
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].count).toBe(1)
+  })
+
+  it('keeps edges the delta did not touch when adding', () => {
+    const merged = mergeTileDelta({
+      existingSegments: [
+        { count: 1, points: [0, 0, 1, 1] },
+        { count: 4, points: [8, 8, 9, 9] }
+      ],
+      existingVersion: 3,
+      buildVersion: 3,
+      delta: buildEdges([{ a: [0, 0], b: [1, 1], count: 2 }])
+    })
+
+    const counts = edgeMultiset(merged)
+    expect(counts).toHaveLength(2)
+    expect(counts.some((entry) => entry.endsWith('=3'))).toBe(true)
+    expect(counts.some((entry) => entry.endsWith('=4'))).toBe(true)
+  })
+
+  it('drops an older build entirely, including edges the delta never mentions', () => {
+    const merged = mergeTileDelta({
+      existingSegments: [
+        { count: 1, points: [0, 0, 1, 1] },
+        { count: 4, points: [8, 8, 9, 9] }
+      ],
+      existingVersion: 2,
+      buildVersion: 3,
+      delta: buildEdges([{ a: [0, 0], b: [1, 1], count: 1 }])
+    })
+
+    expect(edgeMultiset(merged)).toHaveLength(1)
+  })
+
+  it('starts a tile from nothing when the row is empty', () => {
+    const merged = mergeTileDelta({
+      existingSegments: [],
+      existingVersion: 3,
+      buildVersion: 3,
+      delta: buildEdges([{ a: [0, 0], b: [1, 1], count: 1 }])
+    })
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].count).toBe(1)
+  })
+})

--- a/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
@@ -111,14 +111,53 @@ describe('explodeTileToEdges', () => {
 })
 
 describe('assembleEdgesToSegments', () => {
-  it('joins a chain into one polyline', () => {
-    const segments = assembleEdgesToSegments(
-      buildEdges([
-        { a: [0, 0], b: [1, 1], count: 1 },
-        { a: [1, 1], b: [2, 2], count: 1 },
-        { a: [2, 2], b: [3, 3], count: 1 }
-      ])
-    )
+  it.each([
+    {
+      description: 'an end edge inserted first',
+      entries: [
+        {
+          a: [0, 0] as [number, number],
+          b: [1, 1] as [number, number],
+          count: 1
+        },
+        {
+          a: [1, 1] as [number, number],
+          b: [2, 2] as [number, number],
+          count: 1
+        },
+        {
+          a: [2, 2] as [number, number],
+          b: [3, 3] as [number, number],
+          count: 1
+        }
+      ]
+    },
+    {
+      description: 'a middle edge inserted first',
+      // Insertion order is what separates the two passes. Sweeping alone would
+      // start mid-chain here and store two runs; only beginning at an endpoint
+      // — what the odd-degree pass is for — keeps it whole, and fewer, longer
+      // runs is the storage win that pass exists for.
+      entries: [
+        {
+          a: [1, 1] as [number, number],
+          b: [2, 2] as [number, number],
+          count: 1
+        },
+        {
+          a: [0, 0] as [number, number],
+          b: [1, 1] as [number, number],
+          count: 1
+        },
+        {
+          a: [2, 2] as [number, number],
+          b: [3, 3] as [number, number],
+          count: 1
+        }
+      ]
+    }
+  ])('joins a chain into one polyline, given $description', ({ entries }) => {
+    const segments = assembleEdgesToSegments(buildEdges(entries))
     expect(segments).toHaveLength(1)
     expect(segments[0].points).toHaveLength(8)
     expect(segments[0].count).toBe(1)
@@ -295,26 +334,57 @@ describe('assembleEdgesToSegments', () => {
     expect(assembleEdgesToSegments(new Map())).toEqual([])
   })
 
-  it('assembles a dense tile whole, with no cap and no quadratic blowup', () => {
-    // There is deliberately no per-tile maximum, so the assembler has to stay
-    // linear: a downtown tile crossed by thousands of activities is the
-    // ordinary case, not the adversarial one.
-    const entries = Array.from({ length: 4_000 }, (_value, index) => ({
-      a: [index % 200, Math.floor(index / 200)] as [number, number],
-      b: [(index % 200) + 1, Math.floor(index / 200)] as [number, number],
-      count: (index % 3) + 1
-    }))
+  it('assembles a dense tile of long connected runs whole, with no cap', () => {
+    // There is deliberately no per-tile maximum, so this has to hold at the
+    // size a downtown tile really reaches. One count class and shared vertices
+    // on purpose: spreading the fixture across counts leaves isolated single
+    // edges, where the walker never takes a second step and the forward-only
+    // cursor is never consulted at all.
+    const rowLength = 200
+    const rows = 20
+    const entries = Array.from(
+      { length: rowLength * rows },
+      (_value, index) => {
+        const column = index % rowLength
+        const row = Math.floor(index / rowLength)
+        return {
+          a: [column, row] as [number, number],
+          b: [column + 1, row] as [number, number],
+          count: 1
+        }
+      }
+    )
     const edges = buildEdges(entries)
-
-    const startedAt = process.hrtime.bigint()
     const segments = assembleEdgesToSegments(edges)
-    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
 
     expect(edgeMultiset(segments)).toEqual(
       [...edges.entries()].map(([key, edge]) => `${key}=${edge.count}`).sort()
     )
-    // Generous, but a quadratic assembler over 4,000 edges does not finish here.
-    expect(elapsedMs).toBeLessThan(2_000)
+    // Structural rather than timed: each row is one connected chain, so a
+    // correct assembler emits exactly one full-length run per row. A wall-clock
+    // budget would be flaky on a loaded CI box and would not say this.
+    expect(segments).toHaveLength(rows)
+    for (const segment of segments) {
+      expect(segment.points).toHaveLength((rowLength + 1) * 2)
+    }
+  })
+
+  it('walks a high-degree hub without losing an edge', () => {
+    // Every trail through the hub reuses its adjacency list, so a cursor that
+    // moved past an unconsumed entry would drop edges here.
+    const spokes = 2_000
+    const entries = Array.from({ length: spokes }, (_value, index) => ({
+      a: [128, 128] as [number, number],
+      b: [index % 250, 1 + Math.floor(index / 250)] as [number, number],
+      count: 1
+    }))
+    const edges = buildEdges(entries)
+    const segments = assembleEdgesToSegments(edges)
+
+    expect(edges.size).toBe(spokes)
+    expect(edgeMultiset(segments)).toEqual(
+      [...edges.entries()].map(([key, edge]) => `${key}=${edge.count}`).sort()
+    )
   })
 })
 
@@ -322,7 +392,8 @@ describe('explode and assemble round trip', () => {
   it.each([
     {
       description: 'a single run',
-      segments: [{ count: 1, points: [0, 0, 1, 1, 2, 2] }]
+      segments: [{ count: 1, points: [0, 0, 1, 1, 2, 2] }],
+      expectedEdges: 2
     },
     {
       description: 'mixed counts and privacy classes',
@@ -330,17 +401,23 @@ describe('explode and assemble round trip', () => {
         { count: 2, points: [0, 0, 1, 1] },
         { count: 5, points: [1, 1, 2, 2] },
         { count: 1, hidden: true, points: [2, 2, 3, 3] }
-      ]
+      ],
+      expectedEdges: 3
     },
     {
       description: 'coordinates at both ends of the space',
       segments: [
         { count: 1, points: [0, 0, TILE_EXTENT, TILE_EXTENT] },
         { count: 1, points: [0, TILE_EXTENT, TILE_EXTENT, 0] }
-      ]
+      ],
+      expectedEdges: 2
     }
-  ])('preserves $description exactly', ({ segments }) => {
+  ])('preserves $description exactly', ({ segments, expectedEdges }) => {
     const before = edgeMultiset(segments)
+    // Anchored, so the comparison cannot be satisfied by both sides collapsing
+    // to nothing — `edgeMultiset` runs through one of the functions under test.
+    expect(before).toHaveLength(expectedEdges)
+
     const after = edgeMultiset(
       assembleEdgesToSegments(explodeTileToEdges(segments))
     )

--- a/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/edgeMerge.test.ts
@@ -316,7 +316,7 @@ describe('assembleEdgesToSegments', () => {
         },
         {
           a: [0, 0] as [number, number],
-          b: [-0 + 8, 8] as [number, number],
+          b: [8, 8] as [number, number],
           count: 2
         }
       ]

--- a/lib/services/fitness-files/heatmapTiles/edgeMerge.ts
+++ b/lib/services/fitness-files/heatmapTiles/edgeMerge.ts
@@ -98,17 +98,24 @@ interface AdjacencyEntry {
  *    twice and an edge visited once cannot share a run — putting them together
  *    would have to pick a count, and whichever it picked would be wrong for the
  *    other.
- * 2. **Sweep for cycles after the odd-degree starts.** Walking only from
- *    odd-degree vertices is the compact choice, but a closed loop — a
- *    roundabout, a lap, a criterium circuit — has no odd-degree vertex at all,
- *    so a walk that only starts at one never enters it and every edge in it is
- *    silently dropped.
+ * 2. **Sweep every edge afterwards.** Walking only from odd-degree vertices
+ *    would silently drop every closed loop — a roundabout, a lap, a criterium
+ *    circuit has no odd-degree vertex at all, so a walk that only starts at one
+ *    never enters it.
  *
- * Correctness needs completeness (every edge consumed exactly once), not
- * minimality: a walk that dead-ends at a junction just ends that run, and the
- * sweep picks up the rest. Consumption is by flag with per-vertex adjacency, so
- * the whole pass is linear in the number of edges — a dense downtown tile is
- * not capped, so an O(E^2) assembler would be a real cliff.
+ * The sweep is what carries correctness, and it would be complete even on its
+ * own: adjacency lists are built in ascending edge order, so once every edge
+ * before `i` is consumed, edge `i` is necessarily the first unconsumed entry at
+ * its own endpoint, and walking from there consumes it. The odd-degree pass
+ * ahead of it is a STORAGE optimisation, not a second half of the correctness
+ * argument — starting at an endpoint rather than mid-run yields fewer, longer
+ * polylines for the same edges.
+ *
+ * Completeness is what matters, not minimality: a walk that dead-ends at a
+ * junction just ends that run and the sweep picks up the rest. Consumption is
+ * by flag through per-vertex adjacency with a forward-only cursor, so the pass
+ * is linear in the number of edges — tile size is deliberately uncapped, so an
+ * O(E^2) assembler would be a real cliff on a downtown tile.
  */
 export const assembleEdgesToSegments = (edges: TileEdgeMap): TileSegment[] => {
   const partitions = new Map<string, TileEdge[]>()
@@ -173,13 +180,16 @@ export const assembleEdgesToSegments = (edges: TileEdgeMap): TileSegment[] => {
       segments.push({ count, ...(hidden ? { hidden: true } : {}), points })
     }
 
-    // Odd-degree vertices first: starting there produces fewer, longer runs.
+    // Odd-degree vertices first. Purely for compactness — a run started at an
+    // endpoint covers the whole chain, where one started in the middle splits
+    // it in two — so this changes how many polylines are stored, never which
+    // edges survive.
     for (const [vertex, entries] of adjacency) {
       if (entries.length % 2 === 1) walkFrom(vertex)
     }
 
-    // Then whatever is left, which is exactly the closed loops the pass above
-    // cannot reach. Without this they would be dropped outright.
+    // Everything still unconsumed, which is where correctness actually lives:
+    // closed loops are all-even-degree and the pass above cannot reach them.
     for (let edgeIndex = 0; edgeIndex < partition.length; edgeIndex += 1) {
       if (!consumed[edgeIndex]) walkFrom(partition[edgeIndex].a)
     }

--- a/lib/services/fitness-files/heatmapTiles/edgeMerge.ts
+++ b/lib/services/fitness-files/heatmapTiles/edgeMerge.ts
@@ -1,0 +1,226 @@
+import { TILE_EXTENT } from './constants'
+import type { TileSegment } from './tileCodec'
+
+/**
+ * Turning a tile between its two representations: the polylines it is stored
+ * as, and the edge set the build accumulates into.
+ *
+ * Pure and dependency-free, no `'use client'` (see AGENTS.md → Server/Client
+ * Module Boundary).
+ */
+
+/**
+ * One quantized pixel, packed into a single integer so it can key a Map.
+ *
+ * Base `TILE_EXTENT + 1`, not `TILE_EXTENT`. The coordinate space is inclusive
+ * of both ends — 0..256 is 257 distinct values, because a point exactly on a
+ * tile's far boundary is 256 here and 0 in the neighbour — so base 256 would
+ * collide (1,0) with (0,256) and silently weld two unrelated streets together.
+ */
+export const VERTEX_PACK_BASE = TILE_EXTENT + 1
+
+export const packVertex = (x: number, y: number) => x * VERTEX_PACK_BASE + y
+
+export const unpackVertex = (packed: number) => ({
+  x: Math.floor(packed / VERTEX_PACK_BASE),
+  y: packed % VERTEX_PACK_BASE
+})
+
+/**
+ * An undirected edge between two packed vertices, with its privacy class.
+ *
+ * Undirected because which way an activity happened to travel a street is not
+ * something a heatmap shows — normalizing means an out-and-back and two
+ * opposite commutes land on the same edge instead of two. The privacy class is
+ * part of the identity so trimmed geometry can never merge into visible
+ * geometry: they render differently, and a run has only one class.
+ */
+export const edgeKey = (a: number, b: number, hidden: boolean) =>
+  `${Math.min(a, b)}:${Math.max(a, b)}:${hidden ? 1 : 0}`
+
+export interface TileEdge {
+  a: number
+  b: number
+  hidden: boolean
+  count: number
+}
+
+export type TileEdgeMap = Map<string, TileEdge>
+
+/**
+ * Breaks stored polylines back into the edges they are made of, summing the
+ * counts of any edge that appears more than once.
+ */
+export const explodeTileToEdges = (segments: TileSegment[]): TileEdgeMap => {
+  const edges: TileEdgeMap = new Map()
+
+  for (const segment of segments) {
+    const hidden = Boolean(segment.hidden)
+    const { points } = segment
+
+    for (let index = 0; index + 3 < points.length; index += 2) {
+      const a = packVertex(points[index], points[index + 1])
+      const b = packVertex(points[index + 2], points[index + 3])
+      // A polyline should never contain one, but a hand-written or
+      // partially-corrupt payload can; a self-loop is not geometry.
+      if (a === b) continue
+
+      const key = edgeKey(a, b, hidden)
+      const existing = edges.get(key)
+      if (existing) {
+        existing.count += segment.count
+        continue
+      }
+      edges.set(key, {
+        a: Math.min(a, b),
+        b: Math.max(a, b),
+        hidden,
+        count: segment.count
+      })
+    }
+  }
+
+  return edges
+}
+
+interface AdjacencyEntry {
+  to: number
+  edgeIndex: number
+}
+
+/**
+ * Reassembles an edge set into the longest polylines that can carry it.
+ *
+ * Two rules make this lossless, and both are load-bearing:
+ *
+ * 1. **Partition by `(count, hidden)` first.** A stored polyline carries ONE
+ *    count and one privacy class for all of its points, so an edge visited
+ *    twice and an edge visited once cannot share a run — putting them together
+ *    would have to pick a count, and whichever it picked would be wrong for the
+ *    other.
+ * 2. **Sweep for cycles after the odd-degree starts.** Walking only from
+ *    odd-degree vertices is the compact choice, but a closed loop — a
+ *    roundabout, a lap, a criterium circuit — has no odd-degree vertex at all,
+ *    so a walk that only starts at one never enters it and every edge in it is
+ *    silently dropped.
+ *
+ * Correctness needs completeness (every edge consumed exactly once), not
+ * minimality: a walk that dead-ends at a junction just ends that run, and the
+ * sweep picks up the rest. Consumption is by flag with per-vertex adjacency, so
+ * the whole pass is linear in the number of edges — a dense downtown tile is
+ * not capped, so an O(E^2) assembler would be a real cliff.
+ */
+export const assembleEdgesToSegments = (edges: TileEdgeMap): TileSegment[] => {
+  const partitions = new Map<string, TileEdge[]>()
+  for (const edge of edges.values()) {
+    const partitionKey = `${edge.count}:${edge.hidden ? 1 : 0}`
+    const partition = partitions.get(partitionKey)
+    if (partition) partition.push(edge)
+    else partitions.set(partitionKey, [edge])
+  }
+
+  const segments: TileSegment[] = []
+
+  for (const partition of partitions.values()) {
+    const adjacency = new Map<number, AdjacencyEntry[]>()
+    const consumed = new Array<boolean>(partition.length).fill(false)
+
+    const link = (from: number, to: number, edgeIndex: number) => {
+      const entries = adjacency.get(from)
+      if (entries) entries.push({ to, edgeIndex })
+      else adjacency.set(from, [{ to, edgeIndex }])
+    }
+
+    partition.forEach((edge, edgeIndex) => {
+      link(edge.a, edge.b, edgeIndex)
+      link(edge.b, edge.a, edgeIndex)
+    })
+
+    // A cursor per vertex, so skipping already-consumed edges never rescans
+    // from the start of its adjacency list.
+    const cursors = new Map<number, number>()
+    const nextUnconsumed = (vertex: number) => {
+      const entries = adjacency.get(vertex)
+      if (!entries) return null
+
+      let cursor = cursors.get(vertex) ?? 0
+      while (cursor < entries.length && consumed[entries[cursor].edgeIndex]) {
+        cursor += 1
+      }
+      cursors.set(vertex, cursor)
+      return cursor < entries.length ? entries[cursor] : null
+    }
+
+    const walkFrom = (start: number) => {
+      const path = [start]
+      let current = start
+
+      for (;;) {
+        const next = nextUnconsumed(current)
+        if (!next) break
+        consumed[next.edgeIndex] = true
+        path.push(next.to)
+        current = next.to
+      }
+
+      if (path.length < 2) return
+      const { count, hidden } = partition[0]
+      const points: number[] = []
+      for (const packed of path) {
+        const { x, y } = unpackVertex(packed)
+        points.push(x, y)
+      }
+      segments.push({ count, ...(hidden ? { hidden: true } : {}), points })
+    }
+
+    // Odd-degree vertices first: starting there produces fewer, longer runs.
+    for (const [vertex, entries] of adjacency) {
+      if (entries.length % 2 === 1) walkFrom(vertex)
+    }
+
+    // Then whatever is left, which is exactly the closed loops the pass above
+    // cannot reach. Without this they would be dropped outright.
+    for (let edgeIndex = 0; edgeIndex < partition.length; edgeIndex += 1) {
+      if (!consumed[edgeIndex]) walkFrom(partition[edgeIndex].a)
+    }
+  }
+
+  return segments
+}
+
+/**
+ * Folds a build's freshly-computed edges into whatever the tile already holds.
+ *
+ * The version decides whether that is addition or replacement. A row written by
+ * THIS build is this build's own earlier flush, so its counts are added to.
+ * A row written by an older build is the previous generation's answer, and this
+ * build is replacing it — adding there would count every activity twice, once
+ * per build, and the error would be permanent.
+ */
+export const mergeTileDelta = ({
+  existingSegments,
+  existingVersion,
+  buildVersion,
+  delta
+}: {
+  existingSegments: TileSegment[]
+  existingVersion: number
+  buildVersion: number
+  delta: TileEdgeMap
+}): TileSegment[] => {
+  if (existingVersion !== buildVersion) {
+    return assembleEdgesToSegments(delta)
+  }
+
+  const merged = explodeTileToEdges(existingSegments)
+  for (const [key, edge] of delta) {
+    const existing = merged.get(key)
+    if (existing) {
+      existing.count += edge.count
+      continue
+    }
+    merged.set(key, { ...edge })
+  }
+
+  return assembleEdgesToSegments(merged)
+}

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
@@ -35,7 +35,30 @@ describe('tileKey and parseTileKey', () => {
   })
 
   it('accepts the last valid index at a zoom', () => {
-    expect(parseTileKey('2:3:3')).toEqual({ z: 2, x: 3, y: 3 })
+    expect(parseTileKey('4:15:15')).toEqual({ z: 4, x: 15, y: 15 })
+  })
+
+  it.each([
+    { description: 'an empty zoom part', key: ':1:1' },
+    { description: 'an empty x part', key: '12::1' },
+    {
+      description: 'a truncated key with a trailing separator',
+      key: '12:2103:'
+    },
+    { description: 'nothing but separators', key: '::' },
+    { description: 'hex notation', key: '0x4:1:1' },
+    { description: 'exponent notation', key: '1e1:5:5' },
+    { description: 'padded whitespace', key: '4: 1 :1' },
+    { description: 'a zoom below the ladder', key: '2:1:1' },
+    { description: 'a zoom above the ladder', key: '18:1:1' },
+    {
+      description: 'a zoom so large the index bound goes infinite',
+      key: '1024:1:1'
+    }
+  ])('rejects $description rather than coercing it', ({ key }) => {
+    // `Number('')` is 0, so a truncated key would otherwise resolve to a real
+    // but entirely different tile instead of being turned away.
+    expect(parseTileKey(key)).toBeNull()
   })
 })
 
@@ -223,7 +246,17 @@ describe('encodeTile and decodeTile', () => {
   })
 
   it.each([
-    { description: 'an odd-length point list', segment: '{"c":1,"p":[0,0,8]}' },
+    // Long enough to clear the minimum-length guard, so this really does test
+    // the parity check: without it the tile decodes with a dangling coordinate
+    // and `countTilePoints` answers a fraction.
+    {
+      description: 'an odd-length point list',
+      segment: '{"c":1,"p":[0,0,8,8,4]}'
+    },
+    {
+      description: 'a point list too short to be a line',
+      segment: '{"c":1,"p":[0,0,8]}'
+    },
     {
       description: 'a point list too short to be a line',
       segment: '{"c":1,"p":[0,0]}'
@@ -242,10 +275,17 @@ describe('encodeTile and decodeTile', () => {
       segment: '{"c":1,"p":[0,0,"x",8]}'
     },
     { description: 'a missing count', segment: '{"p":[0,0,8,8]}' },
-    { description: 'a zero count', segment: '{"c":0,"p":[0,0,8,8]}' }
+    { description: 'a zero count', segment: '{"c":0,"p":[0,0,8,8]}' },
+    { description: 'a non-finite count', segment: '{"c":null,"p":[0,0,8,8]}' }
   ])('drops $description without taking the tile with it', ({ segment }) => {
     const encoded = `{"e":256,"s":[${segment},{"c":2,"p":[1,1,2,2]}]}`
     expect(decodeTile(encoded)).toEqual([{ count: 2, points: [1, 1, 2, 2] }])
+  })
+
+  it('rounds a fractional count to a whole number of visits', () => {
+    expect(decodeTile('{"e":256,"s":[{"c":2.6,"p":[0,0,8,8]}]}')).toEqual([
+      { count: 3, points: [0, 0, 8, 8] }
+    ])
   })
 
   it('never throws, whatever it is handed', () => {

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
@@ -28,8 +28,10 @@ describe('tileKey and parseTileKey', () => {
     { description: 'a non-numeric part', key: '16:abc:200' },
     { description: 'a fractional index', key: '16:100.5:200' },
     { description: 'a negative index', key: '16:-1:200' },
-    { description: 'an x past the last tile at that zoom', key: '2:4:0' },
-    { description: 'a y past the last tile at that zoom', key: '2:0:4' }
+    // Inside the ladder on purpose: a zoom below it is turned away by the zoom
+    // bound and never reaches the index check at all.
+    { description: 'an x past the last tile at that zoom', key: '4:16:0' },
+    { description: 'a y past the last tile at that zoom', key: '4:0:16' }
   ])('rejects $description', ({ key }) => {
     expect(parseTileKey(key)).toBeNull()
   })
@@ -79,6 +81,23 @@ describe('lngLatToTileLocal', () => {
     const placed = lngLatToTileLocal({ lat: -85.05112878, lng: 0 }, zoom)
 
     expect(placed.y).toBe(tileCountAtZoom(zoom) - 1)
+  })
+
+  it('keeps the local coordinate inside the space at the projection edges', () => {
+    // The projection lands a hair outside its own grid at the limits — the
+    // north edge gives about -1e-4 local units at z16 — and the space is what
+    // callers are promised, so the local coordinate is clamped like the index.
+    for (const zoom of [4, 16]) {
+      const north = lngLatToTileLocal({ lat: 85.05112878, lng: 0 }, zoom)
+      expect(north.v).toBeGreaterThanOrEqual(0)
+      expect(north.v).toBeLessThanOrEqual(TILE_EXTENT)
+
+      const south = lngLatToTileLocal({ lat: -85.05112878, lng: 180 }, zoom)
+      expect(south.u).toBeGreaterThanOrEqual(0)
+      expect(south.u).toBeLessThanOrEqual(TILE_EXTENT)
+      expect(south.v).toBeGreaterThanOrEqual(0)
+      expect(south.v).toBeLessThanOrEqual(TILE_EXTENT)
+    }
   })
 
   it('clamps a latitude beyond the Mercator limit rather than overflowing', () => {
@@ -254,11 +273,11 @@ describe('encodeTile and decodeTile', () => {
       segment: '{"c":1,"p":[0,0,8,8,4]}'
     },
     {
-      description: 'a point list too short to be a line',
+      description: 'a point list too short to be a line, of odd length',
       segment: '{"c":1,"p":[0,0,8]}'
     },
     {
-      description: 'a point list too short to be a line',
+      description: 'a point list holding a single point',
       segment: '{"c":1,"p":[0,0]}'
     },
     {
@@ -276,7 +295,10 @@ describe('encodeTile and decodeTile', () => {
     },
     { description: 'a missing count', segment: '{"p":[0,0,8,8]}' },
     { description: 'a zero count', segment: '{"c":0,"p":[0,0,8,8]}' },
-    { description: 'a non-finite count', segment: '{"c":null,"p":[0,0,8,8]}' }
+    { description: 'a null count', segment: '{"c":null,"p":[0,0,8,8]}' },
+    // Reaches the finiteness check specifically: `null` is turned away one
+    // condition earlier by the type test, so it alone leaves that check unpinned.
+    { description: 'an infinite count', segment: '{"c":1e999,"p":[0,0,8,8]}' }
   ])('drops $description without taking the tile with it', ({ segment }) => {
     const encoded = `{"e":256,"s":[${segment},{"c":2,"p":[1,1,2,2]}]}`
     expect(decodeTile(encoded)).toEqual([{ count: 2, points: [1, 1, 2, 2] }])

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.test.ts
@@ -1,0 +1,271 @@
+import { TILE_EXTENT } from '@/lib/services/fitness-files/heatmapTiles/constants'
+import {
+  countTilePoints,
+  decodeTile,
+  encodeTile,
+  lngLatToTileLocal,
+  parseTileKey,
+  tileCountAtZoom,
+  tileKey,
+  tileLocalToLngLat,
+  tilesForBounds
+} from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+import type { TileSegment } from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+
+describe('tileKey and parseTileKey', () => {
+  it('round trips a coordinate', () => {
+    expect(parseTileKey(tileKey(16, 100, 200))).toEqual({
+      z: 16,
+      x: 100,
+      y: 200
+    })
+  })
+
+  it.each([
+    { description: 'an empty string', key: '' },
+    { description: 'too few parts', key: '16:100' },
+    { description: 'too many parts', key: '16:100:200:1' },
+    { description: 'a non-numeric part', key: '16:abc:200' },
+    { description: 'a fractional index', key: '16:100.5:200' },
+    { description: 'a negative index', key: '16:-1:200' },
+    { description: 'an x past the last tile at that zoom', key: '2:4:0' },
+    { description: 'a y past the last tile at that zoom', key: '2:0:4' }
+  ])('rejects $description', ({ key }) => {
+    expect(parseTileKey(key)).toBeNull()
+  })
+
+  it('accepts the last valid index at a zoom', () => {
+    expect(parseTileKey('2:3:3')).toEqual({ z: 2, x: 3, y: 3 })
+  })
+})
+
+describe('lngLatToTileLocal', () => {
+  it('puts the antimeridian in the last tile, not one past it', () => {
+    // The projection's own edge lands exactly at `scale`, whose floor is
+    // 2**zoom — an index that does not exist. Clamping is what keeps a point
+    // on the date line out of a phantom tile.
+    const zoom = 4
+    const placed = lngLatToTileLocal({ lat: 0, lng: 180 }, zoom)
+
+    expect(placed.x).toBe(tileCountAtZoom(zoom) - 1)
+    expect(placed.u).toBeCloseTo(TILE_EXTENT, 6)
+  })
+
+  it('puts the south Mercator edge in the last tile, not one past it', () => {
+    const zoom = 4
+    const placed = lngLatToTileLocal({ lat: -85.05112878, lng: 0 }, zoom)
+
+    expect(placed.y).toBe(tileCountAtZoom(zoom) - 1)
+  })
+
+  it('clamps a latitude beyond the Mercator limit rather than overflowing', () => {
+    const zoom = 6
+    const placed = lngLatToTileLocal({ lat: -89.9, lng: 0 }, zoom)
+
+    expect(placed.y).toBe(tileCountAtZoom(zoom) - 1)
+    expect(Number.isFinite(placed.v)).toBe(true)
+  })
+
+  it.each([
+    {
+      description: 'the north-west corner of the world',
+      lat: 85.05112878,
+      lng: -180,
+      x: 0,
+      y: 0
+    },
+    { description: 'the origin', lat: 0, lng: 0, x: 2, y: 2 }
+  ])('places $description at zoom 2', ({ lat, lng, x, y }) => {
+    const placed = lngLatToTileLocal({ lat, lng }, 2)
+    expect({ x: placed.x, y: placed.y }).toEqual({ x, y })
+  })
+})
+
+describe('tileLocalToLngLat', () => {
+  it.each([
+    { description: 'the equator on the prime meridian', lat: 0, lng: 0 },
+    { description: 'a northern city', lat: 52.370216, lng: 4.895168 },
+    { description: 'a southern point', lat: -33.8688, lng: 151.2093 },
+    { description: 'a point near the Mercator limit', lat: 84.9, lng: -179.9 }
+  ])('inverts the projection for $description', ({ lat, lng }) => {
+    const zoom = 16
+    const placed = lngLatToTileLocal({ lat, lng }, zoom)
+    const back = tileLocalToLngLat(zoom, placed.x, placed.y, placed.u, placed.v)
+
+    expect(back.lat).toBeCloseTo(lat, 6)
+    expect(back.lng).toBeCloseTo(lng, 6)
+  })
+
+  it('lands within half a pixel once the local coordinate is quantized', () => {
+    // What the stored format actually holds: rounded integers. The error a
+    // reader inherits must stay under the pixel the value was rounded to.
+    const zoom = 16
+    const point = { lat: 52.370216, lng: 4.895168 }
+    const placed = lngLatToTileLocal(point, zoom)
+    const back = tileLocalToLngLat(
+      zoom,
+      placed.x,
+      placed.y,
+      Math.round(placed.u),
+      Math.round(placed.v)
+    )
+
+    const metersPerPixel = 2.3886571337890623
+    const latMeters = Math.abs(back.lat - point.lat) * 111_320
+    expect(latMeters).toBeLessThanOrEqual(metersPerPixel)
+  })
+
+  it('agrees with the tile the forward projection chose', () => {
+    const zoom = 12
+    const placed = lngLatToTileLocal({ lat: 48.8584, lng: 2.2945 }, zoom)
+    const centre = tileLocalToLngLat(
+      zoom,
+      placed.x,
+      placed.y,
+      TILE_EXTENT / 2,
+      TILE_EXTENT / 2
+    )
+
+    const replaced = lngLatToTileLocal(centre, zoom)
+    expect({ x: replaced.x, y: replaced.y }).toEqual({
+      x: placed.x,
+      y: placed.y
+    })
+  })
+})
+
+describe('tilesForBounds', () => {
+  it('covers the tile a small box sits in', () => {
+    const range = tilesForBounds(
+      { minLat: 52.36, maxLat: 52.38, minLng: 4.88, maxLng: 4.9 },
+      10
+    )
+
+    expect(range.minX).toBeLessThanOrEqual(range.maxX)
+    expect(range.minY).toBeLessThanOrEqual(range.maxY)
+    const placed = lngLatToTileLocal({ lat: 52.37, lng: 4.89 }, 10)
+    expect(placed.x).toBeGreaterThanOrEqual(range.minX)
+    expect(placed.x).toBeLessThanOrEqual(range.maxX)
+    expect(placed.y).toBeGreaterThanOrEqual(range.minY)
+    expect(placed.y).toBeLessThanOrEqual(range.maxY)
+  })
+
+  it('orders y from the northern edge, which Mercator numbers lowest', () => {
+    const range = tilesForBounds(
+      { minLat: -10, maxLat: 10, minLng: -10, maxLng: 10 },
+      8
+    )
+    expect(range.minY).toBeLessThanOrEqual(range.maxY)
+  })
+
+  it('clamps a whole-world box to the grid at every ladder zoom', () => {
+    for (const zoom of [4, 8, 16]) {
+      const range = tilesForBounds(
+        { minLat: -90, maxLat: 90, minLng: -180, maxLng: 180 },
+        zoom
+      )
+      expect(range.minX).toBe(0)
+      expect(range.minY).toBe(0)
+      expect(range.maxX).toBe(tileCountAtZoom(zoom) - 1)
+      expect(range.maxY).toBe(tileCountAtZoom(zoom) - 1)
+    }
+  })
+
+  it('reports minX past maxX for an antimeridian-straddling box, for the caller to split', () => {
+    // Deliberate: the range read uses `whereBetween`, which matches nothing in
+    // that state rather than silently wrapping across the whole map.
+    const range = tilesForBounds(
+      { minLat: -10, maxLat: 10, minLng: 170, maxLng: -170 },
+      6
+    )
+    expect(range.minX).toBeGreaterThan(range.maxX)
+  })
+})
+
+describe('encodeTile and decodeTile', () => {
+  const visible: TileSegment = { count: 3, points: [0, 0, 8, 8] }
+  const hidden: TileSegment = { count: 1, hidden: true, points: [1, 1, 2, 2] }
+
+  it('round trips a mixed tile', () => {
+    expect(decodeTile(encodeTile([visible, hidden]))).toEqual([visible, hidden])
+  })
+
+  it('omits the privacy flag for visible geometry and sets it for hidden', () => {
+    expect(encodeTile([visible])).not.toContain('"h"')
+    expect(encodeTile([hidden])).toContain('"h":1')
+  })
+
+  it('records the extent its coordinates are in', () => {
+    expect(JSON.parse(encodeTile([visible])).e).toBe(TILE_EXTENT)
+  })
+
+  it('survives the endpoints of the coordinate space', () => {
+    const edge: TileSegment = {
+      count: 1,
+      points: [0, 0, TILE_EXTENT, TILE_EXTENT]
+    }
+    expect(decodeTile(encodeTile([edge]))).toEqual([edge])
+  })
+
+  it.each([
+    { description: 'an empty string', encoded: '' },
+    { description: 'null', encoded: null },
+    { description: 'undefined', encoded: undefined },
+    { description: 'truncated json', encoded: '{"e":256,"s":[{"c":1,"p":[0,0' },
+    { description: 'json that is not an object', encoded: '42' },
+    { description: 'an object with no segments', encoded: '{"e":256}' },
+    {
+      description: 'segments that are not an array',
+      encoded: '{"e":256,"s":{}}'
+    }
+  ])('answers an empty tile for $description', ({ encoded }) => {
+    expect(decodeTile(encoded)).toEqual([])
+  })
+
+  it.each([
+    { description: 'an odd-length point list', segment: '{"c":1,"p":[0,0,8]}' },
+    {
+      description: 'a point list too short to be a line',
+      segment: '{"c":1,"p":[0,0]}'
+    },
+    {
+      description: 'a coordinate past the extent',
+      segment: '{"c":1,"p":[0,0,257,8]}'
+    },
+    { description: 'a negative coordinate', segment: '{"c":1,"p":[0,0,-1,8]}' },
+    {
+      description: 'a fractional coordinate',
+      segment: '{"c":1,"p":[0,0,8.5,8]}'
+    },
+    {
+      description: 'a non-numeric coordinate',
+      segment: '{"c":1,"p":[0,0,"x",8]}'
+    },
+    { description: 'a missing count', segment: '{"p":[0,0,8,8]}' },
+    { description: 'a zero count', segment: '{"c":0,"p":[0,0,8,8]}' }
+  ])('drops $description without taking the tile with it', ({ segment }) => {
+    const encoded = `{"e":256,"s":[${segment},{"c":2,"p":[1,1,2,2]}]}`
+    expect(decodeTile(encoded)).toEqual([{ count: 2, points: [1, 1, 2, 2] }])
+  })
+
+  it('never throws, whatever it is handed', () => {
+    for (const encoded of ['', '{', 'null', '[]', '{"s":[null]}', 'NaN']) {
+      expect(() => decodeTile(encoded)).not.toThrow()
+    }
+  })
+})
+
+describe('countTilePoints', () => {
+  it('counts stored vertices, which is what the pyramid totals sum', () => {
+    expect(
+      countTilePoints([
+        { count: 1, points: [0, 0, 8, 8] },
+        { count: 2, points: [1, 1, 2, 2, 3, 3] }
+      ])
+    ).toBe(5)
+  })
+
+  it('is zero for an empty tile', () => {
+    expect(countTilePoints([])).toBe(0)
+  })
+})

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.ts
@@ -4,7 +4,7 @@ import {
   projectWebMercator
 } from '@/lib/utils/webMercator'
 
-import { TILE_EXTENT } from './constants'
+import { TILE_EXTENT, TILE_MAX_ZOOM, TILE_MIN_ZOOM } from './constants'
 
 /**
  * The tile payload format, and the projection helpers that produce it.
@@ -45,17 +45,26 @@ export interface TileCoordinate {
 /** `"z:x:y"`, matching the `tileKey` column the pyramid is keyed by. */
 export const tileKey = (z: number, x: number, y: number) => `${z}:${x}:${y}`
 
+const TILE_KEY_PART = /^\d+$/
+
 /**
- * The inverse of `tileKey`, or null for anything that is not one. Tolerant
- * because a key can arrive from a query string.
+ * The inverse of `tileKey`, or null for anything that is not one. A key can
+ * arrive from a query string, so this rejects rather than coerces.
+ *
+ * Each part is matched against digits before `Number` sees it, because
+ * `Number('')` is 0 — so a truncated `"12:2103:"` would otherwise resolve to a
+ * real but entirely different tile instead of being turned away, as would
+ * `"0x4:1:1"` and `" 4 :1:1"`. The zoom is bounded by the ladder for the same
+ * reason: above zoom 1023 `2 ** z` is `Infinity`, which makes the index checks
+ * below vacuous.
  */
 export const parseTileKey = (key: string): TileCoordinate | null => {
   const parts = key.split(':')
   if (parts.length !== 3) return null
+  if (!parts.every((part) => TILE_KEY_PART.test(part))) return null
 
   const [z, x, y] = parts.map((part) => Number(part))
-  if (![z, x, y].every((value) => Number.isInteger(value))) return null
-  if (z < 0 || x < 0 || y < 0) return null
+  if (z < TILE_MIN_ZOOM || z > TILE_MAX_ZOOM) return null
   if (x >= 2 ** z || y >= 2 ** z) return null
 
   return { z, x, y }
@@ -88,11 +97,17 @@ export const lngLatToTileLocal = (
   const x = clampIndex(Math.floor(continuousX))
   const y = clampIndex(Math.floor(continuousY))
 
+  // Clamped for the same reason the index is: at the projection's own edges the
+  // local coordinate lands a hair outside the space (the north Mercator limit
+  // gives about -4e-7), and the space is what callers are promised.
+  const clampLocal = (local: number) =>
+    Math.min(Math.max(local, 0), TILE_EXTENT)
+
   return {
     x,
     y,
-    u: (continuousX - x) * TILE_EXTENT,
-    v: (continuousY - y) * TILE_EXTENT,
+    u: clampLocal((continuousX - x) * TILE_EXTENT),
+    v: clampLocal((continuousY - y) * TILE_EXTENT),
     continuousX,
     continuousY
   }
@@ -127,7 +142,9 @@ export const tileLocalToLngLat = (
  * answered with the edge tiles rather than nothing. A box that wraps the
  * antimeridian is the CALLER's to split: this returns `minX > maxX` for one,
  * and the range read it feeds uses `whereBetween`, which matches no rows in
- * that state rather than wrapping around.
+ * that state rather than wrapping around. An inverted box — `minLat` above
+ * `maxLat` — comes back the same way on the other axis, and reads as empty for
+ * the same reason.
  */
 export const tilesForBounds = (
   bounds: { minLat: number; maxLat: number; minLng: number; maxLng: number },

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.ts
@@ -99,7 +99,8 @@ export const lngLatToTileLocal = (
 
   // Clamped for the same reason the index is: at the projection's own edges the
   // local coordinate lands a hair outside the space (the north Mercator limit
-  // gives about -4e-7), and the space is what callers are promised.
+  // gives about -1e-4 local units at z16), and the space is what callers are
+  // promised.
   const clampLocal = (local: number) =>
     Math.min(Math.max(local, 0), TILE_EXTENT)
 

--- a/lib/services/fitness-files/heatmapTiles/tileCodec.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileCodec.ts
@@ -1,0 +1,246 @@
+import {
+  TILE_SIZE,
+  clampLatitude,
+  projectWebMercator
+} from '@/lib/utils/webMercator'
+
+import { TILE_EXTENT } from './constants'
+
+/**
+ * The tile payload format, and the projection helpers that produce it.
+ *
+ * Dependency-free apart from the shared Web Mercator maths, and carries no
+ * `'use client'`: the build job, the serving routes and the map components all
+ * decode with this (see AGENTS.md → Server/Client Module Boundary). The
+ * database layer deliberately treats a tile's payload as an opaque string and
+ * never parses it, so this module is the ONLY definition of the format.
+ */
+
+/**
+ * One run of connected pixels within a tile, all sharing a visit count and a
+ * privacy class.
+ *
+ * `points` is a FLAT `[x0, y0, x1, y1, …]` array rather than a list of pairs:
+ * it is about half the JSON of `[[x,y],…]` and parses proportionally faster,
+ * and since every value is an integer in `0..TILE_EXTENT` the encoding is exact
+ * — nothing here round-trips through a float.
+ */
+export interface TileSegment {
+  /** How many distinct activities traced this run. */
+  count: number
+  /**
+   * Set only when the run is privacy-trimmed geometry, mirroring how the
+   * untiled format omits `isHiddenByPrivacy` for the ordinary case.
+   */
+  hidden?: boolean
+  points: number[]
+}
+
+export interface TileCoordinate {
+  z: number
+  x: number
+  y: number
+}
+
+/** `"z:x:y"`, matching the `tileKey` column the pyramid is keyed by. */
+export const tileKey = (z: number, x: number, y: number) => `${z}:${x}:${y}`
+
+/**
+ * The inverse of `tileKey`, or null for anything that is not one. Tolerant
+ * because a key can arrive from a query string.
+ */
+export const parseTileKey = (key: string): TileCoordinate | null => {
+  const parts = key.split(':')
+  if (parts.length !== 3) return null
+
+  const [z, x, y] = parts.map((part) => Number(part))
+  if (![z, x, y].every((value) => Number.isInteger(value))) return null
+  if (z < 0 || x < 0 || y < 0) return null
+  if (x >= 2 ** z || y >= 2 ** z) return null
+
+  return { z, x, y }
+}
+
+/** The number of tiles along one axis at a zoom. */
+export const tileCountAtZoom = (zoom: number) => 2 ** zoom
+
+/**
+ * Places a coordinate in the tile grid: which tile owns it, and where inside
+ * that tile it sits in the `0..TILE_EXTENT` local space.
+ *
+ * The index is clamped at BOTH ends, because the projection's own edges fall
+ * outside the grid at both. `lng = +180` and any latitude at or below the
+ * Mercator clamp project to exactly `scale`, whose floor is `2**zoom` — one
+ * past the last tile; and the northern limit projects to a hair under zero, so
+ * its floor is `-1`. Those points belong to the edge tiles, at local coordinate
+ * `TILE_EXTENT` and `0` respectively, not to tiles that do not exist.
+ */
+export const lngLatToTileLocal = (
+  coordinate: { lat: number; lng: number },
+  zoom: number
+) => {
+  const projected = projectWebMercator(coordinate, zoom)
+  const continuousX = projected.x / TILE_SIZE
+  const continuousY = projected.y / TILE_SIZE
+  const lastTile = tileCountAtZoom(zoom) - 1
+  const clampIndex = (index: number) => Math.min(Math.max(index, 0), lastTile)
+
+  const x = clampIndex(Math.floor(continuousX))
+  const y = clampIndex(Math.floor(continuousY))
+
+  return {
+    x,
+    y,
+    u: (continuousX - x) * TILE_EXTENT,
+    v: (continuousY - y) * TILE_EXTENT,
+    continuousX,
+    continuousY
+  }
+}
+
+/**
+ * The inverse: back from a tile-local pixel to the coordinate it stands for.
+ * `projectWebMercator` has no inverse of its own, and the serving path needs
+ * one to clip a tile to a shared region in degrees.
+ */
+export const tileLocalToLngLat = (
+  z: number,
+  x: number,
+  y: number,
+  u: number,
+  v: number
+) => {
+  const scale = tileCountAtZoom(z)
+  const worldX = (x + u / TILE_EXTENT) / scale
+  const worldY = (y + v / TILE_EXTENT) / scale
+
+  const lng = worldX * 360 - 180
+  const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * worldY)))
+
+  return { lat: (latRad * 180) / Math.PI, lng }
+}
+
+/**
+ * The tile index range covering a bounding box at one zoom.
+ *
+ * Latitude is clamped to the Mercator limits, so a box reaching past them is
+ * answered with the edge tiles rather than nothing. A box that wraps the
+ * antimeridian is the CALLER's to split: this returns `minX > maxX` for one,
+ * and the range read it feeds uses `whereBetween`, which matches no rows in
+ * that state rather than wrapping around.
+ */
+export const tilesForBounds = (
+  bounds: { minLat: number; maxLat: number; minLng: number; maxLng: number },
+  zoom: number
+) => {
+  const lastTile = tileCountAtZoom(zoom) - 1
+  const clampIndex = (index: number) => Math.min(Math.max(index, 0), lastTile)
+
+  // North is a SMALLER y in Mercator, so the max latitude gives minY.
+  const topLeft = lngLatToTileLocal(
+    { lat: clampLatitude(bounds.maxLat), lng: bounds.minLng },
+    zoom
+  )
+  const bottomRight = lngLatToTileLocal(
+    { lat: clampLatitude(bounds.minLat), lng: bounds.maxLng },
+    zoom
+  )
+
+  return {
+    z: zoom,
+    minX: clampIndex(topLeft.x),
+    maxX: clampIndex(bottomRight.x),
+    minY: clampIndex(topLeft.y),
+    maxY: clampIndex(bottomRight.y)
+  }
+}
+
+interface EncodedSegment {
+  c: number
+  h?: number
+  p: number[]
+}
+
+interface EncodedTile {
+  e: number
+  s: EncodedSegment[]
+}
+
+/**
+ * `{"e":256,"s":[{"c":3,"h":1,"p":[x0,y0,…]}]}`.
+ *
+ * `h` is omitted entirely for visible geometry, the same way the untiled format
+ * omits `isHiddenByPrivacy`, so the common case costs nothing. `e` records the
+ * extent the coordinates are in: it is redundant with `TILE_EXTENT` today, and
+ * kept only because the row's `version` column counts BUILDS (it drives the
+ * stale sweep) and so cannot signal a format change — this is the one field
+ * that could.
+ */
+export const encodeTile = (segments: TileSegment[]) => {
+  const encoded: EncodedTile = {
+    e: TILE_EXTENT,
+    s: segments.map((segment) => ({
+      c: segment.count,
+      ...(segment.hidden ? { h: 1 } : {}),
+      p: segment.points
+    }))
+  }
+  return JSON.stringify(encoded)
+}
+
+const isValidPointList = (points: unknown): points is number[] =>
+  Array.isArray(points) &&
+  points.length >= 4 &&
+  points.length % 2 === 0 &&
+  points.every(
+    (value) =>
+      typeof value === 'number' &&
+      Number.isInteger(value) &&
+      value >= 0 &&
+      value <= TILE_EXTENT
+  )
+
+/**
+ * The inverse, and deliberately tolerant: anything unreadable answers `[]` and
+ * a single unreadable segment is dropped rather than taking the tile with it. A
+ * corrupt tile is a missing tile — the pyramid is a cache, and throwing here
+ * would turn one bad row into a failed map.
+ */
+export const decodeTile = (
+  encoded: string | null | undefined
+): TileSegment[] => {
+  if (!encoded) return []
+
+  try {
+    const parsed: unknown = JSON.parse(encoded)
+    if (!parsed || typeof parsed !== 'object') return []
+
+    const segments = (parsed as { s?: unknown }).s
+    if (!Array.isArray(segments)) return []
+
+    return segments.flatMap((segment): TileSegment[] => {
+      if (!segment || typeof segment !== 'object') return []
+
+      const { c, h, p } = segment as EncodedSegment
+      if (!isValidPointList(p)) return []
+      if (typeof c !== 'number' || !Number.isFinite(c) || c < 1) return []
+
+      return [
+        {
+          count: Math.round(c),
+          ...(h ? { hidden: true } : {}),
+          points: p
+        }
+      ]
+    })
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Vertices stored in a tile — what the pyramid's `pointCount` column holds, and
+ * what its progress totals sum.
+ */
+export const countTilePoints = (segments: TileSegment[]) =>
+  segments.reduce((total, segment) => total + segment.points.length / 2, 0)

--- a/lib/services/fitness-files/heatmapTiles/tiler.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.test.ts
@@ -1,0 +1,419 @@
+import { TILE_EXTENT } from '@/lib/services/fitness-files/heatmapTiles/constants'
+import { unpackVertex } from '@/lib/services/fitness-files/heatmapTiles/edgeMerge'
+import {
+  lngLatToTileLocal,
+  tileCountAtZoom
+} from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+import { buildTileDeltasForActivity } from '@/lib/services/fitness-files/heatmapTiles/tiler'
+import type {
+  TileDelta,
+  TilerSegment
+} from '@/lib/services/fitness-files/heatmapTiles/tiler'
+
+const FLOOR_METERS = 1
+
+const visible = (points: Array<[number, number]>): TilerSegment => ({
+  isHiddenByPrivacy: false,
+  points: points.map(([lat, lng]) => ({ lat, lng }))
+})
+
+const build = (segments: TilerSegment[], ladderZooms: number[] = [16]) =>
+  buildTileDeltasForActivity({
+    segments,
+    ladderZooms,
+    toleranceFloorMeters: FLOOR_METERS
+  })
+
+const totalEdges = (deltas: Map<string, TileDelta>) =>
+  [...deltas.values()].reduce((sum, delta) => sum + delta.edges.size, 0)
+
+/** A short east-west track that stays well inside one tile at z16. */
+const shortTrack: Array<[number, number]> = [
+  [52.37, 4.89],
+  [52.3701, 4.8902],
+  [52.3702, 4.8905]
+]
+
+/** Tens of kilometres, so it is still several pixels wide at z8. */
+const longTrack: Array<[number, number]> = Array.from(
+  { length: 40 },
+  (_value, index) => [52.37 + index * 0.02, 4.89 + index * 0.03]
+)
+
+describe('buildTileDeltasForActivity', () => {
+  it('turns a track into tile edges', () => {
+    const deltas = build([visible(shortTrack)])
+    expect(deltas.size).toBeGreaterThan(0)
+    expect(totalEdges(deltas)).toBeGreaterThan(0)
+  })
+
+  it('builds every ladder zoom asked for', () => {
+    // Long enough to survive the coarse levels: a z8 pixel is 611m, so a
+    // street-length track legitimately has nothing to say there.
+    const deltas = build([visible(longTrack)], [8, 12, 16])
+    const zooms = new Set([...deltas.values()].map((delta) => delta.z))
+    expect(zooms).toEqual(new Set([8, 12, 16]))
+  })
+
+  it('drops a track too short to register at a coarse zoom', () => {
+    // Not a failure: 40m of road is well under one z8 pixel, so both ends
+    // quantize onto the same cell and there is no edge to store.
+    const deltas = build([visible(shortTrack)], [8])
+    expect(deltas.size).toBe(0)
+  })
+
+  it('is deterministic — the same track twice gives the same tiles and edges', () => {
+    const first = build([visible(shortTrack)], [12, 16])
+    const second = build([visible(shortTrack)], [12, 16])
+
+    expect([...second.keys()].sort()).toEqual([...first.keys()].sort())
+    for (const [key, delta] of first) {
+      expect([...second.get(key)!.edges.keys()].sort()).toEqual(
+        [...delta.edges.keys()].sort()
+      )
+    }
+  })
+
+  it.each([
+    { description: 'an empty segment list', segments: [] as TilerSegment[] },
+    { description: 'a segment with no points', segments: [visible([])] },
+    { description: 'a single point', segments: [visible([[52.37, 4.89]])] },
+    {
+      description: 'points that all quantize onto one pixel',
+      segments: [
+        visible([
+          [52.37, 4.89],
+          [52.37, 4.89],
+          [52.37, 4.89]
+        ])
+      ]
+    }
+  ])('produces nothing for $description', ({ segments }) => {
+    expect(build(segments).size).toBe(0)
+  })
+
+  it('still builds a run whose FIRST point is non-finite', () => {
+    // Not just cosmetic. Simplification anchors its projection at the first
+    // point's latitude, so a leading NaN makes every projected coordinate NaN
+    // and collapses the whole run — the valid points after it would be lost.
+    const deltas = build([
+      {
+        isHiddenByPrivacy: false,
+        points: [
+          { lat: Number.NaN, lng: Number.NaN },
+          { lat: 52.37, lng: 4.89 },
+          { lat: 52.3705, lng: 4.891 },
+          { lat: 52.371, lng: 4.892 }
+        ]
+      }
+    ])
+
+    expect(totalEdges(deltas)).toBeGreaterThan(0)
+  })
+
+  it('skips non-finite coordinates instead of emitting a corrupt tile', () => {
+    const deltas = build([
+      {
+        isHiddenByPrivacy: false,
+        points: [
+          { lat: 52.37, lng: 4.89 },
+          { lat: Number.NaN, lng: 4.8902 },
+          { lat: 52.3705, lng: 4.891 }
+        ]
+      }
+    ])
+
+    for (const key of deltas.keys()) {
+      expect(key).not.toContain('NaN')
+    }
+    for (const delta of deltas.values()) {
+      expect(Number.isInteger(delta.x)).toBe(true)
+      expect(Number.isInteger(delta.y)).toBe(true)
+    }
+  })
+
+  it('counts an out-and-back street once, not twice', () => {
+    // Heat should say how often a street is used, not how an activity was
+    // routed — and a doubled count would be unstable under GPS jitter too.
+    const out: Array<[number, number]> = [
+      [52.37, 4.89],
+      [52.3705, 4.891],
+      [52.371, 4.892]
+    ]
+    const there = build([visible(out)])
+    const andBack = build([visible([...out, ...[...out].reverse().slice(1)])])
+
+    expect(totalEdges(andBack)).toBe(totalEdges(there))
+    for (const [key, delta] of andBack) {
+      for (const edge of delta.edges.values()) {
+        expect(edge.count).toBe(1)
+      }
+      expect(there.has(key)).toBe(true)
+    }
+  })
+
+  it('never merges hidden geometry into a visible edge', () => {
+    const deltas = build([
+      visible(shortTrack),
+      { isHiddenByPrivacy: true, points: visible(shortTrack).points }
+    ])
+
+    for (const delta of deltas.values()) {
+      const hiddenFlags = [...delta.edges.values()].map((edge) => edge.hidden)
+      expect(hiddenFlags).toContain(true)
+      expect(hiddenFlags).toContain(false)
+      // Same geometry, two classes: the keys must differ, never collapse.
+      expect(delta.edges.size).toBe(hiddenFlags.length)
+    }
+  })
+
+  describe('tile boundaries', () => {
+    /** A pair of coordinates known to straddle a tile boundary at `zoom`. */
+    const straddlingPair = (zoom: number) => {
+      const lat = 52.37
+      const placed = lngLatToTileLocal({ lat, lng: 4.89 }, zoom)
+      // The longitude of the next tile's left edge, nudged either side.
+      const edgeLng = ((placed.x + 1) / tileCountAtZoom(zoom)) * 360 - 180
+      const span = 360 / tileCountAtZoom(zoom) / 8
+      return {
+        from: { lat, lng: edgeLng - span },
+        to: { lat, lng: edgeLng + span }
+      }
+    }
+
+    it('splits a crossing pair into both tiles', () => {
+      const zoom = 12
+      const { from, to } = straddlingPair(zoom)
+      const deltas = build(
+        [{ isHiddenByPrivacy: false, points: [from, to] }],
+        [zoom]
+      )
+
+      expect(deltas.size).toBe(2)
+    })
+
+    it('gives both tiles the same boundary vertex, so no seam opens', () => {
+      // The left tile's crossing sits at local 256 and the right tile's at 0 —
+      // the same world position — and the other coordinate must be identical
+      // in both, or a one-pixel seam appears along the boundary.
+      const zoom = 12
+      const { from, to } = straddlingPair(zoom)
+      const deltas = build(
+        [{ isHiddenByPrivacy: false, points: [from, to] }],
+        [zoom]
+      )
+
+      const byTile = [...deltas.values()].sort((a, b) => a.x - b.x)
+      expect(byTile).toHaveLength(2)
+
+      const boundaryVertexOf = (delta: TileDelta, expectedX: number) => {
+        const vertices = [...delta.edges.values()].flatMap((edge) => [
+          unpackVertex(edge.a),
+          unpackVertex(edge.b)
+        ])
+        const match = vertices.find((vertex) => vertex.x === expectedX)
+        expect(match).toBeDefined()
+        return match!
+      }
+
+      const left = boundaryVertexOf(byTile[0], TILE_EXTENT)
+      const right = boundaryVertexOf(byTile[1], 0)
+      expect(left.y).toBe(right.y)
+    })
+
+    it('contributes to every tile a long diagonal passes through', () => {
+      // A pair split only at its first boundary would skip the tiles in
+      // between, leaving gaps in the heat.
+      const zoom = 8
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 10, lng: -20 },
+              { lat: 40, lng: 30 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      expect(deltas.size).toBeGreaterThan(4)
+      // Contiguous: no tile column in the span is missed.
+      const xs = [
+        ...new Set([...deltas.values()].map((delta) => delta.x))
+      ].sort((a, b) => a - b)
+      expect(xs[xs.length - 1] - xs[0] + 1).toBe(xs.length)
+    })
+
+    it('contributes to every tile a north-south track passes through', () => {
+      // The y axis needs subdividing exactly as much as the x axis does.
+      // Subdividing only on x leaves a mostly-vertical track skipping the tile
+      // rows between its endpoints.
+      const zoom = 8
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: -35, lng: 20 },
+              { lat: 35, lng: 20.05 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      const ys = [
+        ...new Set([...deltas.values()].map((delta) => delta.y))
+      ].sort((a, b) => a - b)
+      expect(ys.length).toBeGreaterThan(4)
+      expect(ys[ys.length - 1] - ys[0] + 1).toBe(ys.length)
+    })
+
+    it('keeps every emitted coordinate inside the tile grid and the extent', () => {
+      const zoom = 6
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: -80, lng: -179.9 },
+              { lat: 80, lng: 179.9 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      const lastTile = tileCountAtZoom(zoom) - 1
+      for (const delta of deltas.values()) {
+        expect(delta.x).toBeGreaterThanOrEqual(0)
+        expect(delta.y).toBeGreaterThanOrEqual(0)
+        expect(delta.x).toBeLessThanOrEqual(lastTile)
+        expect(delta.y).toBeLessThanOrEqual(lastTile)
+
+        for (const edge of delta.edges.values()) {
+          for (const packed of [edge.a, edge.b]) {
+            const { x, y } = unpackVertex(packed)
+            expect(x).toBeGreaterThanOrEqual(0)
+            expect(x).toBeLessThanOrEqual(TILE_EXTENT)
+            expect(y).toBeGreaterThanOrEqual(0)
+            expect(y).toBeLessThanOrEqual(TILE_EXTENT)
+          }
+        }
+      }
+    })
+
+    it('places a track on the antimeridian in the last tile, not one past it', () => {
+      const zoom = 6
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 0, lng: 179.8 },
+              { lat: 0.2, lng: 180 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      const lastTile = tileCountAtZoom(zoom) - 1
+      expect(deltas.size).toBeGreaterThan(0)
+      for (const delta of deltas.values()) {
+        expect(delta.x).toBeLessThanOrEqual(lastTile)
+      }
+    })
+  })
+
+  describe('discontinuities', () => {
+    it('does not draw across the antimeridian', () => {
+      // Without the split, the pair projects to opposite edges of the world and
+      // lays edges through every tile column between them.
+      const zoom = 6
+      const wrapped = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 0, lng: 179.9 },
+              { lat: 0, lng: -179.9 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      expect(wrapped.size).toBeLessThanOrEqual(2)
+    })
+
+    it('keeps the runs either side of a discontinuity', () => {
+      const zoom = 10
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 0, lng: 179.8 },
+              { lat: 0, lng: 179.9 },
+              { lat: 0, lng: -179.9 },
+              { lat: 0, lng: -179.8 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      const xs = new Set([...deltas.values()].map((delta) => delta.x))
+      // Both ends present, and nothing spanning the whole map between them.
+      expect(xs.size).toBeGreaterThan(0)
+      expect(deltas.size).toBeLessThan(tileCountAtZoom(zoom) / 2)
+    })
+  })
+
+  describe('the zoom cascade', () => {
+    it('keeps a coarse level within its own tolerance of building it directly', () => {
+      const track: Array<[number, number]> = Array.from(
+        { length: 400 },
+        (_value, index) => [
+          52.37 + index * 0.0004 + (index % 5) * 0.00002,
+          4.89 + index * 0.0006
+        ]
+      )
+
+      const cascaded = build([visible(track)], [8, 12, 16])
+      const direct = build([visible(track)], [8])
+
+      const cascadedAt8 = [...cascaded.values()].filter(
+        (delta) => delta.z === 8
+      )
+      const directAt8 = [...direct.values()]
+
+      // Same tiles touched: the cascade must not shift where geometry lands.
+      expect(
+        new Set(cascadedAt8.map((delta) => `${delta.x}:${delta.y}`))
+      ).toEqual(new Set(directAt8.map((delta) => `${delta.x}:${delta.y}`)))
+    })
+
+    it('stores strictly less at coarser zooms than at finer ones', () => {
+      const track: Array<[number, number]> = Array.from(
+        { length: 300 },
+        (_value, index) => [
+          52.37 + index * 0.0003 + (index % 7) * 0.00004,
+          4.89 + index * 0.0005
+        ]
+      )
+      const deltas = build([visible(track)], [8, 12, 16])
+
+      const edgesAt = (zoom: number) =>
+        [...deltas.values()]
+          .filter((delta) => delta.z === zoom)
+          .reduce((sum, delta) => sum + delta.edges.size, 0)
+
+      expect(edgesAt(16)).toBeGreaterThanOrEqual(edgesAt(12))
+      expect(edgesAt(12)).toBeGreaterThanOrEqual(edgesAt(8))
+    })
+  })
+})

--- a/lib/services/fitness-files/heatmapTiles/tiler.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.test.ts
@@ -344,7 +344,7 @@ describe('buildTileDeltasForActivity', () => {
     })
   })
 
-  describe('the glitch guard', () => {
+  describe('the recording-jump split', () => {
     const pairAt = (zoom: number, fromLng: number, toLng: number) =>
       build(
         [
@@ -359,10 +359,11 @@ describe('buildTileDeltasForActivity', () => {
         [zoom]
       )
 
-    it('drops a pair that crosses absurdly many tiles', () => {
+    it('splits a pair that spans absurdly many tiles', () => {
       // 90 degrees at z16 is a quarter of the world, about 16,000 tiles — no
       // activity has two consecutive points that far apart, so this is a bad
-      // GPS fix and every tile it crosses would be a stored row.
+      // GPS fix and every tile it crosses would be a stored row. The run is
+      // split, leaving two single points, which is nothing to draw.
       expect(pairAt(16, 0, 90).size).toBe(0)
     })
 
@@ -374,8 +375,10 @@ describe('buildTileDeltasForActivity', () => {
     })
 
     it('keeps the geometry either side of a bad fix', () => {
-      // The pair is dropped, not the run: a single dropout must not cost an
-      // activity everything recorded after it.
+      // The run is split at the dropout, not abandoned at it: a single bad fix
+      // must not cost an activity everything recorded after it. The two halves
+      // are then tiled independently, so a one-point remainder either side is
+      // discarded — there is no line to draw through a lone point.
       const ride = Array.from({ length: 40 }, (_value, index) => ({
         lat: 52.37 + index * 0.0004,
         lng: 4.89 + index * 0.0006
@@ -467,6 +470,21 @@ describe('buildTileDeltasForActivity', () => {
     })
 
     it.each([
+      // Straddling the cap itself, at the equator where a z16 tile is 612m:
+      // 5.6 degrees spans 1,019 tiles and 5.7 spans 1,037. Without a pair
+      // either side of the boundary the cap can move by a factor of ten in
+      // both directions with every test still green — the fixtures below sit
+      // at 182 and 32,585, nowhere near it.
+      {
+        description: 'a gap just inside the span cap',
+        lngs: [0, 5.6] as [number, number],
+        split: false
+      },
+      {
+        description: 'a gap just past the span cap',
+        lngs: [0, 5.7] as [number, number],
+        split: true
+      },
       {
         description: 'a sparse but real gap of about 100km',
         lngs: [0, 1] as [number, number],

--- a/lib/services/fitness-files/heatmapTiles/tiler.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.test.ts
@@ -66,6 +66,7 @@ describe('buildTileDeltasForActivity', () => {
     const first = build([visible(shortTrack)], [12, 16])
     const second = build([visible(shortTrack)], [12, 16])
 
+    expect(totalEdges(first)).toBeGreaterThan(0)
     expect([...second.keys()].sort()).toEqual([...first.keys()].sort())
     for (const [key, delta] of first) {
       expect([...second.get(key)!.edges.keys()].sort()).toEqual(
@@ -112,17 +113,23 @@ describe('buildTileDeltasForActivity', () => {
   })
 
   it('skips non-finite coordinates instead of emitting a corrupt tile', () => {
+    // Two valid points EITHER SIDE of the bad one, so both runs survive and
+    // there is real output to inspect — with one point per side the whole
+    // fixture yields nothing and the assertions below run over an empty map.
     const deltas = build([
       {
         isHiddenByPrivacy: false,
         points: [
           { lat: 52.37, lng: 4.89 },
-          { lat: Number.NaN, lng: 4.8902 },
-          { lat: 52.3705, lng: 4.891 }
+          { lat: 52.3702, lng: 4.8904 },
+          { lat: Number.NaN, lng: 4.8906 },
+          { lat: 52.3706, lng: 4.891 },
+          { lat: 52.3709, lng: 4.8914 }
         ]
       }
     ])
 
+    expect(totalEdges(deltas)).toBeGreaterThan(0)
     for (const key of deltas.keys()) {
       expect(key).not.toContain('NaN')
     }
@@ -143,6 +150,7 @@ describe('buildTileDeltasForActivity', () => {
     const there = build([visible(out)])
     const andBack = build([visible([...out, ...[...out].reverse().slice(1)])])
 
+    expect(totalEdges(there)).toBeGreaterThan(0)
     expect(totalEdges(andBack)).toBe(totalEdges(there))
     for (const [key, delta] of andBack) {
       for (const edge of delta.edges.values()) {
@@ -158,6 +166,7 @@ describe('buildTileDeltasForActivity', () => {
       { isHiddenByPrivacy: true, points: visible(shortTrack).points }
     ])
 
+    expect(totalEdges(deltas)).toBeGreaterThan(0)
     for (const delta of deltas.values()) {
       const hiddenFlags = [...delta.edges.values()].map((edge) => edge.hidden)
       expect(hiddenFlags).toContain(true)
@@ -277,9 +286,11 @@ describe('buildTileDeltasForActivity', () => {
         [
           {
             isHiddenByPrivacy: false,
+            // Deliberately under the antimeridian threshold: a wider span is
+            // split as a discontinuity and yields nothing to inspect.
             points: [
-              { lat: -80, lng: -179.9 },
-              { lat: 80, lng: 179.9 }
+              { lat: -80, lng: -80 },
+              { lat: 80, lng: 80 }
             ]
           }
         ],
@@ -287,6 +298,7 @@ describe('buildTileDeltasForActivity', () => {
       )
 
       const lastTile = tileCountAtZoom(zoom) - 1
+      expect(totalEdges(deltas)).toBeGreaterThan(0)
       for (const delta of deltas.values()) {
         expect(delta.x).toBeGreaterThanOrEqual(0)
         expect(delta.y).toBeGreaterThanOrEqual(0)
@@ -328,25 +340,96 @@ describe('buildTileDeltasForActivity', () => {
     })
   })
 
-  describe('discontinuities', () => {
-    it('does not draw across the antimeridian', () => {
-      // Without the split, the pair projects to opposite edges of the world and
-      // lays edges through every tile column between them.
-      const zoom = 6
-      const wrapped = build(
+  describe('the glitch guard', () => {
+    const pairAt = (zoom: number, fromLng: number, toLng: number) =>
+      build(
         [
           {
             isHiddenByPrivacy: false,
             points: [
-              { lat: 0, lng: 179.9 },
-              { lat: 0, lng: -179.9 }
+              { lat: 0, lng: fromLng },
+              { lat: 0, lng: toLng }
             ]
           }
         ],
         [zoom]
       )
 
-      expect(wrapped.size).toBeLessThanOrEqual(2)
+    it('drops a pair that crosses absurdly many tiles', () => {
+      // 90 degrees at z16 is a quarter of the world, about 16,000 tiles — no
+      // activity has two consecutive points that far apart, so this is a bad
+      // GPS fix and every tile it crosses would be a stored row.
+      expect(pairAt(16, 0, 90).size).toBe(0)
+    })
+
+    it('keeps a long straight pair that is merely unusual', () => {
+      // Two degrees is roughly 360 tiles at z16 — longer than any real
+      // straight road, and it must still be stored whole.
+      const deltas = pairAt(16, 0, 2)
+      expect(deltas.size).toBeGreaterThan(300)
+    })
+
+    it('keeps the geometry either side of a bad fix', () => {
+      // The pair is dropped, not the run: a single dropout must not cost an
+      // activity everything recorded after it.
+      const ride = Array.from({ length: 40 }, (_value, index) => ({
+        lat: 52.37 + index * 0.0004,
+        lng: 4.89 + index * 0.0006
+      }))
+      const clean = build([{ isHiddenByPrivacy: false, points: ride }], [16])
+      const glitched = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            // "Null island" — the most common dropout, and entirely in range,
+            // so nothing upstream rejects it.
+            points: [
+              ...ride.slice(0, 20),
+              { lat: 0, lng: 0 },
+              ...ride.slice(20)
+            ]
+          }
+        ],
+        [16]
+      )
+
+      expect(clean.size).toBeGreaterThan(0)
+      // Every clean tile survives, and the glitch adds only a bounded number.
+      for (const key of clean.keys()) {
+        expect(glitched.has(key)).toBe(true)
+      }
+      expect(glitched.size).toBeLessThan(clean.size + 8)
+    })
+  })
+
+  describe('discontinuities', () => {
+    it('does not draw across the antimeridian', () => {
+      // Without the split, the pair projects to opposite edges of the world and
+      // lays edges through every tile column between them.
+      // Two points either side, so both runs survive and there is something to
+      // count: with one point each the whole fixture yields nothing and any
+      // upper bound is satisfied by zero.
+      const zoom = 6
+      const wrapped = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 0, lng: 179.7 },
+              { lat: 0, lng: 179.9 },
+              { lat: 0, lng: -179.9 },
+              { lat: 0, lng: -179.7 }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      // Exactly the two end tiles — not a stripe across every column between.
+      expect(wrapped.size).toBe(2)
+      expect(new Set([...wrapped.values()].map((delta) => delta.x))).toEqual(
+        new Set([0, tileCountAtZoom(zoom) - 1])
+      )
     })
 
     it('keeps the runs either side of a discontinuity', () => {
@@ -366,14 +449,88 @@ describe('buildTileDeltasForActivity', () => {
         [zoom]
       )
 
-      const xs = new Set([...deltas.values()].map((delta) => delta.x))
-      // Both ends present, and nothing spanning the whole map between them.
-      expect(xs.size).toBeGreaterThan(0)
+      // Both ends must actually survive: the run after the jump starts at the
+      // point that caused it, so dropping that point would silently delete the
+      // whole far side.
+      const xs = [
+        ...new Set([...deltas.values()].map((delta) => delta.x))
+      ].sort((a, b) => a - b)
+      const lastTile = tileCountAtZoom(zoom) - 1
+      expect(xs[0]).toBe(0)
+      expect(xs[xs.length - 1]).toBe(lastTile)
+      // And nothing spanning the map between them.
       expect(deltas.size).toBeLessThan(tileCountAtZoom(zoom) / 2)
+    })
+
+    it.each([
+      {
+        description: 'a large but legitimate gap in a sparse recording',
+        lngs: [0, 179] as [number, number],
+        split: false
+      },
+      {
+        description: 'an exact antimeridian jump',
+        lngs: [179.9, -179.9] as [number, number],
+        split: true
+      }
+    ])('treats $description correctly', ({ lngs, split }) => {
+      // The threshold itself. Anything from about 50 degrees upward passes the
+      // other fixtures here, so without this a far tighter threshold — which
+      // would cut real gaps in sparse recordings — would look fine.
+      const zoom = 6
+      const deltas = build(
+        [
+          {
+            isHiddenByPrivacy: false,
+            points: [
+              { lat: 0, lng: lngs[0] },
+              { lat: 0, lng: lngs[1] }
+            ]
+          }
+        ],
+        [zoom]
+      )
+
+      // A split run of two single points yields nothing; an unsplit pair draws.
+      expect(deltas.size === 0).toBe(split)
     })
   })
 
   describe('the zoom cascade', () => {
+    /**
+     * Structure at several scales at once: broad sweeps a coarse zoom keeps,
+     * and fine wiggles only the finest zoom can resolve. A straight or gently
+     * curving fixture cannot tell the cascade's direction apart, because every
+     * level simplifies it to the same two endpoints.
+     */
+    const multiScaleTrack: Array<[number, number]> = Array.from(
+      { length: 1_200 },
+      (_value, index) => [
+        52.37 + Math.sin(index / 90) * 0.05 + Math.sin(index / 3) * 0.00004,
+        4.89 + index * 0.0004
+      ]
+    )
+
+    it('builds fine zooms from the original, not from a coarse simplification', () => {
+      // The direction of the cascade. Ascending, z16 would be built from the
+      // 611m z8 simplification and lose almost everything — and because the
+      // levels then agree, a test comparing them to each other cannot see it.
+      const cascaded = build([visible(multiScaleTrack)], [8, 12, 16])
+      const directAt16 = build([visible(multiScaleTrack)], [16])
+
+      const edgesAt = (deltas: Map<string, TileDelta>, zoom: number) =>
+        [...deltas.values()]
+          .filter((delta) => delta.z === zoom)
+          .reduce((sum, delta) => sum + delta.edges.size, 0)
+
+      const cascadedAt16 = edgesAt(cascaded, 16)
+      expect(cascadedAt16).toBeGreaterThan(0)
+      // Building the ladder together must not cost the finest level its detail.
+      expect(cascadedAt16).toBe(edgesAt(directAt16, 16))
+      // And the finest level must hold strictly more than the coarsest.
+      expect(cascadedAt16).toBeGreaterThan(edgesAt(cascaded, 8) * 2)
+    })
+
     it('keeps a coarse level within its own tolerance of building it directly', () => {
       const track: Array<[number, number]> = Array.from(
         { length: 400 },
@@ -398,22 +555,17 @@ describe('buildTileDeltasForActivity', () => {
     })
 
     it('stores strictly less at coarser zooms than at finer ones', () => {
-      const track: Array<[number, number]> = Array.from(
-        { length: 300 },
-        (_value, index) => [
-          52.37 + index * 0.0003 + (index % 7) * 0.00004,
-          4.89 + index * 0.0005
-        ]
-      )
-      const deltas = build([visible(track)], [8, 12, 16])
+      const deltas = build([visible(multiScaleTrack)], [8, 12, 16])
 
       const edgesAt = (zoom: number) =>
         [...deltas.values()]
           .filter((delta) => delta.z === zoom)
           .reduce((sum, delta) => sum + delta.edges.size, 0)
 
-      expect(edgesAt(16)).toBeGreaterThanOrEqual(edgesAt(12))
-      expect(edgesAt(12)).toBeGreaterThanOrEqual(edgesAt(8))
+      // Strict, not `>=`: three identical levels would satisfy `>=` while
+      // meaning the per-zoom tolerance had stopped doing anything at all.
+      expect(edgesAt(16)).toBeGreaterThan(edgesAt(12))
+      expect(edgesAt(12)).toBeGreaterThan(edgesAt(8))
     })
   })
 })

--- a/lib/services/fitness-files/heatmapTiles/tiler.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.test.ts
@@ -233,14 +233,17 @@ describe('buildTileDeltasForActivity', () => {
     it('contributes to every tile a long diagonal passes through', () => {
       // A pair split only at its first boundary would skip the tiles in
       // between, leaving gaps in the heat.
-      const zoom = 8
+      // At z16 a tile is about 612m, so a 5km pair genuinely crosses several —
+      // the realistic case. The same test at a coarse zoom would need a pair
+      // hundreds of kilometres long, which is a teleport, not a diagonal.
+      const zoom = 16
       const deltas = build(
         [
           {
             isHiddenByPrivacy: false,
             points: [
-              { lat: 10, lng: -20 },
-              { lat: 40, lng: 30 }
+              { lat: 52.34, lng: 4.85 },
+              { lat: 52.38, lng: 4.93 }
             ]
           }
         ],
@@ -259,14 +262,14 @@ describe('buildTileDeltasForActivity', () => {
       // The y axis needs subdividing exactly as much as the x axis does.
       // Subdividing only on x leaves a mostly-vertical track skipping the tile
       // rows between its endpoints.
-      const zoom = 8
+      const zoom = 16
       const deltas = build(
         [
           {
             isHiddenByPrivacy: false,
             points: [
-              { lat: -35, lng: 20 },
-              { lat: 35, lng: 20.05 }
+              { lat: 52.32, lng: 4.89 },
+              { lat: 52.4, lng: 4.892 }
             ]
           }
         ],
@@ -286,11 +289,12 @@ describe('buildTileDeltasForActivity', () => {
         [
           {
             isHiddenByPrivacy: false,
-            // Deliberately under the antimeridian threshold: a wider span is
-            // split as a discontinuity and yields nothing to inspect.
+            // Short pairs sitting ON the extremes, not one pair reaching
+            // across to them: a span that wide is a discontinuity and would
+            // be split, leaving nothing to inspect.
             points: [
-              { lat: -80, lng: -80 },
-              { lat: 80, lng: 80 }
+              { lat: -85, lng: -179.99 },
+              { lat: -84.99, lng: -179.9 }
             ]
           }
         ],
@@ -464,20 +468,25 @@ describe('buildTileDeltasForActivity', () => {
 
     it.each([
       {
-        description: 'a large but legitimate gap in a sparse recording',
-        lngs: [0, 179] as [number, number],
+        description: 'a sparse but real gap of about 100km',
+        lngs: [0, 1] as [number, number],
         split: false
       },
       {
-        description: 'an exact antimeridian jump',
+        description: 'a jump most of the way round the world',
+        lngs: [0, 179] as [number, number],
+        split: true
+      },
+      {
+        description: 'a jump across the date line',
         lngs: [179.9, -179.9] as [number, number],
         split: true
       }
     ])('treats $description correctly', ({ lngs, split }) => {
-      // The threshold itself. Anything from about 50 degrees upward passes the
-      // other fixtures here, so without this a far tighter threshold — which
-      // would cut real gaps in sparse recordings — would look fine.
-      const zoom = 6
+      // The threshold itself, from both sides: loose enough to keep a sparse
+      // recording whole, tight enough that nothing draws a line between
+      // continents.
+      const zoom = 16
       const deltas = build(
         [
           {

--- a/lib/services/fitness-files/heatmapTiles/tiler.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.ts
@@ -4,6 +4,7 @@ import { TILE_SIZE, projectWebMercator } from '@/lib/utils/webMercator'
 import {
   TILE_EXTENT,
   TILE_LADDER_ZOOMS,
+  TILE_MAX_ZOOM,
   tileToleranceMeters
 } from './constants'
 import type { TileEdgeMap } from './edgeMerge'
@@ -33,51 +34,71 @@ export interface TileDelta {
   edges: TileEdgeMap
 }
 
-/** Longitude jump treated as a recording discontinuity rather than travel. */
-const ANTIMERIDIAN_JUMP_DEGREES = 180
-
 /**
- * How many tiles one pair of consecutive points may cross before it is treated
- * as a glitch rather than travel.
+ * How many tiles a pair of consecutive points may span, measured at the FINEST
+ * zoom, before the recording is treated as jumping rather than travelling.
  *
  * A runaway guard, not a fidelity knob. A single bad GPS fix inside the legal
  * coordinate range — a "null island" `{0, 0}` dropout is the common one, and
  * the parser has no reason to reject it — draws a straight line from the route
  * to that point and back. Geometrically that is one wrong stripe, which is what
  * the untiled heatmap used to cost; here every tile the stripe crosses is a
- * STORED ROW, so one bad fix took a measured ride from 84 tiles to 16,563, and
- * a legal-longitude glitch under the antimeridian threshold to 44,918. That is
- * a permanent 200-500x write amplification for the whole pyramid.
+ * STORED ROW, so one bad fix took a measured ride from 84 tiles to 16,563.
  *
- * 1,024 is measured, not guessed. The longest genuinely straight road on earth
- * (~150 km of the Eyre Highway) simplifies to a single pair and stores 395
- * tiles across the ladder — identical at this cap and with the cap four times
- * higher, so nothing real is being clipped — while the null-island ride above
- * drops from 16,563 tiles to 1,090. Tightening to 256 would start eating that
- * road (103 tiles, a quarter of it gone).
+ * Judged ONCE, against `TILE_MAX_ZOOM`, and then applied to every level — which
+ * is why it lives in the discontinuity split rather than in the per-zoom walk.
+ * A tile count only means anything relative to how many tiles exist: the world
+ * is 16 tiles wide at z4 and 65,536 at z16, so a per-zoom test against a fixed
+ * bound cannot fire at all below z10, and the same pair would be travel at z12
+ * and a glitch at z16. That leaves the ladder contradicting itself — a
+ * continental line drawn at every zoom a reader is likely to look at, and gone
+ * when they zoom in.
+ *
+ * 1,024 is measured. The longest genuinely straight road on earth (~150 km of
+ * the Eyre Highway) spans 334 tiles at z16 and is kept whole; a 370 km gap left
+ * by a recorder running through a train journey spans 1,510 and is split, which
+ * is correct — that is a discontinuity, not travel.
  *
  * Deliberately a tile count rather than a distance: a meters threshold would
  * have to guess how sparse a legitimate recording may be, and would silently
  * cut real gaps in one.
  */
-const MAX_TILE_CROSSINGS_PER_PAIR = 1_024
+const MAX_TILE_SPAN_AT_FINEST_ZOOM = 1_024
 
 const isFinitePoint = (point: { lat: number; lng: number }) =>
   Number.isFinite(point.lat) && Number.isFinite(point.lng)
 
 /**
- * Splits a run wherever consecutive points jump the antimeridian.
+ * Whether a pair covers more of the map than travel between two recorded points
+ * could, and so is a jump in the recording rather than a journey.
  *
- * Without this, a pair straddling the date line projects to opposite edges of
- * the world and the boundary walk below would lay edges across every tile
- * column between them. Measured on the ORIGINAL longitudes, before projection
- * normalizes them, because that is where the jump is visible.
+ * One rule, deliberately, because it already subsumes the antimeridian case: a
+ * pair straddling the date line projects to opposite edges of the world, which
+ * is the largest span there is. A separate longitude test would be a branch
+ * nothing could reach.
  *
- * Only longitude wrap is caught. A GPS teleport in latitude, or a longitude
- * glitch under 180°, still draws a straight line of edges through whatever it
- * crosses; the parsers reject non-finite values but do not detect teleports,
- * and inventing a distance threshold here would silently cut legitimate gaps
- * in sparse recordings.
+ * Judged in projected tiles at the finest zoom — see
+ * `MAX_TILE_SPAN_AT_FINEST_ZOOM` for why once, and why not per zoom.
+ */
+const spansTooManyTiles = (
+  from: { lat: number; lng: number },
+  to: { lat: number; lng: number }
+) => {
+  const a = projectWebMercator(from, TILE_MAX_ZOOM)
+  const b = projectWebMercator(to, TILE_MAX_ZOOM)
+  const span =
+    Math.abs(Math.floor(b.x / TILE_SIZE) - Math.floor(a.x / TILE_SIZE)) +
+    Math.abs(Math.floor(b.y / TILE_SIZE) - Math.floor(a.y / TILE_SIZE))
+  return span > MAX_TILE_SPAN_AT_FINEST_ZOOM
+}
+
+/**
+ * Breaks a route into the runs that are actually continuous, dropping any point
+ * the parser let through with a non-finite coordinate.
+ *
+ * Splitting here rather than in the per-zoom walk is what keeps the ladder
+ * self-consistent: the verdict is reached once, so every level builds from the
+ * same runs and no zoom can disagree about whether a stretch of road exists.
  */
 const splitAtDiscontinuities = (
   points: Array<{ lat: number; lng: number }>
@@ -93,10 +114,7 @@ const splitAtDiscontinuities = (
     }
 
     const previous = current[current.length - 1]
-    if (
-      previous &&
-      Math.abs(point.lng - previous.lng) >= ANTIMERIDIAN_JUMP_DEGREES
-    ) {
+    if (previous && spansTooManyTiles(previous, point)) {
       if (current.length >= 2) runs.push(current)
       current = [point]
       continue
@@ -234,7 +252,9 @@ export interface BuildTileDeltasParams {
  * takes: it projects into a local meters plane internally and cannot be run in
  * pixel space. That plane is anchored at the run's FIRST latitude, so a long
  * north-south activity is simplified against its start's pixel size rather than
- * its far end's — over-detailed running poleward, under-detailed running
+ * its far end's. Tolerance scales with cos(latitude), so a run STARTING nearer
+ * the equator carries the coarser tolerance into a far end whose pixels are
+ * finer — under-detailed travelling poleward, over-detailed travelling
  * equatorward, and so not invariant to reversing the run. The error is a
  * cos(latitude) ratio and stays small over any real activity; it never affects
  * where a point LANDS, because placement projects each point exactly.
@@ -278,14 +298,6 @@ export const buildTileDeltasForActivity = ({
           ) {
             continue
           }
-
-          // A pair spanning absurdly many tiles is a glitch, not travel. Left
-          // out entirely rather than ending the run, so the geometry either
-          // side of a bad fix still contributes.
-          const spannedTiles =
-            Math.abs(Math.floor(to.x) - Math.floor(from.x)) +
-            Math.abs(Math.floor(to.y) - Math.floor(from.y))
-          if (spannedTiles > MAX_TILE_CROSSINGS_PER_PAIR) continue
 
           // Solved once here, in the continuous frame, then localized per tile.
           const crossings = boundaryCrossings(from, to)

--- a/lib/services/fitness-files/heatmapTiles/tiler.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.ts
@@ -46,22 +46,28 @@ export interface TileDelta {
  * STORED ROW, so one bad fix took a measured ride from 84 tiles to 16,563.
  *
  * Judged ONCE, against `TILE_MAX_ZOOM`, and then applied to every level — which
- * is why it lives in the discontinuity split rather than in the per-zoom walk.
- * A tile count only means anything relative to how many tiles exist: the world
- * is 16 tiles wide at z4 and 65,536 at z16, so a per-zoom test against a fixed
- * bound cannot fire at all below z10, and the same pair would be travel at z12
- * and a glitch at z16. That leaves the ladder contradicting itself — a
- * continental line drawn at every zoom a reader is likely to look at, and gone
- * when they zoom in.
+ * is why it lives in the run split rather than in the per-zoom walk. A tile
+ * count only means anything relative to how many tiles exist: the world is 16
+ * tiles wide at z4 and 65,536 at z16, so a per-zoom test against a fixed bound
+ * cannot fire at all below z10, and the same pair would be travel at z12 and a
+ * glitch at z16. That leaves the ladder contradicting itself — a continental
+ * line drawn at every zoom a reader is likely to look at, and gone when they
+ * zoom in.
+ *
+ * Pinned to one zoom it is a DISTANCE, scaled by cos(latitude): 1,024 z16 tiles
+ * is about 626 km at the equator, 386 km at 52°N and 55 km at 85°N. A tile
+ * count is still the right invariant, because what is being bounded is stored
+ * rows rather than kilometres — but it does mean the guard is far tighter near
+ * the poles, and an Arctic recording logging every few hours could be split
+ * where a temperate one would not. Only the interpolated line across an
+ * unrecorded gap is ever lost; no recorded point is.
  *
  * 1,024 is measured. The longest genuinely straight road on earth (~150 km of
- * the Eyre Highway) spans 334 tiles at z16 and is kept whole; a 370 km gap left
- * by a recorder running through a train journey spans 1,510 and is split, which
- * is correct — that is a discontinuity, not travel.
- *
- * Deliberately a tile count rather than a distance: a meters threshold would
- * have to guess how sparse a legitimate recording may be, and would silently
- * cut real gaps in one.
+ * the Eyre Highway) spans 335 tiles and is kept whole. A gap left by a recorder
+ * running through a 400 km train journey at 52°N spans 1,116 and is split,
+ * which is correct — that is a discontinuity, not travel — though at 370 km it
+ * is marginal and direction-dependent (1,029 north, 983 east), so the boundary
+ * is a judgement about write amplification rather than a natural edge.
  */
 const MAX_TILE_SPAN_AT_FINEST_ZOOM = 1_024
 
@@ -74,8 +80,11 @@ const isFinitePoint = (point: { lat: number; lng: number }) =>
  *
  * One rule, deliberately, because it already subsumes the antimeridian case: a
  * pair straddling the date line projects to opposite edges of the world, which
- * is the largest span there is. A separate longitude test would be a branch
- * nothing could reach.
+ * is the largest span there is — measured minimum 32,768 tiles, 32x this cap,
+ * at every latitude, since Mercator x does not compress with latitude. A
+ * separate longitude test would be a branch nothing could reach, and it was
+ * also wrong in both directions: it split `-179.9 -> 180.1`, which normalizes
+ * to the same longitude, and missed `179.9 -> 180.1`, which is a real wrap.
  *
  * Judged in projected tiles at the finest zoom — see
  * `MAX_TILE_SPAN_AT_FINEST_ZOOM` for why once, and why not per zoom.

--- a/lib/services/fitness-files/heatmapTiles/tiler.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.ts
@@ -36,6 +36,32 @@ export interface TileDelta {
 /** Longitude jump treated as a recording discontinuity rather than travel. */
 const ANTIMERIDIAN_JUMP_DEGREES = 180
 
+/**
+ * How many tiles one pair of consecutive points may cross before it is treated
+ * as a glitch rather than travel.
+ *
+ * A runaway guard, not a fidelity knob. A single bad GPS fix inside the legal
+ * coordinate range — a "null island" `{0, 0}` dropout is the common one, and
+ * the parser has no reason to reject it — draws a straight line from the route
+ * to that point and back. Geometrically that is one wrong stripe, which is what
+ * the untiled heatmap used to cost; here every tile the stripe crosses is a
+ * STORED ROW, so one bad fix took a measured ride from 84 tiles to 16,563, and
+ * a legal-longitude glitch under the antimeridian threshold to 44,918. That is
+ * a permanent 200-500x write amplification for the whole pyramid.
+ *
+ * 1,024 is measured, not guessed. The longest genuinely straight road on earth
+ * (~150 km of the Eyre Highway) simplifies to a single pair and stores 395
+ * tiles across the ladder — identical at this cap and with the cap four times
+ * higher, so nothing real is being clipped — while the null-island ride above
+ * drops from 16,563 tiles to 1,090. Tightening to 256 would start eating that
+ * road (103 tiles, a quarter of it gone).
+ *
+ * Deliberately a tile count rather than a distance: a meters threshold would
+ * have to guess how sparse a legitimate recording may be, and would silently
+ * cut real gaps in one.
+ */
+const MAX_TILE_CROSSINGS_PER_PAIR = 1_024
+
 const isFinitePoint = (point: { lat: number; lng: number }) =>
   Number.isFinite(point.lat) && Number.isFinite(point.lng)
 
@@ -174,11 +200,9 @@ const foldSubEdge = (
     deltas.set(mapKey, delta)
   }
 
-  const existing = delta.edges.get(key)
-  if (existing) {
-    existing.count += 1
-    return
-  }
+  // Always 1, never accumulated: the dedup above means this edge has not been
+  // seen for this activity, and one activity contributes one visit. Counts add
+  // up across activities, in the merge, not here.
   delta.edges.set(key, {
     a: Math.min(a, b),
     b: Math.max(a, b),
@@ -208,10 +232,12 @@ export interface BuildTileDeltasParams {
  *
  * The tolerance is a distance in METERS because that is what `simplifyPoints`
  * takes: it projects into a local meters plane internally and cannot be run in
- * pixel space. Anchoring that plane at the run's first latitude leaves a long
- * north-south activity slightly over-detailed at its far end, which errs
- * towards keeping shape; it never affects where a point LANDS, since placement
- * projects each point exactly.
+ * pixel space. That plane is anchored at the run's FIRST latitude, so a long
+ * north-south activity is simplified against its start's pixel size rather than
+ * its far end's — over-detailed running poleward, under-detailed running
+ * equatorward, and so not invariant to reversing the run. The error is a
+ * cos(latitude) ratio and stays small over any real activity; it never affects
+ * where a point LANDS, because placement projects each point exactly.
  */
 export const buildTileDeltasForActivity = ({
   segments,
@@ -252,6 +278,14 @@ export const buildTileDeltasForActivity = ({
           ) {
             continue
           }
+
+          // A pair spanning absurdly many tiles is a glitch, not travel. Left
+          // out entirely rather than ending the run, so the geometry either
+          // side of a bad fix still contributes.
+          const spannedTiles =
+            Math.abs(Math.floor(to.x) - Math.floor(from.x)) +
+            Math.abs(Math.floor(to.y) - Math.floor(from.y))
+          if (spannedTiles > MAX_TILE_CROSSINGS_PER_PAIR) continue
 
           // Solved once here, in the continuous frame, then localized per tile.
           const crossings = boundaryCrossings(from, to)

--- a/lib/services/fitness-files/heatmapTiles/tiler.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.ts
@@ -1,0 +1,276 @@
+import { simplifyPoints } from '@/lib/services/fitness-files/simplifyRoute'
+import { TILE_SIZE, projectWebMercator } from '@/lib/utils/webMercator'
+
+import {
+  TILE_EXTENT,
+  TILE_LADDER_ZOOMS,
+  tileToleranceMeters
+} from './constants'
+import type { TileEdgeMap } from './edgeMerge'
+import { edgeKey, packVertex } from './edgeMerge'
+import { tileCountAtZoom, tileKey } from './tileCodec'
+
+/**
+ * Turns one activity's route into the per-tile edges it contributes, at every
+ * zoom in the ladder.
+ *
+ * Pure and dependency-free apart from the shared projection and simplification
+ * helpers; no `'use client'`, no environment (see AGENTS.md → Server/Client
+ * Module Boundary). The simplification floor arrives as a plain number from
+ * whichever server caller read it from config.
+ */
+
+/** A privacy-classified run of an activity's route, as `buildPrivacySegments` emits. */
+export interface TilerSegment {
+  isHiddenByPrivacy: boolean
+  points: Array<{ lat: number; lng: number }>
+}
+
+export interface TileDelta {
+  z: number
+  x: number
+  y: number
+  edges: TileEdgeMap
+}
+
+/** Longitude jump treated as a recording discontinuity rather than travel. */
+const ANTIMERIDIAN_JUMP_DEGREES = 180
+
+const isFinitePoint = (point: { lat: number; lng: number }) =>
+  Number.isFinite(point.lat) && Number.isFinite(point.lng)
+
+/**
+ * Splits a run wherever consecutive points jump the antimeridian.
+ *
+ * Without this, a pair straddling the date line projects to opposite edges of
+ * the world and the boundary walk below would lay edges across every tile
+ * column between them. Measured on the ORIGINAL longitudes, before projection
+ * normalizes them, because that is where the jump is visible.
+ *
+ * Only longitude wrap is caught. A GPS teleport in latitude, or a longitude
+ * glitch under 180°, still draws a straight line of edges through whatever it
+ * crosses; the parsers reject non-finite values but do not detect teleports,
+ * and inventing a distance threshold here would silently cut legitimate gaps
+ * in sparse recordings.
+ */
+const splitAtDiscontinuities = (
+  points: Array<{ lat: number; lng: number }>
+) => {
+  const runs: Array<Array<{ lat: number; lng: number }>> = []
+  let current: Array<{ lat: number; lng: number }> = []
+
+  for (const point of points) {
+    if (!isFinitePoint(point)) {
+      if (current.length >= 2) runs.push(current)
+      current = []
+      continue
+    }
+
+    const previous = current[current.length - 1]
+    if (
+      previous &&
+      Math.abs(point.lng - previous.lng) >= ANTIMERIDIAN_JUMP_DEGREES
+    ) {
+      if (current.length >= 2) runs.push(current)
+      current = [point]
+      continue
+    }
+
+    current.push(point)
+  }
+
+  if (current.length >= 2) runs.push(current)
+  return runs
+}
+
+/**
+ * Every parameter along `p0 -> p1` at which it crosses an integer tile
+ * boundary, on either axis, in ascending order and without duplicates.
+ *
+ * A pair is only ever inside one tile between two consecutive crossings, so
+ * cutting here is what lets a steep diagonal contribute to EVERY tile it
+ * passes through rather than just its two endpoints'.
+ */
+const boundaryCrossings = (
+  p0: { x: number; y: number },
+  p1: { x: number; y: number }
+) => {
+  const crossings: number[] = []
+
+  const collect = (from: number, to: number) => {
+    if (from === to) return
+    const step = to > from ? 1 : -1
+    // The first boundary strictly beyond `from`, walking towards `to`.
+    let boundary = step > 0 ? Math.floor(from) + 1 : Math.ceil(from) - 1
+    while (step > 0 ? boundary < to : boundary > to) {
+      crossings.push((boundary - from) / (to - from))
+      boundary += step
+    }
+  }
+
+  collect(p0.x, p1.x)
+  collect(p0.y, p1.y)
+
+  return [...new Set(crossings)]
+    .filter((t) => t > 0 && t < 1)
+    .sort((a, b) => a - b)
+}
+
+/**
+ * Folds one sub-edge — already known to lie within a single tile — into the
+ * delta map.
+ *
+ * Both endpoints are localized from the CONTINUOUS frame by subtracting the
+ * integer tile origin, which is exact. That is what makes a boundary vertex
+ * shared: a crossing solved once at continuous `(k, Yc)` becomes local 256 in
+ * the left tile and local 0 in the right, and both take their other coordinate
+ * from the identical `Yc`, so the two round to the same pixel and no seam
+ * opens. Re-solving the crossing inside each tile's own shifted frame would be
+ * mathematically equal but numerically different in the last bit, which is
+ * exactly how an intermittent one-pixel seam appears.
+ */
+const foldSubEdge = (
+  deltas: Map<string, TileDelta>,
+  activityEdges: Set<string>,
+  zoom: number,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  hidden: boolean
+) => {
+  const lastTile = tileCountAtZoom(zoom) - 1
+  const clampIndex = (index: number) => Math.min(Math.max(index, 0), lastTile)
+
+  // Which tile owns the sub-edge is decided by a point strictly inside it, so a
+  // crossing that lands exactly on a corner cannot be attributed to one of the
+  // two tiles it merely touches.
+  const midX = (from.x + to.x) / 2
+  const midY = (from.y + to.y) / 2
+  const tileX = clampIndex(Math.floor(midX))
+  const tileY = clampIndex(Math.floor(midY))
+
+  const localize = (value: number, origin: number) => {
+    const local = Math.round((value - origin) * TILE_EXTENT)
+    return Math.min(Math.max(local, 0), TILE_EXTENT)
+  }
+
+  const a = packVertex(localize(from.x, tileX), localize(from.y, tileY))
+  const b = packVertex(localize(to.x, tileX), localize(to.y, tileY))
+  // Both ends quantized onto the same pixel: no length, nothing to draw.
+  if (a === b) return
+
+  const key = edgeKey(a, b, hidden)
+  // Per ACTIVITY, not per pair: an out-and-back along one street, or a lap
+  // repeated within a single ride, is one visit. Counting each traversal would
+  // make heat depend on how an activity happened to be routed rather than on
+  // how often the street is used, and would be unstable under GPS jitter.
+  const activityKey = `${zoom}:${tileX}:${tileY}:${key}`
+  if (activityEdges.has(activityKey)) return
+  activityEdges.add(activityKey)
+
+  const mapKey = tileKey(zoom, tileX, tileY)
+  let delta = deltas.get(mapKey)
+  if (!delta) {
+    delta = { z: zoom, x: tileX, y: tileY, edges: new Map() }
+    deltas.set(mapKey, delta)
+  }
+
+  const existing = delta.edges.get(key)
+  if (existing) {
+    existing.count += 1
+    return
+  }
+  delta.edges.set(key, {
+    a: Math.min(a, b),
+    b: Math.max(a, b),
+    hidden,
+    count: 1
+  })
+}
+
+export interface BuildTileDeltasParams {
+  segments: TilerSegment[]
+  /** Defaults to the full ladder; narrowed only by tests. */
+  ladderZooms?: readonly number[]
+  /** Finest simplification tolerance, in meters — the caller's config floor. */
+  toleranceFloorMeters: number
+}
+
+/**
+ * The tiler.
+ *
+ * For each zoom, DESCENDING, the route is simplified to that zoom's own pixel
+ * and the result feeds the next coarser level — a cascade, so the seven levels
+ * together cost little more than the finest one. Each level re-simplifies from
+ * the level above rather than from the original, which bounds the worst-case
+ * deviation at the coarsest level to 4/3 of its own tolerance (the tolerances
+ * grow about fourfold per step, so the series sums to 4/3) — a small constant,
+ * and in exchange each level's input is already a fraction of the raw track.
+ *
+ * The tolerance is a distance in METERS because that is what `simplifyPoints`
+ * takes: it projects into a local meters plane internally and cannot be run in
+ * pixel space. Anchoring that plane at the run's first latitude leaves a long
+ * north-south activity slightly over-detailed at its far end, which errs
+ * towards keeping shape; it never affects where a point LANDS, since placement
+ * projects each point exactly.
+ */
+export const buildTileDeltasForActivity = ({
+  segments,
+  ladderZooms = TILE_LADDER_ZOOMS,
+  toleranceFloorMeters
+}: BuildTileDeltasParams): Map<string, TileDelta> => {
+  const deltas = new Map<string, TileDelta>()
+  const activityEdges = new Set<string>()
+
+  for (const segment of segments) {
+    const hidden = Boolean(segment.isHiddenByPrivacy)
+
+    for (const run of splitAtDiscontinuities(segment.points)) {
+      const referenceLatitude = run[0].lat
+      let simplified = run
+
+      // Descending, so each level simplifies the level above it.
+      for (const zoom of [...ladderZooms].sort((a, b) => b - a)) {
+        simplified = simplifyPoints(
+          simplified,
+          tileToleranceMeters(zoom, referenceLatitude, toleranceFloorMeters)
+        )
+        if (simplified.length < 2) break
+
+        const projected = simplified.map((point) => {
+          const { x, y } = projectWebMercator(point, zoom)
+          return { x: x / TILE_SIZE, y: y / TILE_SIZE }
+        })
+
+        for (let index = 0; index + 1 < projected.length; index += 1) {
+          const from = projected[index]
+          const to = projected[index + 1]
+          if (
+            !Number.isFinite(from.x) ||
+            !Number.isFinite(from.y) ||
+            !Number.isFinite(to.x) ||
+            !Number.isFinite(to.y)
+          ) {
+            continue
+          }
+
+          // Solved once here, in the continuous frame, then localized per tile.
+          const crossings = boundaryCrossings(from, to)
+          let cursor = from
+
+          for (const t of crossings) {
+            const at = {
+              x: from.x + (to.x - from.x) * t,
+              y: from.y + (to.y - from.y) * t
+            }
+            foldSubEdge(deltas, activityEdges, zoom, cursor, at, hidden)
+            cursor = at
+          }
+
+          foldSubEdge(deltas, activityEdges, zoom, cursor, to, hidden)
+        }
+      }
+    }
+  }
+
+  return deltas
+}

--- a/lib/services/fitness-files/heatmapTiles/tiler.ts
+++ b/lib/services/fitness-files/heatmapTiles/tiler.ts
@@ -65,9 +65,15 @@ export interface TileDelta {
  * 1,024 is measured. The longest genuinely straight road on earth (~150 km of
  * the Eyre Highway) spans 335 tiles and is kept whole. A gap left by a recorder
  * running through a 400 km train journey at 52°N spans 1,116 and is split,
- * which is correct — that is a discontinuity, not travel — though at 370 km it
- * is marginal and direction-dependent (1,029 north, 983 east), so the boundary
- * is a judgement about write amplification rather than a natural edge.
+ * which is correct — that is a discontinuity, not travel.
+ *
+ * The boundary between those falls somewhere around 370-390 km at that
+ * latitude, depending on direction and on which earth model the distance is
+ * measured with — a 370 km northward gap reads as 1,022 tiles against a WGS84
+ * meridian degree and 1,029 against an equatorial one, either side of the cap.
+ * That a plausible gap sits inside the measurement noise is the point: this
+ * boundary is a judgement about write amplification, not a natural edge, so no
+ * single distance near it should be quoted as decisive.
  */
 const MAX_TILE_SPAN_AT_FINEST_ZOOM = 1_024
 


### PR DESCRIPTION
## Summary

Phase 3 of the fitness route heatmap work, stacked on #1452 and #1454 (both merged). **This is where the precision actually changes** — but it ships **inert**: four pure modules with no database, no job, no UI. Nothing calls them until the generation job is reworked in Phase 4, which is exactly what makes this reviewable on its own.

### The problem it solves

Today the whole heatmap is one blob fitted to a single global vertex budget (80,000 points), by doubling the simplification tolerance from 1 m up to 256 m until it fits. So precision degrades as coverage grows: a Singapore-sized heatmap lands at the 1 m floor and looks sharp, while a world-spanning one is coarsened to hundreds of meters and cuts across roads. Zooming in never reveals more, because the geometry was simplified once and is reused at every zoom.

The pyramid inverts that. Each zoom is simplified to **its own pixel**, so detail per screen pixel is constant by construction — 9.8 km at z4, 611 m at z8, 38 m at z12, 2.39 m at z16 — and no longer depends on how far an actor has ridden.

### What's here

| Module | |
|---|---|
| `constants.ts` | the ladder, the extent, the per-zoom tolerance, the heat ramp |
| `tileCodec.ts` | the canonical tile encoding + the projection helpers, including the inverse the repo lacked |
| `tiler.ts` | route → per-zoom tile edges |
| `edgeMerge.ts` | edges ↔ stored polylines, and the version-aware merge |

**The codec owns the format outright.** The database layer stores a tile payload as an opaque string and never parses it (its own comment: *"the build path hands it straight to the tile codec"*), so nothing else had to change to adopt this.

Some decisions worth surfacing:

- **`TILE_EXTENT` equals the Web Mercator tile size on purpose**, so one stored unit is one screen pixel. That identity is what collapses GPS jitter from repeat rides onto *shared* edges rather than near-miss polylines — it's why a street ridden fifty times stores one edge with a count of fifty.
- **No maximum-points constant anywhere.** Per your earlier call ("as much as possible"), tile size is bounded by physical density — 1-pixel tolerance plus quantized-edge dedup means a tile holds only as much as the road network inside it.
- **Counts are per activity, not per traversal.** An out-and-back street or a repeated lap counts once: heat should say how often a street is *used*, not how a ride was routed, and a per-traversal count would be unstable under jitter. Documented trade-off.
- **`tileLocalToLngLat` is new**, not reused — `projectWebMercator` has no inverse and clipping a tile to a shared region needs one.

### The parts that fail silently if wrong

An adversarial design review before implementation found seven concrete holes in the algorithm; all are fixed here and each is pinned by a test that fails when the fix is reverted:

1. **Vertex packing uses base 257, not 256.** The coordinate space is inclusive at both ends (0..256 is 257 values, since a boundary point is 256 here and 0 in the neighbour), so base 256 collides `(1,0)` with `(0,256)` — welding two unrelated streets together.
2. **Tile index clamped at both ends.** The projection's own edges fall outside the grid on both sides: `lng = +180` and the southern Mercator limit land one *past* the last tile, and the northern limit floors to `-1`. (My own test caught the `-1` case during implementation — I'd only clamped the top.)
3. **Assembly partitions by `(count, hidden)`** — a stored polyline carries one count for all its points, so mixing a twice-ridden edge with a once-ridden one has to pick a count, and either choice corrupts the other.
4. **Assembly sweeps for cycles.** A closed loop — roundabout, lap, criterium — has *no odd-degree vertex*, so walking only from odd degrees never enters it and every edge in it disappears without trace.
5. **Boundary crossings are solved once in the continuous frame**, then localized by subtracting the integer origin (exact). Re-solving inside each tile's shifted frame is equal in maths but differs in the last bit — which is how an intermittent one-pixel seam appears.
6. **Pairs subdivide at every crossing on both axes**, so a long diagonal contributes to every tile it passes through instead of just its endpoints'.
7. **Cascade bound is 4/3, not 1.25** (tolerances grow ~4× per step; the series sums to 4/3) — corrected in the docs.

Plus: a non-finite point ends the run rather than being filtered later, because simplification anchors its projection at the **first** point's latitude — a leading `NaN` makes every projected coordinate `NaN` and collapses the whole run, losing the valid points after it.

### Tests

122 new tests. Every invariant above was mutation-tested — reverting the behaviour fails exactly the test that names it and no others. Two mutants survived my first pass (y-axis subdivision, and the non-finite skip, which is only distinguishable via the leading-`NaN` case) and I added tests for both rather than leaving them unguarded.

Also pinned: the heat ramp reproduces today's additive-alpha stacking exactly (`1-(1-0.55)^n`, computed from the formula rather than copied literals), tolerant decoding (one bad segment is dropped, not the tile), and that `lib/clientModuleBoundary.test.ts` stays green — the dir is under `lib/services/` and must be importable from client code, so it carries no `'use client'` and reads no environment (the tolerance floor arrives as a plain number).

Full suite: 816 files / 9633 tests. No migration, so both schema dumps are untouched. No UI surface yet — that lands in Phase 6.

### Next

Phase 4 wires this into the generation job. One integration constraint is already recorded in the plan: the tiler returns per-activity **deltas** rather than encoded tiles precisely so the job can fold them into an in-memory per-tile map and merge to storage only at each 20 s checkpoint — merging per activity would re-explode a hot downtown tile's whole growing edge set every time.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: no command, env var, route, script or convention changed by this PR (the storage doc already describes the pyramid; Phase 4 updates it when the tables go live)
- [x] If migrations changed: none in this PR, so both dumps are unchanged
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELw2T3kDEwCRZjdoveDefw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELw2T3kDEwCRZjdoveDefw)_