### PR TITLE
Bump version to v1.146.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.145.6",
+  "version": "1.146.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.146.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.145.6`
- Base main SHA: `66e3567649e3e3b108d99343b3f90e286034f4b1`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
