### PR TITLE
Bump version to v1.145.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.145.2",
+  "version": "1.145.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.145.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.145.2`
- Base main SHA: `4fcdf31715a461e931a3c07143133b6c6a61e2df`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
