### PR TITLE
fix: add Mastodon compatibility token to link preview User-Agent

### DIFF
--- a/lib/services/link-previews/fetchLinkPreview.test.ts
+++ b/lib/services/link-previews/fetchLinkPreview.test.ts
@@ -88,7 +88,7 @@ describe('fetchLinkPreview', () => {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
   })
 
-  it('sends a descriptive user agent', async () => {
+  it('sends a descriptive user agent with compatibility token', async () => {
     mockedFetch.mockResolvedValue(htmlResponse(PAGE, 'https://example.com/ua'))
 
     await fetchLinkPreview({ database, url: 'https://example.com/ua' })
@@ -96,6 +96,7 @@ describe('fetchLinkPreview', () => {
     const options = mockedFetch.mock.calls[0][0]
     const headers = options.headers as Record<string, string>
     expect(headers['User-Agent']).toContain('activities.next')
+    expect(headers['User-Agent']).toContain('Mastodon')
     expect(headers.Accept).toContain('text/html')
   })
 

--- a/lib/services/link-previews/fetchLinkPreview.ts
+++ b/lib/services/link-previews/fetchLinkPreview.ts
@@ -63,13 +63,15 @@ const UTF8_COMPATIBLE_CHARSETS = new Set(['utf-8', 'utf8', 'us-ascii', 'ascii'])
 
 // The fetcher identifies itself and points at the project, so an operator
 // seeing these requests in their logs can tell what they are and who to
-// contact — the etiquette Mastodon's own crawler UA follows.
-const LINK_PREVIEW_USER_AGENT = `activities.next/${packageJson.version} (+https://github.com/llun/activities.next; link preview)`
+// contact. The `(compatible; Mastodon/4.3.0)` token ensures sites that gate
+// social preview metadata behind recognized crawlers (such as YouTube's EU
+// consent walls) serve the full OpenGraph tags rather than consent interstitials.
+const LINK_PREVIEW_USER_AGENT = `activities.next/${packageJson.version} (compatible; Mastodon/4.3.0; +https://github.com/llun/activities.next; link preview)`
 
 const REQUEST_HEADERS = {
   'User-Agent': LINK_PREVIEW_USER_AGENT,
   Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.1',
-  'Accept-Language': 'en;q=0.9,*;q=0.5'
+  'Accept-Language': 'en-US,en;q=0.9,*;q=0.5'
 }
 
 class LinkPreviewFetchError extends Error {


### PR DESCRIPTION
## Summary

When `fetchLinkPreview` crawls links for OpenGraph metadata (specifically on platforms with regional GDPR consent interstitials or strict bot gating like YouTube/Google when requested from datacenter IPs):
* An unrecognized custom crawler User-Agent (e.g. `activities.next/1.145.1 (+https://github.com/llun/activities.next; link preview)`) causes YouTube to redirect to or serve a generic EU Cookie Consent interstitial (`<title>- YouTube</title>`, `<meta name="description" content="Enjoy the videos...">`) without `og:title` or `og:image`.
* Major platforms allowlist recognized social bots (such as `Mastodon/4.x`) to receive the actual server-rendered OpenGraph metadata (real video title, description, and thumbnail image) without consent redirects.

### Changes
* `lib/services/link-previews/fetchLinkPreview.ts`: Updated `LINK_PREVIEW_USER_AGENT` to include the standard Fediverse compatibility token `(compatible; Mastodon/4.3.0; ...)` and updated `REQUEST_HEADERS` with `'Accept-Language': 'en-US,en;q=0.9,*;q=0.5'`.
* `lib/services/link-previews/fetchLinkPreview.test.ts`: Updated the User-Agent test to assert the presence of both `'activities.next'` and `'Mastodon'`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)