### PR TITLE
Bump version to v1.140.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.139.0",
+  "version": "1.140.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.140.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.139.0`
- Base main SHA: `2a9844e3542d451f5189a2a4a6453ed9a65a5e6a`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
