### PR TITLE
refactor: extract the deferred-promise test helper into one shared module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1657,8 +1657,10 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   settles it, which is the whole point: the pending render and the settled one
   are separate flushes, so a `Promise.resolve(value)` stand-in collapses them
   into the first `act()` and the assertion about the in-flight state passes
-  vacuously. Thirteen tests across `MessagesPage`, `SearchPageClient` and
-  `FitnessHeatmapView` fail if the helper stops deferring.
+  vacuously. `PostBox attachment ref guard` is the sharpest example — it passes
+  with the bug present unless the two picker batches are sequenced — and
+  thirteen more tests across `MessagesPage`, `SearchPageClient` and
+  `FitnessHeatmapView` fail outright if the helper stops deferring.
 - Prefer unit tests near `lib/` and route tests near `app/`.
 - All tests run in parallel using isolated SQLite in-memory databases. The
   schema is loaded from the committed reference dumps (`migrations/schema*.sql`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1649,6 +1649,16 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   is separately `vi.mock`'d, and forces a type-erasing double-cast. `vi.importMock`
   **is** a valid, documented Vitest API — some review bots incorrectly claim it
   does not exist; do not "fix" it on their say-so.
+- **To control when an awaited call settles, import `createDeferred` from
+  `@/lib/testing/deferred` — do not hand-roll another promise-with-exposed-resolve
+  helper.** The same eight lines had been reimplemented in four test files under
+  three different names before they were extracted. It returns
+  `{ promise, resolve, reject }` and the promise stays **pending** until a test
+  settles it, which is the whole point: the pending render and the settled one
+  are separate flushes, so a `Promise.resolve(value)` stand-in collapses them
+  into the first `act()` and the assertion about the in-flight state passes
+  vacuously. Thirteen tests across `MessagesPage`, `SearchPageClient` and
+  `FitnessHeatmapView` fail if the helper stops deferring.
 - Prefer unit tests near `lib/` and route tests near `app/`.
 - All tests run in parallel using isolated SQLite in-memory databases. The
   schema is loaded from the committed reference dumps (`migrations/schema*.sql`)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -451,6 +451,13 @@ change doesn't touch.
 - Tests are co-located, named `*.test.ts(x)`. `describe`/`it` names are plain
   descriptive text — no `#`/`.` sigil — and read as behavior statements.
   Input/expected-only variations use a table-driven `it.each([...])`.
+- A test that needs to control **when** an awaited call settles imports
+  `createDeferred` from `@/lib/testing/deferred` rather than hand-rolling another
+  promise-with-exposed-resolve helper (the same eight lines had been copied into
+  four files under three names). Its promise stays pending until the test settles
+  it — a `Promise.resolve(value)` stand-in collapses the pending render and the
+  settled one into the same `act()` flush, so the assertion about the in-flight
+  state passes whether or not the code under test is correct.
 - Tests run on **Vitest** (`vi.*`, not `jest.*`). To read a mocked module and
   configure it, prefer **`vi.importMock<T>('@/path')`** over
   `(await import('@/path')) as unknown as T`. `vi.importMock` is purpose-built,

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -457,7 +457,9 @@ change doesn't touch.
   four files under three names). Its promise stays pending until the test settles
   it — a `Promise.resolve(value)` stand-in collapses the pending render and the
   settled one into the same `act()` flush, so the assertion about the in-flight
-  state passes whether or not the code under test is correct.
+  state passes whether or not the code under test is correct. `PostBox
+attachment ref guard` is exactly that: it passed with the bug present until
+  the two picker batches were sequenced.
 - Tests run on **Vitest** (`vi.*`, not `jest.*`). To read a mocked module and
   configure it, prefer **`vi.importMock<T>('@/path')`** over
   `(await import('@/path')) as unknown as T`. `vi.importMock` is purpose-built,

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -18,6 +18,7 @@ import type {
   FitnessRouteHeatmapRegionNameData,
   FitnessRouteHeatmapSummaryData
 } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
 import { loadMaplibreModule } from '@/lib/utils/maplibre'
 
@@ -88,16 +89,6 @@ const mockCancelFitnessRouteHeatmap =
   cancelFitnessRouteHeatmap as jest.MockedFunction<
     typeof cancelFitnessRouteHeatmap
   >
-
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void
-  let reject!: (error: unknown) => void
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve
-    reject = promiseReject
-  })
-  return { promise, resolve, reject }
-}
 
 // A minimal GL map double whose `load` handler fires synchronously, so the map
 // reaches its ready state within the test. `onAddSource` lets a test capture the

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -20,6 +20,7 @@ import {
   searchAccounts
 } from '@/lib/client'
 import type { DirectConversationView } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
@@ -46,22 +47,6 @@ vi.mock('@/lib/components/posts/posts', () => ({
     </div>
   )
 }))
-
-type Deferred<T> = {
-  promise: Promise<T>
-  resolve: (value: T) => void
-  reject: (error: Error) => void
-}
-
-const createDeferred = <T,>(): Deferred<T> => {
-  let resolve!: (value: T) => void
-  let reject!: (error: Error) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
 
 const currentTime = new Date('2026-05-17T12:00:00.000Z').getTime()
 

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { search } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 
 import { SearchPageClient } from './SearchPageClient'
 
@@ -101,16 +102,6 @@ const selectTab = (name: string) => {
     button: 0,
     ctrlKey: false
   })
