### PR TITLE
Bump version to v1.143.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.143.1",
+  "version": "1.143.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.143.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.143.1`
- Base main SHA: `f7756dc8472469b4f1a29c279f668641b5a3e991`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
