### PR TITLE
chore: drop the unused recipientsTypeActorIdIndex from recipients

### DIFF
--- a/migrations/20260820120000_drop_recipients_type_actorId_index.js
+++ b/migrations/20260820120000_drop_recipients_type_actorId_index.js
@@ -1,0 +1,34 @@
+/**
+ * Drops `recipientsTypeActorIdIndex` ON recipients (type, "actorId"), added by
+ * `20250216112921_add_recipients_type_actorId_index.js`.
+ *
+ * `20260207220000_add_recipients_timeline_local_public_index.js` added
+ * `recipients_type_actor_created_status_idx` ON (type, "actorId", "createdAt",
+ * "statusId") — a strict prefix-superset, so every access path the two-column
+ * index could serve is also served by the four-column one. No query builds a
+ * (type, "actorId") predicate: reads of `recipients` are either correlated on
+ * `statusId` (covered by recipients_status_type_actor_idx) or filter on
+ * `actorId` alone (covered by recipients_actorId_statusId_idx), which a
+ * type-led index cannot serve at all.
+ *
+ * Migrations run with `disableTransactions: true`, so this stays a single
+ * statement.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = function (knex) {
+  return knex.schema.alterTable('recipients', function (table) {
+    table.dropIndex(['type', 'actorId'], 'recipientsTypeActorIdIndex')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = function (knex) {
+  return knex.schema.alterTable('recipients', function (table) {
+    table.index(['type', 'actorId'], 'recipientsTypeActorIdIndex')
+  })
+}

--- a/migrations/20260820120000_drop_recipients_type_actorId_index.js
+++ b/migrations/20260820120000_drop_recipients_type_actorId_index.js
@@ -11,10 +11,10 @@
  * `actorId` alone (covered by recipients_actorId_statusId_idx), which a
  * type-led index cannot serve at all.
  *
- * The app runs its migrations with `disableTransactions: true`
- * (`lib/database/sql/index.ts`), so this stays a single statement — the CLI and
- * the archive script do wrap migrations in a transaction, but a lone
- * `dropIndex` is safe either way.
+ * Some paths run migrations with no transaction — `disableTransactions: true`
+ * in `lib/database/sql/index.ts`, and `--disable-transactions` on the
+ * Dockerfile's build-time `knex migrate:latest` — so this stays a single
+ * statement, leaving nothing half-applied to roll back.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }

--- a/migrations/20260820120000_drop_recipients_type_actorId_index.js
+++ b/migrations/20260820120000_drop_recipients_type_actorId_index.js
@@ -5,11 +5,12 @@
  * `20260207220000_add_recipients_timeline_local_public_index.js` added
  * `recipients_type_actor_created_status_idx` ON (type, "actorId", "createdAt",
  * "statusId") — a strict prefix-superset, so every access path the two-column
- * index could serve is also served by the four-column one. No query builds a
- * (type, "actorId") predicate: reads of `recipients` are either correlated on
+ * index could serve is also served by the four-column one. No query drives
+ * from (type, "actorId"): reads of `recipients` are either correlated on
  * `statusId` (covered by recipients_status_type_actor_idx) or filter on
  * `actorId` alone (covered by recipients_actorId_statusId_idx), which a
- * type-led index cannot serve at all.
+ * type-led index cannot serve at all. The two that do constrain `type` and
+ * `actorId` together pin `statusId` in the same predicate.
  *
  * Some paths run migrations with no transaction — `disableTransactions: true`
  * in `lib/database/sql/index.ts`, and `--disable-transactions` on the

--- a/migrations/20260820120000_drop_recipients_type_actorId_index.js
+++ b/migrations/20260820120000_drop_recipients_type_actorId_index.js
@@ -11,8 +11,10 @@
  * `actorId` alone (covered by recipients_actorId_statusId_idx), which a
  * type-led index cannot serve at all.
  *
- * Migrations run with `disableTransactions: true`, so this stays a single
- * statement.
+ * The app runs its migrations with `disableTransactions: true`
+ * (`lib/database/sql/index.ts`), so this stays a single statement — the CLI and
+ * the archive script do wrap migrations in a transaction, but a lone
+ * `dropIndex` is safe either way.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1760,8 +1760,6 @@ CREATE INDEX push_subscriptions_actor_idx ON public.push_subscriptions USING btr
 
 CREATE INDEX "recipiences_statusId_type_idx" ON public.recipients USING btree ("statusId", type, "createdAt", "updatedAt");
 
-CREATE INDEX "recipientsTypeActorIdIndex" ON public.recipients USING btree (type, "actorId");
-
 CREATE INDEX "recipients_actorId_statusId_idx" ON public.recipients USING btree ("actorId", "statusId");
 
 CREATE INDEX recipients_status_type_actor_idx ON public.recipients USING btree ("statusId", type, "actorId");

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -35,7 +35,6 @@ CREATE TABLE IF NOT EXISTS "actors" (`id` varchar(255), `username` varchar(255),
 CREATE UNIQUE INDEX `actors_id_unique` on `actors` (`id`);
 CREATE INDEX `actorsIndex` on `actors` (`username`, `createdAt`, `updatedAt`);
 CREATE UNIQUE INDEX `actors_username_domain_unique` on `actors` (`username`, `domain`);
-CREATE INDEX `recipientsTypeActorIdIndex` on `recipients` (`type`, `actorId`);
 CREATE INDEX `timelinesActorIdTimelineCreatedAtIndex` on `timelines` (`actorId`, `timeline`, `createdAt`);
 CREATE INDEX `timelinesStatusIdIndex` on `timelines` (`statusId`);
 CREATE TABLE `notifications` (`id` varchar(255), `actorId` varchar(255) not null, `type` varchar(255) not null, `sourceActorId` varchar(255) not null, `statusId` varchar(255), `followId` varchar(255), `isRead` boolean default '0', `readAt` datetime, `groupKey` varchar(255), `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `filtered` boolean not null default '0', `reactionName` varchar(255) null, primary key (`id`));


### PR DESCRIPTION
## Summary

Adds a migration dropping `recipientsTypeActorIdIndex` — the index on `recipients (type, "actorId")` added by `20250216112921_add_recipients_type_actorId_index.js` — and regenerates both reference schema dumps.

An ops review of the production instance found this index has never been scanned: `idx_scan = 0`, `idx_tup_read = 0`, `idx_tup_fetch = 0` over 164 days (stats epoch 2026-03-09), against 7136 kB / 888 pages of storage. `recipients` carries ~434k rows and ~350 MB of indexes in total.

## Why it is redundant

`20260207220000_add_recipients_timeline_local_public_index.js` added `recipients_type_actor_created_status_idx` on `(type, "actorId", "createdAt", "statusId")`. That is a **strict prefix-superset**: any access path reachable through a leading `type` or `(type, "actorId")` is reachable through the wider index too. It was created 2026-02-07, a month *before* the counter epoch, so the whole 164-day window of zero scans was measured with the replacement already in place. Its own scan count over the same window is 1,565.

Sweeping every reference to `recipients` in `lib/` — not just `timeline.ts`, since the table is also read by trends, conversations, collections, search, featured tags, admin hashtags and status hydration, and including aliased forms like `recipients as followers_recipients` that a quoted-name grep misses — **no query drives from `(type, "actorId")`**. Every read falls into one of two shapes:

- **`statusId`-led** — the local-public timeline gate (`timeline.ts`), the trending-statuses gate (`trends.ts`), conversation hydration (`conversation.ts`), per-status recipient lookups and the hashtag joins (`status.ts`), featured tags, hashtag search, document search (`search/documents.ts`), the admin hashtag list (`admin.ts`) and the reply-visibility filters (`utils/statusVisibility.ts`). `timeline.ts` and `trends.ts` do constrain `type` and `actorId` together, but both pin a correlated `statusId` in the same predicate — far more selective, and covered by `recipients_status_type_actor_idx` / `recipiences_statusId_type_idx`.
- **`actorId`-only, no `type`** — status hydration (`status.ts`), collections, and status visibility. A `type`-led index cannot serve these at all; `recipients_actorId_statusId_idx` does.

The only non-read use is the inserts in `status.ts`, where the index is pure write overhead.

### Planner check

I reproduced the table locally on PostgreSQL 17 (434k recipient rows over 145k statuses, public-`to`-heavy like production), restored the index, and ran `EXPLAIN` over each real query shape. Every one picked a different index — `recipiences_statusId_type_idx` for the timeline and trends gates, `recipients_status_type_actor_idx` for the per-status and conversation lookups, a sequential scan for the `actorId`-only subqueries. After exercising all of them, the two-column index still showed `idx_scan = 0`, the same signature as production.

To be precise about the limit of the claim: the index is not *unusable*. A bare `(type, "actorId")` equality probe with no `statusId` correlation does prefer it, because at ~4 MB it is much smaller than the 67 MB four-column index. **No query in the codebase emits that shape.** Forcing the fallback on such a probe, the four-column index served it at the same plan shape and heap cost, differing only by a handful of index buffers (3 → 9 for a 290-row match) — so even if a query of that shape appeared, the wider index would cover it acceptably.

## Risks

- **`idx_scan` is per-instance and resets.** It is cleared by crash recovery, `pg_upgrade`, and explicit stats resets. 164 days is strong evidence, but it is one instance. A seasonal or admin-only path that runs rarely enough to never register during the window would not show up here — the static analysis above is what rules that out, and it is the stronger of the two arguments.
- **Reversible, but not instantly.** The `down` migration recreates the index exactly. On the local 434k-row reproduction the rebuild took 350–650 ms warm; on Cloud SQL with colder I/O, budget a few seconds. A plain index build takes a lock that blocks writes to `recipients` (reads are unaffected) for that duration, so a rollback would briefly stall new status writes.
- Migrations run with `disableTransactions: true`, so this is kept to a single statement.

## Testing

- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors (45 pre-existing warnings, none in the new file)
- `yarn build` — green
- `yarn test` — 818 files / 9778 tests passed

Both dumps were regenerated by running all 153 migrations against fresh local databases (PostgreSQL 17 and SQLite), verifying `knex_migrations` count matched the migration file count, and stripping pg_dump chatter / SQLite internal tables per AGENTS.md. Both regenerated files differ from `main` by exactly the removed index line, which also confirms the procedure reproduces the committed dumps otherwise. The SQLite dump reloads cleanly.

## Review

Three sub-agents reviewed this diff (AGENTS.md → Code Review Loop): migration correctness, schema-dump integrity, and an adversarial attempt to refute the redundancy claim. No defects were found in the migration or either dump. The adversarial pass could not refute the claim — it inventoried every read and write of `recipients` across `lib/`, `app/`, `scripts/` and the migration chain and found zero predicates of the risky shape. Two results are worth recording here:

- **`scripts/` never references the table at all.** That retires the "admin-only path that runs too rarely to register in stats" risk noted above — there is no such path.
- **Where the narrower index could theoretically be used, the wider one is strictly better, not merely equivalent.** Driving the timeline/trends semi-joins from `recipients` needs `statusId`; the four-column index carries it, so the join key comes out of the index instead of costing a heap fetch per row.

It also caught that my original sweep missed the aliased sites in `search/documents.ts` (both `statusId`-correlated, so the conclusion was unchanged) and that a comment in the migration overstated `disableTransactions: true` as universal when it holds only for the app runtime path. Both are fixed.

## What would make us want it back

A query that filters `recipients` on `type` **and** `actorId` with no `statusId` correlation and no `createdAt` ordering — for example an instance-wide "all statuses addressed to this actor as `cc`" scan. If such a path is added, measure first: the four-column index already covers it, and it would need to be hot enough for the ~7 MB saving in index maintenance to be worth paying again.
