### PR TITLE
Bump version to v1.143.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.143.3",
+  "version": "1.143.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.143.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.143.3`
- Base main SHA: `0d15baddb968f113b8d8ec11f4976f479f4201b4`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
