### PR TITLE
fix: hide blurhash placeholder once image is loaded and check image complete state

### DIFF
--- a/lib/components/posts/media.test.tsx
+++ b/lib/components/posts/media.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { Attachment } from '@/lib/types/domain/attachment'
@@ -63,7 +63,7 @@ describe('Media', () => {
     expect(img).toHaveStyle({ objectPosition: '0% 0%' })
   })
 
-  it('renders BlurhashCanvas when blurhash is present', () => {
+  it('renders BlurhashCanvas and transitions opacity when image loads', () => {
     const attachmentWithBlurhash: Attachment = {
       ...baseAttachment,
       blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
@@ -77,9 +77,17 @@ describe('Media', () => {
       'data-blurhash',
       'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
     )
+    expect(canvas.className).toContain('opacity-100')
 
     const img = screen.getByRole('img')
     expect(img).toBeInTheDocument()
+    expect(img.className).toContain('opacity-0')
+
+    // Simulate image load event
+    fireEvent.load(img)
+
+    expect(img.className).toContain('opacity-100')
+    expect(canvas.className).toContain('opacity-0')
   })
 
   it('renders video with poster and focal point object position', () => {

--- a/lib/components/posts/media.tsx
+++ b/lib/components/posts/media.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { CSSProperties, FC, MouseEvent, useState } from 'react'
+import {
+  CSSProperties,
+  FC,
+  MouseEvent,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import { Attachment } from '@/lib/types/domain/attachment'
 import { cn } from '@/lib/utils'
@@ -24,6 +31,15 @@ export const Media: FC<Props> = ({
   onClick
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)
+  const imgRef = useRef<HTMLImageElement | null>(null)
+
+  useEffect(() => {
+    if (imgRef.current?.complete && imgRef.current.naturalWidth > 0) {
+      setIsLoaded(true)
+    } else {
+      setIsLoaded(false)
+    }
+  }, [attachment?.url])
 
   if (!attachment) {
     return null
@@ -49,9 +65,18 @@ export const Media: FC<Props> = ({
         <div className={cn('relative overflow-hidden', className)}>
           <BlurhashCanvas
             blurhash={blurhash}
-            className="absolute inset-0 h-full w-full object-cover"
+            className={cn(
+              'absolute inset-0 h-full w-full object-cover transition-opacity duration-300 pointer-events-none',
+              isLoaded ? 'opacity-0' : 'opacity-100'
+            )}
           />
           <img
+            ref={(node) => {
+              imgRef.current = node
+              if (node?.complete && node.naturalWidth > 0 && !isLoaded) {
+                setIsLoaded(true)
+              }
+            }}
             onClick={onClick}
             key={id}
             className={cn(


### PR DESCRIPTION
## Summary

Fixes an issue where image blurhash placeholders were showing permanently on the website.

### Root Cause
1. **Cached / fast-loaded images in React**: When an image was already cached by the browser or completed before React hydration, the native `load` event had already fired and React's synthetic `onLoad` did not trigger, leaving `isLoaded` as `false` and the `<img>` at `opacity: 0`.
2. **Persistent Canvas Overlay**: `BlurhashCanvas` had no opacity fade/hide styling and remained at `opacity: 1` under the image even when loaded (visible through transparent image regions, letterboxed `object-contain` views, or unhydrated images).

### Fix
- Added `imgRef` callback and `useEffect` checking `img.complete && img.naturalWidth > 0` to accurately detect loaded/cached images on mount and URL change.
- Added smooth opacity transition to `BlurhashCanvas` (`isLoaded ? 'opacity-0' : 'opacity-100'`) with `pointer-events-none` so the blurhash is only visible while the image is loading.
- Added automated tests in `media.test.tsx` asserting the load transition.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated (N/A)
- [x] If migrations changed: N/A
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description