### PR TITLE
Bump version to v1.144.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.144.3",
+  "version": "1.144.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.144.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.144.3`
- Base main SHA: `6bf05c843f4d6c3c1cb2a728266fbf34f9284264`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
