### PR TITLE
Bump version to v1.144.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.144.4",
+  "version": "1.144.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.144.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.144.4`
- Base main SHA: `dfe95a5c61b14691659d5a0c22ec815446bf7ea9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
