### PR TITLE
fix: make tracing spans nest, link, and always close

### DIFF
--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -13,7 +13,7 @@ import type { Knex } from 'knex'
 
 import { getKnex } from '@/lib/database'
 import { Scope } from '@/lib/types/database/operations'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import type {
   ErrorResponse,
@@ -103,9 +103,10 @@ export const createApplication = async (
   request: PostRequest,
   options: CreateApplicationOptions = {}
 ): Promise<PostResponse> => {
-  return getTracer().startActiveSpan(
+  return withSpan(
+    'api',
     'createApplication',
-    { attributes: { clientName: request.client_name, scopes: request.scopes } },
+    { clientName: request.client_name, scopes: request.scopes },
     async (span) => {
       const scopes = request.scopes ?? Scope.enum.read
       const db = getKnex()
@@ -267,8 +268,6 @@ export const createApplication = async (
         const nodeError = error as NodeJS.ErrnoException
         span.recordException(nodeError)
         return validationErrorResponse()
-      } finally {
-        span.end()
       }
     }
   )

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -14,7 +14,7 @@ import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { generatePublicId } from '@/lib/utils/publicId'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UserAnnounceParams {
   currentActor: Actor
@@ -59,7 +59,7 @@ export const userAnnounce = async ({
   database,
   visibility
 }: UserAnnounceParams) =>
-  getTracer().startActiveSpan('userAnnounce', async (span) => {
+  withSpan('actions', 'userAnnounce', {}, async () => {
     const [originalStatus, actorAnnounceStatus] = await Promise.all([
       database.getStatus({
         statusId,
@@ -69,7 +69,6 @@ export const userAnnounce = async ({
     ])
 
     if (!originalStatus || actorAnnounceStatus) {
-      span.end()
       return null
     }
 
@@ -85,7 +84,6 @@ export const userAnnounce = async ({
       originalStatusId: originalStatus.id
     })
     if (!status) {
-      span.end()
       return null
     }
     await addStatusToTimelines(database, status)
@@ -149,6 +147,5 @@ export const userAnnounce = async ({
       }
     })
 
-    span.end()
     return status
   })

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -38,7 +38,7 @@ import { MENTION_GLOBAL_REGEX } from '@/lib/utils/text/convertMarkdownText'
 import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
 import { getHashtags } from '@/lib/utils/text/getHashtags'
 import { getMentions } from '@/lib/utils/text/getMentions'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 const getNotificationEligibleActorIds = async (
   database: Database,
@@ -347,399 +347,358 @@ export const createNoteFromUserInput = async ({
   language = null,
   application,
   database
-}: CreateNoteFromUserInputParams) => {
-  const span = getSpan('actions', 'createNoteFromUser', { text, replyNoteId })
-  const fitnessFile = fitnessFileId
-    ? await database.getFitnessFile({ id: fitnessFileId })
-    : null
+}: CreateNoteFromUserInputParams) =>
+  withSpan('actions', 'createNoteFromUser', { text, replyNoteId }, async () => {
+    const fitnessFile = fitnessFileId
+      ? await database.getFitnessFile({ id: fitnessFileId })
+      : null
 
-  if (
-    fitnessFileId &&
-    (!fitnessFile ||
-      fitnessFile.actorId !== currentActor.id ||
-      Boolean(fitnessFile.statusId))
-  ) {
-    span.end()
-    return null
-  }
+    if (
+      fitnessFileId &&
+      (!fitnessFile ||
+        fitnessFile.actorId !== currentActor.id ||
+        Boolean(fitnessFile.statusId))
+    ) {
+      return null
+    }
 
-  const replyStatus = replyNoteId
-    ? await database.getStatus({ statusId: replyNoteId, withReplies: false })
-    : null
+    const replyStatus = replyNoteId
+      ? await database.getStatus({ statusId: replyNoteId, withReplies: false })
+      : null
 
-  const postId = generatePublicId()
-  const statusId = getLocalStatusId({
-    actorId: currentActor.id,
-    statusId: postId
-  })
-  const mentions = await getMentions({ text, currentActor, replyStatus })
-  const explicitMentions = getExplicitMentions(text, mentions)
+    const postId = generatePublicId()
+    const statusId = getLocalStatusId({
+      actorId: currentActor.id,
+      statusId: postId
+    })
+    const mentions = await getMentions({ text, currentActor, replyStatus })
+    const explicitMentions = getExplicitMentions(text, mentions)
 
-  // Determine effective visibility:
-  // 1. Use provided visibility if specified
-  // 2. Otherwise inherit from reply status if replying
-  // 3. Default to 'public'
-  const replyVisibility = getVisibilityFromReplyStatus(replyStatus)
-  const effectiveVisibility = visibility ?? replyVisibility ?? 'public'
-  const isReplyingToDirectThread = replyStatus && replyVisibility === 'direct'
-  if (
-    effectiveVisibility === 'direct' &&
-    explicitMentions.length === 0 &&
-    !isReplyingToDirectThread
-  ) {
-    span.end()
-    return null
-  }
-  const recipientMentions =
-    effectiveVisibility === 'direct' &&
-    replyStatus &&
-    replyVisibility !== 'direct'
-      ? explicitMentions
-      : mentions
-  const shouldNotifyReply =
-    Boolean(replyStatus) &&
-    !(
+    // Determine effective visibility:
+    // 1. Use provided visibility if specified
+    // 2. Otherwise inherit from reply status if replying
+    // 3. Default to 'public'
+    const replyVisibility = getVisibilityFromReplyStatus(replyStatus)
+    const effectiveVisibility = visibility ?? replyVisibility ?? 'public'
+    const isReplyingToDirectThread = replyStatus && replyVisibility === 'direct'
+    if (
+      effectiveVisibility === 'direct' &&
+      explicitMentions.length === 0 &&
+      !isReplyingToDirectThread
+    ) {
+      return null
+    }
+    const recipientMentions =
       effectiveVisibility === 'direct' &&
       replyStatus &&
       replyVisibility !== 'direct'
+        ? explicitMentions
+        : mentions
+    const shouldNotifyReply =
+      Boolean(replyStatus) &&
+      !(
+        effectiveVisibility === 'direct' &&
+        replyStatus &&
+        replyVisibility !== 'direct'
+      )
+
+    const to = statusRecipientsTo(
+      currentActor,
+      recipientMentions,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
     )
-
-  const to = statusRecipientsTo(
-    currentActor,
-    recipientMentions,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  )
-  const cc = statusRecipientsCC(
-    currentActor,
-    recipientMentions,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  )
-  const mentionTags = getMentionTagsForStatus({
-    mentions,
-    currentActor,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  })
-
-  const createdStatus = await database.createNote({
-    id: statusId,
-    url: `https://${currentActor.domain}/${getMention(currentActor)}/${postId}`,
-    publicId: postId,
-
-    actorId: currentActor.id,
-
-    text,
-    summary: summary?.trim() || null,
-
-    to,
-    cc,
-
-    reply: replyStatus?.id || '',
-    // A sensitized actor's new statuses are forced sensitive at creation, so
-    // the flag is persisted and federated copies inherit it (Admin moderation).
-    sensitive: sensitive || Boolean(currentActor.sensitizedAt),
-    language,
-    quoteApprovalPolicy,
-    applicationName: application?.name ?? null,
-    applicationWebsite: application?.website ?? null
-  })
-
-  // Quote handling (FEP-044f). The caller has already authorized the quote
-  // (visibility + canQuoteStatus), so record the edge and drive the handshake.
-  // Doing this before the final status re-fetch means the returned status (and
-  // the federated note) already carry the quote edge.
-  if (quotedStatusId) {
-    const quotedStatus = await database.getStatus({
-      statusId: quotedStatusId,
-      withReplies: false
+    const cc = statusRecipientsCC(
+      currentActor,
+      recipientMentions,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
+    )
+    const mentionTags = getMentionTagsForStatus({
+      mentions,
+      currentActor,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
     })
-    if (quotedStatus) {
-      const quotedAuthorId = getOriginalStatus(quotedStatus).actorId
-      if (quotedStatus.isLocalActor) {
-        // We host the quoted author (FEP same-authority shortcut): approve
-        // immediately, no QuoteRequest handshake.
-        await database.createStatusQuote({
-          statusId,
-          quotedStatusId,
-          state: 'accepted'
-        })
-        if (quotedAuthorId !== currentActor.id) {
-          const quoteNotification = await createNotificationWithPolicy(
-            database,
-            {
-              actorId: quotedAuthorId,
-              type: NotificationType.enum.quote,
-              sourceActorId: currentActor.id,
-              statusId,
-              groupKey: `quote:${quotedStatusId}`
-            }
-          )
-          if (quoteNotification && !quoteNotification.filtered) {
-            // Fire-and-forget (sendNotificationAlerts handles its own errors):
-            // alert delivery must not fail the create action.
-            sendNotificationAlerts({
+
+    const createdStatus = await database.createNote({
+      id: statusId,
+      url: `https://${currentActor.domain}/${getMention(currentActor)}/${postId}`,
+      publicId: postId,
+
+      actorId: currentActor.id,
+
+      text,
+      summary: summary?.trim() || null,
+
+      to,
+      cc,
+
+      reply: replyStatus?.id || '',
+      // A sensitized actor's new statuses are forced sensitive at creation, so
+      // the flag is persisted and federated copies inherit it (Admin moderation).
+      sensitive: sensitive || Boolean(currentActor.sensitizedAt),
+      language,
+      quoteApprovalPolicy,
+      applicationName: application?.name ?? null,
+      applicationWebsite: application?.website ?? null
+    })
+
+    // Quote handling (FEP-044f). The caller has already authorized the quote
+    // (visibility + canQuoteStatus), so record the edge and drive the handshake.
+    // Doing this before the final status re-fetch means the returned status (and
+    // the federated note) already carry the quote edge.
+    if (quotedStatusId) {
+      const quotedStatus = await database.getStatus({
+        statusId: quotedStatusId,
+        withReplies: false
+      })
+      if (quotedStatus) {
+        const quotedAuthorId = getOriginalStatus(quotedStatus).actorId
+        if (quotedStatus.isLocalActor) {
+          // We host the quoted author (FEP same-authority shortcut): approve
+          // immediately, no QuoteRequest handshake.
+          await database.createStatusQuote({
+            statusId,
+            quotedStatusId,
+            state: 'accepted'
+          })
+          if (quotedAuthorId !== currentActor.id) {
+            const quoteNotification = await createNotificationWithPolicy(
               database,
-              actorId: quotedAuthorId,
-              sourceActorId: currentActor.id,
-              sourceActor: currentActor,
-              statusId,
-              events: [
-                {
-                  type: NotificationType.enum.quote,
-                  notificationId: quoteNotification.id
-                }
-              ]
-            })
+              {
+                actorId: quotedAuthorId,
+                type: NotificationType.enum.quote,
+                sourceActorId: currentActor.id,
+                statusId,
+                groupKey: `quote:${quotedStatusId}`
+              }
+            )
+            if (quoteNotification && !quoteNotification.filtered) {
+              // Fire-and-forget (sendNotificationAlerts handles its own errors):
+              // alert delivery must not fail the create action.
+              sendNotificationAlerts({
+                database,
+                actorId: quotedAuthorId,
+                sourceActorId: currentActor.id,
+                sourceActor: currentActor,
+                statusId,
+                events: [
+                  {
+                    type: NotificationType.enum.quote,
+                    notificationId: quoteNotification.id
+                  }
+                ]
+              })
+            }
           }
+        } else {
+          // Remote quoted author: create a pending edge and start the
+          // QuoteRequest handshake; their Accept/Reject settles it.
+          const quoteRequestId = `${statusId}#quote-request`
+          await database.createStatusQuote({
+            statusId,
+            quotedStatusId,
+            state: 'pending',
+            quoteRequestId
+          })
+          await getQueue().publish({
+            id: getHashFromString(quoteRequestId),
+            name: SEND_QUOTE_REQUEST_JOB_NAME,
+            data: { actorId: currentActor.id, statusId, quotedStatusId }
+          })
         }
-      } else {
-        // Remote quoted author: create a pending edge and start the
-        // QuoteRequest handshake; their Accept/Reject settles it.
-        const quoteRequestId = `${statusId}#quote-request`
-        await database.createStatusQuote({
-          statusId,
-          quotedStatusId,
-          state: 'pending',
-          quoteRequestId
-        })
-        await getQueue().publish({
-          id: getHashFromString(quoteRequestId),
-          name: SEND_QUOTE_REQUEST_JOB_NAME,
-          data: { actorId: currentActor.id, statusId, quotedStatusId }
-        })
       }
     }
-  }
 
-  // Content-detected language, stored separately from the declared `language`
-  // above so the Translate gate can fall back to it when the author's
-  // declared/default language doesn't match what they actually wrote.
-  await persistDetectedLanguage({ database, statusId, text })
+    // Content-detected language, stored separately from the declared `language`
+    // above so the Translate gate can fall back to it when the author's
+    // declared/default language doesn't match what they actually wrote.
+    await persistDetectedLanguage({ database, statusId, text })
 
-  // Tags must be persisted before timeline rules run so that
-  // notifyRemoteReplyAndMention can verify mentions via tags rather than text
-  // content.
-  const hashtags = getHashtags(text, currentActor.domain)
-  await Promise.all([
-    ...mentionTags.map((mention) =>
-      database.createTag({
-        statusId,
-        name: mention.name || '',
-        value: mention.href,
-        type: 'mention'
-      })
-    ),
-    ...hashtags.map(async (hashtag) => {
-      await database.createTag({
-        statusId,
-        name: hashtag.name,
-        value: hashtag.value,
-        type: 'hashtag',
-        skipSearchIndex: true
-      })
-      await database.increaseHashtagCounter({ hashtag: hashtag.name })
-    })
-  ])
-  if (hashtags.length > 0) {
-    await database.indexHashtagSearchDocuments({
-      hashtags: hashtags.map((hashtag) => hashtag.name)
-    })
-  }
-
-  await persistEmojiTagsForStatus({ database, statusId, text })
-
-  await Promise.all([
-    addStatusToTimelines(database, createdStatus),
-    ...attachments.map((attachment) =>
-      database.createAttachment({
-        actorId: currentActor.id,
-        statusId,
-        mediaType: attachment.mediaType,
-        url: attachment.url,
-        width: attachment.width,
-        height: attachment.height,
-        name: attachment.name,
-        mediaId: attachment.id
-      })
-    )
-  ])
-
-  if (fitnessFile) {
-    await database.updateFitnessFileStatus(fitnessFile.id, statusId)
-  }
-
-  // Create notifications for replies and mentions
-  const notificationMentions =
-    effectiveVisibility === 'direct' &&
-    replyStatus &&
-    replyVisibility === 'direct'
-      ? mentionTags
-      : recipientMentions
-  const eligibleNotificationActorIds = await getNotificationEligibleActorIds(
-    database,
-    [
-      ...(shouldNotifyReply && replyStatus ? [replyStatus.actorId] : []),
-      ...notificationMentions.map((mention) => mention.href)
-    ],
-    currentActor.id
-  )
-
-  // Map actorId → notification promise so we can gate alert dispatch on the verdict.
-  const notificationEntries: Array<
-    [string, ReturnType<typeof createNotificationWithPolicy>]
-  > = []
-
-  // Create reply notification if this is a reply
-  const replyNotifiedActorId =
-    shouldNotifyReply &&
-    replyStatus &&
-    eligibleNotificationActorIds.has(replyStatus.actorId)
-      ? replyStatus.actorId
-      : null
-  if (replyNotifiedActorId && replyStatus) {
-    notificationEntries.push([
-      replyNotifiedActorId,
-      createNotificationWithPolicy(database, {
-        actorId: replyNotifiedActorId,
-        type: NotificationType.enum.reply,
-        sourceActorId: currentActor.id,
-        statusId,
-        groupKey: `reply:${replyStatus.id}`
+    // Tags must be persisted before timeline rules run so that
+    // notifyRemoteReplyAndMention can verify mentions via tags rather than text
+    // content.
+    const hashtags = getHashtags(text, currentActor.domain)
+    await Promise.all([
+      ...mentionTags.map((mention) =>
+        database.createTag({
+          statusId,
+          name: mention.name || '',
+          value: mention.href,
+          type: 'mention'
+        })
+      ),
+      ...hashtags.map(async (hashtag) => {
+        await database.createTag({
+          statusId,
+          name: hashtag.name,
+          value: hashtag.value,
+          type: 'hashtag',
+          skipSearchIndex: true
+        })
+        await database.increaseHashtagCounter({ hashtag: hashtag.name })
       })
     ])
-  }
-
-  // Create mention notifications
-  for (const mention of notificationMentions) {
-    const mentionedActorId = mention.href
-    // A reply that also mentions the parent author is a single event: the reply
-    // notification above already covers them, so skip the duplicate mention one.
-    if (mentionedActorId === replyNotifiedActorId) {
-      continue
+    if (hashtags.length > 0) {
+      await database.indexHashtagSearchDocuments({
+        hashtags: hashtags.map((hashtag) => hashtag.name)
+      })
     }
-    // Don't create notification for self-mentions
-    if (eligibleNotificationActorIds.has(mentionedActorId)) {
+
+    await persistEmojiTagsForStatus({ database, statusId, text })
+
+    await Promise.all([
+      addStatusToTimelines(database, createdStatus),
+      ...attachments.map((attachment) =>
+        database.createAttachment({
+          actorId: currentActor.id,
+          statusId,
+          mediaType: attachment.mediaType,
+          url: attachment.url,
+          width: attachment.width,
+          height: attachment.height,
+          name: attachment.name,
+          mediaId: attachment.id
+        })
+      )
+    ])
+
+    if (fitnessFile) {
+      await database.updateFitnessFileStatus(fitnessFile.id, statusId)
+    }
+
+    // Create notifications for replies and mentions
+    const notificationMentions =
+      effectiveVisibility === 'direct' &&
+      replyStatus &&
+      replyVisibility === 'direct'
+        ? mentionTags
+        : recipientMentions
+    const eligibleNotificationActorIds = await getNotificationEligibleActorIds(
+      database,
+      [
+        ...(shouldNotifyReply && replyStatus ? [replyStatus.actorId] : []),
+        ...notificationMentions.map((mention) => mention.href)
+      ],
+      currentActor.id
+    )
+
+    // Map actorId → notification promise so we can gate alert dispatch on the verdict.
+    const notificationEntries: Array<
+      [string, ReturnType<typeof createNotificationWithPolicy>]
+    > = []
+
+    // Create reply notification if this is a reply
+    const replyNotifiedActorId =
+      shouldNotifyReply &&
+      replyStatus &&
+      eligibleNotificationActorIds.has(replyStatus.actorId)
+        ? replyStatus.actorId
+        : null
+    if (replyNotifiedActorId && replyStatus) {
       notificationEntries.push([
-        mentionedActorId,
+        replyNotifiedActorId,
         createNotificationWithPolicy(database, {
-          actorId: mentionedActorId,
-          type: NotificationType.enum.mention,
+          actorId: replyNotifiedActorId,
+          type: NotificationType.enum.reply,
           sourceActorId: currentActor.id,
           statusId,
-          groupKey: `mention:${statusId}`
+          groupKey: `reply:${replyStatus.id}`
         })
       ])
     }
-  }
 
-  // Only send push/email alerts for notifications that were accepted (non-null, filtered=false).
-  const notificationResults = await Promise.all(
-    notificationEntries.map(([, p]) => p)
-  )
-  const alertActorIds = new Set(
-    notificationEntries
-      .filter((_, i) => {
-        const n = notificationResults[i]
-        return n && !n.filtered
-      })
-      .map(([actorId]) => actorId)
-  )
-  // Map each alerted actor to its accepted notification id so the Mastodon Web
-  // Push payload can carry `notification_id`. Each actor has at most one
-  // accepted notification here (reply and mention to the same actor are deduped
-  // above), so a last-write-wins map is sufficient.
-  const notificationIdByActorId = new Map<string, string>()
-  notificationEntries.forEach(([actorId], i) => {
-    const n = notificationResults[i]
-    if (n && !n.filtered) {
-      notificationIdByActorId.set(actorId, n.id)
+    // Create mention notifications
+    for (const mention of notificationMentions) {
+      const mentionedActorId = mention.href
+      // A reply that also mentions the parent author is a single event: the reply
+      // notification above already covers them, so skip the duplicate mention one.
+      if (mentionedActorId === replyNotifiedActorId) {
+        continue
+      }
+      // Don't create notification for self-mentions
+      if (eligibleNotificationActorIds.has(mentionedActorId)) {
+        notificationEntries.push([
+          mentionedActorId,
+          createNotificationWithPolicy(database, {
+            actorId: mentionedActorId,
+            type: NotificationType.enum.mention,
+            sourceActorId: currentActor.id,
+            statusId,
+            groupKey: `mention:${statusId}`
+          })
+        ])
+      }
     }
-  })
 
-  const status = (await database.getStatus({
-    statusId,
-    withReplies: false
-  })) as StatusNote
-  if (!status) {
-    span.end()
-    return null
-  }
-
-  // Dispatch notification alerts (push + email) per target, fire-and-forget.
-  // Uses the fetched status (with actor info) to build email content.
-  const seenActorIds = new Set<string>()
-
-  if (
-    shouldNotifyReply &&
-    replyStatus &&
-    alertActorIds.has(replyStatus.actorId)
-  ) {
-    seenActorIds.add(replyStatus.actorId)
-    database
-      .getActorFromId({ id: replyStatus.actorId })
-      // A failed actor lookup only skips the email content; the push alert
-      // must still be dispatched.
-      .catch(() => null)
-      .then((targetActor) =>
-        sendNotificationAlerts({
-          database,
-          actorId: replyStatus.actorId,
-          sourceActorId: currentActor.id,
-          sourceActor: currentActor,
-          statusId,
-          events: [
-            {
-              type: NotificationType.enum.reply,
-              notificationId: notificationIdByActorId.get(replyStatus.actorId),
-              emailContent: targetActor?.account
-                ? {
-                    recipientEmail: targetActor.account.email,
-                    ...buildReplyEmail({
-                      recipient: targetActor,
-                      actor: currentActor,
-                      status
-                    })
-                  }
-                : undefined
-            }
-          ]
+    // Only send push/email alerts for notifications that were accepted (non-null, filtered=false).
+    const notificationResults = await Promise.all(
+      notificationEntries.map(([, p]) => p)
+    )
+    const alertActorIds = new Set(
+      notificationEntries
+        .filter((_, i) => {
+          const n = notificationResults[i]
+          return n && !n.filtered
         })
-      )
-      .catch(() => undefined)
-  }
+        .map(([actorId]) => actorId)
+    )
+    // Map each alerted actor to its accepted notification id so the Mastodon Web
+    // Push payload can carry `notification_id`. Each actor has at most one
+    // accepted notification here (reply and mention to the same actor are deduped
+    // above), so a last-write-wins map is sufficient.
+    const notificationIdByActorId = new Map<string, string>()
+    notificationEntries.forEach(([actorId], i) => {
+      const n = notificationResults[i]
+      if (n && !n.filtered) {
+        notificationIdByActorId.set(actorId, n.id)
+      }
+    })
 
-  for (const mention of notificationMentions) {
-    const mentionedActorId = mention.href
+    const status = (await database.getStatus({
+      statusId,
+      withReplies: false
+    })) as StatusNote
+    if (!status) {
+      return null
+    }
+
+    // Dispatch notification alerts (push + email) per target, fire-and-forget.
+    // Uses the fetched status (with actor info) to build email content.
+    const seenActorIds = new Set<string>()
+
     if (
-      !seenActorIds.has(mentionedActorId) &&
-      alertActorIds.has(mentionedActorId)
+      shouldNotifyReply &&
+      replyStatus &&
+      alertActorIds.has(replyStatus.actorId)
     ) {
-      seenActorIds.add(mentionedActorId)
+      seenActorIds.add(replyStatus.actorId)
       database
-        .getActorFromId({ id: mentionedActorId })
+        .getActorFromId({ id: replyStatus.actorId })
         // A failed actor lookup only skips the email content; the push alert
         // must still be dispatched.
         .catch(() => null)
         .then((targetActor) =>
           sendNotificationAlerts({
             database,
-            actorId: mentionedActorId,
+            actorId: replyStatus.actorId,
             sourceActorId: currentActor.id,
             sourceActor: currentActor,
             statusId,
             events: [
               {
-                type: NotificationType.enum.mention,
-                notificationId: notificationIdByActorId.get(mentionedActorId),
+                type: NotificationType.enum.reply,
+                notificationId: notificationIdByActorId.get(
+                  replyStatus.actorId
+                ),
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,
-                      ...buildMentionEmail({
+                      ...buildReplyEmail({
                         recipient: targetActor,
                         actor: currentActor,
                         status
@@ -752,36 +711,75 @@ export const createNoteFromUserInput = async ({
         )
         .catch(() => undefined)
     }
-  }
 
-  if (fitnessFile) {
-    await getQueue().publish({
-      id: getHashFromString(status.id),
-      name: PROCESS_FITNESS_FILE_JOB_NAME,
-      data: {
-        actorId: currentActor.id,
-        statusId: status.id,
-        fitnessFileId: fitnessFile.id
+    for (const mention of notificationMentions) {
+      const mentionedActorId = mention.href
+      if (
+        !seenActorIds.has(mentionedActorId) &&
+        alertActorIds.has(mentionedActorId)
+      ) {
+        seenActorIds.add(mentionedActorId)
+        database
+          .getActorFromId({ id: mentionedActorId })
+          // A failed actor lookup only skips the email content; the push alert
+          // must still be dispatched.
+          .catch(() => null)
+          .then((targetActor) =>
+            sendNotificationAlerts({
+              database,
+              actorId: mentionedActorId,
+              sourceActorId: currentActor.id,
+              sourceActor: currentActor,
+              statusId,
+              events: [
+                {
+                  type: NotificationType.enum.mention,
+                  notificationId: notificationIdByActorId.get(mentionedActorId),
+                  emailContent: targetActor?.account
+                    ? {
+                        recipientEmail: targetActor.account.email,
+                        ...buildMentionEmail({
+                          recipient: targetActor,
+                          actor: currentActor,
+                          status
+                        })
+                      }
+                    : undefined
+                }
+              ]
+            })
+          )
+          .catch(() => undefined)
       }
-    })
-  } else {
-    await getQueue().publish({
-      id: getHashFromString(status.id),
-      name: SEND_NOTE_JOB_NAME,
-      data: {
-        actorId: currentActor.id,
-        statusId: status.id
-      }
-    })
-  }
+    }
 
-  // Scheduled AFTER the send/process job is published, because on the default
-  // in-process queue `publish` runs the handler inline — so doing this first
-  // made a link post wait on a third-party fetch before it federated. It never
-  // throws (see syncStatusLinkPreview), so a preview failure cannot fail a post
-  // that is already written and already on its way out.
-  await syncStatusLinkPreview({ database, status })
+    if (fitnessFile) {
+      await getQueue().publish({
+        id: getHashFromString(status.id),
+        name: PROCESS_FITNESS_FILE_JOB_NAME,
+        data: {
+          actorId: currentActor.id,
+          statusId: status.id,
+          fitnessFileId: fitnessFile.id
+        }
+      })
+    } else {
+      await getQueue().publish({
+        id: getHashFromString(status.id),
+        name: SEND_NOTE_JOB_NAME,
+        data: {
+          actorId: currentActor.id,
+          statusId: status.id
+        }
+      })
+    }
 
-  span.end()
-  return status
-}
+    // Scheduled AFTER the send/process job is published, because on the default
+    // in-process queue `publish` runs the handler inline — so doing this first
+    // made a link post wait on a third-party fetch before it federated. It never
+    // throws (see syncStatusLinkPreview), so a preview failure cannot fail a post
+    // that is already written and already on its way out.
+    await syncStatusLinkPreview({ database, status })
+
+    return status
+  })

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -16,7 +16,7 @@ import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { generatePublicId } from '@/lib/utils/publicId'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 import { getMentions } from '@/lib/utils/text/getMentions'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface CreatePollFromUserInputParams {
   text: string
@@ -50,114 +50,112 @@ export const createPollFromUserInput = async ({
   sensitive = false,
   language = null,
   application
-}: CreatePollFromUserInputParams) => {
-  const config = getConfig()
-  const span = getSpan('actions', 'createPollFromUser', {
-    replyStatusId
-  })
-  const replyStatus = replyStatusId
-    ? await database.getStatus({ statusId: replyStatusId, withReplies: false })
-    : null
+}: CreatePollFromUserInputParams) =>
+  withSpan('actions', 'createPollFromUser', { replyStatusId }, async () => {
+    const config = getConfig()
+    const replyStatus = replyStatusId
+      ? await database.getStatus({
+          statusId: replyStatusId,
+          withReplies: false
+        })
+      : null
 
-  const postId = generatePublicId()
-  const statusId = getLocalStatusId({
-    actorId: currentActor.id,
-    statusId: postId
-  })
-  const mentions = await getMentions({ text, currentActor, replyStatus })
-  const explicitMentions = getExplicitMentions(text, mentions)
+    const postId = generatePublicId()
+    const statusId = getLocalStatusId({
+      actorId: currentActor.id,
+      statusId: postId
+    })
+    const mentions = await getMentions({ text, currentActor, replyStatus })
+    const explicitMentions = getExplicitMentions(text, mentions)
 
-  // Determine effective visibility:
-  // 1. Use explicit visibility if provided
-  // 2. Inherit from reply status if replying
-  // 3. Default to 'public'
-  const replyVisibility = getVisibilityFromReplyStatus(replyStatus)
-  const effectiveVisibility = visibility ?? replyVisibility ?? 'public'
-  const isReplyingToDirectThread = replyStatus && replyVisibility === 'direct'
-  if (
-    effectiveVisibility === 'direct' &&
-    explicitMentions.length === 0 &&
-    !isReplyingToDirectThread
-  ) {
-    span.end()
-    return null
-  }
-  const recipientMentions =
-    effectiveVisibility === 'direct' &&
-    replyStatus &&
-    replyVisibility !== 'direct'
-      ? explicitMentions
-      : mentions
+    // Determine effective visibility:
+    // 1. Use explicit visibility if provided
+    // 2. Inherit from reply status if replying
+    // 3. Default to 'public'
+    const replyVisibility = getVisibilityFromReplyStatus(replyStatus)
+    const effectiveVisibility = visibility ?? replyVisibility ?? 'public'
+    const isReplyingToDirectThread = replyStatus && replyVisibility === 'direct'
+    if (
+      effectiveVisibility === 'direct' &&
+      explicitMentions.length === 0 &&
+      !isReplyingToDirectThread
+    ) {
+      return null
+    }
+    const recipientMentions =
+      effectiveVisibility === 'direct' &&
+      replyStatus &&
+      replyVisibility !== 'direct'
+        ? explicitMentions
+        : mentions
 
-  const to = statusRecipientsTo(
-    currentActor,
-    recipientMentions,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  )
-  const cc = statusRecipientsCC(
-    currentActor,
-    recipientMentions,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  )
-  const mentionTags = getMentionTagsForStatus({
-    mentions,
-    currentActor,
-    replyStatus,
-    effectiveVisibility,
-    replyVisibility
-  })
-
-  const createdPoll = await database.createPoll({
-    id: statusId,
-    url: `https://${currentActor.domain}/${getMention(currentActor)}/${postId}`,
-    publicId: postId,
-    actorId: currentActor.id,
-    text: convertMarkdownText(config.host)(text),
-    summary: summary?.trim() || null,
-    to,
-    cc,
-    reply: replyStatus?.id || '',
-    choices,
-    endAt,
-    pollType,
-    hideTotals,
-    // A sensitized actor's new statuses are forced sensitive at creation, so
-    // the flag is persisted and federated copies inherit it (Admin moderation).
-    sensitive: sensitive || Boolean(currentActor.sensitizedAt),
-    language,
-    applicationName: application?.name ?? null,
-    applicationWebsite: application?.website ?? null
-  })
-
-  // Content-detected language, stored separately from the declared `language`
-  // above so the Translate gate can fall back to it when the author's
-  // declared/default language doesn't match what they actually wrote.
-  await persistDetectedLanguage({ database, statusId, text })
-
-  await Promise.all([
-    addStatusToTimelines(database, createdPoll),
-    ...mentionTags.map((mention) =>
-      database.createTag({
-        statusId,
-        name: mention.name || '',
-        value: mention.href,
-        type: 'mention'
-      })
+    const to = statusRecipientsTo(
+      currentActor,
+      recipientMentions,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
     )
-  ])
+    const cc = statusRecipientsCC(
+      currentActor,
+      recipientMentions,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
+    )
+    const mentionTags = getMentionTagsForStatus({
+      mentions,
+      currentActor,
+      replyStatus,
+      effectiveVisibility,
+      replyVisibility
+    })
 
-  await persistEmojiTagsForStatus({ database, statusId, text })
+    const createdPoll = await database.createPoll({
+      id: statusId,
+      url: `https://${currentActor.domain}/${getMention(currentActor)}/${postId}`,
+      publicId: postId,
+      actorId: currentActor.id,
+      text: convertMarkdownText(config.host)(text),
+      summary: summary?.trim() || null,
+      to,
+      cc,
+      reply: replyStatus?.id || '',
+      choices,
+      endAt,
+      pollType,
+      hideTotals,
+      // A sensitized actor's new statuses are forced sensitive at creation, so
+      // the flag is persisted and federated copies inherit it (Admin moderation).
+      sensitive: sensitive || Boolean(currentActor.sensitizedAt),
+      language,
+      applicationName: application?.name ?? null,
+      applicationWebsite: application?.website ?? null
+    })
 
-  const status = await database.getStatus({ statusId, withReplies: false })
-  if (!status) {
-    span.end()
-    return null
-  }
+    // Content-detected language, stored separately from the declared `language`
+    // above so the Translate gate can fall back to it when the author's
+    // declared/default language doesn't match what they actually wrote.
+    await persistDetectedLanguage({ database, statusId, text })
 
-  span.end()
-  return status
-}
+    await Promise.all([
+      addStatusToTimelines(database, createdPoll),
+      ...mentionTags.map((mention) =>
+        database.createTag({
+          statusId,
+          name: mention.name || '',
+          value: mention.href,
+          type: 'mention'
+        })
+      )
+    ])
+
+    await persistEmojiTagsForStatus({ database, statusId, text })
+
+    const status = await database.getStatus({ statusId, withReplies: false })
+    if (!status) {
+      return null
+    }
+
+    return status
+  })

--- a/lib/actions/deleteStatus.ts
+++ b/lib/actions/deleteStatus.ts
@@ -4,7 +4,7 @@ import { getFederatedStatusDeliveryInboxes } from '@/lib/services/federation/sta
 import { Actor } from '@/lib/types/domain/actor'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getVisibility } from '@/lib/utils/getVisibility'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface DeleteStatusFromUserInputParams {
   currentActor: Actor
@@ -15,45 +15,42 @@ export const deleteStatusFromUserInput = async ({
   currentActor,
   statusId,
   database
-}: DeleteStatusFromUserInputParams): Promise<void> => {
-  const span = getSpan('actions', 'deleteNote', { statusId })
-  const originalStatus = await database.getStatus({
-    statusId,
-    withReplies: false
-  })
-  if (!originalStatus) {
-    span.end()
-    return
-  }
-  const normalizedCurrentActorId = normalizeActorId(currentActor.id)
-  const normalizedStatusActorId = normalizeActorId(originalStatus.actorId)
-  if (
-    !normalizedCurrentActorId ||
-    !normalizedStatusActorId ||
-    normalizedCurrentActorId !== normalizedStatusActorId
-  ) {
-    span.end()
-    return
-  }
-
-  const inboxes = await getFederatedStatusDeliveryInboxes({
-    database,
-    currentActor,
-    status: originalStatus
-  })
-  const isDirect =
-    getVisibility(originalStatus.to, originalStatus.cc) === 'direct'
-  await Promise.all(
-    inboxes.map((inbox) => {
-      return deleteStatus({
-        currentActor,
-        inbox,
-        statusId,
-        to: isDirect ? originalStatus.to : undefined,
-        cc: isDirect ? originalStatus.cc : undefined
-      })
+}: DeleteStatusFromUserInputParams): Promise<void> =>
+  withSpan('actions', 'deleteNote', { statusId }, async () => {
+    const originalStatus = await database.getStatus({
+      statusId,
+      withReplies: false
     })
-  )
-  await database.deleteStatus({ statusId, actorId: currentActor.id })
-  span.end()
-}
+    if (!originalStatus) {
+      return
+    }
+    const normalizedCurrentActorId = normalizeActorId(currentActor.id)
+    const normalizedStatusActorId = normalizeActorId(originalStatus.actorId)
+    if (
+      !normalizedCurrentActorId ||
+      !normalizedStatusActorId ||
+      normalizedCurrentActorId !== normalizedStatusActorId
+    ) {
+      return
+    }
+
+    const inboxes = await getFederatedStatusDeliveryInboxes({
+      database,
+      currentActor,
+      status: originalStatus
+    })
+    const isDirect =
+      getVisibility(originalStatus.to, originalStatus.cc) === 'direct'
+    await Promise.all(
+      inboxes.map((inbox) => {
+        return deleteStatus({
+          currentActor,
+          inbox,
+          statusId,
+          to: isDirect ? originalStatus.to : undefined,
+          cc: isDirect ? originalStatus.cc : undefined
+        })
+      })
+    )
+    await database.deleteStatus({ statusId, actorId: currentActor.id })
+  })

--- a/lib/actions/revokeStatusQuote.ts
+++ b/lib/actions/revokeStatusQuote.ts
@@ -4,7 +4,7 @@ import { getQueue } from '@/lib/services/queue'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status, getOriginalStatus } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface RevokeStatusQuoteFromUserInput {
   currentActor: Actor
@@ -32,67 +32,63 @@ export const revokeStatusQuoteFromUserInput = async ({
   quotedStatusId,
   quotingStatusId,
   database
-}: RevokeStatusQuoteFromUserInput): Promise<RevokeStatusQuoteResult> => {
-  const span = getSpan('actions', 'revokeStatusQuoteFromUser', {
-    quotedStatusId,
-    quotingStatusId
-  })
-
-  const quotedStatus = await database.getStatus({
-    statusId: quotedStatusId,
-    withReplies: false
-  })
-  if (!quotedStatus) {
-    span.end()
-    return { ok: false, reason: 'not_found' }
-  }
-  if (getOriginalStatus(quotedStatus).actorId !== currentActor.id) {
-    span.end()
-    return { ok: false, reason: 'forbidden' }
-  }
-
-  // The edge must exist and actually link these two statuses.
-  const edge = await database.getStatusQuote({ statusId: quotingStatusId })
-  if (!edge || edge.quotedStatusId !== quotedStatusId) {
-    span.end()
-    return { ok: false, reason: 'not_found' }
-  }
-
-  // One-way state machine: accepted -> revoked; already-revoked is a no-op
-  // (idempotent). `authorizationUri` is preserved so we can still address the
-  // Delete below.
-  await database.updateStatusQuoteState({
-    statusId: quotingStatusId,
-    state: 'revoked'
-  })
-
-  const quotingStatus = await database.getStatus({
-    statusId: quotingStatusId,
-    withReplies: false
-  })
-  if (!quotingStatus) {
-    span.end()
-    return { ok: false, reason: 'not_found' }
-  }
-
-  // Federate the stamp revocation (best-effort). The job fans the Delete out to
-  // the quoting author's inbox and every named recipient of the quoting note, so
-  // every server that saw the quote honors the revocation (FEP-044f). Only when
-  // a hosted stamp was actually issued and the quoter is a different actor.
-  const quotingActorId = getOriginalStatus(quotingStatus).actorId
-  if (edge.authorizationUri && quotingActorId !== currentActor.id) {
-    await getQueue().publish({
-      id: getHashFromString(`${edge.authorizationUri}#revoke`),
-      name: SEND_QUOTE_REVOKE_JOB_NAME,
-      data: {
-        actorId: currentActor.id,
-        quotingActorId,
-        quotingStatusId,
-        stampId: edge.authorizationUri
+}: RevokeStatusQuoteFromUserInput): Promise<RevokeStatusQuoteResult> =>
+  withSpan(
+    'actions',
+    'revokeStatusQuoteFromUser',
+    { quotedStatusId, quotingStatusId },
+    async () => {
+      const quotedStatus = await database.getStatus({
+        statusId: quotedStatusId,
+        withReplies: false
+      })
+      if (!quotedStatus) {
+        return { ok: false, reason: 'not_found' }
       }
-    })
-  }
+      if (getOriginalStatus(quotedStatus).actorId !== currentActor.id) {
+        return { ok: false, reason: 'forbidden' }
+      }
 
-  span.end()
-  return { ok: true, status: quotingStatus }
-}
+      // The edge must exist and actually link these two statuses.
+      const edge = await database.getStatusQuote({ statusId: quotingStatusId })
+      if (!edge || edge.quotedStatusId !== quotedStatusId) {
+        return { ok: false, reason: 'not_found' }
+      }
+
+      // One-way state machine: accepted -> revoked; already-revoked is a no-op
+      // (idempotent). `authorizationUri` is preserved so we can still address the
+      // Delete below.
+      await database.updateStatusQuoteState({
+        statusId: quotingStatusId,
+        state: 'revoked'
+      })
+
+      const quotingStatus = await database.getStatus({
+        statusId: quotingStatusId,
+        withReplies: false
+      })
+      if (!quotingStatus) {
+        return { ok: false, reason: 'not_found' }
+      }
+
+      // Federate the stamp revocation (best-effort). The job fans the Delete out to
+      // the quoting author's inbox and every named recipient of the quoting note, so
+      // every server that saw the quote honors the revocation (FEP-044f). Only when
+      // a hosted stamp was actually issued and the quoter is a different actor.
+      const quotingActorId = getOriginalStatus(quotingStatus).actorId
+      if (edge.authorizationUri && quotingActorId !== currentActor.id) {
+        await getQueue().publish({
+          id: getHashFromString(`${edge.authorizationUri}#revoke`),
+          name: SEND_QUOTE_REVOKE_JOB_NAME,
+          data: {
+            actorId: currentActor.id,
+            quotingActorId,
+            quotingStatusId,
+            stampId: edge.authorizationUri
+          }
+        })
+      }
+
+      return { ok: true, status: quotingStatus }
+    }
+  )

--- a/lib/actions/undoAnnounce.ts
+++ b/lib/actions/undoAnnounce.ts
@@ -4,7 +4,7 @@ import { getQueue } from '@/lib/services/queue'
 import { Actor } from '@/lib/types/domain/actor'
 import { StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UserUndoAnnounceParams {
   currentActor: Actor
@@ -17,16 +17,14 @@ export const userUndoAnnounce = async ({
   database,
   statusId
 }: UserUndoAnnounceParams) =>
-  getTracer().startActiveSpan('userUndoAnnounce', async (span) => {
+  withSpan('actions', 'userUndoAnnounce', {}, async (span) => {
     const status = await database.getStatus({ statusId, withReplies: false })
     if (!status || status.type !== StatusType.enum.Announce) {
-      span.end()
       return null
     }
 
     if (status.actorId !== currentActor.id) {
       span.setAttribute('unauthorized', true)
-      span.end()
       return null
     }
 
@@ -40,6 +38,5 @@ export const userUndoAnnounce = async ({
       }
     })
 
-    span.end()
     return status
   })

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -10,7 +10,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UpdateNoteFromUserInput {
   statusId: string
@@ -36,83 +36,80 @@ export const updateNoteFromUserInput = async ({
   publish = true,
   status: preloadedStatus,
   database
-}: UpdateNoteFromUserInput) => {
-  const span = getSpan('actions', 'updateNoteFromUser', { statusId })
-  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
-  if (
-    !status ||
-    status.id !== statusId ||
-    status.type !== StatusType.enum.Note ||
-    status.actorId !== currentActor.id
-  ) {
-    span.end()
-    return null
-  }
+}: UpdateNoteFromUserInput) =>
+  withSpan('actions', 'updateNoteFromUser', { statusId }, async () => {
+    const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+    if (
+      !status ||
+      status.id !== statusId ||
+      status.type !== StatusType.enum.Note ||
+      status.actorId !== currentActor.id
+    ) {
+      return null
+    }
 
-  let updatedStatus = await database.updateNote({
-    statusId,
-    summary: summary === undefined ? status.summary : summary?.trim() || null,
-    text: text ?? status.text,
-    ...(attachments !== undefined ? { attachments } : {}),
-    ...(sensitive !== undefined ? { sensitive } : {}),
-    ...(language !== undefined ? { language } : {})
+    let updatedStatus = await database.updateNote({
+      statusId,
+      summary: summary === undefined ? status.summary : summary?.trim() || null,
+      text: text ?? status.text,
+      ...(attachments !== undefined ? { attachments } : {}),
+      ...(sensitive !== undefined ? { sensitive } : {}),
+      ...(language !== undefined ? { language } : {})
+    })
+    if (!updatedStatus) {
+      return null
+    }
+
+    // Re-sync emoji tags when the text changes so newly added `:shortcode:`
+    // tokens federate and removed ones stop federating, then re-fetch so the
+    // returned status and the timeline cache reflect the re-synced tags (mirroring
+    // createNoteFromUserInput).
+    if (text !== undefined) {
+      await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
+      await persistEmojiTagsForStatus({ database, statusId, text })
+
+      // Re-detect the content language alongside the edit; the previous
+      // detection (if any) is stale once the text changes — persistDetectedLanguage
+      // clears the old row when the new text no longer detects confidently.
+      await persistDetectedLanguage({ database, statusId, text })
+
+      updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
+    }
+
+    await addStatusToTimelines(database, updatedStatus)
+
+    if (publish) {
+      await getQueue().publish({
+        id: getHashFromString(statusId),
+        name: SEND_UPDATE_NOTE_JOB_NAME,
+        data: {
+          actorId: currentActor.id,
+          statusId
+        }
+      })
+
+      // Notify the authors of accepted quotes of this status that a post they
+      // quoted was edited. Only published (federated) edits notify quoters.
+      await notifyQuotedStatusUpdate({
+        database,
+        quotedStatusId: statusId,
+        sourceActorId: currentActor.id,
+        sourceActor: currentActor
+      })
+    }
+
+    // The edit may have added, changed or removed the link the card was for.
+    // Only when the text actually changed: an attachment-only or visibility-only
+    // edit cannot move the card.
+    //
+    // Scheduled AFTER the edit has federated, for the same reason
+    // createNoteFromUserInput schedules after its send job: on the default
+    // in-process queue `publish` runs the handler inline, so doing this first made
+    // an edit to a post containing a link wait on a third-party fetch before the
+    // edit reached timelines or went out to other servers.
+    if (text !== undefined) {
+      await syncStatusLinkPreview({ database, status: updatedStatus })
+    }
+
+    return updatedStatus
   })
-  if (!updatedStatus) {
-    span.end()
-    return null
-  }
-
-  // Re-sync emoji tags when the text changes so newly added `:shortcode:`
-  // tokens federate and removed ones stop federating, then re-fetch so the
-  // returned status and the timeline cache reflect the re-synced tags (mirroring
-  // createNoteFromUserInput).
-  if (text !== undefined) {
-    await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
-    await persistEmojiTagsForStatus({ database, statusId, text })
-
-    // Re-detect the content language alongside the edit; the previous
-    // detection (if any) is stale once the text changes — persistDetectedLanguage
-    // clears the old row when the new text no longer detects confidently.
-    await persistDetectedLanguage({ database, statusId, text })
-
-    updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
-  }
-
-  await addStatusToTimelines(database, updatedStatus)
-
-  if (publish) {
-    await getQueue().publish({
-      id: getHashFromString(statusId),
-      name: SEND_UPDATE_NOTE_JOB_NAME,
-      data: {
-        actorId: currentActor.id,
-        statusId
-      }
-    })
-
-    // Notify the authors of accepted quotes of this status that a post they
-    // quoted was edited. Only published (federated) edits notify quoters.
-    await notifyQuotedStatusUpdate({
-      database,
-      quotedStatusId: statusId,
-      sourceActorId: currentActor.id,
-      sourceActor: currentActor
-    })
-  }
-
-  // The edit may have added, changed or removed the link the card was for.
-  // Only when the text actually changed: an attachment-only or visibility-only
-  // edit cannot move the card.
-  //
-  // Scheduled AFTER the edit has federated, for the same reason
-  // createNoteFromUserInput schedules after its send job: on the default
-  // in-process queue `publish` runs the handler inline, so doing this first made
-  // an edit to a post containing a link wait on a third-party fetch before the
-  // edit reached timelines or went out to other servers.
-  if (text !== undefined) {
-    await syncStatusLinkPreview({ database, status: updatedStatus })
-  }
-
-  span.end()
-  return updatedStatus
-}

--- a/lib/actions/updateNoteVisibility.ts
+++ b/lib/actions/updateNoteVisibility.ts
@@ -12,7 +12,7 @@ import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getMentionFromTag } from '@/lib/types/domain/tag'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UpdateNoteVisibilityFromUserInput {
   statusId: string
@@ -30,50 +30,65 @@ export const updateNoteVisibilityFromUserInput = async ({
   publish = true,
   status: preloadedStatus,
   database
-}: UpdateNoteVisibilityFromUserInput) => {
-  const span = getSpan('actions', 'updateNoteVisibilityFromUser', { statusId })
-  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
-  if (
-    !status ||
-    status.id !== statusId ||
-    status.type !== StatusType.enum.Note ||
-    status.actorId !== currentActor.id
-  ) {
-    span.end()
-    return null
-  }
+}: UpdateNoteVisibilityFromUserInput) =>
+  withSpan(
+    'actions',
+    'updateNoteVisibilityFromUser',
+    { statusId },
+    async () => {
+      const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+      if (
+        !status ||
+        status.id !== statusId ||
+        status.type !== StatusType.enum.Note ||
+        status.actorId !== currentActor.id
+      ) {
+        return null
+      }
 
-  const mentions = status.tags
-    .filter((tag) => tag.type === 'mention')
-    .map((tag) => getMentionFromTag(tag))
-    .filter((tag): tag is Mention => tag !== null)
+      const mentions = status.tags
+        .filter((tag) => tag.type === 'mention')
+        .map((tag) => getMentionFromTag(tag))
+        .filter((tag): tag is Mention => tag !== null)
 
-  const replyStatus = status.reply
-    ? await database.getStatus({ statusId: status.reply, withReplies: false })
-    : null
+      const replyStatus = status.reply
+        ? await database.getStatus({
+            statusId: status.reply,
+            withReplies: false
+          })
+        : null
 
-  const to = statusRecipientsTo(currentActor, mentions, replyStatus, visibility)
-  const cc = statusRecipientsCC(currentActor, mentions, replyStatus, visibility)
-  const updatedStatus = await database.updateNoteVisibility({
-    statusId,
-    to,
-    cc
-  })
-  if (!updatedStatus) {
-    span.end()
-    return null
-  }
+      const to = statusRecipientsTo(
+        currentActor,
+        mentions,
+        replyStatus,
+        visibility
+      )
+      const cc = statusRecipientsCC(
+        currentActor,
+        mentions,
+        replyStatus,
+        visibility
+      )
+      const updatedStatus = await database.updateNoteVisibility({
+        statusId,
+        to,
+        cc
+      })
+      if (!updatedStatus) {
+        return null
+      }
 
-  await addStatusToTimelines(database, updatedStatus)
+      await addStatusToTimelines(database, updatedStatus)
 
-  if (publish) {
-    await getQueue().publish({
-      id: getHashFromString(statusId),
-      name: SEND_UPDATE_NOTE_JOB_NAME,
-      data: { actorId: currentActor.id, statusId }
-    })
-  }
+      if (publish) {
+        await getQueue().publish({
+          id: getHashFromString(statusId),
+          name: SEND_UPDATE_NOTE_JOB_NAME,
+          data: { actorId: currentActor.id, statusId }
+        })
+      }
 
-  span.end()
-  return updatedStatus
-}
+      return updatedStatus
+    }
+  )

--- a/lib/actions/updatePoll.ts
+++ b/lib/actions/updatePoll.ts
@@ -4,7 +4,7 @@ import { persistDetectedLanguage } from '@/lib/services/language-detection'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
 import { StatusPoll, StatusType } from '@/lib/types/domain/status'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UpdatePollFromUserInput {
   statusId: string
@@ -33,74 +33,75 @@ export const updatePollFromUserInput = async ({
   poll,
   status: preloadedStatus,
   database
-}: UpdatePollFromUserInput) => {
-  const span = getSpan('actions', 'updatePollFromUser', { statusId })
-  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
-  if (
-    !status ||
-    status.id !== statusId ||
-    status.type !== StatusType.enum.Poll ||
-    status.actorId !== currentActor.id
-  ) {
-    span.end()
-    return null
-  }
+}: UpdatePollFromUserInput) =>
+  withSpan('actions', 'updatePollFromUser', { statusId }, async () => {
+    const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+    if (
+      !status ||
+      status.id !== statusId ||
+      status.type !== StatusType.enum.Poll ||
+      status.actorId !== currentActor.id
+    ) {
+      return null
+    }
 
-  const existingTitles = status.choices.map((choice) => choice.title)
-  const nextPollType =
-    poll?.multiple === undefined
-      ? status.pollType
-      : poll.multiple
-        ? 'anyOf'
-        : 'oneOf'
-  // Mastodon resets votes only when the option set or the multiple-choice mode
-  // actually changes (UpdateStatusService#update_poll!); expiry and
-  // hide_totals adjust in place without invalidating existing votes.
-  const resetVotes =
-    poll !== undefined &&
-    (poll.options.length !== existingTitles.length ||
-      poll.options.some((option, index) => option !== existingTitles[index]) ||
-      nextPollType !== status.pollType)
+    const existingTitles = status.choices.map((choice) => choice.title)
+    const nextPollType =
+      poll?.multiple === undefined
+        ? status.pollType
+        : poll.multiple
+          ? 'anyOf'
+          : 'oneOf'
+    // Mastodon resets votes only when the option set or the multiple-choice mode
+    // actually changes (UpdateStatusService#update_poll!); expiry and
+    // hide_totals adjust in place without invalidating existing votes.
+    const resetVotes =
+      poll !== undefined &&
+      (poll.options.length !== existingTitles.length ||
+        poll.options.some(
+          (option, index) => option !== existingTitles[index]
+        ) ||
+        nextPollType !== status.pollType)
 
-  let updatedStatus = await database.updatePoll({
-    statusId,
-    text: text ?? status.text,
-    summary: summary === undefined ? undefined : summary?.trim() || '',
-    choices: resetVotes
-      ? poll!.options.map((title) => ({ title, totalVotes: 0 }))
-      : status.choices.map((choice) => ({
-          title: choice.title,
-          totalVotes: choice.totalVotes
-        })),
-    ...(sensitive !== undefined ? { sensitive } : {}),
-    ...(language !== undefined ? { language } : {}),
-    ...(poll?.expiresIn !== undefined
-      ? { endAt: Date.now() + poll.expiresIn * 1000 }
-      : {}),
-    ...(poll?.multiple !== undefined ? { pollType: nextPollType } : {}),
-    ...(poll?.hideTotals !== undefined ? { hideTotals: poll.hideTotals } : {}),
-    resetVotes
+    let updatedStatus = await database.updatePoll({
+      statusId,
+      text: text ?? status.text,
+      summary: summary === undefined ? undefined : summary?.trim() || '',
+      choices: resetVotes
+        ? poll!.options.map((title) => ({ title, totalVotes: 0 }))
+        : status.choices.map((choice) => ({
+            title: choice.title,
+            totalVotes: choice.totalVotes
+          })),
+      ...(sensitive !== undefined ? { sensitive } : {}),
+      ...(language !== undefined ? { language } : {}),
+      ...(poll?.expiresIn !== undefined
+        ? { endAt: Date.now() + poll.expiresIn * 1000 }
+        : {}),
+      ...(poll?.multiple !== undefined ? { pollType: nextPollType } : {}),
+      ...(poll?.hideTotals !== undefined
+        ? { hideTotals: poll.hideTotals }
+        : {}),
+      resetVotes
+    })
+    if (!updatedStatus) {
+      return null
+    }
+
+    // Mirror updateNoteFromUserInput: re-sync emoji tags and re-detect the
+    // content language when the text changes.
+    if (text !== undefined) {
+      await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
+      await persistEmojiTagsForStatus({ database, statusId, text })
+      await persistDetectedLanguage({ database, statusId, text })
+      updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
+    }
+
+    await addStatusToTimelines(database, updatedStatus)
+
+    // Outbound federation of poll edits (Update(Question)) is not wired up:
+    // getNoteFromStatus returns null for polls and sendUpdateNoteJob rejects
+    // non-Note statuses, so the edit stays local for now.
+
+    return updatedStatus
   })
-  if (!updatedStatus) {
-    span.end()
-    return null
-  }
-
-  // Mirror updateNoteFromUserInput: re-sync emoji tags and re-detect the
-  // content language when the text changes.
-  if (text !== undefined) {
-    await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
-    await persistEmojiTagsForStatus({ database, statusId, text })
-    await persistDetectedLanguage({ database, statusId, text })
-    updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
-  }
-
-  await addStatusToTimelines(database, updatedStatus)
-
-  // Outbound federation of poll edits (Update(Question)) is not wired up:
-  // getNoteFromStatus returns null for polls and sendUpdateNoteJob rejects
-  // non-Note statuses, so the edit stays local for now.
-
-  span.end()
-  return updatedStatus
-}

--- a/lib/actions/updateStatusInteractionPolicy.ts
+++ b/lib/actions/updateStatusInteractionPolicy.ts
@@ -8,7 +8,7 @@ import {
   StatusType
 } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface UpdateStatusInteractionPolicyFromUserInput {
   statusId: string
@@ -34,39 +34,39 @@ export const updateStatusInteractionPolicyFromUserInput = async ({
   publish = true,
   status: preloadedStatus,
   database
-}: UpdateStatusInteractionPolicyFromUserInput): Promise<Status | null> => {
-  const span = getSpan('actions', 'updateStatusInteractionPolicyFromUser', {
-    statusId
-  })
-  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
-  if (
-    !status ||
-    status.id !== statusId ||
-    status.actorId !== currentActor.id ||
-    (status.type !== StatusType.enum.Note &&
-      status.type !== StatusType.enum.Poll)
-  ) {
-    span.end()
-    return null
-  }
+}: UpdateStatusInteractionPolicyFromUserInput): Promise<Status | null> =>
+  withSpan(
+    'actions',
+    'updateStatusInteractionPolicyFromUser',
+    { statusId },
+    async () => {
+      const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+      if (
+        !status ||
+        status.id !== statusId ||
+        status.actorId !== currentActor.id ||
+        (status.type !== StatusType.enum.Note &&
+          status.type !== StatusType.enum.Poll)
+      ) {
+        return null
+      }
 
-  const updatedStatus = await database.updateStatusQuoteApprovalPolicy({
-    statusId,
-    quoteApprovalPolicy
-  })
-  if (!updatedStatus) {
-    span.end()
-    return null
-  }
+      const updatedStatus = await database.updateStatusQuoteApprovalPolicy({
+        statusId,
+        quoteApprovalPolicy
+      })
+      if (!updatedStatus) {
+        return null
+      }
 
-  if (publish) {
-    await getQueue().publish({
-      id: getHashFromString(`${statusId}#interaction-policy`),
-      name: SEND_UPDATE_NOTE_JOB_NAME,
-      data: { actorId: currentActor.id, statusId }
-    })
-  }
+      if (publish) {
+        await getQueue().publish({
+          id: getHashFromString(`${statusId}#interaction-policy`),
+          name: SEND_UPDATE_NOTE_JOB_NAME,
+          data: { actorId: currentActor.id, statusId }
+        })
+      }
 
-  span.end()
-  return updatedStatus
-}
+      return updatedStatus
+    }
+  )

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -8,7 +8,7 @@ import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface Params {
   person: Actor
@@ -72,15 +72,16 @@ export const getActorCollections = async ({
   signingActor,
   pageUrl
 }: Params) => {
-  return getTracer().startActiveSpan(
-    `activities.${field}`,
+  return withSpan(
+    'activity',
+    field,
     {
-      attributes: { actorId: person.id, field }
+      actorId: person.id,
+      field
     },
     async (span) => {
       if (!person[field]) {
         span.recordException(new Error(`Person ${field} is undefined`))
-        span.end()
         return null
       }
 
@@ -96,7 +97,6 @@ export const getActorCollections = async ({
         span.recordException(
           new Error(`Person ${field} returns ${fieldResponse.statusCode}`)
         )
-        span.end()
         return null
       }
 
@@ -111,7 +111,6 @@ export const getActorCollections = async ({
       // This is common for remote actors where Mastodon only provides totalItems
       // without exposing the actual list of followers/following
       if (!collectionPageUrl) {
-        span.end()
         return {
           page: null,
           totalItems: collection.totalItems ?? 0
@@ -155,8 +154,6 @@ export const getActorCollections = async ({
           page: null,
           totalItems: collection.totalItems ?? 0
         }
-      } finally {
-        span.end()
       }
     }
   )

--- a/lib/activities/getActorPerson.ts
+++ b/lib/activities/getActorPerson.ts
@@ -4,7 +4,7 @@ import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export type GetActorPersonFunction = (params: {
   actorId: string
@@ -17,7 +17,7 @@ export const getActorPerson: GetActorPersonFunction = ({
   withNetworkRetry = true,
   signingActor
 }) =>
-  getTracer().startActiveSpan('activities.getActorProfile', async (span) => {
+  withSpan('activity', 'getActorProfile', { actorId }, async (span) => {
     try {
       const { statusCode, body } = await request({
         url: actorId,
@@ -43,7 +43,5 @@ export const getActorPerson: GetActorPersonFunction = ({
       span.recordException(nodeError)
       logger.error(`[getActorProfile] ${nodeError.message}`)
       return null
-    } finally {
-      span.end()
     }
   })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -25,7 +25,7 @@ import {
   isOpaqueActorUsername
 } from '@/lib/utils/activitypubActor'
 import { logger } from '@/lib/utils/logger'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
 import { getActorPerson } from './getActorPerson'
@@ -65,150 +65,142 @@ export const getActorPosts: GetActorPostsFunction = async ({
   signingActor,
   pageUrl
 }) =>
-  getTracer().startActiveSpan(
-    'activities.getActorPosts',
+  withSpan(
+    'activity',
+    'getActorPosts',
     {
-      attributes: { actorId: person.id }
+      actorId: person.id
     },
-    async (span) => {
-      try {
-        const actor = await database.getActorFromId({ id: person.id })
-        const actorProfileCache = new Map<
-          string,
-          Promise<ActorProfile | null>
-        >()
-        const getActorProfile = (actorId: string) => {
-          let actorProfile = actorProfileCache.get(actorId)
-          if (!actorProfile) {
-            actorProfile = (async () => {
-              const persistedActor = await database.getActorFromId({
-                id: actorId
-              })
-              if (
-                persistedActor &&
-                !isOpaqueActorUsername(actorId, persistedActor.username)
-              ) {
-                return ActorProfile.parse(persistedActor)
-              }
+    async () => {
+      const actor = await database.getActorFromId({ id: person.id })
+      const actorProfileCache = new Map<string, Promise<ActorProfile | null>>()
+      const getActorProfile = (actorId: string) => {
+        let actorProfile = actorProfileCache.get(actorId)
+        if (!actorProfile) {
+          actorProfile = (async () => {
+            const persistedActor = await database.getActorFromId({
+              id: actorId
+            })
+            if (
+              persistedActor &&
+              !isOpaqueActorUsername(actorId, persistedActor.username)
+            ) {
+              return ActorProfile.parse(persistedActor)
+            }
 
-              const actorPerson = await getActorPerson({
-                actorId,
+            const actorPerson = await getActorPerson({
+              actorId,
+              signingActor
+            })
+            if (!actorPerson) {
+              return persistedActor ? ActorProfile.parse(persistedActor) : null
+            }
+
+            return getActorProfileFromPerson(actorPerson)
+          })()
+          actorProfileCache.set(actorId, actorProfile)
+        }
+
+        return actorProfile
+      }
+
+      const value = await getActorCollections({
+        person,
+        field: 'outbox',
+        signingActor,
+        pageUrl
+      })
+      if (!value) {
+        return {
+          statusesCount: 0,
+          statuses: [],
+          nextPageUrl: null,
+          prevPageUrl: null
+        }
+      }
+
+      const items = value.page?.orderedItems ?? []
+      const statuses = await Promise.all(
+        items.map(async (item) => {
+          // This should be impossible for status api
+          if (typeof item === 'string') return null
+
+          // Canonicalise the activity (and any embedded object) via JSON-LD
+          // compaction before validating, so dialect variations in `type`,
+          // recipients and id references collapse to a predictable shape.
+          const activity = await compactActivityPub(item)
+
+          if (activity.type === AnnounceAction) {
+            const announceResult = Announce.safeParse(
+              normalizeActivityPubAnnounce(activity)
+            )
+            if (!announceResult.success) return null
+
+            const announce = announceResult.data
+            const localStatus = await database.getStatus({
+              statusId: announce.object
+            })
+
+            let originalStatus =
+              localStatus?.type !== StatusType.enum.Announce
+                ? localStatus
+                : null
+
+            if (!originalStatus) {
+              const note = await getNote({
+                statusId: announce.object,
                 signingActor
               })
-              if (!actorPerson) {
-                return persistedActor
-                  ? ActorProfile.parse(persistedActor)
-                  : null
-              }
+              if (!note) return null
 
-              return getActorProfileFromPerson(actorPerson)
-            })()
-            actorProfileCache.set(actorId, actorProfile)
+              const noteResult = Note.safeParse(
+                normalizeActivityPubContent(note)
+              )
+              if (!noteResult.success) return null
+
+              originalStatus = getStatusFromNote(noteResult.data)
+              if (!originalStatus) return null
+            }
+
+            const originalStatusWithActor = {
+              ...originalStatus,
+              actor: await getActorProfile(originalStatus.actorId)
+            }
+            const announceStatus = fromAnnounce(
+              announce,
+              originalStatusWithActor
+            )
+            if (actor) announceStatus.actor = actor
+            return announceStatus
           }
 
-          return actorProfile
-        }
+          // Unsupported activity
+          if (activity.type !== CreateAction) return null
+          // Unsupported Object
+          if (!activity.object || typeof activity.object === 'string')
+            return null
+          const obj = activity.object as {
+            type?: string
+            [key: string]: unknown
+          }
+          if (obj.type !== 'Note') return null
 
-        const value = await getActorCollections({
-          person,
-          field: 'outbox',
-          signingActor,
-          pageUrl
+          const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
+          if (!noteResult.success) return null
+
+          const status = getStatusFromNote(noteResult.data)
+          if (!status) return null
+
+          if (actor) status.actor = actor
+          return status
         })
-        if (!value) {
-          return {
-            statusesCount: 0,
-            statuses: [],
-            nextPageUrl: null,
-            prevPageUrl: null
-          }
-        }
+      )
 
-        const items = value.page?.orderedItems ?? []
-        const statuses = await Promise.all(
-          items.map(async (item) => {
-            // This should be impossible for status api
-            if (typeof item === 'string') return null
-
-            // Canonicalise the activity (and any embedded object) via JSON-LD
-            // compaction before validating, so dialect variations in `type`,
-            // recipients and id references collapse to a predictable shape.
-            const activity = await compactActivityPub(item)
-
-            if (activity.type === AnnounceAction) {
-              const announceResult = Announce.safeParse(
-                normalizeActivityPubAnnounce(activity)
-              )
-              if (!announceResult.success) return null
-
-              const announce = announceResult.data
-              const localStatus = await database.getStatus({
-                statusId: announce.object
-              })
-
-              let originalStatus =
-                localStatus?.type !== StatusType.enum.Announce
-                  ? localStatus
-                  : null
-
-              if (!originalStatus) {
-                const note = await getNote({
-                  statusId: announce.object,
-                  signingActor
-                })
-                if (!note) return null
-
-                const noteResult = Note.safeParse(
-                  normalizeActivityPubContent(note)
-                )
-                if (!noteResult.success) return null
-
-                originalStatus = getStatusFromNote(noteResult.data)
-                if (!originalStatus) return null
-              }
-
-              const originalStatusWithActor = {
-                ...originalStatus,
-                actor: await getActorProfile(originalStatus.actorId)
-              }
-              const announceStatus = fromAnnounce(
-                announce,
-                originalStatusWithActor
-              )
-              if (actor) announceStatus.actor = actor
-              return announceStatus
-            }
-
-            // Unsupported activity
-            if (activity.type !== CreateAction) return null
-            // Unsupported Object
-            if (!activity.object || typeof activity.object === 'string')
-              return null
-            const obj = activity.object as {
-              type?: string
-              [key: string]: unknown
-            }
-            if (obj.type !== 'Note') return null
-
-            const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
-            if (!noteResult.success) return null
-
-            const status = getStatusFromNote(noteResult.data)
-            if (!status) return null
-
-            if (actor) status.actor = actor
-            return status
-          })
-        )
-
-        return {
-          statusesCount: value.totalItems ?? 0,
-          statuses: statuses.filter((item) => item !== null),
-          nextPageUrl: value.page?.next ?? null,
-          prevPageUrl: value.page?.prev ?? null
-        }
-      } finally {
-        span.end()
+      return {
+        statusesCount: value.totalItems ?? 0,
+        statuses: statuses.filter((item) => item !== null),
+        nextPageUrl: value.page?.next ?? null,
+        prevPageUrl: value.page?.prev ?? null
       }
     }
   )

--- a/lib/activities/getWebfingerDocument.ts
+++ b/lib/activities/getWebfingerDocument.ts
@@ -2,7 +2,7 @@ import { WebFinger } from '@/lib/types/activitypub/webfinger'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 // Standard OStatus rel carrying the URL template a server wants remote-follow
 // visitors sent to. Mirrors REMOTE_FOLLOW_SUBSCRIBE_REL on the serving side.
@@ -19,44 +19,37 @@ export const getWebfingerDocument = async ({
 }: {
   account: string
 }): Promise<WebFinger | null> =>
-  getTracer().startActiveSpan(
-    'activities.getWebfingerDocument',
-    { attributes: { account } },
-    async (span) => {
-      const [user, domain, ...rest] = account.split('@')
-      if (!user || !domain || rest.length > 0) {
-        span.end()
-        return null
-      }
-
-      try {
-        const url = new URL(`https://${domain}/.well-known/webfinger`)
-        url.searchParams.set('resource', `acct:${account}`)
-
-        const { statusCode, body } = await request({
-          url: url.toString(),
-          headers: {
-            Accept: 'application/jrd+json, application/json'
-          },
-          numberOfRetry: 0
-        })
-        if (statusCode !== 200) return null
-
-        const parsed = WebFinger.safeParse(JSON.parse(body))
-        return parsed.success ? parsed.data : null
-      } catch (error) {
-        span.recordException(error as Error)
-        logger.warn({
-          message: 'Failed to fetch webfinger document',
-          account,
-          err: toLoggableError(error)
-        })
-        return null
-      } finally {
-        span.end()
-      }
+  withSpan('activity', 'getWebfingerDocument', { account }, async (span) => {
+    const [user, domain, ...rest] = account.split('@')
+    if (!user || !domain || rest.length > 0) {
+      return null
     }
-  )
+
+    try {
+      const url = new URL(`https://${domain}/.well-known/webfinger`)
+      url.searchParams.set('resource', `acct:${account}`)
+
+      const { statusCode, body } = await request({
+        url: url.toString(),
+        headers: {
+          Accept: 'application/jrd+json, application/json'
+        },
+        numberOfRetry: 0
+      })
+      if (statusCode !== 200) return null
+
+      const parsed = WebFinger.safeParse(JSON.parse(body))
+      return parsed.success ? parsed.data : null
+    } catch (error) {
+      span.recordException(error as Error)
+      logger.warn({
+        message: 'Failed to fetch webfinger document',
+        account,
+        err: toLoggableError(error)
+      })
+      return null
+    }
+  })
 
 /**
  * Reads the remote-follow URL template a server advertises, or null when it

--- a/lib/activities/getWebfingerSelf.ts
+++ b/lib/activities/getWebfingerSelf.ts
@@ -1,54 +1,46 @@
 import { WebFinger } from '@/lib/types/activitypub/webfinger'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 type GetWebfingerSelfFunction = (params: {
   account: string
 }) => Promise<string | null>
 
 export const getWebfingerSelf: GetWebfingerSelfFunction = async ({ account }) =>
-  getTracer().startActiveSpan(
-    'activities.getWebfingerSelf',
-    { attributes: { account } },
-    async (span) => {
-      const [user, domain, ...rest] = account.split('@')
-      if (!user || !domain) {
-        span.end()
-        return null
-      }
-      if (rest.length > 0) {
-        span.end()
-        return null
-      }
-
-      try {
-        const url = new URL(`https://${domain}/.well-known/webfinger`)
-        url.searchParams.set('resource', `acct:${account}`)
-
-        const { statusCode, body } = await request({
-          url: url.toString(),
-          headers: {
-            Accept: 'application/jrd+json, application/json'
-          }
-        })
-        if (statusCode !== 200) {
-          return null
-        }
-
-        const data = WebFinger.parse(JSON.parse(body))
-        const item = data.links.find((item) => item.rel === 'self')
-        if (!item || !('href' in item)) {
-          return null
-        }
-        return item.href
-      } catch (error) {
-        const nodeError = error as NodeJS.ErrnoException
-        span.recordException(nodeError)
-        logger.error(`[getWebfingerSelf] ${nodeError.message}`)
-        return null
-      } finally {
-        span.end()
-      }
+  withSpan('activity', 'getWebfingerSelf', { account }, async (span) => {
+    const [user, domain, ...rest] = account.split('@')
+    if (!user || !domain) {
+      return null
     }
-  )
+    if (rest.length > 0) {
+      return null
+    }
+
+    try {
+      const url = new URL(`https://${domain}/.well-known/webfinger`)
+      url.searchParams.set('resource', `acct:${account}`)
+
+      const { statusCode, body } = await request({
+        url: url.toString(),
+        headers: {
+          Accept: 'application/jrd+json, application/json'
+        }
+      })
+      if (statusCode !== 200) {
+        return null
+      }
+
+      const data = WebFinger.parse(JSON.parse(body))
+      const item = data.links.find((item) => item.rel === 'self')
+      if (!item || !('href' in item)) {
+        return null
+      }
+      return item.href
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      span.recordException(nodeError)
+      logger.error(`[getWebfingerSelf] ${nodeError.message}`)
+      return null
+    }
+  })

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -54,7 +54,7 @@ import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface PostActivityToInboxParams {
   span: Span
@@ -117,37 +117,31 @@ export const getNote = async ({
   statusId,
   signingActor
 }: GetNoteParams): Promise<Note | null> =>
-  getTracer().startActiveSpan(
-    'activities.getNote',
-    { attributes: { statusId } },
-    async (span) => {
-      try {
-        const { statusCode, body } = await request({
+  withSpan('activity', 'getNote', { statusId }, async (span) => {
+    try {
+      const { statusCode, body } = await request({
+        url: statusId,
+        headers: activityPubRequestHeaders({
           url: statusId,
-          headers: activityPubRequestHeaders({
-            url: statusId,
-            signingActor
-          })
+          signingActor
         })
-        if (statusCode !== 200) return null
-        // Canonicalise the fetched note via JSON-LD compaction so every caller
-        // (including boosted-note resolution) gets a predictable shape.
-        return compactActivityPub(JSON.parse(body))
-      } catch (error) {
-        const nodeError = error as NodeJS.ErrnoException
-        if (nodeError.code === 'ETIMEDOUT') {
-          span.setAttribute('timeout', true)
-          return
-        }
-
-        span.recordException(nodeError)
-        logger.error(`[getNote] ${nodeError.message}`)
+      })
+      if (statusCode !== 200) return null
+      // Canonicalise the fetched note via JSON-LD compaction so every caller
+      // (including boosted-note resolution) gets a predictable shape.
+      return compactActivityPub(JSON.parse(body))
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      if (nodeError.code === 'ETIMEDOUT') {
+        span.setAttribute('timeout', true)
         return null
-      } finally {
-        span.end()
       }
+
+      span.recordException(nodeError)
+      logger.error(`[getNote] ${nodeError.message}`)
+      return null
     }
-  )
+  })
 
 interface SendNoteParams {
   currentActor: Actor
@@ -155,13 +149,12 @@ interface SendNoteParams {
   note: Note
 }
 export const sendNote = async ({ currentActor, inbox, note }: SendNoteParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendNote',
+  withSpan(
+    'activity',
+    'sendNote',
     {
-      attributes: {
-        actorId: currentActor.id,
-        inbox
-      }
+      actorId: currentActor.id,
+      inbox
     },
     async (span) => {
       const activity: CreateStatus = {
@@ -182,7 +175,6 @@ export const sendNote = async ({ currentActor, inbox, note }: SendNoteParams) =>
         logPrefix: 'sendNote',
         silenceTimeout: true
       })
-      span.end()
     }
   )
 
@@ -196,18 +188,16 @@ export const sendUpdateNote = async ({
   inbox,
   status
 }: SendUpdateNoteParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendUpdateNote',
+  withSpan(
+    'activity',
+    'sendUpdateNote',
     {
-      attributes: {
-        actorId: currentActor.id,
-        inbox
-      }
+      actorId: currentActor.id,
+      inbox
     },
     async (span) => {
       const note = getNoteFromStatus(status, { includeUpdated: true })
       if (!note) {
-        span.end()
         return
       }
 
@@ -229,7 +219,6 @@ export const sendUpdateNote = async ({
         logPrefix: 'sendUpdateNote',
         silenceTimeout: true
       })
-      span.end()
     }
   )
 
@@ -250,9 +239,10 @@ export const sendQuoteRequest = async ({
   quotedStatusId,
   instrument
 }: SendQuoteRequestParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendQuoteRequest',
-    { attributes: { actorId: currentActor.id, inbox } },
+  withSpan(
+    'activity',
+    'sendQuoteRequest',
+    { actorId: currentActor.id, inbox },
     async (span) => {
       const activity = {
         '@context': QUOTE_ACTIVITY_CONTEXT,
@@ -270,7 +260,6 @@ export const sendQuoteRequest = async ({
         logPrefix: 'sendQuoteRequest',
         silenceTimeout: true
       })
-      span.end()
       return statusCode
     }
   )
@@ -289,9 +278,10 @@ export const sendQuoteAccept = async ({
   quoteRequest,
   stampId
 }: SendQuoteAcceptParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendQuoteAccept',
-    { attributes: { actorId: currentActor.id, inbox } },
+  withSpan(
+    'activity',
+    'sendQuoteAccept',
+    { actorId: currentActor.id, inbox },
     async (span) => {
       const activity = {
         '@context': QUOTE_ACTIVITY_CONTEXT,
@@ -309,7 +299,6 @@ export const sendQuoteAccept = async ({
         logPrefix: 'sendQuoteAccept',
         silenceTimeout: true
       })
-      span.end()
       return statusCode
     }
   )
@@ -325,9 +314,10 @@ export const sendQuoteReject = async ({
   inbox,
   quoteRequest
 }: SendQuoteRejectParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendQuoteReject',
-    { attributes: { actorId: currentActor.id, inbox } },
+  withSpan(
+    'activity',
+    'sendQuoteReject',
+    { actorId: currentActor.id, inbox },
     async (span) => {
       const activity = {
         '@context': QUOTE_ACTIVITY_CONTEXT,
@@ -344,7 +334,6 @@ export const sendQuoteReject = async ({
         logPrefix: 'sendQuoteReject',
         silenceTimeout: true
       })
-      span.end()
       return statusCode
     }
   )
@@ -360,9 +349,10 @@ export const sendQuoteRevoke = async ({
   inbox,
   stampId
 }: SendQuoteRevokeParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendQuoteRevoke',
-    { attributes: { actorId: currentActor.id, inbox } },
+  withSpan(
+    'activity',
+    'sendQuoteRevoke',
+    { actorId: currentActor.id, inbox },
     async (span) => {
       // FEP-044f revocation is a Delete of the QuoteAuthorization stamp. The
       // receiver matches it by stamp id and requires the sender to be the
@@ -382,7 +372,6 @@ export const sendQuoteRevoke = async ({
         logPrefix: 'sendQuoteRevoke',
         silenceTimeout: true
       })
-      span.end()
       return statusCode
     }
   )
@@ -397,17 +386,15 @@ export const sendAnnounce = async ({
   inbox,
   status
 }: SendAnnounceParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendAnnounce',
+  withSpan(
+    'activity',
+    'sendAnnounce',
     {
-      attributes: {
-        actorId: currentActor.id,
-        inbox
-      }
+      actorId: currentActor.id,
+      inbox
     },
     async (span) => {
       if (status.type !== StatusType.enum.Announce) {
-        span.end()
         return null
       }
 
@@ -429,7 +416,6 @@ export const sendAnnounce = async ({
         logPrefix: 'sendAnnounce',
         silenceTimeout: true
       })
-      span.end()
     }
   )
 
@@ -447,13 +433,12 @@ export const deleteStatus = async ({
   to,
   cc
 }: DeleteStatusParams) =>
-  getTracer().startActiveSpan(
-    'activities.deleteStatus',
+  withSpan(
+    'activity',
+    'deleteStatus',
     {
-      attributes: {
-        actorId: currentActor.id,
-        inbox
-      }
+      actorId: currentActor.id,
+      inbox
     },
     async (span) => {
       const activity: DeleteStatus = {
@@ -476,7 +461,6 @@ export const deleteStatus = async ({
         logPrefix: 'deleteStatus',
         silenceTimeout: true
       })
-      span.end()
     }
   )
 
@@ -490,13 +474,12 @@ export const undoAnnounce = async ({
   inbox,
   announce
 }: UndoAnnounceParams) =>
-  getTracer().startActiveSpan(
-    'activities.undoAnnounce',
+  withSpan(
+    'activity',
+    'undoAnnounce',
     {
-      attributes: {
-        actorId: currentActor.id,
-        inbox
-      }
+      actorId: currentActor.id,
+      inbox
     },
     async (span) => {
       const activity: UndoStatus = {
@@ -523,7 +506,6 @@ export const undoAnnounce = async ({
         logPrefix: 'undoAnnounce',
         silenceTimeout: true
       })
-      span.end()
     }
   )
 
@@ -533,14 +515,13 @@ export const follow = async (
   targetActorId: string,
   signingActor?: Actor
 ) =>
-  getTracer().startActiveSpan(
-    'activities.follow',
+  withSpan(
+    'activity',
+    'follow',
     {
-      attributes: {
-        id,
-        actorId: currentActor.id,
-        targetActorId
-      }
+      id,
+      actorId: currentActor.id,
+      targetActorId
     },
     async (span) => {
       const activity: FollowRequest = {
@@ -556,7 +537,6 @@ export const follow = async (
       })
       const targetInbox = person?.inbox
       if (!targetInbox) {
-        span.end()
         return false
       }
 
@@ -567,7 +547,6 @@ export const follow = async (
         activity,
         logPrefix: 'follow'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -577,13 +556,12 @@ export const unfollow = async (
   follow: Follow,
   signingActor?: Actor
 ) =>
-  getTracer().startActiveSpan(
-    'activities.unfollow',
+  withSpan(
+    'activity',
+    'unfollow',
     {
-      attributes: {
-        actorId: currentActor.id,
-        follow: follow.id
-      }
+      actorId: currentActor.id,
+      follow: follow.id
     },
     async (span) => {
       const activity: UndoFollow = {
@@ -612,7 +590,6 @@ export const unfollow = async (
         activity,
         logPrefix: 'unfollow'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -627,9 +604,10 @@ export const followRelay = async (
   relay: Relay,
   signingActor: Actor
 ): Promise<{ followActivityId: string; ok: boolean }> =>
-  getTracer().startActiveSpan(
-    'activities.followRelay',
-    { attributes: { relayId: relay.id, inbox: relay.inboxUrl } },
+  withSpan(
+    'activity',
+    'followRelay',
+    { relayId: relay.id, inbox: relay.inboxUrl },
     async (span) => {
       const followActivityId = `https://${signingActor.domain}/${crypto.randomUUID()}`
       const activity: FollowRequest = {
@@ -646,7 +624,6 @@ export const followRelay = async (
         activity,
         logPrefix: 'followRelay'
       })
-      span.end()
       return { followActivityId, ok: statusCode === 202 }
     }
   )
@@ -657,9 +634,10 @@ export const unfollowRelay = async (
   relay: Relay,
   signingActor: Actor
 ): Promise<boolean> =>
-  getTracer().startActiveSpan(
-    'activities.unfollowRelay',
-    { attributes: { relayId: relay.id, inbox: relay.inboxUrl } },
+  withSpan(
+    'activity',
+    'unfollowRelay',
+    { relayId: relay.id, inbox: relay.inboxUrl },
     async (span) => {
       const followActivityId =
         relay.followActivityId ??
@@ -683,7 +661,6 @@ export const unfollowRelay = async (
         activity,
         logPrefix: 'unfollowRelay'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -701,14 +678,13 @@ export const block = async ({
   targetActorId,
   signingActor
 }: BlockParams) =>
-  getTracer().startActiveSpan(
-    'activities.block',
+  withSpan(
+    'activity',
+    'block',
     {
-      attributes: {
-        actorId: currentActor.id,
-        targetActorId,
-        uri
-      }
+      actorId: currentActor.id,
+      targetActorId,
+      uri
     },
     async (span) => {
       const activity: BlockRequest = {
@@ -732,7 +708,6 @@ export const block = async ({
         activity,
         logPrefix: 'block'
       })
-      span.end()
       return { ok: statusCode === 202, uri }
     }
   )
@@ -754,14 +729,13 @@ export const sendFlag = async ({
   content,
   signingActor
 }: FlagParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendFlag',
+  withSpan(
+    'activity',
+    'sendFlag',
     {
-      attributes: {
-        actorId: currentActor.id,
-        targetActorId,
-        uri
-      }
+      actorId: currentActor.id,
+      targetActorId,
+      uri
     },
     async (span) => {
       const activity: FlagRequest = {
@@ -786,7 +760,6 @@ export const sendFlag = async ({
         activity,
         logPrefix: 'sendFlag'
       })
-      span.end()
       return { ok: statusCode === 202, uri }
     }
   )
@@ -796,13 +769,12 @@ export const unblock = async (
   block: DomainBlock,
   signingActor?: Actor
 ) =>
-  getTracer().startActiveSpan(
-    'activities.unblock',
+  withSpan(
+    'activity',
+    'unblock',
     {
-      attributes: {
-        actorId: currentActor.id,
-        block: block.id
-      }
+      actorId: currentActor.id,
+      block: block.id
     },
     async (span) => {
       const activity: UndoBlock = {
@@ -831,7 +803,6 @@ export const unblock = async (
         activity,
         logPrefix: 'unblock'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -841,13 +812,12 @@ export const acceptFollow = async (
   followingInbox: string,
   followRequest: FollowRequest
 ) =>
-  getTracer().startActiveSpan(
-    'activities.acceptFollow',
+  withSpan(
+    'activity',
+    'acceptFollow',
     {
-      attributes: {
-        actorId: currentActor.id,
-        followingInbox
-      }
+      actorId: currentActor.id,
+      followingInbox
     },
     async (span) => {
       const activity: AcceptFollow = {
@@ -869,7 +839,6 @@ export const acceptFollow = async (
         activity,
         logPrefix: 'acceptFollow'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -879,13 +848,12 @@ export const rejectFollow = async (
   followingInbox: string,
   followRequest: FollowRequest
 ) =>
-  getTracer().startActiveSpan(
-    'activities.rejectFollow',
+  withSpan(
+    'activity',
+    'rejectFollow',
     {
-      attributes: {
-        actorId: currentActor.id,
-        followingInbox
-      }
+      actorId: currentActor.id,
+      followingInbox
     },
     async (span) => {
       const activity: RejectFollow = {
@@ -907,7 +875,6 @@ export const rejectFollow = async (
         activity,
         logPrefix: 'rejectFollow'
       })
-      span.end()
       return statusCode === 202
     }
   )
@@ -920,9 +887,10 @@ interface LikeParams {
   status: Status
 }
 export const sendLike = async ({ currentActor, status }: LikeParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendLike',
-    { attributes: { actorId: currentActor.id, statusId: status.id } },
+  withSpan(
+    'activity',
+    'sendLike',
+    { actorId: currentActor.id, statusId: status.id },
     async (span) => {
       if (!status.actor) return
 
@@ -940,7 +908,6 @@ export const sendLike = async ({ currentActor, status }: LikeParams) =>
         activity,
         logPrefix: 'sendLike'
       })
-      span.end()
     }
   )
 
@@ -975,13 +942,12 @@ const buildReactionActivity = ({
 }
 
 export const sendReaction = async (params: ReactionParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendReaction',
+  withSpan(
+    'activity',
+    'sendReaction',
     {
-      attributes: {
-        actorId: params.currentActor.id,
-        statusId: params.status.id
-      }
+      actorId: params.currentActor.id,
+      statusId: params.status.id
     },
     async (span) => {
       const { currentActor, status } = params
@@ -994,18 +960,16 @@ export const sendReaction = async (params: ReactionParams) =>
         activity: buildReactionActivity(params),
         logPrefix: 'sendReaction'
       })
-      span.end()
     }
   )
 
 export const sendUndoReaction = async (params: ReactionParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendUndoReaction',
+  withSpan(
+    'activity',
+    'sendUndoReaction',
     {
-      attributes: {
-        actorId: params.currentActor.id,
-        statusId: params.status.id
-      }
+      actorId: params.currentActor.id,
+      statusId: params.status.id
     },
     async (span) => {
       const { currentActor, status } = params
@@ -1028,7 +992,6 @@ export const sendUndoReaction = async (params: ReactionParams) =>
         activity,
         logPrefix: 'sendUndoReaction'
       })
-      span.end()
     }
   )
 
@@ -1037,9 +1000,10 @@ interface UndoLikeParams {
   status: Status
 }
 export const sendUndoLike = async ({ currentActor, status }: UndoLikeParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendUndoLike',
-    { attributes: { actorId: currentActor.id, statusId: status.id } },
+  withSpan(
+    'activity',
+    'sendUndoLike',
+    { actorId: currentActor.id, statusId: status.id },
     async (span) => {
       if (!status.actor) return
 
@@ -1062,7 +1026,6 @@ export const sendUndoLike = async ({ currentActor, status }: UndoLikeParams) =>
         activity,
         logPrefix: 'sendUndoLike'
       })
-      span.end()
     }
   )
 
@@ -1077,14 +1040,13 @@ export const sendPollVotes = async ({
   status,
   choices
 }: SendPollVotesParams) =>
-  getTracer().startActiveSpan(
-    'activities.sendPollVotes',
+  withSpan(
+    'activity',
+    'sendPollVotes',
     {
-      attributes: {
-        actorId: currentActor.id,
-        statusId: status.id,
-        choices: choices.join(',')
-      }
+      actorId: currentActor.id,
+      statusId: status.id,
+      choices: choices.join(',')
     },
     async (span) => {
       if (!status.actor) return
@@ -1126,7 +1088,5 @@ export const sendPollVotes = async ({
           logPrefix: 'sendPollVotes'
         })
       }
-
-      span.end()
     }
   )

--- a/lib/jobs/createJobHandle.ts
+++ b/lib/jobs/createJobHandle.ts
@@ -1,21 +1,13 @@
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const createJobHandle = (
   jobName: string,
   handle: JobHandle
 ): JobHandle => {
   return async (database, message) => {
-    await getTracer().startActiveSpan(jobName, async (span) => {
-      try {
-        await handle(database, message)
-      } catch (error) {
-        const nodeError = error as NodeJS.ErrnoException
-        span.recordException(nodeError)
-        throw error
-      } finally {
-        span.end()
-      }
+    return withSpan('job', jobName, {}, async () => {
+      await handle(database, message)
     })
   }
 }

--- a/lib/jobs/deleteActorJob.ts
+++ b/lib/jobs/deleteActorJob.ts
@@ -6,7 +6,7 @@ import { sendMail } from '@/lib/services/email'
 import { buildActorDeletedEmail } from '@/lib/services/email/templates/actorDeleted'
 import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { logger } from '@/lib/utils/logger'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { createJobHandle } from './createJobHandle'
 import { DELETE_ACTOR_JOB_NAME } from './names'
@@ -18,182 +18,184 @@ const DeleteActorJobData = z.object({
 export const deleteActorJob = createJobHandle(
   DELETE_ACTOR_JOB_NAME,
   async (database, message) => {
-    const span = getSpan('job', 'deleteActor')
-    logger.info({
-      message: 'Delete actor job started',
-      messageId: message.id,
-      data: message.data
-    })
-
-    let data
-    try {
-      data = DeleteActorJobData.parse(message.data)
-    } catch (err) {
-      logger.error({
-        message: 'Invalid delete actor job data',
+    return withSpan('job', 'deleteActor', {}, async (span) => {
+      logger.info({
+        message: 'Delete actor job started',
         messageId: message.id,
-        data: message.data,
-        err: err instanceof Error ? err : new Error(String(err))
+        data: message.data
       })
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: 'Invalid job data'
+
+      let data
+      try {
+        data = DeleteActorJobData.parse(message.data)
+      } catch (err) {
+        logger.error({
+          message: 'Invalid delete actor job data',
+          messageId: message.id,
+          data: message.data,
+          err: err instanceof Error ? err : new Error(String(err))
+        })
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: 'Invalid job data'
+        })
+        span.recordException(
+          err instanceof Error ? err : new Error(String(err))
+        )
+        throw err
+      }
+
+      const { actorId } = data
+      span.setAttribute('actorId', actorId)
+      logger.info({
+        message: 'Processing delete actor job',
+        actorId
       })
-      span.recordException(err instanceof Error ? err : new Error(String(err)))
-      span.end()
-      throw err
-    }
 
-    const { actorId } = data
-    span.setAttribute('actorId', actorId)
-    logger.info({
-      message: 'Processing delete actor job',
-      actorId
-    })
+      // Get the actor before deletion to use for email
+      let actor
+      try {
+        actor = await database.getActorFromId({ id: actorId })
+        logger.debug({
+          message: 'Retrieved actor for deletion',
+          actorId,
+          found: !!actor
+        })
+      } catch (err) {
+        logger.error({
+          message: 'Failed to get actor for deletion',
+          actorId,
+          err: err instanceof Error ? err : new Error(String(err))
+        })
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: 'Failed to get actor'
+        })
+        span.recordException(
+          err instanceof Error ? err : new Error(String(err))
+        )
+        throw err
+      }
 
-    // Get the actor before deletion to use for email
-    let actor
-    try {
-      actor = await database.getActorFromId({ id: actorId })
+      if (!actor) {
+        logger.warn({
+          message: 'Actor not found for deletion job',
+          actorId
+        })
+        span.setStatus({ code: SpanStatusCode.OK, message: 'Actor not found' })
+        return
+      }
+
+      // Check if deletion was cancelled before proceeding
+      if (actor.deletionStatus !== 'scheduled') {
+        logger.info({
+          message: 'Actor deletion was cancelled or already processed',
+          actorId,
+          currentStatus: actor.deletionStatus
+        })
+        span.setStatus({
+          code: SpanStatusCode.OK,
+          message: 'Deletion cancelled or processed'
+        })
+        return
+      }
+
+      // Store email for notification before deletion
+      const accountEmail = actor.account?.email
       logger.debug({
-        message: 'Retrieved actor for deletion',
+        message: 'Actor email for notification',
         actorId,
-        found: !!actor
+        hasEmail: !!accountEmail
       })
-    } catch (err) {
-      logger.error({
-        message: 'Failed to get actor for deletion',
-        actorId,
-        err: err instanceof Error ? err : new Error(String(err))
-      })
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: 'Failed to get actor'
-      })
-      span.recordException(err instanceof Error ? err : new Error(String(err)))
-      span.end()
-      throw err
-    }
 
-    if (!actor) {
-      logger.warn({
-        message: 'Actor not found for deletion job',
-        actorId
-      })
-      span.setStatus({ code: SpanStatusCode.OK, message: 'Actor not found' })
-      span.end()
-      return
-    }
+      // Mark actor as deleting
+      try {
+        await database.startActorDeletion({ actorId })
+        logger.info({
+          message: 'Marked actor as deleting',
+          actorId
+        })
+      } catch (err) {
+        logger.error({
+          message: 'Failed to mark actor as deleting',
+          actorId,
+          err: err instanceof Error ? err : new Error(String(err))
+        })
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: 'Failed to start deletion'
+        })
+        span.recordException(
+          err instanceof Error ? err : new Error(String(err))
+        )
+        throw err
+      }
 
-    // Check if deletion was cancelled before proceeding
-    if (actor.deletionStatus !== 'scheduled') {
-      logger.info({
-        message: 'Actor deletion was cancelled or already processed',
-        actorId,
-        currentStatus: actor.deletionStatus
-      })
-      span.setStatus({
-        code: SpanStatusCode.OK,
-        message: 'Deletion cancelled or processed'
-      })
-      span.end()
-      return
-    }
+      // Delete all actor data
+      try {
+        await database.deleteActorData({ actorId })
+        logger.info({
+          message: 'Deleted actor data',
+          actorId
+        })
+      } catch (err) {
+        logger.error({
+          message: 'Failed to delete actor data',
+          actorId,
+          err: err instanceof Error ? err : new Error(String(err))
+        })
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: 'Failed to delete actor data'
+        })
+        span.recordException(
+          err instanceof Error ? err : new Error(String(err))
+        )
+        throw err
+      }
 
-    // Store email for notification before deletion
-    const accountEmail = actor.account?.email
-    logger.debug({
-      message: 'Actor email for notification',
-      actorId,
-      hasEmail: !!accountEmail
-    })
-
-    // Mark actor as deleting
-    try {
-      await database.startActorDeletion({ actorId })
-      logger.info({
-        message: 'Marked actor as deleting',
-        actorId
-      })
-    } catch (err) {
-      logger.error({
-        message: 'Failed to mark actor as deleting',
-        actorId,
-        err: err instanceof Error ? err : new Error(String(err))
-      })
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: 'Failed to start deletion'
-      })
-      span.recordException(err instanceof Error ? err : new Error(String(err)))
-      span.end()
-      throw err
-    }
-
-    // Delete all actor data
-    try {
-      await database.deleteActorData({ actorId })
-      logger.info({
-        message: 'Deleted actor data',
-        actorId
-      })
-    } catch (err) {
-      logger.error({
-        message: 'Failed to delete actor data',
-        actorId,
-        err: err instanceof Error ? err : new Error(String(err))
-      })
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: 'Failed to delete actor data'
-      })
-      span.recordException(err instanceof Error ? err : new Error(String(err)))
-      span.end()
-      throw err
-    }
-
-    // Send email notification
-    if (accountEmail) {
-      const config = getConfig()
-      if (config.email) {
-        try {
-          // The admin can leave the instance contact address blank, in which
-          // case the notice falls back to naming no address rather than
-          // pointing the user at the no-reply sender.
-          const { instance } = await getResolvedServerSettings(database)
-          const email = buildActorDeletedEmail({
-            recipient: actor,
-            recipientEmail: accountEmail,
-            contactEmail: instance.contactEmail || undefined
-          })
-          await sendMail({
-            from: config.email.serviceFromAddress,
-            to: [accountEmail],
-            subject: email.subject,
-            content: { text: email.text, html: email.html }
-          })
-          logger.info({
-            message: 'Sent actor deletion email notification',
-            actorId,
-            email: accountEmail
-          })
-        } catch (err) {
-          logger.error({
-            message: 'Failed to send actor deletion email notification',
-            actorId,
-            email: accountEmail,
-            err: err instanceof Error ? err : new Error(String(err))
-          })
-          // Don't fail the job if email fails
+      // Send email notification
+      if (accountEmail) {
+        const config = getConfig()
+        if (config.email) {
+          try {
+            // The admin can leave the instance contact address blank, in which
+            // case the notice falls back to naming no address rather than
+            // pointing the user at the no-reply sender.
+            const { instance } = await getResolvedServerSettings(database)
+            const email = buildActorDeletedEmail({
+              recipient: actor,
+              recipientEmail: accountEmail,
+              contactEmail: instance.contactEmail || undefined
+            })
+            await sendMail({
+              from: config.email.serviceFromAddress,
+              to: [accountEmail],
+              subject: email.subject,
+              content: { text: email.text, html: email.html }
+            })
+            logger.info({
+              message: 'Sent actor deletion email notification',
+              actorId,
+              email: accountEmail
+            })
+          } catch (err) {
+            logger.error({
+              message: 'Failed to send actor deletion email notification',
+              actorId,
+              email: accountEmail,
+              err: err instanceof Error ? err : new Error(String(err))
+            })
+            // Don't fail the job if email fails
+          }
         }
       }
-    }
 
-    logger.info({
-      message: 'Delete actor job completed successfully',
-      actorId
+      logger.info({
+        message: 'Delete actor job completed successfully',
+        actorId
+      })
+      span.setStatus({ code: SpanStatusCode.OK })
     })
-    span.setStatus({ code: SpanStatusCode.OK })
-    span.end()
   }
 )

--- a/lib/jobs/deleteObjectJob.ts
+++ b/lib/jobs/deleteObjectJob.ts
@@ -4,7 +4,7 @@ import {
   normalizeActivityPubAnnounce,
   normalizeActorId
 } from '@/lib/utils/activitypub'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { createJobHandle } from './createJobHandle'
 import { DELETE_OBJECT_JOB_NAME } from './names'
@@ -31,7 +31,7 @@ const getStampUri = (data: unknown): string | null => {
 export const deleteObjectJob = createJobHandle(
   DELETE_OBJECT_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('deleteObject', async (span) => {
+    await withSpan('job', 'deleteObject', {}, async (span) => {
       const data = message.data
 
       // FEP-044f revocation: a Delete of a QuoteAuthorization stamp revokes the
@@ -72,7 +72,6 @@ export const deleteObjectJob = createJobHandle(
           } else {
             span.setAttribute('quoteRevocationSenderMismatch', true)
           }
-          span.end()
           return
         }
       }
@@ -80,7 +79,6 @@ export const deleteObjectJob = createJobHandle(
       if (typeof data === 'string') {
         if (!actorMatchesVerifiedSender(data, message)) {
           span.setAttribute('senderMismatch', true)
-          span.end()
           return
         }
 
@@ -88,7 +86,6 @@ export const deleteObjectJob = createJobHandle(
         await database.deleteActor({
           actorId: data
         })
-        span.end()
         return
       }
 
@@ -100,7 +97,6 @@ export const deleteObjectJob = createJobHandle(
           statusId: tombStone.id,
           actorId: getVerifiedSenderActorId(message.verifiedSenderActorId)
         })
-        span.end()
         return
       }
 
@@ -111,7 +107,6 @@ export const deleteObjectJob = createJobHandle(
         const announce = announceResult.data
         if (!actorMatchesVerifiedSender(announce.actor, message)) {
           span.setAttribute('senderMismatch', true)
-          span.end()
           return
         }
 
@@ -120,13 +115,11 @@ export const deleteObjectJob = createJobHandle(
           statusId: announce.id,
           actorId: getVerifiedSenderActorId(message.verifiedSenderActorId)
         })
-        span.end()
         return
       }
 
       span.recordException(new Error('Invalid data'))
       span.setAttribute('data', JSON.stringify(data))
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendAnnounceJob.ts
+++ b/lib/jobs/sendAnnounceJob.ts
@@ -6,7 +6,7 @@ import { loadStatusAndActor } from '@/lib/jobs/loadStatusAndActor'
 import { SEND_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -16,7 +16,7 @@ export const JobData = z.object({
 export const sendAnnounceJob: JobHandle = createJobHandle(
   SEND_ANNOUNCE_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendAnnounceJob', async (span) => {
+    await withSpan('job', 'sendAnnounce', {}, async (span) => {
       const { actorId, statusId } = JobData.parse(message.data)
       const { status, actor } = await loadStatusAndActor(database, span, {
         actorId,
@@ -24,7 +24,6 @@ export const sendAnnounceJob: JobHandle = createJobHandle(
       })
       if (!status || !actor) {
         span.recordException(new Error('Status or actor not found'))
-        span.end()
         return
       }
 
@@ -37,7 +36,6 @@ export const sendAnnounceJob: JobHandle = createJobHandle(
           sendAnnounce({ currentActor: actor, inbox, status })
         )
       )
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendBlockJob.ts
+++ b/lib/jobs/sendBlockJob.ts
@@ -6,7 +6,7 @@ import { SEND_BLOCK_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -17,14 +17,13 @@ export const JobData = z.object({
 export const sendBlockJob: JobHandle = createJobHandle(
   SEND_BLOCK_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendBlockJob', async (span) => {
+    await withSpan('job', 'sendBlock', {}, async (span) => {
       const { actorId, targetActorId, uri } = JobData.parse(message.data)
       span.setAttribute('actorId', actorId)
       span.setAttribute('targetActorId', targetActorId)
       span.setAttribute('uri', uri)
 
       if (!(await canFederateWithDomain(database, targetActorId))) {
-        span.end()
         return
       }
 
@@ -34,7 +33,6 @@ export const sendBlockJob: JobHandle = createJobHandle(
       ])
       if (!currentActor) {
         span.recordException(new Error('Actor not found'))
-        span.end()
         return
       }
 
@@ -44,7 +42,6 @@ export const sendBlockJob: JobHandle = createJobHandle(
       })
       // Skip stale Block jobs after unblock or re-block; the latest persisted block owns federation.
       if (currentBlock?.uri !== uri) {
-        span.end()
         return
       }
 
@@ -57,10 +54,8 @@ export const sendBlockJob: JobHandle = createJobHandle(
       if (!result.ok) {
         const error = new Error('Failed to send Block')
         span.recordException(error)
-        span.end()
         throw error
       }
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendFlagJob.ts
+++ b/lib/jobs/sendFlagJob.ts
@@ -6,7 +6,7 @@ import { SEND_FLAG_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   reportId: z.string(),
@@ -18,7 +18,7 @@ export const JobData = z.object({
 export const sendFlagJob: JobHandle = createJobHandle(
   SEND_FLAG_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendFlagJob', async (span) => {
+    await withSpan('job', 'sendFlag', {}, async (span) => {
       const { reportId, targetActorId, statusIds, content } = JobData.parse(
         message.data
       )
@@ -26,7 +26,6 @@ export const sendFlagJob: JobHandle = createJobHandle(
       span.setAttribute('targetActorId', targetActorId)
 
       if (!(await canFederateWithDomain(database, targetActorId))) {
-        span.end()
         return
       }
 
@@ -34,7 +33,6 @@ export const sendFlagJob: JobHandle = createJobHandle(
       // A local target (identified by a stored private key) is handled in-app;
       // there is no remote inbox to forward the Flag to.
       if (targetActor?.privateKey) {
-        span.end()
         return
       }
 
@@ -43,7 +41,6 @@ export const sendFlagJob: JobHandle = createJobHandle(
       const signingActor = await getFederationSigningActor(database)
       if (!signingActor) {
         span.recordException(new Error('Federation signing actor not found'))
-        span.end()
         return
       }
 
@@ -60,10 +57,8 @@ export const sendFlagJob: JobHandle = createJobHandle(
       if (!result.ok) {
         const error = new Error('Failed to send Flag')
         span.recordException(error)
-        span.end()
         throw error
       }
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendNoteJob.ts
+++ b/lib/jobs/sendNoteJob.ts
@@ -11,7 +11,7 @@ import { StatusType } from '@/lib/types/domain/status'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { logger } from '@/lib/utils/logger'
 import { UNFOLLOW_NETWORK_ERROR_CODES } from '@/lib/utils/response'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -21,7 +21,7 @@ export const JobData = z.object({
 export const sendNoteJob: JobHandle = createJobHandle(
   SEND_NOTE_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendNoteJob', async (span) => {
+    await withSpan('job', 'sendNote', {}, async (span) => {
       const { actorId, statusId } = JobData.parse(message.data)
       const { status, actor } = await loadStatusAndActor(database, span, {
         actorId,
@@ -30,7 +30,6 @@ export const sendNoteJob: JobHandle = createJobHandle(
 
       if (!status || !actor) {
         span.recordException(new Error('Status or actor not found'))
-        span.end()
         return
       }
 
@@ -41,7 +40,6 @@ export const sendNoteJob: JobHandle = createJobHandle(
           status.type !== StatusType.enum.Poll)
       ) {
         span.recordException(new Error('Failed to get note from status'))
-        span.end()
         return
       }
 
@@ -79,8 +77,6 @@ export const sendNoteJob: JobHandle = createJobHandle(
           }
         })
       )
-
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendQuoteAcceptJob.ts
+++ b/lib/jobs/sendQuoteAcceptJob.ts
@@ -7,7 +7,7 @@ import { SEND_QUOTE_ACCEPT_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   // The quoted author (inbox owner) who approves the quote.
@@ -26,7 +26,7 @@ export const JobData = z.object({
 export const sendQuoteAcceptJob: JobHandle = createJobHandle(
   SEND_QUOTE_ACCEPT_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendQuoteAcceptJob', async (span) => {
+    await withSpan('job', 'sendQuoteAccept', {}, async () => {
       const {
         actorId,
         quotingActorId,
@@ -37,7 +37,6 @@ export const sendQuoteAcceptJob: JobHandle = createJobHandle(
       } = JobData.parse(message.data)
 
       if (!(await canFederateWithDomain(database, quotingActorId))) {
-        span.end()
         return
       }
 
@@ -46,7 +45,6 @@ export const sendQuoteAcceptJob: JobHandle = createJobHandle(
         getFederationSigningActor(database)
       ])
       if (!currentActor) {
-        span.end()
         return
       }
 
@@ -68,8 +66,6 @@ export const sendQuoteAcceptJob: JobHandle = createJobHandle(
         },
         stampId
       })
-
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendQuoteRejectJob.ts
+++ b/lib/jobs/sendQuoteRejectJob.ts
@@ -7,7 +7,7 @@ import { SEND_QUOTE_REJECT_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   // The quoted author (inbox owner) who declines the quote.
@@ -24,7 +24,7 @@ export const JobData = z.object({
 export const sendQuoteRejectJob: JobHandle = createJobHandle(
   SEND_QUOTE_REJECT_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendQuoteRejectJob', async (span) => {
+    await withSpan('job', 'sendQuoteReject', {}, async () => {
       const {
         actorId,
         quotingActorId,
@@ -34,7 +34,6 @@ export const sendQuoteRejectJob: JobHandle = createJobHandle(
       } = JobData.parse(message.data)
 
       if (!(await canFederateWithDomain(database, quotingActorId))) {
-        span.end()
         return
       }
 
@@ -43,7 +42,6 @@ export const sendQuoteRejectJob: JobHandle = createJobHandle(
         getFederationSigningActor(database)
       ])
       if (!currentActor) {
-        span.end()
         return
       }
 
@@ -64,8 +62,6 @@ export const sendQuoteRejectJob: JobHandle = createJobHandle(
           instrument: instrumentId
         }
       })
-
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendQuoteRequestJob.ts
+++ b/lib/jobs/sendQuoteRequestJob.ts
@@ -9,7 +9,7 @@ import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -22,11 +22,10 @@ export const JobData = z.object({
 export const sendQuoteRequestJob: JobHandle = createJobHandle(
   SEND_QUOTE_REQUEST_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendQuoteRequestJob', async (span) => {
+    await withSpan('job', 'sendQuoteRequest', {}, async (span) => {
       const { actorId, statusId, quotedStatusId } = JobData.parse(message.data)
 
       if (!(await canFederateWithDomain(database, quotedStatusId))) {
-        span.end()
         return
       }
 
@@ -35,13 +34,11 @@ export const sendQuoteRequestJob: JobHandle = createJobHandle(
         getFederationSigningActor(database)
       ])
       if (!status || !actor) {
-        span.end()
         return
       }
 
       const instrument = getNoteFromStatus(status)
       if (!instrument) {
-        span.end()
         return
       }
 
@@ -56,7 +53,6 @@ export const sendQuoteRequestJob: JobHandle = createJobHandle(
         (await getNote({ statusId: quotedStatusId, signingActor }))
           ?.attributedTo
       if (typeof quotedAuthorId !== 'string') {
-        span.end()
         return
       }
 
@@ -73,8 +69,6 @@ export const sendQuoteRequestJob: JobHandle = createJobHandle(
         quotedStatusId,
         instrument
       })
-
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendQuoteRevokeJob.ts
+++ b/lib/jobs/sendQuoteRevokeJob.ts
@@ -9,7 +9,7 @@ import { getFederationSigningActor } from '@/lib/services/federation/getFederati
 import { getExplicitRecipientInboxes } from '@/lib/services/federation/statusDelivery'
 import { JobHandle } from '@/lib/services/queue/type'
 import { logger } from '@/lib/utils/logger'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   // The quoted author revoking their approval (signs the Delete).
@@ -35,12 +35,11 @@ export const JobData = z.object({
 export const sendQuoteRevokeJob: JobHandle = createJobHandle(
   SEND_QUOTE_REVOKE_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendQuoteRevokeJob', async (span) => {
+    await withSpan('job', 'sendQuoteRevoke', {}, async () => {
       const { actorId, quotingActorId, quotingStatusId, stampId } =
         JobData.parse(message.data)
 
       if (!(await canFederateWithDomain(database, quotingActorId))) {
-        span.end()
         return
       }
 
@@ -55,7 +54,6 @@ export const sendQuoteRevokeJob: JobHandle = createJobHandle(
           : Promise.resolve(null)
       ])
       if (!currentActor) {
-        span.end()
         return
       }
 
@@ -91,8 +89,6 @@ export const sendQuoteRevokeJob: JobHandle = createJobHandle(
           }
         })
       )
-
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendUnblockJob.ts
+++ b/lib/jobs/sendUnblockJob.ts
@@ -7,7 +7,7 @@ import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
 import { Block } from '@/lib/types/domain/block'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -17,13 +17,12 @@ export const JobData = z.object({
 export const sendUnblockJob: JobHandle = createJobHandle(
   SEND_UNBLOCK_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendUnblockJob', async (span) => {
+    await withSpan('job', 'sendUnblock', {}, async (span) => {
       const { actorId, block } = JobData.parse(message.data)
       span.setAttribute('actorId', actorId)
       span.setAttribute('blockId', block.id)
 
       if (!(await canFederateWithDomain(database, block.targetActorId))) {
-        span.end()
         return
       }
 
@@ -33,7 +32,6 @@ export const sendUnblockJob: JobHandle = createJobHandle(
       ])
       if (!currentActor) {
         span.recordException(new Error('Actor not found'))
-        span.end()
         return
       }
 
@@ -42,7 +40,6 @@ export const sendUnblockJob: JobHandle = createJobHandle(
         targetActorId: block.targetActorId
       })
       if (currentBlock && currentBlock.uri !== block.uri) {
-        span.end()
         return
       }
 
@@ -50,10 +47,8 @@ export const sendUnblockJob: JobHandle = createJobHandle(
       if (!ok) {
         const error = new Error('Failed to send Undo Block')
         span.recordException(error)
-        span.end()
         throw error
       }
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendUndoAnnounceJob.ts
+++ b/lib/jobs/sendUndoAnnounceJob.ts
@@ -7,7 +7,7 @@ import { SEND_UNDO_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { StatusType } from '@/lib/types/domain/status'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -17,7 +17,7 @@ export const JobData = z.object({
 export const sendUndoAnnounceJob: JobHandle = createJobHandle(
   SEND_UNDO_ANNOUNCE_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendUndoAnnounceJob', async (span) => {
+    await withSpan('job', 'sendUndoAnnounce', {}, async (span) => {
       const { actorId, statusId } = JobData.parse(message.data)
       const { status, actor } = await loadStatusAndActor(database, span, {
         actorId,
@@ -27,7 +27,6 @@ export const sendUndoAnnounceJob: JobHandle = createJobHandle(
         span.recordException(
           new Error('Status or actor not found or status is not an announce')
         )
-        span.end()
         return
       }
 
@@ -40,7 +39,6 @@ export const sendUndoAnnounceJob: JobHandle = createJobHandle(
           undoAnnounce({ currentActor: actor, inbox, announce: status })
         )
       )
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendUndoFollowJob.ts
+++ b/lib/jobs/sendUndoFollowJob.ts
@@ -6,7 +6,7 @@ import { SEND_UNDO_FOLLOW_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   actorId: z.string(),
@@ -16,7 +16,7 @@ export const JobData = z.object({
 export const sendUndoFollowJob: JobHandle = createJobHandle(
   SEND_UNDO_FOLLOW_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendUndoFollowJob', async (span) => {
+    await withSpan('job', 'sendUndoFollow', {}, async (span) => {
       const { actorId, follow } = JobData.parse(message.data)
       span.setAttribute('actorId', actorId)
       span.setAttribute('followId', follow.id)
@@ -30,7 +30,6 @@ export const sendUndoFollowJob: JobHandle = createJobHandle(
         currentFollow.actorId !== actorId ||
         currentFollow.targetActorId !== follow.targetActorId
       ) {
-        span.end()
         return
       }
 
@@ -39,21 +38,18 @@ export const sendUndoFollowJob: JobHandle = createJobHandle(
         targetActorId: currentFollow.targetActorId
       })
       if (activeFollow) {
-        span.end()
         return
       }
 
       if (
         !(await canFederateWithDomain(database, currentFollow.targetActorId))
       ) {
-        span.end()
         return
       }
 
       const actor = await database.getActorFromId({ id: actorId })
       if (!actor) {
         span.recordException(new Error('Actor not found'))
-        span.end()
         return
       }
 
@@ -61,10 +57,8 @@ export const sendUndoFollowJob: JobHandle = createJobHandle(
       if (!ok) {
         const error = new Error('Failed to send Undo Follow')
         span.recordException(error)
-        span.end()
         throw error
       }
-      span.end()
     })
   }
 )

--- a/lib/jobs/sendUpdateNoteJob.ts
+++ b/lib/jobs/sendUpdateNoteJob.ts
@@ -10,7 +10,7 @@ import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
 import { logger } from '@/lib/utils/logger'
 import { UNFOLLOW_NETWORK_ERROR_CODES } from '@/lib/utils/response'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 /**
  * Job data schema for sending note updates
@@ -29,7 +29,7 @@ export const JobData = z.object({
 export const sendUpdateNoteJob: JobHandle = createJobHandle(
   SEND_UPDATE_NOTE_JOB_NAME,
   async (database, message) => {
-    await getTracer().startActiveSpan('sendUpdateNoteJob', async (span) => {
+    await withSpan('job', 'sendUpdateNote', {}, async (span) => {
       const { actorId, statusId } = JobData.parse(message.data)
       const { status, actor } = await loadStatusAndActor(database, span, {
         actorId,
@@ -38,13 +38,11 @@ export const sendUpdateNoteJob: JobHandle = createJobHandle(
 
       if (!status || !actor) {
         span.recordException(new Error('Status or actor not found'))
-        span.end()
         return
       }
 
       if (status.type !== StatusType.enum.Note) {
         span.recordException(new Error('Status is not a Note'))
-        span.end()
         return
       }
 
@@ -88,8 +86,6 @@ export const sendUpdateNoteJob: JobHandle = createJobHandle(
           }
         })
       )
-
-      span.end()
     })
   }
 )

--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -17,14 +17,18 @@ enableFetchMocks()
 
 const mockSpan = {
   end: vi.fn(),
-  recordException: vi.fn()
+  recordException: vi.fn(),
+  setAttribute: vi.fn(),
+  setStatus: vi.fn()
 }
-const mockStartActiveSpan = vi.fn((...params: unknown[]) => {
-  const callback = params[params.length - 1] as (
-    span: typeof mockSpan
-  ) => unknown
-  return callback(mockSpan)
-})
+const mockWithSpan = vi.fn(
+  (
+    _op: string,
+    _name: string,
+    _data: unknown,
+    fn: (span: typeof mockSpan) => unknown
+  ) => fn(mockSpan)
+)
 const mockWarn = logger.warn as jest.Mock
 
 vi.mock('@/lib/utils/logger', () => ({
@@ -37,9 +41,12 @@ vi.mock('@/lib/utils/logger', () => ({
 }))
 
 vi.mock('@/lib/utils/trace', () => ({
-  getTracer: () => ({
-    startActiveSpan: mockStartActiveSpan
-  })
+  withSpan: (
+    op: string,
+    name: string,
+    data: unknown,
+    fn: (span: typeof mockSpan) => unknown
+  ) => mockWithSpan(op, name, data, fn)
 }))
 
 const createActorDocument = ({
@@ -114,7 +121,7 @@ describe('getSenderPublicKey', () => {
     mockRequests(fetchMock)
     mockSpan.end.mockClear()
     mockSpan.recordException.mockClear()
-    mockStartActiveSpan.mockClear()
+    mockWithSpan.mockClear()
     mockWarn.mockReset()
   })
 
@@ -556,12 +563,12 @@ describe('getSenderPublicKey', () => {
 
     await getSenderPublicKeyDetails(database, actorId)
 
-    expect(mockStartActiveSpan).toHaveBeenCalledWith(
-      'guard.getSenderPublicKey',
-      { attributes: { actorId } },
+    expect(mockWithSpan).toHaveBeenCalledWith(
+      'guard',
+      'getSenderPublicKey',
+      { actorId },
       expect.any(Function)
     )
-    expect(mockSpan.end).toHaveBeenCalled()
   })
 
   it('logs malformed sender public key responses', async () => {

--- a/lib/services/guards/getSenderPublicKey.ts
+++ b/lib/services/guards/getSenderPublicKey.ts
@@ -11,7 +11,7 @@ import {
 } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 const PublicKeyDocument = z
   .object({
@@ -299,27 +299,20 @@ export async function getSenderPublicKeyDetails(
   database: Database,
   actorId: string
 ): Promise<SenderPublicKeyDetails> {
-  const tracer = getTracer()
-  return tracer.startActiveSpan(
-    'guard.getSenderPublicKey',
-    { attributes: { actorId } },
-    async (span) => {
-      try {
-        return await resolveSenderPublicKeyDetails(database, actorId)
-      } catch (error) {
-        const nodeError = error as Error
-        span.recordException(nodeError)
-        logger.warn({
-          actorId,
-          err: nodeError,
-          message: 'Unable to resolve sender public key'
-        })
-        return EMPTY_PUBLIC_KEY_DETAILS
-      } finally {
-        span.end()
-      }
+  return withSpan('guard', 'getSenderPublicKey', { actorId }, async (span) => {
+    try {
+      return await resolveSenderPublicKeyDetails(database, actorId)
+    } catch (error) {
+      const nodeError = error as Error
+      span.recordException(nodeError)
+      logger.warn({
+        actorId,
+        err: nodeError,
+        message: 'Unable to resolve sender public key'
+      })
+      return EMPTY_PUBLIC_KEY_DETAILS
     }
-  )
+  })
 }
 
 export async function getSenderPublicKey(database: Database, actorId: string) {

--- a/lib/services/queue/base.ts
+++ b/lib/services/queue/base.ts
@@ -3,40 +3,46 @@ import { SpanStatusCode } from '@opentelemetry/api'
 import { getDatabase } from '@/lib/database'
 import { JOBS, JobHandle } from '@/lib/jobs'
 import { logger } from '@/lib/utils/logger'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { JobMessage } from './type'
 
 export const defaultJobHandle =
   (queueName: string) => async (message: JobMessage) => {
-    await getTracer().startActiveSpan('queue.handle', async (span) => {
-      logger.debug({ message }, `${queueName} handle job`)
-      const database = getDatabase()
-      if (!database) {
-        logger.error('Database is not available')
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: 'Database is not available'
-        })
-        span.end()
-        return
-      }
+    return withSpan(
+      'queue',
+      'handle',
+      {
+        queueName,
+        jobName: String(message.name)
+      },
+      async (span) => {
+        logger.debug({ message }, `${queueName} handle job`)
+        const database = getDatabase()
+        if (!database) {
+          logger.error('Database is not available')
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: 'Database is not available'
+          })
+          return
+        }
 
-      const jobName = String(message.name)
-      const hasJob = Object.prototype.hasOwnProperty.call(JOBS, jobName)
-      const job = hasJob
-        ? (JOBS as Record<string, JobHandle>)[jobName]
-        : undefined
-      if (!hasJob || typeof job !== 'function') {
-        logger.error({ message }, 'Unknown job name')
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: 'Unknown job name'
-        })
-        span.end()
-        return
-      }
+        const jobName = String(message.name)
+        const hasJob = Object.prototype.hasOwnProperty.call(JOBS, jobName)
+        const job = hasJob
+          ? (JOBS as Record<string, JobHandle>)[jobName]
+          : undefined
+        if (!hasJob || typeof job !== 'function') {
+          logger.error({ message }, 'Unknown job name')
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: 'Unknown job name'
+          })
+          return
+        }
 
-      await job(database, message)
-    })
+        await job(database, message)
+      }
+    )
   }

--- a/lib/services/queue/qstash.test.ts
+++ b/lib/services/queue/qstash.test.ts
@@ -1,28 +1,41 @@
+import {
+  Context,
+  TextMapGetter,
+  TextMapPropagator,
+  TextMapSetter,
+  propagation
+} from '@opentelemetry/api'
 import { Client } from '@upstash/qstash'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { QStashQueue } from './qstash'
 
 vi.mock('@upstash/qstash')
 vi.mock('@/lib/utils/trace', () => ({
-  getTracer: () => ({
-    startActiveSpan: vi.fn((name, callback) =>
-      callback({
-        recordException: vi.fn(),
-        end: vi.fn()
+  withSpan: vi.fn(
+    (
+      _op: string,
+      _name: string,
+      _data: unknown,
+      fn: (span: unknown) => unknown
+    ) =>
+      fn({
+        setAttribute: vi.fn(),
+        setStatus: vi.fn(),
+        recordException: vi.fn()
       })
-    )
-  })
+  )
 }))
 
 describe('QStashQueue', () => {
   const mockPublishJSON = vi.fn()
 
   beforeEach(() => {
-    ;(Client as unknown as jest.Mock).mockImplementation(function () {
+    vi.mocked(Client).mockImplementation(function (this: unknown) {
       return {
         publishJSON: mockPublishJSON
-      }
-    })
+      } as unknown as Client
+    } as unknown as typeof Client)
     mockPublishJSON.mockClear()
   })
 
@@ -72,5 +85,54 @@ describe('QStashQueue', () => {
         deduplicationId: Buffer.from('simple-job').toString('base64url')
       })
     )
+  })
+
+  it('injects active trace context into QStash publish headers when propagator is set', async () => {
+    // Fake propagator that writes a dummy header
+    const fakePropagator: TextMapPropagator = {
+      inject(_ctx: Context, carrier: unknown, setter: TextMapSetter): void {
+        setter.set(
+          carrier as Record<string, string>,
+          'traceparent',
+          '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+        )
+      },
+      extract(
+        _ctx: Context,
+        _carrier: unknown,
+        _getter: TextMapGetter
+      ): Context {
+        return _ctx
+      },
+      fields(): string[] {
+        return ['traceparent']
+      }
+    }
+
+    propagation.setGlobalPropagator(fakePropagator)
+
+    const queue = new QStashQueue({
+      type: 'qstash',
+      url: 'https://example.com/queue',
+      token: 'token',
+      currentSigningKey: 'key',
+      nextSigningKey: 'nextKey'
+    })
+
+    await queue.publish({
+      id: 'job-1',
+      name: 'sendNote',
+      data: {}
+    })
+
+    expect(mockPublishJSON).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+        }
+      })
+    )
+
+    propagation.disable()
   })
 })

--- a/lib/services/queue/qstash.ts
+++ b/lib/services/queue/qstash.ts
@@ -1,7 +1,8 @@
+import { context, propagation } from '@opentelemetry/api'
 import { Client } from '@upstash/qstash'
 import { z } from 'zod'
 
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { defaultJobHandle } from './base'
 import { JobMessage, Queue } from './type'
@@ -33,25 +34,23 @@ export class QStashQueue implements Queue {
   }
 
   async publish(message: JobMessage): Promise<void> {
-    await getTracer().startActiveSpan('queue.publish', async (span) => {
-      try {
-        await this._client.publishJSON({
-          url: this._url,
-          body: message,
-          timeout: MAX_JOB_TIMEOUT_SECONDS,
-          retries: MAX_JOB_RETRIES,
-          deduplicationId: Buffer.from(message.id).toString('base64url'),
-          ...(message.delaySeconds && message.delaySeconds > 0
-            ? { delay: message.delaySeconds }
-            : {})
-        })
-      } catch (error) {
-        const nodeError = error as NodeJS.ErrnoException
-        span.recordException(nodeError)
-        throw error
-      } finally {
-        span.end()
-      }
+    return withSpan('queue', 'publish', { jobName: message.name }, async () => {
+      const traceHeaders: Record<string, string> = {}
+      propagation.inject(context.active(), traceHeaders)
+
+      await this._client.publishJSON({
+        url: this._url,
+        body: message,
+        timeout: MAX_JOB_TIMEOUT_SECONDS,
+        retries: MAX_JOB_RETRIES,
+        deduplicationId: Buffer.from(message.id).toString('base64url'),
+        ...(Object.keys(traceHeaders).length > 0
+          ? { headers: traceHeaders }
+          : {}),
+        ...(message.delaySeconds && message.delaySeconds > 0
+          ? { delay: message.delaySeconds }
+          : {})
+      })
     })
   }
 

--- a/lib/services/timelines/index.ts
+++ b/lib/services/timelines/index.ts
@@ -3,7 +3,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { isDirectStatus } from '@/lib/utils/directStatus'
 import { logger } from '@/lib/utils/logger'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { getBlockedRecipientActorIdsForStatus } from './blockFilter'
 import { mainTimelineRule } from './main'
@@ -40,10 +40,11 @@ export const addStatusToTimelines = async (
   database: Database,
   status: Status
 ): Promise<void> => {
-  return getTracer().startActiveSpan(
-    'timelines.addStatusToTimelines',
-    { attributes: { statusId: status.id } },
-    async (span) => {
+  return withSpan(
+    'timeline',
+    'addStatusToTimelines',
+    { statusId: status.id },
+    async () => {
       const { to, cc, actorId } = status
       const recipients = [...to, ...cc, actorId]
       const localActors = (
@@ -157,7 +158,6 @@ export const addStatusToTimelines = async (
           ])
         })
       )
-      span.end()
     }
   )
 }

--- a/lib/services/timelines/main.ts
+++ b/lib/services/timelines/main.ts
@@ -1,6 +1,6 @@
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { MainTimelineRule, Timeline } from './types'
 
@@ -28,15 +28,14 @@ export const mainTimelineRule: MainTimelineRule = async ({
   currentActor,
   status
 }) =>
-  getTracer().startActiveSpan(
-    'timelines.mainTimelineRule',
+  withSpan(
+    'timeline',
+    'mainTimelineRule',
     {
-      attributes: {
-        actorId: currentActor.id,
-        statusId: status.id
-      }
+      actorId: currentActor.id,
+      statusId: status.id
     },
-    async (span) => {
+    async () => {
       if (status.type === StatusType.enum.Announce) {
         // The viewer's own boosts always belong in their home timeline; only
         // boosts from others are gated on the follow. A single lookup yields
@@ -54,7 +53,6 @@ export const mainTimelineRule: MainTimelineRule = async ({
             announceFollow.status !== FollowStatus.enum.Accepted ||
             announceFollow.reblogs === false
           ) {
-            span.end()
             return null
           }
         }
@@ -65,13 +63,11 @@ export const mainTimelineRule: MainTimelineRule = async ({
           currentActor,
           status: originalStatus
         })
-        span.end()
         if (timeline === Timeline.MAIN) return null
         return Timeline.MAIN
       }
 
       if (status.actorId === currentActor.id) {
-        span.end()
         return Timeline.MAIN
       }
       const isFollowing = await database.isCurrentActorFollowing({
@@ -80,7 +76,6 @@ export const mainTimelineRule: MainTimelineRule = async ({
       })
 
       if (!status.reply) {
-        span.end()
         if (isFollowing) return Timeline.MAIN
         return null
       }
@@ -91,15 +86,12 @@ export const mainTimelineRule: MainTimelineRule = async ({
       })
       // Deleted parent status, don't show child status
       if (!repliedStatus) {
-        span.end()
         return null
       }
       if (repliedStatus.actorId === currentActor.id) {
-        span.end()
         return Timeline.MAIN
       }
       if (!isFollowing) {
-        span.end()
         return null
       }
       const value = await mainTimelineRule({
@@ -107,7 +99,6 @@ export const mainTimelineRule: MainTimelineRule = async ({
         currentActor,
         status: repliedStatus
       })
-      span.end()
       return value
     }
   )

--- a/lib/services/timelines/mentionNotification.ts
+++ b/lib/services/timelines/mentionNotification.ts
@@ -12,7 +12,7 @@ import { NotificationType } from '@/lib/types/database/operations'
 import { getActorURL } from '@/lib/types/domain/actor'
 import { StatusType } from '@/lib/types/domain/status'
 import { TagType } from '@/lib/types/domain/tag'
-import { getTracer } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 import { TimelineRuleParams } from './types'
 
@@ -35,13 +35,12 @@ export const notifyRemoteReplyAndMention = async ({
   currentActor,
   status
 }: TimelineRuleParams): Promise<void> =>
-  getTracer().startActiveSpan(
-    'timelines.notifyRemoteReplyAndMention',
+  withSpan(
+    'timeline',
+    'notifyRemoteReplyAndMention',
     {
-      attributes: {
-        actorId: currentActor.id,
-        statusId: status.id
-      }
+      actorId: currentActor.id,
+      statusId: status.id
     },
     async (span) => {
       const config = getConfig()
@@ -52,7 +51,6 @@ export const notifyRemoteReplyAndMention = async ({
         status.isLocalActor ||
         status.actorId === currentActor.id
       ) {
-        span.end()
         return
       }
       if (
@@ -61,7 +59,6 @@ export const notifyRemoteReplyAndMention = async ({
           actorIdB: status.actorId
         })
       ) {
-        span.end()
         return
       }
 
@@ -195,7 +192,5 @@ export const notifyRemoteReplyAndMention = async ({
           events: alertEvents
         })
       }
-
-      span.end()
     }
   )

--- a/lib/utils/signature.ts
+++ b/lib/utils/signature.ts
@@ -6,7 +6,7 @@ import { getConfig } from '@/lib/config'
 import { getHeadersValue } from '@/lib/services/guards/getHeaderValue'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Actor } from '@/lib/types/domain/actor'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface StringMap {
   [key: string]: string
@@ -33,39 +33,34 @@ export async function verify(
   headers: IncomingHttpHeaders | Headers,
   publicKey: string
 ) {
-  const span = getSpan('signature', 'verify', {
-    requestTarget
+  return withSpan('signature', 'verify', { requestTarget }, async () => {
+    const requestSignature = getHeadersValue(headers, 'signature')
+    const parsedSignature = await parse(requestSignature as string)
+    if (!parsedSignature.headers) {
+      return false
+    }
+
+    const comparedSignedString = parsedSignature.headers
+      .split(' ')
+      .map((item) => {
+        if (item === '(request-target)') {
+          return `(request-target): ${requestTarget}`
+        }
+        if (item === 'host') {
+          return `${item}: ${headerHost(headers)}`
+        }
+        return `${item}: ${getHeadersValue(headers, item)}`
+      })
+      .join('\n')
+    const signature = parsedSignature.signature
+    const verifier = crypto.createVerify(parsedSignature.algorithm)
+    verifier.update(comparedSignedString)
+    try {
+      return verifier.verify(publicKey, signature, 'base64')
+    } catch {
+      return false
+    }
   })
-
-  const requestSignature = getHeadersValue(headers, 'signature')
-  const parsedSignature = await parse(requestSignature as string)
-  if (!parsedSignature.headers) {
-    span.end()
-    return false
-  }
-
-  const comparedSignedString = parsedSignature.headers
-    .split(' ')
-    .map((item) => {
-      if (item === '(request-target)') {
-        return `(request-target): ${requestTarget}`
-      }
-      if (item === 'host') {
-        return `${item}: ${headerHost(headers)}`
-      }
-      return `${item}: ${getHeadersValue(headers, item)}`
-    })
-    .join('\n')
-  const signature = parsedSignature.signature
-  const verifier = crypto.createVerify(parsedSignature.algorithm)
-  verifier.update(comparedSignedString)
-  try {
-    return verifier.verify(publicKey, signature, 'base64')
-  } catch {
-    return false
-  } finally {
-    span.end()
-  }
 }
 
 export function signedHeaders(

--- a/lib/utils/text/getMentions.ts
+++ b/lib/utils/text/getMentions.ts
@@ -10,7 +10,7 @@ import {
   MENTION_GLOBAL_REGEX,
   MentionMatchGroup
 } from '@/lib/utils/text/convertMarkdownText'
-import { getSpan } from '@/lib/utils/trace'
+import { withSpan } from '@/lib/utils/trace'
 
 interface GetMentionsParams {
   text: string
@@ -21,56 +21,59 @@ export const getMentions = async ({
   text,
   currentActor,
   replyStatus
-}: GetMentionsParams): Promise<Mention[]> => {
-  const span = getSpan('link', 'getMentions', {
-    text,
-    actorId: currentActor.id,
-    replyStatusId: replyStatus?.id
-  })
+}: GetMentionsParams): Promise<Mention[]> =>
+  withSpan(
+    'link',
+    'getMentions',
+    {
+      text,
+      actorId: currentActor.id,
+      replyStatusId: replyStatus?.id
+    },
+    async () => {
+      const mentions = await Promise.all(
+        Array.from(text.matchAll(MENTION_GLOBAL_REGEX)).map(async (match) => {
+          const mention = match.groups as MentionMatchGroup
+          try {
+            const userHost = mention.domain ?? currentActor.domain
+            const actorId = await getWebfingerSelf({
+              account: `${mention.username}@${userHost}`
+            })
+            if (!actorId) return null
 
-  const mentions = await Promise.all(
-    Array.from(text.matchAll(MENTION_GLOBAL_REGEX)).map(async (match) => {
-      const mention = match.groups as MentionMatchGroup
-      try {
-        const userHost = mention.domain ?? currentActor.domain
-        const actorId = await getWebfingerSelf({
-          account: `${mention.username}@${userHost}`
+            return Mention.parse({
+              type: 'Mention',
+              href: actorId,
+              name: match[0].trim()
+            })
+          } catch {
+            return null
+          }
         })
-        if (!actorId) return null
+      )
 
-        return Mention.parse({
+      if (replyStatus) {
+        const name = replyStatus.actor
+          ? getMention(replyStatus.actor, true)
+          : getMentionFromActorID(replyStatus.actorId, true)
+
+        mentions.push({
           type: 'Mention',
-          href: actorId,
-          name: match[0].trim()
+          href: replyStatus.actorId,
+          name
         })
-      } catch {
-        return null
       }
-    })
+
+      const mentionsMap = mentions
+        .filter((item): item is Mention => item !== null)
+        .reduce(
+          (out, item) => {
+            out[item.name] = item
+            return out
+          },
+          {} as { [key: string]: Mention }
+        )
+
+      return Object.values(mentionsMap)
+    }
   )
-
-  if (replyStatus) {
-    const name = replyStatus.actor
-      ? getMention(replyStatus.actor, true)
-      : getMentionFromActorID(replyStatus.actorId, true)
-
-    mentions.push({
-      type: 'Mention',
-      href: replyStatus.actorId,
-      name
-    })
-  }
-
-  const mentionsMap = mentions
-    .filter((item): item is Mention => item !== null)
-    .reduce(
-      (out, item) => {
-        out[item.name] = item
-        return out
-      },
-      {} as { [key: string]: Mention }
-    )
-
-  span.end()
-  return Object.values(mentionsMap)
-}

--- a/lib/utils/trace.test.ts
+++ b/lib/utils/trace.test.ts
@@ -1,60 +1,238 @@
-import { Trace, getSpan, getTracer } from './trace'
+import {
+  Context,
+  ContextManager,
+  ROOT_CONTEXT,
+  Span,
+  SpanContext,
+  SpanOptions,
+  SpanStatus,
+  SpanStatusCode,
+  TraceFlags,
+  Tracer,
+  TracerProvider,
+  context,
+  trace
+} from '@opentelemetry/api'
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-describe('trace utilities', () => {
-  describe('getTracer', () => {
-    it('returns a tracer', () => {
-      const tracer = getTracer()
-      expect(tracer).toBeDefined()
-    })
+import { withSpan } from './trace'
+
+class AsyncLocalStorageContextManager implements ContextManager {
+  private _storage = new AsyncLocalStorage<Context>()
+
+  active(): Context {
+    return this._storage.getStore() ?? ROOT_CONTEXT
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    ctx: Context,
+    fn: (...args: A) => ReturnType<F>,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    return this._storage.run(ctx, () => fn.apply(thisArg, args))
+  }
+
+  bind<T>(_context: Context, target: T): T {
+    return target
+  }
+
+  enable(): this {
+    return this
+  }
+
+  disable(): this {
+    this._storage.disable()
+    return this
+  }
+}
+
+// Minimal in-memory tracer that records spans for assertion without an SDK.
+interface RecordedSpan {
+  name: string
+  spanId: string
+  parentSpanId?: string
+  attributes: Record<string, unknown>
+  status?: SpanStatus
+  exception?: Error
+  ended: boolean
+}
+
+function createFakeTracerProvider() {
+  const recordedSpans: RecordedSpan[] = []
+  let spanIdCounter = 0
+
+  class FakeSpan implements Span {
+    readonly spanContextValue: SpanContext
+    private _rec: RecordedSpan
+
+    constructor(name: string, options?: SpanOptions, parentContext?: Context) {
+      const parentSpan = parentContext
+        ? trace.getSpan(parentContext)
+        : undefined
+      const id = String(++spanIdCounter).padStart(16, '0')
+      this.spanContextValue = {
+        traceId:
+          parentSpan?.spanContext().traceId ??
+          '11111111111111111111111111111111',
+        spanId: id,
+        traceFlags: TraceFlags.SAMPLED
+      }
+      this._rec = {
+        name,
+        spanId: id,
+        parentSpanId: parentSpan?.spanContext().spanId,
+        attributes: { ...(options?.attributes ?? {}) },
+        ended: false
+      }
+      recordedSpans.push(this._rec)
+    }
+
+    spanContext(): SpanContext {
+      return this.spanContextValue
+    }
+    setAttribute(key: string, value: unknown): this {
+      this._rec.attributes[key] = value
+      return this
+    }
+    setAttributes(attributes: Record<string, unknown>): this {
+      Object.assign(this._rec.attributes, attributes)
+      return this
+    }
+    addEvent(): this {
+      return this
+    }
+    addLink(): this {
+      return this
+    }
+    addLinks(): this {
+      return this
+    }
+    setStatus(status: SpanStatus): this {
+      this._rec.status = status
+      return this
+    }
+    updateName(name: string): this {
+      this._rec.name = name
+      return this
+    }
+    end(): void {
+      this._rec.ended = true
+    }
+    isRecording(): boolean {
+      return true
+    }
+    recordException(exception: Error): void {
+      this._rec.exception = exception
+    }
+  }
+
+  class FakeTracer implements Tracer {
+    startSpan(name: string, options?: SpanOptions, ctx?: Context): Span {
+      return new FakeSpan(name, options, ctx ?? context.active())
+    }
+    startActiveSpan<F extends (span: Span) => unknown>(
+      name: string,
+      optionsOrFn: SpanOptions | F,
+      contextOrFn?: Context | F,
+      maybeFn?: F
+    ): ReturnType<F> {
+      let fn: F
+      let options: SpanOptions | undefined
+      let ctx: Context | undefined
+
+      if (typeof optionsOrFn === 'function') {
+        fn = optionsOrFn
+      } else if (typeof contextOrFn === 'function') {
+        fn = contextOrFn
+        options = optionsOrFn
+      } else {
+        fn = maybeFn!
+        options = optionsOrFn
+        ctx = contextOrFn
+      }
+
+      const activeCtx = ctx ?? context.active()
+      const span = new FakeSpan(name, options, activeCtx)
+      const newCtx = trace.setSpan(activeCtx, span)
+      return context.with(newCtx, () => fn(span)) as ReturnType<F>
+    }
+  }
+
+  const provider: TracerProvider = {
+    getTracer: () => new FakeTracer()
+  }
+
+  return { provider, recordedSpans }
+}
+
+describe('withSpan', () => {
+  let recordedSpans: RecordedSpan[]
+
+  beforeEach(() => {
+    const contextManager = new AsyncLocalStorageContextManager()
+    contextManager.enable()
+    context.setGlobalContextManager(contextManager)
+    const fake = createFakeTracerProvider()
+    trace.setGlobalTracerProvider(fake.provider)
+    recordedSpans = fake.recordedSpans
   })
 
-  describe('getSpan', () => {
-    it('creates a span with op and name', () => {
-      const span = getSpan('test', 'operation')
+  afterEach(() => {
+    trace.disable()
+    context.disable()
+  })
 
-      expect(span).toBeDefined()
-      span.end()
-    })
+  it('runs fn, sets attributes, and ends span on success', async () => {
+    const result = await withSpan(
+      'actions',
+      'testOp',
+      { key: 'val' },
+      async (span) => {
+        span.setAttribute('extra', 42)
+        return 'success'
+      }
+    )
 
-    it('creates a span with data attributes', () => {
-      const span = getSpan('test', 'operation', {
-        key: 'value',
-        num: 123,
-        bool: true
+    expect(result).toBe('success')
+    expect(recordedSpans).toHaveLength(1)
+    expect(recordedSpans[0].name).toBe('actions.testOp')
+    expect(recordedSpans[0].attributes).toEqual({ key: 'val', extra: 42 })
+    expect(recordedSpans[0].ended).toBe(true)
+    expect(recordedSpans[0].exception).toBeUndefined()
+  })
+
+  it('nests child spans under parent when called inside withSpan', async () => {
+    await withSpan('parent', 'outer', {}, async () => {
+      await withSpan('child', 'inner', {}, async () => {
+        return 'child done'
       })
-
-      expect(span).toBeDefined()
-      span.end()
     })
+
+    expect(recordedSpans).toHaveLength(2)
+    const [outer, inner] = recordedSpans
+    expect(outer.name).toBe('parent.outer')
+    expect(inner.name).toBe('child.inner')
+    expect(inner.parentSpanId).toBe(outer.spanId)
   })
 
-  describe('Trace decorator', () => {
-    it('wraps async function with tracing', async () => {
-      class TestClass {
-        @Trace('test')
-        async asyncMethod() {
-          return 'async result'
-        }
-      }
+  it('records exception, sets status ERROR, ends span, and rethrows on failure', async () => {
+    const err = new Error('boom')
 
-      const instance = new TestClass()
-      const result = await instance.asyncMethod()
+    await expect(
+      withSpan('actions', 'failingOp', {}, async () => {
+        throw err
+      })
+    ).rejects.toThrow('boom')
 
-      expect(result).toBe('async result')
-    })
-
-    it('wraps sync function with tracing', () => {
-      class TestClass {
-        @Trace('test')
-        syncMethod() {
-          return 'sync result'
-        }
-      }
-
-      const instance = new TestClass()
-      const result = instance.syncMethod()
-
-      expect(result).toBe('sync result')
+    expect(recordedSpans).toHaveLength(1)
+    expect(recordedSpans[0].name).toBe('actions.failingOp')
+    expect(recordedSpans[0].ended).toBe(true)
+    expect(recordedSpans[0].exception).toBe(err)
+    expect(recordedSpans[0].status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: 'Error: boom'
     })
   })
 })

--- a/lib/utils/trace.ts
+++ b/lib/utils/trace.ts
@@ -1,6 +1,5 @@
-import { trace } from '@opentelemetry/api'
+import { Span, SpanStatusCode, trace } from '@opentelemetry/api'
 
-import { logger } from '@/lib/utils/logger'
 import { VERSION } from '@/lib/utils/version'
 
 export const TRACE_APPLICATION_SCOPE = 'activities.next'
@@ -10,50 +9,33 @@ export interface Data {
   [key: string]: string | boolean | number | undefined
 }
 
-export const getSpan = (op: string, name: string, data: Data = {}) => {
-  const tracer = trace.getTracer(
-    TRACE_APPLICATION_SCOPE,
-    TRACE_APPLICATION_VERSION
-  )
-  const span = tracer.startSpan(`${op}.${name}`, { attributes: data })
-  return span
-}
-
 export const getTracer = () =>
   trace.getTracer(TRACE_APPLICATION_SCOPE, TRACE_APPLICATION_VERSION)
 
-const AsyncFunction = async function () {}.constructor
-type AsyncFunction = typeof AsyncFunction
-
-export function Trace(op: string) {
-  return function (
-    target: object,
-    propertyKey: string,
-    descriptor: PropertyDescriptor
-  ) {
-    const original = descriptor.value as AsyncFunction
-    if (original instanceof AsyncFunction) {
-      return {
-        ...descriptor,
-        value: async function (...args: unknown[]) {
-          const span = getSpan(op, propertyKey)
-          logger.debug({ target: target.constructor.name, op, propertyKey })
-          const value = await original.apply(this, args)
-          span.end()
-          return value
-        }
-      }
-    }
-
-    return {
-      ...descriptor,
-      value: function (...args: unknown[]) {
-        const span = getSpan(op, propertyKey)
-        logger.debug({ target: target.constructor.name, op, propertyKey })
-        const value = original.apply(this, args)
+/**
+ * Runs `fn` inside an active span named `${op}.${name}`.
+ * The span is the active context while `fn` runs (so nested work links to it),
+ * records exceptions and ERROR status on throw, and always ends — on success,
+ * on early return, and on throw. Without a registered provider this is a no-op.
+ */
+export const withSpan = <T>(
+  op: string,
+  name: string,
+  data: Data = {},
+  fn: (span: Span) => Promise<T>
+): Promise<T> =>
+  getTracer().startActiveSpan(
+    `${op}.${name}`,
+    { attributes: data },
+    async (span) => {
+      try {
+        return await fn(span)
+      } catch (error) {
+        span.recordException(error instanceof Error ? error : String(error))
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) })
+        throw error
+      } finally {
         span.end()
-        return value
       }
     }
-  }
-}
+  )


### PR DESCRIPTION
## Summary

- Rewrote `lib/utils/trace.ts` with `withSpan<T>(op, name, data, fn)` to guarantee spans nest under active context, record exceptions, set error status, and always close in `finally`.
- Removed broken `getSpan` and `@Trace` decorator helpers.
- Migrated all call sites across `lib/actions/`, `lib/activities/`, `lib/jobs/`, `lib/services/timelines/`, `lib/services/guards/`, `lib/services/queue/`, and `app/api/` from manual span handling / `getSpan` / `@Trace` to `withSpan`.
- Fixed leaked span lifecycles across job handlers and queue handlers.
- Updated `QStashQueue.publish` to inject active trace context (`traceparent`) into outgoing HTTP headers via OpenTelemetry W3C propagation.
- Added comprehensive unit tests for `withSpan` and QStash trace propagation using in-memory tracer without introducing any SDK/exporter dependencies to `main`.

## Verification

Passed all Definition of Done quality gates in required order:
1. `yarn run prettier --write .` (PASSED)
2. `yarn lint` (PASSED)
3. `yarn typecheck` (PASSED)
4. `yarn build` (PASSED)
5. `yarn test` (863 test files, 10,872 tests PASSED)