### PR TITLE
Bump version to v1.136.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.135.1",
+  "version": "1.136.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.136.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.135.1`
- Base main SHA: `975950d063f12278f14b0b0bbcc72e140ec1cb17`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
