### PR TITLE
Bump version to v1.138.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.137.2",
+  "version": "1.138.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.138.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.137.2`
- Base main SHA: `fbd3fe4453de0586a028a4c7c1324af801f29318`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
