### PR TITLE
Bump version to v1.145.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.145.4",
+  "version": "1.145.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.145.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.145.4`
- Base main SHA: `a6de3142067968703f07684353fb9ee88af787bb`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
