### PR TITLE
Bump version to v1.143.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.143.0",
+  "version": "1.143.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.143.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.143.0`
- Base main SHA: `737fd19e8af81f5ef20fe4c035c66d6413973ba0`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
