### PR TITLE
Bump version to v1.144.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.144.2",
+  "version": "1.144.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.144.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.144.2`
- Base main SHA: `341fc5f1802405da9de9111d198cd93bf3c41c78`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