-}
-
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve
-    reject = promiseReject
-  })
-  return { promise, resolve, reject }
 }
 
 const withoutDOMException = async (callback: () => Promise<void>) => {

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -12,6 +12,7 @@ import {
   uploadAttachment
 } from '@/lib/client'
 import { InstanceLimitsProvider } from '@/lib/components/instance-limits'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
@@ -1381,17 +1382,6 @@ describe('PostBox new post character limit with attachments', () => {
 })
 
 describe('PostBox attachment ref guard', () => {
-  // Lets the test resolve each file's resizeImage step on its own schedule,
-  // rather than the file-name-based Promise.resolve() every other describe
-  // block in this file installs.
-  const deferred = <T,>() => {
-    let resolve!: (value: T) => void
-    const promise = new Promise<T>((res) => {
-      resolve = res
-    })
-    return { promise, resolve }
-  }
-
   beforeEach(() => {
     vi.clearAllMocks()
     global.URL.createObjectURL = vi.fn(() => 'blob:test-media')
@@ -1433,8 +1423,11 @@ describe('PostBox attachment ref guard', () => {
   it('keeps the submitted attachments at the configured cap across two overlapping picker batches', async () => {
     const fileA = new File(['a'], 'a.png', { type: 'image/png' })
     const fileB = new File(['b'], 'b.png', { type: 'image/png' })
-    const resizeA = deferred<File>()
-    const resizeB = deferred<File>()
+    // Each file's resizeImage step settles on its own schedule, rather than
+    // via the file-name-based Promise.resolve() every other describe block in
+    // this file installs.
+    const resizeA = createDeferred<File>()
+    const resizeB = createDeferred<File>()
     resizeImageMock.mockImplementation((file: File) => {
       if (file.name === fileA.name) return resizeA.promise
       if (file.name === fileB.name) return resizeB.promise

--- a/lib/testing/deferred.ts
+++ b/lib/testing/deferred.ts
@@ -1,0 +1,22 @@
+/**
+ * A promise together with the functions that settle it, so a test can decide
+ * exactly when an awaited call resolves or rejects and sequence async React
+ * updates deterministically. Handing a mock `deferred.promise` and resolving it
+ * inside `act()` is what separates the pending render from the settled one — an
+ * already-resolved `Promise.resolve()` collapses both into the first flush.
+ */
+export type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+export const createDeferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}


### PR DESCRIPTION
## Summary

The same eight-line "deferred promise" helper — a promise plus its exposed `resolve` (and sometimes `reject`), used to control exactly when an awaited call settles — had been independently reimplemented in four test files, under two names and three different `reject` signatures. This extracts one copy into `lib/testing/deferred.ts` and migrates all four call sites to it.

| File | Was | Now |
| --- | --- | --- |
| `app/(timeline)/messages/MessagesPage.test.tsx` | `createDeferred` + local `Deferred<T>` type, `reject: (error: Error)` | imports `createDeferred` |
| `app/(timeline)/search/SearchPageClient.test.tsx` | `createDeferred`, `reject: (reason?: unknown)` | imports `createDeferred` |
| `app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx` | `createDeferred`, `reject: (error: unknown)` | imports `createDeferred` |
| `lib/components/post-box/post-box.test.tsx` | `deferred`, no `reject` | imports `createDeferred` |

The shared helper lives in the existing `lib/testing/` directory (alongside `routeTestUtils.ts`) rather than a new one, and keeps the majority name `createDeferred`. Its `reject` is typed `(reason?: unknown) => void`, the widest of the three; only `MessagesPage` calls it, at two sites, both with `new Error(...)`.

This is a pure refactor — no test's behaviour changes, no runtime code is touched, and nothing here ships in a runtime path.

### Why it is worth extracting rather than tolerating

The property that makes this helper useful is that its promise stays **pending** until the test settles it, so the pending render and the settled one are separate `act()` flushes. A `Promise.resolve(value)` stand-in collapses them into the first flush, and any assertion about the in-flight state then passes whether or not the code under test is correct. Four independent reimplementations is four chances to get that subtly wrong, so the rule is now recorded in `AGENTS.md` → Testing Guidelines and `REVIEW.md` → Style, imports & tests.

## Test results

Full gate run in order on the final tree, all exit `0`:

`yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test` (**853 files, 10594 tests passed**).

Beyond the suite passing, the deferral was verified to be load-bearing rather than incidental:

- **Swapping the shared helper for an already-resolved promise fails 13 tests** across `MessagesPage`, `SearchPageClient` and `FitnessHeatmapView` — `ignores stale responses from earlier searches`, `keeps stale thread requests from overwriting the selected conversation`, `shows a loading indicator until the map finishes initializing`, and others that assert on the in-flight render before resolving.
- **`PostBox attachment ref guard` was checked against the bug it guards**, since that test passes even with the bug present if the two picker batches are not sequenced. With the shared helper in place, deleting the `postExtensionRef` cap in `post-box.tsx` fails that test — and only that test. The guard was restored before committing; `post-box.tsx` is unchanged in this PR.

## Notes

The `post-box.test.tsx` copy arrived on `main` with #1498 while this branch was in progress, and was picked up in the third commit here.

**Review loop:** the sub-agent code-review loop (`AGENTS.md` → Code Review Loop) did **not** run — this session is configured not to spawn sub-agents unless explicitly asked. Per `AGENTS.md` → When sub-agents are unavailable, the diff was self-reviewed in one pass against `REVIEW.md` instead (imports, test naming, Vitest API, docs hygiene). Do not read this PR as having been through the loop.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: `AGENTS.md` and `REVIEW.md` record the new convention; grepped `*.md` and `docs/` — nothing else referenced these helpers
- [x] If migrations changed: n/a, no migrations in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
