### PR TITLE
fix: restore image container aspect ratio and backfill unlinked attachments

### DIFF
--- a/lib/components/posts/BlurhashCanvas.tsx
+++ b/lib/components/posts/BlurhashCanvas.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { decode } from 'blurhash'
-import { FC, useEffect, useRef } from 'react'
+import { CSSProperties, FC, useEffect, useRef } from 'react'
 
 interface Props {
   blurhash: string
   className?: string
+  style?: CSSProperties
   width?: number
   height?: number
 }
@@ -13,6 +14,7 @@ interface Props {
 export const BlurhashCanvas: FC<Props> = ({
   blurhash,
   className,
+  style,
   width = 32,
   height = 32
 }) => {
@@ -41,6 +43,7 @@ export const BlurhashCanvas: FC<Props> = ({
       width={width}
       height={height}
       className={className}
+      style={style}
       aria-hidden="true"
     />
   )

--- a/lib/components/posts/media.test.tsx
+++ b/lib/components/posts/media.test.tsx
@@ -13,15 +13,18 @@ import { Media } from './media'
 vi.mock('./BlurhashCanvas', () => ({
   BlurhashCanvas: ({
     blurhash,
-    className
+    className,
+    style
   }: {
     blurhash: string
     className?: string
+    style?: React.CSSProperties
   }) => (
     <div
       data-testid="blurhash-canvas"
       data-blurhash={blurhash}
       className={className}
+      style={style}
     />
   )
 }))
@@ -66,10 +69,14 @@ describe('Media', () => {
   it('renders BlurhashCanvas and transitions opacity when image loads', () => {
     const attachmentWithBlurhash: Attachment = {
       ...baseAttachment,
-      blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
+      blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+      focus: { x: -1, y: 1 }
     }
 
-    render(<Media attachment={attachmentWithBlurhash} />)
+    const { container } = render(<Media attachment={attachmentWithBlurhash} />)
+
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toHaveStyle({ aspectRatio: '800 / 600' })
 
     const canvas = screen.getByTestId('blurhash-canvas')
     expect(canvas).toBeInTheDocument()
@@ -77,10 +84,12 @@ describe('Media', () => {
       'data-blurhash',
       'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
     )
+    expect(canvas).toHaveStyle({ objectPosition: '0% 0%' })
     expect(canvas.className).toContain('opacity-100')
 
     const img = screen.getByRole('img')
     expect(img).toBeInTheDocument()
+    expect(img).toHaveStyle({ objectPosition: '0% 0%' })
     expect(img.className).toContain('opacity-0')
 
     // Simulate image load event

--- a/lib/components/posts/media.tsx
+++ b/lib/components/posts/media.tsx
@@ -58,13 +58,21 @@ export const Media: FC<Props> = ({
   } = attachment
   const objectPosition = focalPointToCssObjectPosition(focus)
   const style: CSSProperties = { objectPosition }
+  const aspectRatio =
+    width && height && width > 0 && height > 0
+      ? `${width} / ${height}`
+      : undefined
 
   if (mediaType.startsWith('image')) {
     if (blurhash) {
       return (
-        <div className={cn('relative overflow-hidden', className)}>
+        <div
+          className={cn('relative overflow-hidden', className)}
+          style={{ aspectRatio }}
+        >
           <BlurhashCanvas
             blurhash={blurhash}
+            style={style}
             className={cn(
               'absolute inset-0 h-full w-full object-cover transition-opacity duration-300 pointer-events-none',
               isLoaded ? 'opacity-0' : 'opacity-100'

--- a/scripts/maintenance/backfillMediaBlurhash.test.ts
+++ b/scripts/maintenance/backfillMediaBlurhash.test.ts
@@ -1,0 +1,114 @@
+import knex, { Knex } from 'knex'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { backfillAttachments, parseArgs } from './backfillMediaBlurhash'
+
+describe('backfillMediaBlurhash parseArgs', () => {
+  it('parses flags correctly', () => {
+    expect(parseArgs([])).toEqual({
+      batchSize: 50,
+      dryRun: false,
+      force: false
+    })
+
+    expect(parseArgs(['--dry-run', '--force', '--batch-size=100'])).toEqual({
+      batchSize: 100,
+      dryRun: true,
+      force: true
+    })
+
+    expect(parseArgs(['--batch-size', '25'])).toEqual({
+      batchSize: 25,
+      dryRun: false,
+      force: false
+    })
+  })
+})
+
+describe('backfillMediaBlurhash execution', () => {
+  let db: Knex
+
+  beforeEach(async () => {
+    db = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+
+    await db.schema.createTable('medias', (table) => {
+      table.increments('id').primary()
+      table.string('actorId')
+      table.string('original')
+      table.integer('originalBytes')
+      table.string('originalMimeType')
+      table.string('thumbnail')
+      table.integer('thumbnailBytes')
+      table.string('thumbnailMimeType')
+      table.float('focusX').nullable()
+      table.float('focusY').nullable()
+      table.string('blurhash').nullable()
+    })
+
+    await db.schema.createTable('attachments', (table) => {
+      table.string('id').primary()
+      table.string('statusId')
+      table.string('actorId')
+      table.string('mediaId').nullable()
+      table.string('mediaType')
+      table.string('url')
+      table.integer('width')
+      table.integer('height')
+      table.string('name')
+      table.string('blurhash').nullable()
+      table.float('focusX').nullable()
+      table.float('focusY').nullable()
+      table.string('thumbnailUrl').nullable()
+      table.timestamp('createdAt').defaultTo(db.fn.now())
+      table.timestamp('updatedAt').defaultTo(db.fn.now())
+    })
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  it('backfills attachments linked to media rows', async () => {
+    await db('medias').insert({
+      id: 1,
+      actorId: 'actor-1',
+      original: 'orig.jpg',
+      originalBytes: 100,
+      originalMimeType: 'image/jpeg',
+      blurhash: 'L6PZfSi_.AyE_3t7t7R**0o#DgR4',
+      focusX: 0.25,
+      focusY: -0.5
+    })
+
+    await db('attachments').insert({
+      id: 'att-1',
+      statusId: 'status-1',
+      actorId: 'actor-1',
+      mediaId: '1',
+      mediaType: 'image/jpeg',
+      url: 'https://example.com/api/v1/files/orig.jpg',
+      blurhash: null,
+      focusX: null,
+      focusY: null
+    })
+
+    const mockStorage = {
+      getFile: vi.fn().mockResolvedValue(null)
+    } as any
+
+    await backfillAttachments(db, mockStorage, {
+      batchSize: 50,
+      dryRun: false,
+      force: false
+    })
+
+    const updated = await db('attachments').where('id', 'att-1').first()
+    expect(updated.blurhash).toBe('L6PZfSi_.AyE_3t7t7R**0o#DgR4')
+    expect(updated.focusX).toBe(0.25)
+    expect(updated.focusY).toBe(-0.5)
+  })
+})

--- a/scripts/maintenance/backfillMediaBlurhash.ts
+++ b/scripts/maintenance/backfillMediaBlurhash.ts
@@ -22,13 +22,13 @@ import { analyzeImageBuffer } from '@/lib/services/medias/imageAnalysis'
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
 
-interface CliOptions {
+export interface CliOptions {
   batchSize: number
   dryRun: boolean
   force: boolean
 }
 
-const parseArgs = (args: string[]): CliOptions => {
+export const parseArgs = (args: string[]): CliOptions => {
   let batchSize = 50
   let dryRun = false
   let force = false
@@ -50,7 +50,7 @@ const parseArgs = (args: string[]): CliOptions => {
   return { batchSize, dryRun, force }
 }
 
-const getFileBuffer = async (
+export const getFileBuffer = async (
   storage: NonNullable<ReturnType<typeof getMediaStorage>>,
   targetPath: string
 ): Promise<Buffer | null> => {
@@ -66,7 +66,7 @@ const getFileBuffer = async (
   return null
 }
 
-const backfillMedias = async (
+export const backfillMedias = async (
   db: Knex,
   storage: NonNullable<ReturnType<typeof getMediaStorage>>,
   options: CliOptions
@@ -155,9 +155,9 @@ const backfillMedias = async (
   )
 }
 
-const backfillAttachments = async (
+export const backfillAttachments = async (
   db: Knex,
-  _storage: NonNullable<ReturnType<typeof getMediaStorage>>,
+  storage: NonNullable<ReturnType<typeof getMediaStorage>>,
   options: CliOptions
 ) => {
   console.log('--- Backfilling attachments table ---')
@@ -227,6 +227,46 @@ const backfillAttachments = async (
           if (media.thumbnail && !thumbnailUrl) {
             thumbnailUrl = `/api/v1/files/${media.thumbnail}`
           }
+        }
+      }
+
+      // 2. If blurhash is still missing on an image attachment, analyze image directly from URL
+      if (!blurhash && row.mediaType?.startsWith('image') && row.url) {
+        try {
+          let buffer: Buffer | null = null
+          const filesIndex = row.url.indexOf('/api/v1/files/')
+          if (filesIndex !== -1) {
+            const targetPath = row.url.slice(
+              filesIndex + '/api/v1/files/'.length
+            )
+            buffer = await getFileBuffer(storage, targetPath)
+          } else if (
+            row.url.startsWith('http://') ||
+            row.url.startsWith('https://')
+          ) {
+            const res = await fetch(row.url)
+            if (res.ok) {
+              buffer = Buffer.from(await res.arrayBuffer())
+            }
+          }
+
+          if (buffer) {
+            const analysis = await analyzeImageBuffer(buffer, {
+              manualFocus:
+                focusX !== null && focusY !== null
+                  ? { x: Number(focusX), y: Number(focusY) }
+                  : null
+            })
+            if (analysis.blurhash) {
+              blurhash = analysis.blurhash
+            }
+            if (analysis.focus && focusX === null && focusY === null) {
+              focusX = analysis.focus.x
+              focusY = analysis.focus.y
+            }
+          }
+        } catch {
+          // Ignore individual attachment analysis error
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes image rendering and blurhash backfilling issues across modals, timeline, and multi-image posts:

### Issues Fixed
1. **Image Aspect Ratio & Cropping in Modal/Timeline**: In `Media`, wrapping `BlurhashCanvas` and `img` in a `<div>` without `aspectRatio` caused flex/max-constraint containers (such as `medias-modal.tsx` with `max-h-[80vh] max-w-full object-contain`) to stretch the `<div>` to 100% width and clip oversized images. Setting `style={{ aspectRatio }}` on the wrapper `<div>` restores natural image dimensions within any max-height / flex container.
2. **Blurhash Canvas Focal Point Alignment**: Added `style?: CSSProperties` to `BlurhashCanvas` and forwarded `style={{ objectPosition }}` so the blurhash placeholder matches the image's smart focal point during loading.
3. **Multi-Image / Unlinked Attachment Backfill**: In `scripts/maintenance/backfillMediaBlurhash.ts`, attachments without a `mediaId` (or unlinked from `medias`) were previously skipped. The script now falls back to analyzing the image buffer directly from `row.url` (via storage or fetch), computing `blurhash` and focal point for all image attachments.
4. **Unit Tests**: Added test coverage for `backfillMediaBlurhash.ts` and updated `media.test.tsx` to verify `aspectRatio` and focal point styling.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated (N/A)
- [x] If migrations changed: N/A
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description