### PR TITLE
minor: set YTD as default preset on fitness dashboard and remove 2Y

### DIFF
--- a/app/(timeline)/fitness/ActorFitnessDashboard.test.tsx
+++ b/app/(timeline)/fitness/ActorFitnessDashboard.test.tsx
@@ -63,6 +63,13 @@ const expectedWindow = (now: number, days: number) => {
   return { startDate: startMs, endDate: endMs + DAY_MS }
 }
 
+const expectedYearWindow = (now: number) => {
+  const year = new Date(now).getFullYear()
+  const startMs = new Date(formatLocalDateInput(new Date(year, 0, 1))).getTime()
+  const endMs = new Date(formatLocalDateInput(new Date(year, 11, 31))).getTime()
+  return { startDate: startMs, endDate: endMs + DAY_MS }
+}
+
 describe('ActorFitnessDashboard', () => {
   beforeEach(() => {
     // Pin Date.now() (read by the hydration effect + applyPreset) so the query
@@ -79,7 +86,7 @@ describe('ActorFitnessDashboard', () => {
     vi.clearAllMocks()
   })
 
-  it('renders exactly the 1Y/2Y/5Y/10Y presets and no 30D/90D presets', () => {
+  it('renders exactly the YTD/1Y/5Y/10Y presets and no 30D/90D presets', () => {
     render(
       <ActorFitnessDashboard
         actorId={ACTOR_ID}
@@ -87,11 +94,12 @@ describe('ActorFitnessDashboard', () => {
       />
     )
 
+    expect(screen.getByRole('button', { name: 'YTD' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '1Y' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '2Y' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '5Y' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '10Y' })).toBeInTheDocument()
 
+    expect(screen.queryByRole('button', { name: '2Y' })).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: '30D' })
     ).not.toBeInTheDocument()
@@ -100,7 +108,7 @@ describe('ActorFitnessDashboard', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('marks 1Y as the initially selected preset', () => {
+  it('marks YTD as the initially selected preset', () => {
     render(
       <ActorFitnessDashboard
         actorId={ACTOR_ID}
@@ -109,17 +117,17 @@ describe('ActorFitnessDashboard', () => {
     )
 
     const activeClasses = ['bg-foreground', 'text-background']
-    expect(screen.getByRole('button', { name: '1Y' })).toHaveClass(
+    expect(screen.getByRole('button', { name: 'YTD' })).toHaveClass(
       ...activeClasses
     )
-    for (const label of ['2Y', '5Y', '10Y']) {
+    for (const label of ['1Y', '5Y', '10Y']) {
       expect(screen.getByRole('button', { name: label })).not.toHaveClass(
         ...activeClasses
       )
     }
   })
 
-  it('requests a 365-day window for the default 1Y preset on load', async () => {
+  it('requests the full calendar year window for the default YTD preset on load', async () => {
     render(
       <ActorFitnessDashboard
         actorId={ACTOR_ID}
@@ -127,21 +135,21 @@ describe('ActorFitnessDashboard', () => {
       />
     )
 
-    const window365 = expectedWindow(FIXED_CURRENT_TIME, 365)
+    const windowYtd = expectedYearWindow(FIXED_CURRENT_TIME)
     await waitFor(() => {
       expect(mockedGetFitnessSummary).toHaveBeenLastCalledWith({
         actorId: ACTOR_ID,
-        ...window365
+        ...windowYtd
       })
     })
     expect(mockedGetFitnessCalendarData).toHaveBeenLastCalledWith({
       actorId: ACTOR_ID,
-      ...window365
+      ...windowYtd
     })
   })
 
   it.each([
-    { label: '2Y', days: 730 },
+    { label: '1Y', days: 365 },
     { label: '5Y', days: 1825 },
     { label: '10Y', days: 3650 }
   ])(
@@ -169,4 +177,37 @@ describe('ActorFitnessDashboard', () => {
       })
     }
   )
+
+  it('requests the full calendar year window when switching back to YTD', async () => {
+    render(
+      <ActorFitnessDashboard
+        actorId={ACTOR_ID}
+        currentTime={FIXED_CURRENT_TIME}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '1Y' }))
+
+    const window365 = expectedWindow(FIXED_CURRENT_TIME, 365)
+    await waitFor(() => {
+      expect(mockedGetFitnessSummary).toHaveBeenLastCalledWith({
+        actorId: ACTOR_ID,
+        ...window365
+      })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'YTD' }))
+
+    const windowYtd = expectedYearWindow(FIXED_CURRENT_TIME)
+    await waitFor(() => {
+      expect(mockedGetFitnessSummary).toHaveBeenLastCalledWith({
+        actorId: ACTOR_ID,
+        ...windowYtd
+      })
+    })
+    expect(mockedGetFitnessCalendarData).toHaveBeenLastCalledWith({
+      actorId: ACTOR_ID,
+      ...windowYtd
+    })
+  })
 })

--- a/app/(timeline)/fitness/ActorFitnessDashboard.tsx
+++ b/app/(timeline)/fitness/ActorFitnessDashboard.tsx
@@ -29,11 +29,11 @@ interface Props {
   currentTime: number
 }
 
-type PresetKey = '1y' | '2y' | '5y' | '10y' | 'custom'
+type PresetKey = 'ytd' | '1y' | '5y' | '10y' | 'custom'
 
-const PRESETS: Array<{ key: PresetKey; label: string; days: number }> = [
+const PRESETS: Array<{ key: PresetKey; label: string; days?: number }> = [
+  { key: 'ytd', label: 'YTD' },
   { key: '1y', label: '1Y', days: 365 },
-  { key: '2y', label: '2Y', days: 730 },
   { key: '5y', label: '5Y', days: 1825 },
   { key: '10y', label: '10Y', days: 3650 }
 ]
@@ -41,9 +41,7 @@ const PRESETS: Array<{ key: PresetKey; label: string; days: number }> = [
 // Single source of truth for the initial range: the active preset pill and the
 // seeded date window both derive from this key, so changing the default can't
 // silently desync the highlighted preset from the computed dates.
-const DEFAULT_PRESET_KEY: PresetKey = '1y'
-const DEFAULT_PRESET_DAYS =
-  PRESETS.find((item) => item.key === DEFAULT_PRESET_KEY)?.days ?? 365
+const DEFAULT_PRESET_KEY: PresetKey = 'ytd'
 
 const CALENDAR_METRICS: Array<[CalendarMetric, string]> = [
   ['count', 'Count'],
@@ -68,6 +66,39 @@ const formatLocalDateInput = (date: Date): string => {
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
+}
+
+const getPresetRange = (
+  key: PresetKey,
+  currentTime: number,
+  mode: 'utc' | 'local'
+): { start: string; end: string } => {
+  if (key === 'ytd') {
+    if (mode === 'utc') {
+      const year = new Date(currentTime).getUTCFullYear()
+      return { start: `${year}-01-01`, end: `${year}-12-31` }
+    }
+    const year = new Date(currentTime).getFullYear()
+    return {
+      start: formatLocalDateInput(new Date(year, 0, 1)),
+      end: formatLocalDateInput(new Date(year, 11, 31))
+    }
+  }
+
+  const presetDef = PRESETS.find((item) => item.key === key)
+  const days = presetDef?.days ?? 365
+
+  if (mode === 'utc') {
+    return {
+      start: formatDateInput(currentTime - days * DAY_MS),
+      end: formatDateInput(currentTime)
+    }
+  }
+
+  return {
+    start: formatLocalDateInput(new Date(currentTime - days * DAY_MS)),
+    end: formatLocalDateInput(new Date(currentTime))
+  }
 }
 
 const formatDistance = (meters: number): string => {
@@ -104,20 +135,20 @@ const getTotals = (summary: FitnessActivitySummary[]) =>
 
 export const ActorFitnessDashboard: FC<Props> = ({ actorId, currentTime }) => {
   const [preset, setPreset] = useState<PresetKey>(DEFAULT_PRESET_KEY)
-  const [startDate, setStartDate] = useState(() =>
-    formatDateInput(currentTime - DEFAULT_PRESET_DAYS * DAY_MS)
+  const [startDate, setStartDate] = useState(
+    () => getPresetRange(DEFAULT_PRESET_KEY, currentTime, 'utc').start
   )
-  const [endDate, setEndDate] = useState(() => formatDateInput(currentTime))
+  const [endDate, setEndDate] = useState(
+    () => getPresetRange(DEFAULT_PRESET_KEY, currentTime, 'utc').end
+  )
 
   // After hydration, align the default range with the user's local calendar:
   // the SSR-deterministic UTC defaults above can be a day off for non-UTC
   // users, which would silently exclude today's activities.
   useEffect(() => {
-    const now = Date.now()
-    setStartDate(
-      formatLocalDateInput(new Date(now - DEFAULT_PRESET_DAYS * DAY_MS))
-    )
-    setEndDate(formatLocalDateInput(new Date(now)))
+    const range = getPresetRange(DEFAULT_PRESET_KEY, Date.now(), 'local')
+    setStartDate(range.start)
+    setEndDate(range.end)
   }, [])
   const [summary, setSummary] = useState<FitnessActivitySummary[]>([])
   const [calendarDays, setCalendarDays] = useState<FitnessCalendarDay[]>([])
@@ -184,10 +215,10 @@ export const ActorFitnessDashboard: FC<Props> = ({ actorId, currentTime }) => {
     if (!presetDef) return
     setPreset(newPreset)
     // Event handler: use the actual current time, not the server-render
-    // snapshot, so a long-lived page still gets a range ending today.
-    const now = Date.now()
-    setStartDate(formatLocalDateInput(new Date(now - presetDef.days * DAY_MS)))
-    setEndDate(formatLocalDateInput(new Date(now)))
+    // snapshot, so a long-lived page still gets a range aligned to now.
+    const range = getPresetRange(newPreset, Date.now(), 'local')
+    setStartDate(range.start)
+    setEndDate(range.end)
   }
 
   return (


### PR DESCRIPTION
## Summary

On the fitness overview (`app/(timeline)/fitness/ActorFitnessDashboard.tsx`):
- Added a **Year-to-date (YTD)** preset as the first preset option (`YTD 1Y 5Y 10Y`).
- YTD renders the full current calendar year (Jan 1 – Dec 31) in the training calendar heatmap, providing a complete GitHub-style grid with inactive/future days in grey (`bg-muted`) and activity days in green.
- Made **YTD** the default selected preset on initial page load (replacing `1Y`).
- Removed the `2Y` preset entirely.
- Added a shared `getPresetRange` helper for consistent UTC (SSR) and local timezone (post-hydration & event handler) date calculation.
- Updated component unit tests in `ActorFitnessDashboard.test.tsx` for preset list, default selection, and YTD date queries.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)