### PR TITLE
Bump version to v1.144.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.144.1",
+  "version": "1.144.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.144.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.144.1`
- Base main SHA: `f03b064d7628f43f28e44b10ba8c4417ead8d64b`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
