### PR TITLE
Bump version to v1.139.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.138.0",
+  "version": "1.139.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.139.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.138.0`
- Base main SHA: `f51dcb8045d9fdd39028ebfe2cc46aa730285c77`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
