### PR TITLE
Bump version to v1.143.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.143.2",
+  "version": "1.143.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.143.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.143.2`
- Base main SHA: `ebfd5c1653b830c1c5bf048759e8fecd7e4e5951`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
