### PR TITLE
fix: truncate oversized link preview fetches and raise head parsing cap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,11 +210,12 @@ that both the web UI and the Mastodon API's `Status.card` render.
   normalized URL, and `status_link_previews` maps a status to the card it shows.
   A link shared by many posts is fetched once, not once per post.
 - Pages are fetched through `safeRemoteFetch` (HTTPS only, private-IP
-  blocklists, DNS pinning, redirect and body caps) with a 1 MiB body cap and a
+  blocklists, DNS pinning, redirect and body caps) with a 2 MiB transfer cap
+  (bodies over 2 MiB are truncated rather than rejected) and a
   5s-per-hop budget over at most one redirect,
-  and must answer `text/html` in UTF-8 to be parsed at all. Only the document
-  `<head>` is parsed: the byte cap bounds transfer, not CPU, and the HTML parser
-  is quadratic in nesting depth.
+  and must answer `text/html` in UTF-8 to be parsed at all. Up to 1 MiB of the
+  document `<head>` is parsed: the byte cap bounds transfer, not CPU, and the
+  HTML parser is quadratic in nesting depth.
 - A completed card is re-read after 7 days. A failure is stored as a
   negative-cache row for an hour, so an unreachable host is not re-contacted for
   every post that mentions it.

--- a/lib/services/link-previews/fetchLinkPreview.test.ts
+++ b/lib/services/link-previews/fetchLinkPreview.test.ts
@@ -28,6 +28,7 @@ const mockedFetch = vi.mocked(safeRemoteFetch)
 
 const htmlResponse = (html: string, url = 'https://example.com/article') => ({
   body: html,
+  bodyTruncated: false,
   headers: { 'content-type': 'text/html; charset=utf-8' },
   statusCode: 200,
   url
@@ -179,6 +180,7 @@ describe('fetchLinkPreview', () => {
       description: 'rejects a non-200 response',
       response: {
         body: PAGE,
+        bodyTruncated: false,
         headers: { 'content-type': 'text/html' },
         statusCode: 404,
         url: 'https://example.com/missing'
@@ -189,6 +191,7 @@ describe('fetchLinkPreview', () => {
       description: 'rejects a non-html content type',
       response: {
         body: '{}',
+        bodyTruncated: false,
         headers: { 'content-type': 'application/json' },
         statusCode: 200,
         url: 'https://example.com/json'
@@ -199,6 +202,7 @@ describe('fetchLinkPreview', () => {
       description: 'rejects a pdf',
       response: {
         body: '%PDF-1.4',
+        bodyTruncated: false,
         headers: { 'content-type': 'application/pdf' },
         statusCode: 200,
         url: 'https://example.com/doc.pdf'
@@ -209,6 +213,7 @@ describe('fetchLinkPreview', () => {
       description: 'rejects a non-utf8 charset',
       response: {
         body: PAGE,
+        bodyTruncated: false,
         headers: { 'content-type': 'text/html; charset=iso-8859-1' },
         statusCode: 200,
         url: 'https://example.com/latin'
@@ -219,6 +224,7 @@ describe('fetchLinkPreview', () => {
       description: 'rejects a response with no content type',
       response: {
         body: PAGE,
+        bodyTruncated: false,
         headers: {},
         statusCode: 200,
         url: 'https://example.com/notype'
@@ -241,6 +247,7 @@ describe('fetchLinkPreview', () => {
     const url = 'https://example.com/xhtml'
     mockedFetch.mockResolvedValue({
       body: PAGE,
+      bodyTruncated: false,
       headers: { 'content-type': 'application/xhtml+xml' },
       statusCode: 200,
       url
@@ -254,6 +261,7 @@ describe('fetchLinkPreview', () => {
     const url = 'https://example.com/empty'
     mockedFetch.mockResolvedValue({
       body: '<html><head></head><body>nothing</body></html>',
+      bodyTruncated: false,
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
       url
@@ -273,6 +281,7 @@ describe('fetchLinkPreview', () => {
     mockedFetch.mockResolvedValue({
       body: `<html><head><meta property="og:title" content="Moved">
              <meta property="og:image" content="/img/a.png"></head><body></body></html>`,
+      bodyTruncated: false,
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
       // safeRemoteFetch reports where the redirect chain actually ended.
@@ -304,6 +313,7 @@ describe('fetchLinkPreview', () => {
     const options = mockedFetch.mock.calls[0][0]
     expect(options.maxBodyBytes).toBe(LINK_PREVIEW_MAX_BODY_BYTES)
     expect(options.maxRedirects).toBe(LINK_PREVIEW_MAX_REDIRECTS)
+    expect(options.onBodyTooLarge).toBe('truncate')
     // Set explicitly, never via the single `timeoutInMilliseconds` knob: that
     // one is used for BOTH connect and read, so a lone value silently buys a
     // hop of double the intended budget.
@@ -325,7 +335,26 @@ describe('fetchLinkPreview', () => {
     expect(
       LINK_PREVIEW_TIMEOUT_MS * (LINK_PREVIEW_MAX_REDIRECTS + 1)
     ).toBeLessThanOrEqual(10_000)
-    expect(LINK_PREVIEW_MAX_BODY_BYTES).toBeLessThan(2 * 1024 * 1024)
+    expect(LINK_PREVIEW_MAX_BODY_BYTES).toBeLessThanOrEqual(2 * 1024 * 1024)
+  })
+
+  it('stores a card when safeRemoteFetch returns a truncated body with valid head metadata', async () => {
+    const url = 'https://example.com/truncated-page'
+    mockedFetch.mockResolvedValue({
+      body: `${PAGE}<div>${'x'.repeat(1000)}`,
+      bodyTruncated: true,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+      statusCode: 200,
+      url
+    })
+
+    const card = await fetchLinkPreview({ database, url })
+
+    expect(card).toMatchObject({
+      url,
+      title: 'A good article',
+      fetchStatus: 'completed'
+    })
   })
 
   // The card's domain is presented to the reader as "where this link goes", so
@@ -353,6 +382,7 @@ describe('fetchLinkPreview', () => {
     const url = 'https://trusted.example.com/redirect?to=evil'
     mockedFetch.mockResolvedValue({
       body: PAGE,
+      bodyTruncated: false,
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
       url: `https://evil.example/${'a'.repeat(3000)}`
@@ -381,6 +411,7 @@ describe('fetchLinkPreview', () => {
         <meta property="og:image:width" content="99999999999999">
         <meta property="og:image:height" content="99999999999999">
       </head><body></body></html>`,
+      bodyTruncated: false,
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
       url
@@ -400,6 +431,7 @@ describe('fetchLinkPreview', () => {
     const url = 'https://example.com/meta-charset'
     mockedFetch.mockResolvedValue({
       body: '<html><head><meta charset="windows-1251"><meta property="og:title" content="T"></head><body></body></html>',
+      bodyTruncated: false,
       // A bare text/html header: the encoding is declared only in the markup.
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
@@ -420,6 +452,7 @@ describe('fetchLinkPreview', () => {
     const url = `https://example.com/ascii-${charset.toLowerCase()}`
     mockedFetch.mockResolvedValue({
       body: PAGE,
+      bodyTruncated: false,
       headers: { 'content-type': `text/html; charset=${charset}` },
       statusCode: 200,
       url
@@ -434,6 +467,7 @@ describe('fetchLinkPreview', () => {
     const url = 'https://example.com/meta-ascii'
     mockedFetch.mockResolvedValue({
       body: '<html><head><meta charset="us-ascii"><meta property="og:title" content="T"></head><body></body></html>',
+      bodyTruncated: false,
       headers: { 'content-type': 'text/html' },
       statusCode: 200,
       url

--- a/lib/services/link-previews/fetchLinkPreview.ts
+++ b/lib/services/link-previews/fetchLinkPreview.ts
@@ -22,10 +22,10 @@ export const LINK_PREVIEW_REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000
 // the same trap the remote-actor refresh path avoids by stamping its failures.
 export const LINK_PREVIEW_FAILURE_TTL_MS = 60 * 60 * 1000
 
-// Deliberately tighter than the 2 MiB `safeRemoteFetch` default: the metadata
-// lives in <head>, and a page bigger than this is not one we want to parse
-// inline in a request on a NoQueue deployment.
-export const LINK_PREVIEW_MAX_BODY_BYTES = 1024 * 1024
+// Bounds transfer over the wire for inline NoQueue fetches. Responses exceeding
+// this cap are truncated rather than rejected, allowing the <head> to be parsed
+// without downloading unbounded response bodies.
+export const LINK_PREVIEW_MAX_BODY_BYTES = 2 * 1024 * 1024
 
 // Connect and read budgets are set SEPARATELY on purpose. `safeRemoteFetch`
 // falls back to using `timeoutInMilliseconds` for both, and got's own request
@@ -152,7 +152,8 @@ export const fetchLinkPreview = async ({
       maxBodyBytes: LINK_PREVIEW_MAX_BODY_BYTES,
       maxRedirects: LINK_PREVIEW_MAX_REDIRECTS,
       connectTimeoutInMilliseconds: LINK_PREVIEW_CONNECT_TIMEOUT_MS,
-      readTimeoutInMilliseconds: LINK_PREVIEW_READ_TIMEOUT_MS
+      readTimeoutInMilliseconds: LINK_PREVIEW_READ_TIMEOUT_MS,
+      onBodyTooLarge: 'truncate'
     })
 
     if (response.statusCode !== 200) {

--- a/lib/services/link-previews/parseOpenGraph.test.ts
+++ b/lib/services/link-previews/parseOpenGraph.test.ts
@@ -374,6 +374,15 @@ describe('parseOpenGraphMetadata', () => {
     expect(result?.title).toBe('Headless')
   })
 
+  it('reads metadata from a large head exceeding 128 KiB', () => {
+    // 700 KB of scripts in head before the OG tags (e.g. YouTube)
+    const padding = '<script>/* ' + 'x'.repeat(700 * 1024) + ' */</script>'
+    const html = `<html><head>${padding}<meta property="og:title" content="YouTube Video Title"></head><body></body></html>`
+
+    const result = parseOpenGraphMetadata(html, BASE_URL)
+    expect(result?.title).toBe('YouTube Video Title')
+  })
+
   describe('getDeclaredCharset', () => {
     it.each([
       {

--- a/lib/services/link-previews/parseOpenGraph.ts
+++ b/lib/services/link-previews/parseOpenGraph.ts
@@ -19,7 +19,10 @@ export const MAX_SHORT_TEXT_LENGTH = 255
 // in-process queue runs inside the request that created the status. Every tag
 // this reads is defined to live in <head>, so slicing there removes the entire
 // class of hostile <body> payloads rather than trying to time-bound them.
-export const MAX_HEAD_LENGTH = 128 * 1024
+// The 1 MiB cap allows heavy <head> tags (such as YouTube with ~680 KB of inline
+// config scripts in <head> before its OpenGraph tags) while keeping the parse
+// strictly head-bounded.
+export const MAX_HEAD_LENGTH = 1024 * 1024
 
 const HEAD_END = '</head>'
 

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -110,6 +110,77 @@ describe('safeRemoteFetch', () => {
     expect(body.destroyed).toBe(true)
   })
 
+  it('truncates body and destroys stream when onBodyTooLarge is truncate', async () => {
+    let chunksPushed = 0
+    const body = new Readable({
+      read() {
+        chunksPushed += 1
+        this.push('1234')
+        this.push('5678')
+        this.push('9012')
+        this.push(null)
+      }
+    })
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async () => ({
+        statusCode: 200,
+        headers: {},
+        body
+      })
+    })
+
+    const result = await safeRemoteFetch({
+      url: 'https://safe.example/truncate',
+      maxBodyBytes: 8,
+      onBodyTooLarge: 'truncate'
+    })
+
+    expect(result.body).toBe('12345678')
+    expect(result.bodyTruncated).toBe(true)
+    expect(body.destroyed).toBe(true)
+  })
+
+  it('does not reject on over-cap content-length when onBodyTooLarge is truncate', async () => {
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async () => ({
+        statusCode: 200,
+        headers: { 'content-length': '100' },
+        body: streamFrom(['1234', '5678', '9012'])
+      })
+    })
+
+    const result = await safeRemoteFetch({
+      url: 'https://safe.example/truncate-length',
+      maxBodyBytes: 8,
+      onBodyTooLarge: 'truncate'
+    })
+
+    expect(result.body).toBe('12345678')
+    expect(result.bodyTruncated).toBe(true)
+  })
+
+  it('returns bodyTruncated false when body is within byte limit', async () => {
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async () => ({
+        statusCode: 200,
+        headers: {},
+        body: streamFrom(['1234', '5678'])
+      })
+    })
+
+    const result = await safeRemoteFetch({
+      url: 'https://safe.example/exact',
+      maxBodyBytes: 8,
+      onBodyTooLarge: 'truncate'
+    })
+
+    expect(result.body).toBe('12345678')
+    expect(result.bodyTruncated).toBe(false)
+  })
+
   it('rejects redirects beyond the configured cap', async () => {
     const safeRemoteFetch = createSafeRemoteFetch({
       resolveHost: async () => [SAFE_ADDRESS],

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -77,6 +77,7 @@ export type SafeRemoteFetchOptions = {
   maxBodyBytes?: number
   maxRedirects?: number
   method?: SafeRemoteFetchMethod
+  onBodyTooLarge?: 'fail' | 'truncate'
   readTimeoutInMilliseconds?: number
   timeoutInMilliseconds?: number
   url: string
@@ -84,6 +85,7 @@ export type SafeRemoteFetchOptions = {
 
 export type SafeRemoteFetchResult = {
   body: string
+  bodyTruncated: boolean
   headers: Record<string, string | string[] | undefined>
   statusCode: number
   url: string
@@ -570,12 +572,17 @@ const getRequestHeaders = ({
 
 const readResponseBody = async (
   response: SafeRemoteFetchTransportResponse,
-  maxBodyBytes: number
+  maxBodyBytes: number,
+  onBodyTooLarge: 'fail' | 'truncate' = 'fail'
 ) => {
   const declaredLength = Number(
     getHeaderValue(response.headers, 'content-length')
   )
-  if (Number.isFinite(declaredLength) && declaredLength > maxBodyBytes) {
+  if (
+    onBodyTooLarge === 'fail' &&
+    Number.isFinite(declaredLength) &&
+    declaredLength > maxBodyBytes
+  ) {
     const error = createResponseTooLargeError()
     response.body.destroy()
     throw error
@@ -583,21 +590,36 @@ const readResponseBody = async (
 
   const chunks: Buffer[] = []
   let bodyBytes = 0
+  let bodyTruncated = false
 
   for await (const chunk of response.body) {
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-    bodyBytes += buffer.byteLength
+    const newTotal = bodyBytes + buffer.byteLength
 
-    if (bodyBytes > maxBodyBytes) {
+    if (newTotal > maxBodyBytes) {
+      if (onBodyTooLarge === 'truncate') {
+        const remaining = maxBodyBytes - bodyBytes
+        if (remaining > 0) {
+          chunks.push(buffer.subarray(0, remaining))
+        }
+        bodyTruncated = true
+        response.body.destroy()
+        break
+      }
+
       const error = createResponseTooLargeError()
       response.body.destroy()
       throw error
     }
 
+    bodyBytes = newTotal
     chunks.push(buffer)
   }
 
-  return Buffer.concat(chunks).toString('utf8')
+  return {
+    body: Buffer.concat(chunks).toString('utf8'),
+    bodyTruncated
+  }
 }
 
 const getRedirectLocation = (
@@ -645,6 +667,7 @@ export const createSafeRemoteFetch = ({
     maxBodyBytes = DEFAULT_SAFE_REMOTE_FETCH_MAX_BODY_BYTES,
     maxRedirects = DEFAULT_SAFE_REMOTE_FETCH_MAX_REDIRECTS,
     method = 'GET',
+    onBodyTooLarge = 'fail',
     readTimeoutInMilliseconds,
     timeoutInMilliseconds = 10000,
     url
@@ -703,9 +726,14 @@ export const createSafeRemoteFetch = ({
       })
       const redirectUrl = getRedirectLocation(response, currentUrl)
       if (!redirectUrl) {
-        const responseBody = await readResponseBody(response, maxBodyBytes)
+        const { body: responseBody, bodyTruncated } = await readResponseBody(
+          response,
+          maxBodyBytes,
+          onBodyTooLarge
+        )
         return {
           body: responseBody,
+          bodyTruncated,
           headers: response.headers,
           statusCode: response.statusCode,
           url: currentUrl.toString()


### PR DESCRIPTION
## Summary

When fetching link preview cards for posts containing links:
1. **Oversized bodies / Transfer cap**: Pages with large payloads (e.g. heatmap share pages with inlined RSC geometry, or rich content pages > 2 MiB) were previously rejected with `ERR_RESPONSE_TOO_LARGE`, recording a failure in the negative cache for 1 hour.
2. **Oversized `<head>` structures**: Modern SPAs (such as YouTube) often place hundreds of kilobytes of inline configuration scripts inside `<head>` before the `<meta property="og:...">` tags (e.g. YouTube has ~680 KB of scripts in `<head>` with OG tags sitting at ~694 KB, before `</head>` at ~700 KB). With `MAX_HEAD_LENGTH` previously set to 128 KiB, `getHeadMarkup` sliced the head before reaching the OG tags.

### Changes
* `lib/utils/safeRemoteFetch.ts`: Added opt-in `onBodyTooLarge: 'truncate'` (default: `'fail'`) and `bodyTruncated: boolean` to `SafeRemoteFetchResult`. When truncating, the body is sliced at `maxBodyBytes` and the readable stream is destroyed early to halt network transfer.
* `lib/services/link-previews/fetchLinkPreview.ts`: Updated `LINK_PREVIEW_MAX_BODY_BYTES = 2 * 1024 * 1024` (2 MiB) and passed `onBodyTooLarge: 'truncate'` to `safeRemoteFetch`.
* `lib/services/link-previews/parseOpenGraph.ts`: Updated `MAX_HEAD_LENGTH = 1024 * 1024` (1 MiB), allowing pages with heavy scripts in `<head>` to be parsed completely while preserving protection against deeply nested `<body>` structures.
* `docs/architecture.md`: Updated link preview documentation to reflect the 2 MiB transfer cap, truncation behavior, and 1 MiB head parsing limit.
* Added unit and integration tests across `safeRemoteFetch.test.ts`, `parseOpenGraph.test.ts`, and `fetchLinkPreview.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)