### PR TITLE
minor: draw the shared heatmap image from tiles so a city thumbnail shows streets

### DIFF
--- a/app/embed/heatmap/[token]/image/route.test.ts
+++ b/app/embed/heatmap/[token]/image/route.test.ts
@@ -205,6 +205,80 @@ describe('/embed/heatmap/[token]/image', () => {
       }
     )
 
+    // Enough distinct runs to overrun both basemap renderers: Apple refuses
+    // past MAX_SNAPSHOT_OVERLAYS (24) and Mapbox drops whatever overruns its
+    // URL budget.
+    const manyTiles = (count: number) =>
+      Array.from({ length: count }, (_, index) =>
+        tileRow(
+          12,
+          2100 + index,
+          1340,
+          encodeTile([
+            { count: 3, points: [10, 10, 120, 130] },
+            { count: 1, points: [130, 140, 250, 250] }
+          ])
+        )
+      )
+
+    it('keeps the Apple basemap by drawing the blob when tiles overrun its ceiling', async () => {
+      // The regression this guards: tiles would make buildAppleSnapshotPath
+      // refuse, dropping the instance all the way to the keyless SVG. Trading
+      // a basemap away for fidelity it cannot draw is a worse image.
+      mockGetMapProviderConfig.mockReturnValue(appleProvider)
+      mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid)
+      mockGetFitnessRouteHeatmapTilesInRange.mockResolvedValue(manyTiles(40))
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { 'content-type': 'image/png' }
+        })
+      )
+      try {
+        const response = await GET(imageRequest(), {
+          params: Promise.resolve({ token: 'token-1' })
+        })
+
+        expect(response.headers.get('Content-Type')).toBe('image/png')
+        expect(fetchSpy.mock.calls[0]?.[0] as string).toContain(
+          'https://snapshot.apple-mapkit.com/api/v1/snapshot?'
+        )
+      } finally {
+        fetchSpy.mockRestore()
+      }
+    })
+
+    it('draws the blob on Mapbox rather than a truncated corner of the tiles', async () => {
+      // Tile runs arrive in tile order, so the overlays that survive the URL
+      // budget are one contiguous corner of the view -- and `/auto/` then
+      // frames the whole image on that corner.
+      mockGetMapProviderConfig.mockReturnValue({
+        type: 'mapbox',
+        accessToken: 'pk.test-token'
+      })
+      mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid)
+      mockGetFitnessRouteHeatmapTilesInRange.mockResolvedValue(manyTiles(400))
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { 'content-type': 'image/png' }
+        })
+      )
+      try {
+        await GET(imageRequest(), {
+          params: Promise.resolve({ token: 'token-1' })
+        })
+
+        const requestedUrl = fetchSpy.mock.calls[0]?.[0] as string
+        // The blob is one segment; the tiles would have been hundreds.
+        expect(requestedUrl.match(/path-2%2B|path-2\+/g)).toHaveLength(
+          sharedHeatmap.segments.length
+        )
+      } finally {
+        fetchSpy.mockRestore()
+      }
+    })
+
     it('keeps the stored blob when the pyramid read fails', async () => {
       // An image the owner already had beats no image at all.
       mockGetFitnessRouteHeatmapPyramid.mockRejectedValue(

--- a/app/embed/heatmap/[token]/image/route.test.ts
+++ b/app/embed/heatmap/[token]/image/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import crypto from 'node:crypto'
 
 import { Database } from '@/lib/database/types'
+import { encodeTile } from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
 import { simplifySegmentsToBudget } from '@/lib/services/fitness-files/simplifyRoute'
 
 import { GET } from './route'
@@ -26,10 +27,18 @@ vi.mock('@/lib/services/fitness-files/simplifyRoute', async () => {
 })
 
 const mockGetFitnessRouteHeatmapByShareToken = vi.fn()
-let mockDatabase: Pick<Database, 'getFitnessRouteHeatmapByShareToken'> | null =
-  {
-    getFitnessRouteHeatmapByShareToken: mockGetFitnessRouteHeatmapByShareToken
-  }
+const mockGetFitnessRouteHeatmapPyramid = vi.fn()
+const mockGetFitnessRouteHeatmapTilesInRange = vi.fn()
+let mockDatabase: Pick<
+  Database,
+  | 'getFitnessRouteHeatmapByShareToken'
+  | 'getFitnessRouteHeatmapPyramid'
+  | 'getFitnessRouteHeatmapTilesInRange'
+> | null = {
+  getFitnessRouteHeatmapByShareToken: mockGetFitnessRouteHeatmapByShareToken,
+  getFitnessRouteHeatmapPyramid: mockGetFitnessRouteHeatmapPyramid,
+  getFitnessRouteHeatmapTilesInRange: mockGetFitnessRouteHeatmapTilesInRange
+}
 vi.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
 }))
