### PR TITLE
Bump version to v1.143.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.143.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.142.0`
- Base main SHA: `1fd76461ab14086041e10379c870a662b168535a`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
