### PR TITLE
Bump version to v1.141.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.141.1",
+  "version": "1.141.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.141.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.141.1`
- Base main SHA: `90c22b1ba0ef37a6465a726d860e5fdc7731b107`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