@@ -85,10 +94,111 @@ describe('/embed/heatmap/[token]/image', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDatabase = {
-      getFitnessRouteHeatmapByShareToken: mockGetFitnessRouteHeatmapByShareToken
+      getFitnessRouteHeatmapByShareToken:
+        mockGetFitnessRouteHeatmapByShareToken,
+      getFitnessRouteHeatmapPyramid: mockGetFitnessRouteHeatmapPyramid,
+      getFitnessRouteHeatmapTilesInRange: mockGetFitnessRouteHeatmapTilesInRange
     }
     mockGetFitnessRouteHeatmapByShareToken.mockResolvedValue(sharedHeatmap)
+    // No pyramid by default: every existing case is about the blob path.
+    mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(null)
+    mockGetFitnessRouteHeatmapTilesInRange.mockResolvedValue([])
     mockGetMapProviderConfig.mockReturnValue({ type: 'osm' })
+  })
+
+  describe('pyramid-backed images', () => {
+    const pyramid = {
+      id: 'pyramid-1',
+      actorId: sharedHeatmap.actorId,
+      status: 'completed' as const,
+      version: 3,
+      claimSeq: 1,
+      totalCount: 1,
+      scannedCount: 1,
+      activityCount: 1,
+      tileCount: 1,
+      pointCount: 4,
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    const tileRow = (z: number, x: number, y: number, segments: string) => ({
+      actorId: sharedHeatmap.actorId,
+      tileKey: `${z}:${x}:${y}`,
+      z,
+      x,
+      y,
+      version: 3,
+      segments,
+      pointCount: 2,
+      createdAt: 1,
+      updatedAt: 2
+    })
+
+    it('draws from tiles, shading each run by its visit count', async () => {
+      // The blob was simplified once to a single global budget, so a city
+      // thumbnail drawn from it shows the same coarse lines a whole-world view
+      // would. Tiles are simplified per rung.
+      mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid)
+      mockGetFitnessRouteHeatmapTilesInRange.mockImplementation(
+        async ({ z, minX, minY }) => [
+          tileRow(
+            z,
+            minX,
+            minY,
+            encodeTile([{ count: 6, points: [0, 0, 128, 128] }])
+          )
+        ]
+      )
+
+      const response = await GET(imageRequest(), {
+        params: Promise.resolve({ token: 'token-1' })
+      })
+      const svg = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(mockGetFitnessRouteHeatmapTilesInRange).toHaveBeenCalled()
+      // Shaded, not the flat opacity the untiled path uses.
+      expect(svg).not.toContain('stroke-opacity="0.85"')
+      expect(svg).toContain('<polyline')
+    })
+
+    it('keeps the stored blob when the actor has no completed build', async () => {
+      mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(null)
+
+      const response = await GET(imageRequest(), {
+        params: Promise.resolve({ token: 'token-1' })
+      })
+      const svg = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(svg).toContain('stroke-opacity="0.85"')
+    })
+
+    it('keeps the stored blob when the pyramid read fails', async () => {
+      // An image the owner already had beats no image at all.
+      mockGetFitnessRouteHeatmapPyramid.mockRejectedValue(
+        new Error('pyramid table unavailable')
+      )
+
+      const response = await GET(imageRequest(), {
+        params: Promise.resolve({ token: 'token-1' })
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('stroke-opacity="0.85"')
+    })
+
+    it('keeps the stored blob when the pyramid holds nothing for this view', async () => {
+      mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid)
+      mockGetFitnessRouteHeatmapTilesInRange.mockResolvedValue([])
+
+      const response = await GET(imageRequest(), {
+        params: Promise.resolve({ token: 'token-1' })
+      })
+
+      expect(await response.text()).toContain('stroke-opacity="0.85"')
+    })
   })
 
   it('returns 404 for an unknown share token', async () => {

--- a/app/embed/heatmap/[token]/image/route.test.ts
+++ b/app/embed/heatmap/[token]/image/route.test.ts
@@ -175,6 +175,36 @@ describe('/embed/heatmap/[token]/image', () => {
       expect(svg).toContain('stroke-opacity="0.85"')
     })
 
+    it.each([
+      {
+        description: 'one sport',
+        activityType: 'Ride',
+        periodType: 'all_time'
+      },
+      { description: 'one year', activityType: null, periodType: 'year' }
+    ])(
+      'keeps the stored blob for a share scoped to $description',
+      async ({ activityType, periodType }) => {
+        // The pyramid is built from the actor's whole history and carries no
+        // sport or date, so drawing a scoped share from it would publish every
+        // sport and every year. Region clipping cannot catch that -- it only
+        // bounds geography.
+        mockGetFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid)
+        mockGetFitnessRouteHeatmapByShareToken.mockResolvedValue({
+          ...sharedHeatmap,
+          activityType,
+          periodType
+        })
+
+        const response = await GET(imageRequest(), {
+          params: Promise.resolve({ token: 'token-1' })
+        })
+
+        expect(await response.text()).toContain('stroke-opacity="0.85"')
+        expect(mockGetFitnessRouteHeatmapTilesInRange).not.toHaveBeenCalled()
+      }
+    )
+
     it('keeps the stored blob when the pyramid read fails', async () => {
       // An image the owner already had beats no image at all.
       mockGetFitnessRouteHeatmapPyramid.mockRejectedValue(

--- a/app/embed/heatmap/[token]/image/route.ts
+++ b/app/embed/heatmap/[token]/image/route.ts
@@ -171,8 +171,14 @@ export const GET = traceApiRoute(
     if (mapProvider.type === 'apple') {
       const appleSize = fitAppleDimensions(width, height)
       for (const candidate of candidates) {
-        // Costs nothing to try: `buildAppleSnapshotPath` refuses an over-ceiling
-        // input before it signs or fetches anything.
+        // Trying the tiles first is free when they are over the ceiling:
+        // `buildAppleSnapshotPath` refuses that input before it signs or
+        // fetches anything, so the blob is reached without a request. When the
+        // tiles DO fit, a failed attempt costs a real fetch and the blob is
+        // then tried for real — which is the point. Apple answers 413 once the
+        // URL grows too long and `SNAPSHOT_URL_BUDGET` is this module's guess
+        // at where that is, so the candidate most likely to be refused upstream
+        // is exactly the long one.
         const snapshot = await fetchAppleSnapshot(
           {
             segments: candidate,

--- a/app/embed/heatmap/[token]/image/route.ts
+++ b/app/embed/heatmap/[token]/image/route.ts
@@ -16,6 +16,7 @@ import {
   buildHeatmapSvg,
   buildMapboxStaticUrl
 } from '@/lib/services/fitness-files/staticHeatmapImage'
+import type { FitnessRouteHeatmapSegment } from '@/lib/types/database/fitnessRouteHeatmap'
 import { logger } from '@/lib/utils/logger'
 import { apiErrorResponse } from '@/lib/utils/response'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
@@ -146,7 +147,21 @@ export const GET = traceApiRoute(
           return null
         })
       : null
-    const segments = tiled?.length ? tiled : publicHeatmap.segments
+    // Tiles first, the stored blob second — and the renderer decides.
+    //
+    // Tile geometry is one run per way per tile where the blob is one polyline
+    // per activity, so a street-level view is hundreds of overlays rather than
+    // tens. The two basemap renderers cannot draw that: Apple refuses outright
+    // past MAX_SNAPSHOT_OVERLAYS, and Mapbox silently drops whatever overruns
+    // its URL budget, which for tile-ordered geometry means one contiguous
+    // corner of the view that `/auto/` then frames the whole image on. Handing
+    // the blob to a renderer that cannot take the tiles keeps exactly the image
+    // such an instance serves today, instead of trading its basemap away for
+    // fidelity it cannot show.
+    const blobSegments = publicHeatmap.segments
+    const candidates: FitnessRouteHeatmapSegment[][] = tiled?.length
+      ? [tiled, blobSegments]
+      : [blobSegments]
 
     const mapProvider = getMapProviderConfig()
 
@@ -155,18 +170,24 @@ export const GET = traceApiRoute(
     // server-side and only the bytes are streamed back.
     if (mapProvider.type === 'apple') {
       const appleSize = fitAppleDimensions(width, height)
-      const snapshot = await fetchAppleSnapshot(
-        {
-          segments,
-          width: appleSize.width,
-          height: appleSize.height,
-          scale: APPLE_SNAPSHOT_SCALE
-        },
-        mapProvider
-      )
-      // Apple Web Snapshots answer with PNG bytes; pin the type rather than
-      // trusting the upstream header on this anonymous, CORS-* response.
-      if (snapshot) return imageResponse(new Uint8Array(snapshot), 'image/png')
+      for (const candidate of candidates) {
+        // Costs nothing to try: `buildAppleSnapshotPath` refuses an over-ceiling
+        // input before it signs or fetches anything.
+        const snapshot = await fetchAppleSnapshot(
+          {
+            segments: candidate,
+            width: appleSize.width,
+            height: appleSize.height,
+            scale: APPLE_SNAPSHOT_SCALE
+          },
+          mapProvider
+        )
+        // Apple Web Snapshots answer with PNG bytes; pin the type rather than
+        // trusting the upstream header on this anonymous, CORS-* response.
+        if (snapshot) {
+          return imageResponse(new Uint8Array(snapshot), 'image/png')
+        }
+      }
       // Otherwise fall through to the keyless SVG renderer below.
     }
 
@@ -175,13 +196,20 @@ export const GET = traceApiRoute(
     // token never reaches the browser. Any Mapbox token works here (including a
     // secret `sk.` one), unlike the browser-side descriptor.
     if (mapProvider.type === 'mapbox') {
-      const mapboxUrl = buildMapboxStaticUrl({
-        segments,
-        bounds: publicHeatmap.bounds ?? null,
-        width,
-        height,
-        token: mapProvider.accessToken
-      })
+      const mapboxUrl = candidates.reduce<string | null>(
+        (found, candidate) =>
+          found ??
+          buildMapboxStaticUrl({
+            segments: candidate,
+            bounds: publicHeatmap.bounds ?? null,
+            width,
+            height,
+            token: mapProvider.accessToken,
+            // Only the blob may be truncated, which is what it has always done.
+            requireAllOverlays: candidate !== blobSegments
+          }),
+        null
+      )
       if (mapboxUrl) {
         try {
           const upstream = await fetch(mapboxUrl, {
@@ -205,10 +233,11 @@ export const GET = traceApiRoute(
       }
     }
 
-    // Keyless fallback: route lines on a plain background.
+    // Keyless fallback: route lines on a plain background. No overlay ceiling
+    // and no URL to overrun, so it always takes the finest candidate.
     return svgResponse(
       buildHeatmapSvg({
-        segments,
+        segments: candidates[0],
         bounds: publicHeatmap.bounds ?? null,
         width,
         height

--- a/app/embed/heatmap/[token]/image/route.ts
+++ b/app/embed/heatmap/[token]/image/route.ts
@@ -126,11 +126,12 @@ export const GET = traceApiRoute(
     //
     // Best-effort in both directions — an actor with no completed build, and a
     // read that fails, both keep the blob, which is an image the owner already
-    // had. Clipping to the share's region is NOT optional here: the pyramid
-    // covers the actor's whole history.
+    // had. The whole row goes in, not just its actor id: the pyramid covers the
+    // actor's whole history, so the builder has to refuse a share scoped to one
+    // sport or one year and clip what is left to the share's own region.
     const tiled = publicHeatmap.bounds
       ? await buildHeatmapSegmentsFromTiles(database, {
-          actorId: heatmap.actorId,
+          heatmap,
           bounds: publicHeatmap.bounds,
           width,
           height,

--- a/app/embed/heatmap/[token]/image/route.ts
+++ b/app/embed/heatmap/[token]/image/route.ts
@@ -7,6 +7,7 @@ import {
   APPLE_SNAPSHOT_MIN_DIMENSION,
   fetchAppleSnapshot
 } from '@/lib/services/fitness-files/appleMapsSnapshot'
+import { buildHeatmapSegmentsFromTiles } from '@/lib/services/fitness-files/heatmapTiles/segmentsFromTiles'
 import {
   resolveSharedHeatmapRegionBounds,
   toPublicHeatmap
@@ -15,7 +16,9 @@ import {
   buildHeatmapSvg,
   buildMapboxStaticUrl
 } from '@/lib/services/fitness-files/staticHeatmapImage'
+import { logger } from '@/lib/utils/logger'
 import { apiErrorResponse } from '@/lib/utils/response'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const dynamic = 'force-dynamic'
@@ -108,12 +111,41 @@ export const GET = traceApiRoute(
     if (!heatmap || heatmap.status !== 'completed') return apiErrorResponse(404)
     // See resolveSharedHeatmapRegionBounds: an unresolvable region means the
     // stored geometry was never clipped, so rendering it publishes the world.
-    if (!resolveSharedHeatmapRegionBounds(heatmap)) return apiErrorResponse(404)
+    const regionBounds = resolveSharedHeatmapRegionBounds(heatmap)
+    if (!regionBounds) return apiErrorResponse(404)
 
     const publicHeatmap = toPublicHeatmap(heatmap)
     const url = new URL(req.url)
     const width = snapDimension(url.searchParams.get('w'), DEFAULT_WIDTH)
     const height = snapDimension(url.searchParams.get('h'), DEFAULT_HEIGHT)
+
+    // Prefer the pyramid: the stored blob was simplified once to a single
+    // global budget, so a thumbnail of a city drawn from it shows the same
+    // coarse lines a whole-world view would. Tiles are simplified per rung, so
+    // the image is drawn at the fidelity its own size warrants.
+    //
+    // Best-effort in both directions — an actor with no completed build, and a
+    // read that fails, both keep the blob, which is an image the owner already
+    // had. Clipping to the share's region is NOT optional here: the pyramid
+    // covers the actor's whole history.
+    const tiled = publicHeatmap.bounds
+      ? await buildHeatmapSegmentsFromTiles(database, {
+          actorId: heatmap.actorId,
+          bounds: publicHeatmap.bounds,
+          width,
+          height,
+          regionBounds
+        }).catch((error) => {
+          logger.warn({
+            message: 'Failed to build a route heatmap image from tiles',
+            heatmapId: heatmap.id,
+            actorId: heatmap.actorId,
+            err: toLoggableError(error)
+          })
+          return null
+        })
+      : null
+    const segments = tiled?.length ? tiled : publicHeatmap.segments
 
     const mapProvider = getMapProviderConfig()
 
@@ -124,7 +156,7 @@ export const GET = traceApiRoute(
       const appleSize = fitAppleDimensions(width, height)
       const snapshot = await fetchAppleSnapshot(
         {
-          segments: publicHeatmap.segments,
+          segments,
           width: appleSize.width,
           height: appleSize.height,
           scale: APPLE_SNAPSHOT_SCALE
@@ -143,7 +175,7 @@ export const GET = traceApiRoute(
     // secret `sk.` one), unlike the browser-side descriptor.
     if (mapProvider.type === 'mapbox') {
       const mapboxUrl = buildMapboxStaticUrl({
-        segments: publicHeatmap.segments,
+        segments,
         bounds: publicHeatmap.bounds ?? null,
         width,
         height,
@@ -175,7 +207,7 @@ export const GET = traceApiRoute(
     // Keyless fallback: route lines on a plain background.
     return svgResponse(
       buildHeatmapSvg({
-        segments: publicHeatmap.segments,
+        segments,
         bounds: publicHeatmap.bounds ?? null,
         width,
         height

--- a/lib/components/fitness/heatmapTileGeometry.ts
+++ b/lib/components/fitness/heatmapTileGeometry.ts
@@ -1,55 +1,10 @@
-import type { LatLng } from '@/lib/fitness/regions'
 import {
-  TileSegment,
-  tileLocalToLngLat
-} from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+  HeatmapTileRun,
+  tileRunsToLngLat
+} from '@/lib/services/fitness-files/heatmapTiles/tileRuns'
 
-/**
- * One drawable run from a tile, in degrees.
- *
- * A stored `TileSegment` is meaningless on its own: its points are integers in
- * the tile's own 0..TILE_EXTENT space, so the same numbers mean different
- * places in different tiles. Everything downstream of the decode therefore
- * carries degrees, and the `(z, x, y)` that produced them is consumed here and
- * never travels further.
- */
-export interface HeatmapTileRun {
-  /** Distinct activities that traced this run; drives colour and opacity. */
-  count: number
-  hidden: boolean
-  points: LatLng[]
-}
-
-/**
- * Places a decoded tile's runs on the globe.
- *
- * Runs of fewer than two points are dropped, matching `buildRouteGeoJson`:
- * one vertex draws no line, and on the public path its presence alone would
- * say something happened there.
- */
-export const tileRunsToLngLat = (
-  z: number,
-  x: number,
-  y: number,
-  segments: TileSegment[]
-): HeatmapTileRun[] =>
-  segments.flatMap((segment) => {
-    if (segment.points.length < 4) return []
-
-    const points: LatLng[] = []
-    for (let index = 0; index < segment.points.length; index += 2) {
-      points.push(
-        tileLocalToLngLat(
-          z,
-          x,
-          y,
-          segment.points[index],
-          segment.points[index + 1]
-        )
-      )
-    }
-    return [{ count: segment.count, hidden: Boolean(segment.hidden), points }]
-  })
+export type { HeatmapTileRun }
+export { tileRunsToLngLat }
 
 /**
  * The GeoJSON the GL line layer draws.

--- a/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.test.ts
@@ -1,0 +1,278 @@
+import { Database } from '@/lib/database/types'
+import { FitnessRouteHeatmapPyramid } from '@/lib/types/database/fitnessRouteHeatmapTile'
+
+import {
+  buildHeatmapSegmentsFromTiles,
+  imageZoomForBounds
+} from './segmentsFromTiles'
+import { encodeTile, tileKey } from './tileCodec'
+import { tileBounds } from './tileRegion'
+
+describe('imageZoomForBounds', () => {
+  // Amsterdam, then progressively wider scopes around it.
+  const CITY_BLOCK = { minLat: 52.36, maxLat: 52.38, minLng: 4.88, maxLng: 4.9 }
+  const CITY = { minLat: 52.3, maxLat: 52.42, minLng: 4.8, maxLng: 5.0 }
+  const COUNTRY = { minLat: 50.7, maxLat: 53.6, minLng: 3.3, maxLng: 7.2 }
+  const CONTINENT = { minLat: 35, maxLat: 70, minLng: -10, maxLng: 30 }
+
+  it.each([
+    { description: 'a city block', bounds: CITY_BLOCK, expected: 16 },
+    { description: 'a city', bounds: CITY, expected: 14 },
+    { description: 'a country', bounds: COUNTRY, expected: 8 },
+    { description: 'a continent', bounds: CONTINENT, expected: 4 }
+  ])('picks rung $expected for $description', ({ bounds, expected }) => {
+    expect(imageZoomForBounds(bounds, 1200, 630)).toBe(expected)
+  })
+
+  it('drops a rung when the same scope is drawn half the size', () => {
+    // What "one pixel" means is a property of the image, not of the ground, so
+    // a thumbnail must not read tiles whose detail it cannot show.
+    expect(imageZoomForBounds(CITY, 1200, 630)).toBe(14)
+    expect(imageZoomForBounds(CITY, 600, 315)).toBe(12)
+  })
+
+  it('follows whichever axis the image is fitted by', () => {
+    // `buildHeatmapSvg` fits with min(innerWidth / spanX, innerHeight / spanY),
+    // so a tall scope in a wide image is limited by its height and a wide flat
+    // one by its width. Reading longitude alone would ask for a rung finer than
+    // the image can draw and fetch tiles nobody sees.
+    const tall = { minLat: 52.3, maxLat: 52.42, minLng: 4.88, maxLng: 4.9 }
+    const flat = { minLat: 52.35, maxLat: 52.37, minLng: 4.6, maxLng: 5.4 }
+
+    expect(imageZoomForBounds(tall, 1200, 630)).toBe(14)
+    expect(imageZoomForBounds(flat, 1200, 630)).toBe(12)
+  })
+
+  it.each([
+    { description: 'a zero-width image', width: 0, height: 630 },
+    { description: 'a zero-height image', width: 1200, height: 0 },
+    {
+      description: 'an empty span',
+      width: 1200,
+      height: 630,
+      bounds: { minLat: 52, maxLat: 52, minLng: 5, maxLng: 5 }
+    }
+  ])(
+    'falls back to the coarsest rung for $description',
+    ({ width, height, bounds }) => {
+      expect(imageZoomForBounds(bounds ?? CITY, width, height)).toBe(4)
+    }
+  )
+})
+
+describe('buildHeatmapSegmentsFromTiles', () => {
+  const ACTOR_ID = 'https://llun.test/users/user1'
+  const Z = 12
+  const X = 2102
+  const Y = 1344
+  const tile = tileBounds(Z, X, Y)
+  // Padded so a 600x400 image really does select rung 12 (0.02 - 0.1 degrees
+  // of pad around the tile does; 0.01 buys rung 14 and 0.15 falls to 10). A
+  // fixture whose geometry and rung disagree passes for the wrong reason.
+  const PAD = 0.05
+  const bounds = {
+    minLat: tile.minLat - PAD,
+    maxLat: tile.maxLat + PAD,
+    minLng: tile.minLng - PAD,
+    maxLng: tile.maxLng + PAD
+  }
+
+  const mockDb = {
+    getFitnessRouteHeatmapPyramid: vi.fn(),
+    getFitnessRouteHeatmapTilesInRange: vi.fn()
+  }
+  const database = mockDb as unknown as Database
+
+  const pyramid = (
+    overrides: Partial<FitnessRouteHeatmapPyramid> = {}
+  ): FitnessRouteHeatmapPyramid => ({
+    id: 'pyramid-1',
+    actorId: ACTOR_ID,
+    status: 'completed',
+    version: 4,
+    claimSeq: 1,
+    totalCount: 1,
+    scannedCount: 1,
+    activityCount: 1,
+    tileCount: 1,
+    pointCount: 4,
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  })
+
+  const row = (segments: string, version = 4, x = X, y = Y) => ({
+    actorId: ACTOR_ID,
+    tileKey: tileKey(Z, x, y),
+    z: Z,
+    x,
+    y,
+    version,
+    segments,
+    pointCount: 2,
+    createdAt: 1,
+    updatedAt: 2
+  })
+
+  const build = (regionBounds = [] as never[]) =>
+    buildHeatmapSegmentsFromTiles(database, {
+      actorId: ACTOR_ID,
+      bounds,
+      width: 600,
+      height: 400,
+      regionBounds
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDb.getFitnessRouteHeatmapPyramid.mockResolvedValue(pyramid())
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([])
+  })
+
+  it('reads nothing for bounds that enclose no tile row', async () => {
+    // Inverted bounds resolve to an empty row range: north is a smaller y in
+    // Mercator, so a swapped pair puts minY past maxY. Handing that to the
+    // database as a WHERE clause is a query that cannot match. The inversion
+    // has to straddle tile rows to show it -- a swap of a tenth of a degree
+    // collapses onto one row at the coarsest rung.
+    const inverted = { minLat: 60, maxLat: -60, minLng: 4, maxLng: 5 }
+
+    const segments = await buildHeatmapSegmentsFromTiles(database, {
+      actorId: ACTOR_ID,
+      bounds: inverted,
+      width: 600,
+      height: 400,
+      regionBounds: []
+    })
+
+    expect(segments).toBeNull()
+    expect(mockDb.getFitnessRouteHeatmapTilesInRange).not.toHaveBeenCalled()
+  })
+
+  it("places geometry with the tile row's own rung, not the view's", async () => {
+    // A row carries its own z/x/y. Placing it with the rung the view happened
+    // to ask for would draw it at the same tile index on a different rung,
+    // which is a different part of the world entirely.
+    const COARSE_Z = 10
+    const coarseX = Math.floor(X / 4)
+    const coarseY = Math.floor(Y / 4)
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      {
+        ...row(encodeTile([{ count: 1, points: [128, 128, 129, 129] }])),
+        tileKey: tileKey(COARSE_Z, coarseX, coarseY),
+        z: COARSE_Z,
+        x: coarseX,
+        y: coarseY
+      }
+    ])
+
+    const segments = await build()
+    const [point] = segments?.[0].points ?? []
+    const coarse = tileBounds(COARSE_Z, coarseX, coarseY)
+
+    expect(point.lng).toBeGreaterThanOrEqual(coarse.minLng)
+    expect(point.lng).toBeLessThanOrEqual(coarse.maxLng)
+    expect(point.lat).toBeGreaterThanOrEqual(coarse.minLat)
+    expect(point.lat).toBeLessThanOrEqual(coarse.maxLat)
+  })
+
+  it.each([
+    { description: 'no pyramid', value: null },
+    {
+      description: 'a build still running',
+      value: pyramid({ status: 'generating' })
+    },
+    { description: 'a row that never built', value: pyramid({ version: 0 }) }
+  ])(
+    'answers null for $description, so the caller keeps the blob',
+    async ({ value }) => {
+      mockDb.getFitnessRouteHeatmapPyramid.mockResolvedValue(value)
+      expect(await build()).toBeNull()
+      expect(mockDb.getFitnessRouteHeatmapTilesInRange).not.toHaveBeenCalled()
+    }
+  )
+
+  it('turns stored tiles into segments carrying their visit count', async () => {
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      row(encodeTile([{ count: 7, points: [0, 0, 128, 128] }]))
+    ])
+
+    const segments = await build()
+    expect(segments).toHaveLength(1)
+    expect(segments![0].count).toBe(7)
+    expect(segments![0].points).toHaveLength(2)
+    // Placed on the globe from the tile's own coordinate, not tile-local.
+    expect(segments![0].points[0].lat).toBeCloseTo(tile.maxLat, 6)
+  })
+
+  it('drops the privacy class while keeping the geometry', async () => {
+    // The same flattening the other public surfaces apply: a hole or a
+    // highlight around home would pinpoint it.
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      row(encodeTile([{ count: 2, hidden: true, points: [0, 0, 64, 64] }]))
+    ])
+
+    const segments = await build()
+    expect(segments).toHaveLength(1)
+    expect(segments![0]).not.toHaveProperty('isHiddenByPrivacy')
+  })
+
+  it('ignores a tile left behind at an older version', async () => {
+    // A rebuild in flight leaves two versions in the table at once, and drawing
+    // them together shows heat no build ever produced.
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      row(encodeTile([{ count: 3, points: [0, 0, 64, 64] }]), 3)
+    ])
+
+    expect(await build()).toEqual([])
+  })
+
+  it('clips a boundary tile to the share region rather than serving it whole', async () => {
+    // The pyramid is stored UNCLIPPED and covers the actor's whole history, so
+    // an image built from it without clipping publishes everywhere they ride.
+    const northHalf = [
+      {
+        minLat: (tile.minLat + tile.maxLat) / 2,
+        maxLat: tile.maxLat + 1,
+        minLng: tile.minLng - 1,
+        maxLng: tile.maxLng + 1
+      }
+    ]
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      row(encodeTile([{ count: 5, points: [0, 0, 8, 20, 16, 250, 24, 255] }]))
+    ])
+
+    const segments = await build(northHalf as never)
+    expect(segments).toHaveLength(1)
+    expect(segments![0].points).toHaveLength(2)
+    for (const point of segments![0].points) {
+      expect(point.lat).toBeGreaterThanOrEqual(northHalf[0].minLat)
+    }
+  })
+
+  it('drops a tile the share region cannot contain, without decoding it', async () => {
+    const elsewhere = [{ minLat: -40, maxLat: -39, minLng: 170, maxLng: 171 }]
+    mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([
+      row(encodeTile([{ count: 5, points: [0, 0, 64, 64] }]))
+    ])
+
+    expect(await build(elsewhere as never)).toEqual([])
+  })
+
+  it('reads both sides of the antimeridian as two ranges', async () => {
+    // The range read is a `whereBetween`, which matches nothing when minX
+    // exceeds maxX rather than wrapping around.
+    await buildHeatmapSegmentsFromTiles(database, {
+      actorId: ACTOR_ID,
+      bounds: { minLat: -18.2, maxLat: -18.1, minLng: 179.9, maxLng: -179.9 },
+      width: 600,
+      height: 400,
+      regionBounds: []
+    })
+
+    expect(mockDb.getFitnessRouteHeatmapTilesInRange).toHaveBeenCalledTimes(2)
+    const [first, second] = mockDb.getFitnessRouteHeatmapTilesInRange.mock.calls
+    expect(first[0].maxX).toBe(2 ** first[0].z - 1)
+    expect(second[0].minX).toBe(0)
+  })
+})

--- a/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.test.ts
+++ b/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.test.ts
@@ -114,9 +114,16 @@ describe('buildHeatmapSegmentsFromTiles', () => {
     updatedAt: 2
   })
 
+  // An all-activities, all-time share: the only scope the pyramid can answer.
+  const scope = {
+    actorId: ACTOR_ID,
+    activityType: null,
+    periodType: 'all_time'
+  }
+
   const build = (regionBounds = [] as never[]) =>
     buildHeatmapSegmentsFromTiles(database, {
-      actorId: ACTOR_ID,
+      heatmap: scope,
       bounds,
       width: 600,
       height: 400,
@@ -129,6 +136,31 @@ describe('buildHeatmapSegmentsFromTiles', () => {
     mockDb.getFitnessRouteHeatmapTilesInRange.mockResolvedValue([])
   })
 
+  it.each([
+    { description: 'one sport', activityType: 'Ride', periodType: 'all_time' },
+    { description: 'one year', activityType: null, periodType: 'year' },
+    { description: 'both', activityType: 'Run', periodType: 'year' }
+  ])(
+    'refuses a share scoped to $description without reading the pyramid',
+    async ({ activityType, periodType }) => {
+      // The filters live on the heatmap row; the tiles are built from the
+      // actor's whole history and carry no sport or date. Serving them to a
+      // scoped share publishes every sport and every year, and clipping cannot
+      // catch it because clipping only bounds geography.
+      const segments = await buildHeatmapSegmentsFromTiles(database, {
+        heatmap: { actorId: ACTOR_ID, activityType, periodType },
+        bounds,
+        width: 600,
+        height: 400,
+        regionBounds: []
+      })
+
+      expect(segments).toBeNull()
+      expect(mockDb.getFitnessRouteHeatmapPyramid).not.toHaveBeenCalled()
+      expect(mockDb.getFitnessRouteHeatmapTilesInRange).not.toHaveBeenCalled()
+    }
+  )
+
   it('reads nothing for bounds that enclose no tile row', async () => {
     // Inverted bounds resolve to an empty row range: north is a smaller y in
     // Mercator, so a swapped pair puts minY past maxY. Handing that to the
@@ -138,7 +170,7 @@ describe('buildHeatmapSegmentsFromTiles', () => {
     const inverted = { minLat: 60, maxLat: -60, minLng: 4, maxLng: 5 }
 
     const segments = await buildHeatmapSegmentsFromTiles(database, {
-      actorId: ACTOR_ID,
+      heatmap: scope,
       bounds: inverted,
       width: 600,
       height: 400,
@@ -263,7 +295,7 @@ describe('buildHeatmapSegmentsFromTiles', () => {
     // The range read is a `whereBetween`, which matches nothing when minX
     // exceeds maxX rather than wrapping around.
     await buildHeatmapSegmentsFromTiles(database, {
-      actorId: ACTOR_ID,
+      heatmap: scope,
       bounds: { minLat: -18.2, maxLat: -18.1, minLng: 179.9, maxLng: -179.9 },
       width: 600,
       height: 400,

--- a/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.ts
+++ b/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.ts
@@ -1,0 +1,172 @@
+import type { Database } from '@/lib/database/types'
+import type { RegionBounds } from '@/lib/fitness/regions'
+import type {
+  FitnessRouteHeatmapBounds,
+  FitnessRouteHeatmapSegment
+} from '@/lib/types/database/fitnessRouteHeatmap'
+import { projectWebMercator } from '@/lib/utils/webMercator'
+
+import { TILE_LADDER_ZOOMS, TILE_MAX_ZOOM, TILE_MIN_ZOOM } from './constants'
+import { decodeTile, tilesForBounds } from './tileCodec'
+import {
+  classifyTileAgainstRegion,
+  clipTileSegmentsToRegion
+} from './tileRegion'
+import { HeatmapTileRun, tileRunsToLngLat } from './tileRuns'
+
+/**
+ * A run with its visit count kept, so a renderer can shade by it.
+ *
+ * `FitnessRouteHeatmapSegment` has no count and never will — it describes one
+ * activity's polyline, not a shared stretch of road — so the count rides
+ * alongside rather than being forced into it.
+ */
+export interface HeatmapSegmentWithCount extends FitnessRouteHeatmapSegment {
+  count: number
+}
+
+interface BuildParams {
+  actorId: string
+  bounds: FitnessRouteHeatmapBounds
+  width: number
+  height: number
+  /** The share's own scope. Empty means world; see resolveSharedHeatmapRegionBounds. */
+  regionBounds: RegionBounds[]
+}
+
+/**
+ * The stored rung to render an image of `width` pixels at.
+ *
+ * The same round-UP rule the interactive client uses, for the same reason: a
+ * rung is simplified to one pixel AT ITS OWN zoom, so drawing a coarser one
+ * into a larger image magnifies the simplification. Derived from the image's
+ * own width rather than a viewport, because that is what "one pixel" means
+ * here.
+ */
+export const imageZoomForBounds = (
+  bounds: FitnessRouteHeatmapBounds,
+  width: number,
+  height: number
+): number => {
+  if (!(width > 0) || !(height > 0)) return TILE_MIN_ZOOM
+
+  // Both axes, and the SMALLER wins, because that is how the renderer scales:
+  // `buildHeatmapSvg` fits the projected box with `min(innerWidth / spanX,
+  // innerHeight / spanY)`, so a tall narrow scope in a wide image is limited by
+  // its height. Taking longitude alone would ask for a finer rung than the
+  // image can show and read tiles nobody sees.
+  //
+  // Measured in projected units rather than degrees: a degree of latitude is
+  // not a fixed number of pixels in Mercator, and away from the equator the
+  // difference is large.
+  const topLeft = projectWebMercator(
+    { lat: bounds.maxLat, lng: bounds.minLng },
+    0
+  )
+  const bottomRight = projectWebMercator(
+    { lat: bounds.minLat, lng: bounds.maxLng },
+    0
+  )
+  const spanX = bottomRight.x - topLeft.x
+  const spanY = bottomRight.y - topLeft.y
+  if (!(spanX > 0) || !(spanY > 0)) return TILE_MIN_ZOOM
+
+  const exact = Math.min(Math.log2(width / spanX), Math.log2(height / spanY))
+  const wanted = Math.ceil(exact)
+  if (wanted <= TILE_MIN_ZOOM) return TILE_MIN_ZOOM
+  return (
+    (TILE_LADDER_ZOOMS as readonly number[]).find((zoom) => zoom >= wanted) ??
+    TILE_MAX_ZOOM
+  )
+}
+
+/**
+ * Builds the geometry for a static heatmap image out of the tile pyramid, or
+ * null when the pyramid cannot answer for this actor.
+ *
+ * Null is the caller's signal to keep using the stored blob — an actor with no
+ * completed build, or a build that has since moved on, still has an image to
+ * serve. The downstream point budgets in `staticHeatmapImage` apply unchanged;
+ * this only changes where the geometry comes from, and at what fidelity.
+ *
+ * Clipping to the share's region happens HERE rather than being assumed: the
+ * pyramid is stored unclipped and covers the actor's whole history, so an image
+ * built from it without clipping would publish everywhere they have been. That
+ * is the same boundary the tile routes enforce, and it has to be enforced again
+ * on every path that reads the pyramid.
+ */
+export const buildHeatmapSegmentsFromTiles = async (
+  database: Database,
+  { actorId, bounds, width, height, regionBounds }: BuildParams
+): Promise<HeatmapSegmentWithCount[] | null> => {
+  const pyramid = await database.getFitnessRouteHeatmapPyramid({ actorId })
+  if (!pyramid || pyramid.status !== 'completed' || pyramid.version < 1) {
+    return null
+  }
+
+  const z = imageZoomForBounds(bounds, width, height)
+  const range = tilesForBounds(bounds, z)
+  if (range.maxY < range.minY) return null
+
+  // Two reads when the bounds wrap the antimeridian: `tilesForBounds` answers
+  // `minX > maxX` for a wrap and the range read is a `whereBetween`, which
+  // matches nothing in that state rather than wrapping around.
+  const lastColumn = 2 ** z - 1
+  const spans =
+    range.minX <= range.maxX
+      ? [{ minX: range.minX, maxX: range.maxX }]
+      : [
+          { minX: range.minX, maxX: lastColumn },
+          { minX: 0, maxX: range.maxX }
+        ]
+
+  const rows = (
+    await Promise.all(
+      spans.map((span) =>
+        database.getFitnessRouteHeatmapTilesInRange({
+          actorId,
+          z,
+          minX: span.minX,
+          maxX: span.maxX,
+          minY: range.minY,
+          maxY: range.maxY
+        })
+      )
+    )
+  ).flat()
+
+  const segments: HeatmapSegmentWithCount[] = []
+  for (const row of rows) {
+    // Only the build's own version. A rebuild in flight leaves two versions in
+    // the table at once, and drawing them together shows heat no build ever
+    // produced — the same rule the tile routes apply.
+    if (row.version !== pyramid.version) continue
+
+    // The ROW's own coordinate, not the zoom the query asked for. They agree —
+    // the read is scoped to `z` — but a tile's points are only meaningful
+    // against the tile that stored them, and reading that from anywhere else is
+    // how geometry silently relocates.
+    const { z: rowZ, x, y } = row
+    const overlap = classifyTileAgainstRegion(rowZ, x, y, regionBounds)
+    if (overlap === 'outside') continue
+
+    const decoded = decodeTile(row.segments)
+    const runs: HeatmapTileRun[] = tileRunsToLngLat(
+      rowZ,
+      x,
+      y,
+      overlap === 'partial'
+        ? clipTileSegmentsToRegion(rowZ, x, y, decoded, regionBounds)
+        : decoded
+    )
+
+    for (const run of runs) {
+      // The privacy class is dropped, never the geometry — the same flattening
+      // `flattenPrivacySegmentsForPublic` applies, for the same reason: a hole
+      // or a highlight around home would pinpoint it.
+      segments.push({ count: run.count, points: run.points })
+    }
+  }
+
+  return segments
+}

--- a/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.ts
+++ b/lib/services/fitness-files/heatmapTiles/segmentsFromTiles.ts
@@ -13,6 +13,7 @@ import {
   clipTileSegmentsToRegion
 } from './tileRegion'
 import { HeatmapTileRun, tileRunsToLngLat } from './tileRuns'
+import { buildHeatmapTileSource, isPyramidVariantHeatmap } from './tileSource'
 
 /**
  * A run with its visit count kept, so a renderer can shade by it.
@@ -25,8 +26,21 @@ export interface HeatmapSegmentWithCount extends FitnessRouteHeatmapSegment {
   count: number
 }
 
-interface BuildParams {
+/**
+ * The scope the share was published at, alongside whose history it is.
+ *
+ * Taken as one object rather than as an actor id plus loose filters: the two
+ * have to describe the same row, and splitting them lets a caller pair one
+ * actor's id with another row's scope.
+ */
+interface HeatmapScope {
   actorId: string
+  activityType?: string | null
+  periodType: string
+}
+
+interface BuildParams {
+  heatmap: HeatmapScope
   bounds: FitnessRouteHeatmapBounds
   width: number
   height: number
@@ -89,6 +103,16 @@ export const imageZoomForBounds = (
  * serve. The downstream point budgets in `staticHeatmapImage` apply unchanged;
  * this only changes where the geometry comes from, and at what fidelity.
  *
+ * Two boundaries are enforced here rather than assumed, because every path
+ * that reads the pyramid has to enforce them again.
+ *
+ * The share must be one the pyramid can ANSWER. Tiles are built from the
+ * actor's whole history and the filters live in the row, not in the tiles, so a
+ * share scoped to one sport or one year cannot be served from them at all --
+ * clipping bounds the geography and nothing else, so it cannot catch this.
+ * `buildHeatmapTileSource` is the same predicate the public tile route refuses
+ * on, and it carries the version the rows are then held to.
+ *
  * Clipping to the share's region happens HERE rather than being assumed: the
  * pyramid is stored unclipped and covers the actor's whole history, so an image
  * built from it without clipping would publish everywhere they have been. That
@@ -97,12 +121,16 @@ export const imageZoomForBounds = (
  */
 export const buildHeatmapSegmentsFromTiles = async (
   database: Database,
-  { actorId, bounds, width, height, regionBounds }: BuildParams
+  { heatmap, bounds, width, height, regionBounds }: BuildParams
 ): Promise<HeatmapSegmentWithCount[] | null> => {
+  const { actorId } = heatmap
+  // Before the read, because a variant is not something the pyramid can answer
+  // however complete it is.
+  if (!isPyramidVariantHeatmap(heatmap)) return null
+
   const pyramid = await database.getFitnessRouteHeatmapPyramid({ actorId })
-  if (!pyramid || pyramid.status !== 'completed' || pyramid.version < 1) {
-    return null
-  }
+  const source = buildHeatmapTileSource(heatmap, pyramid)
+  if (!source) return null
 
   const z = imageZoomForBounds(bounds, width, height)
   const range = tilesForBounds(bounds, z)
@@ -140,7 +168,7 @@ export const buildHeatmapSegmentsFromTiles = async (
     // Only the build's own version. A rebuild in flight leaves two versions in
     // the table at once, and drawing them together shows heat no build ever
     // produced — the same rule the tile routes apply.
-    if (row.version !== pyramid.version) continue
+    if (row.version !== source.version) continue
 
     // The ROW's own coordinate, not the zoom the query asked for. They agree —
     // the read is scoped to `z` — but a tile's points are only meaningful

--- a/lib/services/fitness-files/heatmapTiles/tileRuns.ts
+++ b/lib/services/fitness-files/heatmapTiles/tileRuns.ts
@@ -1,0 +1,54 @@
+import type { LatLng } from '@/lib/fitness/regions'
+
+import { TileSegment, tileLocalToLngLat } from './tileCodec'
+
+/**
+ * One drawable run from a tile, in degrees.
+ *
+ * A stored `TileSegment` is meaningless on its own: its points are integers in
+ * the tile's own 0..TILE_EXTENT space, so the same numbers mean different
+ * places in different tiles. Everything downstream of the decode therefore
+ * carries degrees, and the `(z, x, y)` that produced them is consumed here and
+ * never travels further.
+ *
+ * This lives in the service layer rather than beside the map components because
+ * the static image renderer needs it too, and a server module must not import
+ * a value out of `lib/components`.
+ */
+export interface HeatmapTileRun {
+  /** How many distinct activities traced this run; drives colour and opacity. */
+  count: number
+  hidden: boolean
+  points: LatLng[]
+}
+
+/**
+ * Places a decoded tile's runs on the globe.
+ *
+ * Runs of fewer than two points are dropped, matching `buildRouteGeoJson`: one
+ * vertex draws no line, and on a public surface its presence alone would say
+ * something happened there.
+ */
+export const tileRunsToLngLat = (
+  z: number,
+  x: number,
+  y: number,
+  segments: TileSegment[]
+): HeatmapTileRun[] =>
+  segments.flatMap((segment) => {
+    if (segment.points.length < 4) return []
+
+    const points: LatLng[] = []
+    for (let index = 0; index < segment.points.length; index += 2) {
+      points.push(
+        tileLocalToLngLat(
+          z,
+          x,
+          y,
+          segment.points[index],
+          segment.points[index + 1]
+        )
+      )
+    }
+    return [{ count: segment.count, hidden: Boolean(segment.hidden), points }]
+  })

--- a/lib/services/fitness-files/staticHeatmapImage.test.ts
+++ b/lib/services/fitness-files/staticHeatmapImage.test.ts
@@ -1,3 +1,7 @@
+import {
+  HEAT_VISIBLE_BASE_OPACITY,
+  heatOpacityForCount
+} from '@/lib/services/fitness-files/heatmapTiles/constants'
 import { FitnessRouteHeatmapSegment } from '@/lib/types/database/fitnessRouteHeatmap'
 
 import { buildHeatmapSvg, buildMapboxStaticUrl } from './staticHeatmapImage'
@@ -169,5 +173,52 @@ describe('buildHeatmapSvg', () => {
       expect(numbers[index + 1]).toBeGreaterThanOrEqual(0)
       expect(numbers[index + 1]).toBeLessThanOrEqual(420)
     }
+  })
+})
+
+describe('buildHeatmapSvg stroke shading', () => {
+  const bounds = { minLat: 52, maxLat: 52.6, minLng: 5.6, maxLng: 6.2 }
+  const points = [
+    { lat: 52.1, lng: 5.7 },
+    { lat: 52.5, lng: 6.1 }
+  ]
+
+  it('shades a tiled segment by its visit count', () => {
+    // The same `heatOpacityForCount` the interactive map's ramp is generated
+    // from, so a thumbnail and the map it links to read alike.
+    const svg = buildHeatmapSvg({
+      segments: [{ count: 6, points } as never],
+      bounds,
+      width: 600,
+      height: 400
+    })
+    const expected =
+      Math.round(heatOpacityForCount(6, HEAT_VISIBLE_BASE_OPACITY) * 100) / 100
+    expect(svg).toContain(`stroke-opacity="${expected}"`)
+  })
+
+  it('draws a busy road more strongly than a quiet one', () => {
+    const opacityOf = (count: number) => {
+      const svg = buildHeatmapSvg({
+        segments: [{ count, points } as never],
+        bounds,
+        width: 600,
+        height: 400
+      })
+      return Number(/stroke-opacity="([\d.]+)"/.exec(svg)?.[1])
+    }
+    expect(opacityOf(6)).toBeGreaterThan(opacityOf(1))
+  })
+
+  it('keeps the flat opacity for untiled geometry, which has no count', () => {
+    // The blob is one polyline per activity, not a shared stretch of road.
+    // Inventing a count for it would be a lie about how often a road was ridden.
+    const svg = buildHeatmapSvg({
+      segments: [{ points }],
+      bounds,
+      width: 600,
+      height: 400
+    })
+    expect(svg).toContain('stroke-opacity="0.85"')
   })
 })

--- a/lib/services/fitness-files/staticHeatmapImage.ts
+++ b/lib/services/fitness-files/staticHeatmapImage.ts
@@ -106,10 +106,23 @@ export const buildMapboxStaticUrl = ({
   width,
   height,
   token,
-  retina = true
+  retina = true,
+  requireAllOverlays = false
 }: StaticHeatmapImageInput & {
   token: string
   retina?: boolean
+  /**
+   * Refuse rather than truncate.
+   *
+   * The packing loop below drops whatever does not fit the URL budget, which is
+   * the right trade for the stored blob: its overlays are whole activities in
+   * activity order, so the survivors are still spread across the map and
+   * `/auto/` frames the map on them. Tile geometry is ordered by tile, so the
+   * survivors would be one contiguous corner of the view and `/auto/` would
+   * frame the image on that corner. A caller holding a second, coarser source
+   * passes this to find out that the finer one does not fit.
+   */
+  requireAllOverlays?: boolean
 }): string | null => {
   const downsampled = downsampleToBudget(
     usableSegments(segments),
@@ -134,6 +147,7 @@ export const buildMapboxStaticUrl = ({
   }
 
   if (overlays.length === 0) return null
+  if (requireAllOverlays && overlays.length < chunks.length) return null
 
   const size = `${Math.round(width)}x${Math.round(height)}${retina ? '@2x' : ''}`
   return (

--- a/lib/services/fitness-files/staticHeatmapImage.ts
+++ b/lib/services/fitness-files/staticHeatmapImage.ts
@@ -1,4 +1,8 @@
 import {
+  HEAT_VISIBLE_BASE_OPACITY,
+  heatOpacityForCount
+} from '@/lib/services/fitness-files/heatmapTiles/constants'
+import {
   FitnessRouteHeatmapBounds,
   FitnessRouteHeatmapSegment
 } from '@/lib/types/database/fitnessRouteHeatmap'
@@ -140,6 +144,10 @@ export const buildMapboxStaticUrl = ({
 }
 
 const round1 = (value: number) => Math.round(value * 10) / 10
+const round2 = (value: number) => Math.round(value * 100) / 100
+
+/** The flat opacity an untiled polyline has always been drawn at. */
+const STATIC_ROUTE_STROKE_OPACITY = 0.85
 
 const emptyHeatmapSvg = (width: number, height: number): string =>
   `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="Route heatmap">` +
@@ -172,8 +180,12 @@ export const buildHeatmapSvg = ({
   let maxX = Number.NEGATIVE_INFINITY
   let minY = Number.POSITIVE_INFINITY
   let maxY = Number.NEGATIVE_INFINITY
-  const projected = downsampled.map((segment) =>
-    segment.points.map((point) => {
+  const projected = downsampled.map((segment) => ({
+    // Carried through so the stroke can shade by it. A segment from the untiled
+    // blob has no count — it is one activity's polyline, not a shared stretch
+    // of road — and falls back to the flat opacity the image always used.
+    count: (segment as { count?: number }).count,
+    points: segment.points.map((point) => {
       const { x, y } = projectWebMercator(point, 0)
       if (x < minX) minX = x
       if (x > maxX) maxX = x
@@ -181,7 +193,7 @@ export const buildHeatmapSvg = ({
       if (y > maxY) maxY = y
       return { x, y }
     })
-  )
+  }))
 
   const spanX = Math.max(maxX - minX, 1e-9)
   const spanY = Math.max(maxY - minY, 1e-9)
@@ -192,14 +204,23 @@ export const buildHeatmapSvg = ({
   const offsetY = SVG_PADDING + (innerHeight - spanY * scale) / 2
 
   const polylines = projected
-    .map((points) => {
+    .map(({ count, points }) => {
       const coords = points
         .map(
           ({ x, y }) =>
             `${round1((x - minX) * scale + offsetX)},${round1((y - minY) * scale + offsetY)}`
         )
         .join(' ')
-      return `<polyline points="${coords}" fill="none" stroke="#${ROUTE_COLOR_HEX}" stroke-width="1.4" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>`
+      // Shaded by visit count when the geometry came from the pyramid, using
+      // the same `heatOpacityForCount` the interactive map's ramp is generated
+      // from — so a thumbnail and the map it links to read alike. Untiled
+      // geometry keeps the flat opacity: inventing a count for it would be a
+      // lie about how often a road was ridden.
+      const opacity =
+        typeof count === 'number'
+          ? round2(heatOpacityForCount(count, HEAT_VISIBLE_BASE_OPACITY))
+          : STATIC_ROUTE_STROKE_OPACITY
+      return `<polyline points="${coords}" fill="none" stroke="#${ROUTE_COLOR_HEX}" stroke-width="1.4" stroke-opacity="${opacity}" stroke-linecap="round" stroke-linejoin="round"/>`
     })
     .join('')
 


### PR DESCRIPTION
## Why

The share page's preview image and the embed image are drawn from the stored heatmap blob. That blob is simplified **once**, against a single global budget (`DEFAULT_ROUTE_HEATMAP_MAX_POINTS = 80_000`) set by the actor's whole history — so for anyone whose history overruns that cap, every street is drawn at the same flattened fidelity no matter what the image is scoped to, and no street carries any indication of how often it was ridden.

Phase 6 gave the interactive maps a tile pyramid. This gives it to the images, which are what render in a link preview.

## What changed

**`buildHeatmapSegmentsFromTiles`** (new, `lib/services/fitness-files/heatmapTiles/segmentsFromTiles.ts`) reads the pyramid for a view and returns segments the existing renderers already understand.

The rung follows the **image**, not the ground. `buildHeatmapSvg` fits the projected box with `min(innerWidth / spanX, innerHeight / spanY)`, so the zoom is derived from whichever axis actually binds, measured in projected units rather than degrees — a degree of latitude is not a fixed number of pixels in Mercator, and at 52°N it is ~1.6× a degree of longitude. Reading longitude alone asks for a rung finer than the image can draw and fetches tiles nobody sees.

Three things the tile routes already do, done here too:

- geometry is placed with **each row's own `z`/`x`/`y`**, never the rung the view asked for — the same index on a different rung is a different part of the world;
- a view crossing the antimeridian arrives as `minX > maxX` and is read as two spans;
- the region is applied per tile (`outside` skipped, `partial` clipped).

**A scoped share is refused.** The pyramid covers the actor's whole history and carries no sport and no date — those filters live on the heatmap row — so a share scoped to one sport or one year is gated out through `buildHeatmapTileSource`, the same predicate the public tile route refuses on. Region clipping cannot catch this: it bounds geography and nothing else. The builder takes the heatmap row rather than a bare actor id so a scope cannot be paired with the wrong actor's history.

**Every failure keeps the blob.** No completed build, a version-0 build, a read that throws, or a pyramid holding nothing for this view all fall back to the image the owner already had.

**Each renderer chooses its own source.** Tile geometry is one run per way per tile where the blob is ~one polyline per activity, so a street-level view is hundreds of overlays rather than tens, and neither basemap renderer can draw that: Apple refuses past `MAX_SNAPSHOT_OVERLAYS` (24) and Mapbox silently drops whatever overruns its 7000-character URL budget — and since tile runs arrive in tile order, the survivors are one contiguous corner that `/auto/` then frames the whole image on. Each renderer is now offered the tiles first and the blob second: Apple's refusal costs nothing (it happens before anything is signed or fetched), Mapbox gained `requireAllOverlays` so the tiled candidate is refused rather than truncated, and the SVG renderer — which has no ceiling — always takes the tiles.

**Strokes carry their visit count**, using the same `heatOpacityForCount` ramp as the interactive maps. The untiled path keeps its flat opacity.

`tileRunsToLngLat` moved from `lib/components/fitness/` into the service, so a server route no longer imports a runtime value from the components layer.

## Verification

`prettier` → `lint` (0 errors) → `build` → `test` (840 files, 10482 tests) all clean.

Mutation-tested the new and changed logic — every mutant killed except two that are optimizations rather than behaviour (clipping a fully-inside tile is a geometric no-op; the empty-range guard is pinned by its own "does not touch the database" test, added when the mutant survived).

Rendered end to end against a local SQLite fixture: 70 activities over a jittered street grid, folded through the production tiler (`buildTileDeltasForActivity` → `mergeTileDelta` → `encodeTile`), with the blob rebuilt at the retention a history over the 80k cap actually gets. Same row, same extent, rendered both ways:

| | polylines | vertices | distinct opacities |
|---|---|---|---|
| blob | 103 | 1,347 | 1 |
| tiles | 228 | 1,397 | 5 |

The tiled image resolves the street network and shades each street by how often it was ridden; the blob draws every street at one flat weight. Rung selection tracks image size as intended (300×200 → rung 12, 600×400 and up → rung 14, capped by `MAX_DIMENSION = 1200`), and the tile read is bounded by that cap and the fixed ladder, so no caller input can grow it.

Three fixture bugs were found and fixed along the way, each a case of a fixture passing for the wrong reason: a zoom table whose box ran past the north pole, builder bounds that selected rung 10 while the rows fed in were rung 12, and a seed script that omitted `toleranceFloorMeters` — a required argument that Vitest does not typecheck, so `Math.max(undefined, …)` became a `NaN` tolerance and collapsed every route to a straight chord.
