### PR TITLE
Bump version to v1.141.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.141.2",
+  "version": "1.141.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.141.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.141.2`
- Base main SHA: `47d321dbc3da45dee44500517eb16dea46ee2140`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
