### PR TITLE
Bump version to v1.144.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.144.0",
+  "version": "1.144.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.144.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.144.0`
- Base main SHA: `6d974d57c73dd4b610cca310f030f40e06b921c3`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
