### PR TITLE
Bump version to v1.141.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.141.0",
+  "version": "1.141.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.141.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.141.0`
- Base main SHA: `269ada176260d5d35abf0e421f66fcf3e6ba6d1c`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
