### PR TITLE
Bump version to v1.136.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.136.0",
+  "version": "1.136.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.136.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.136.0`
- Base main SHA: `f013fe041353d5363bd384e84b639d907fd31ebf`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
