### PR TITLE
Bump version to v1.145.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.145.1",
+  "version": "1.145.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.145.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.145.1`
- Base main SHA: `9a060b486089db0c6ee3af91375e70ddccb03399`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
