### PR TITLE
fix: delete status locally before queueing federation fan-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1557,6 +1557,41 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   own. There is deliberately no prop for hiding one of the menu's own items;
   that is the per-page drift this whole section exists to prevent.
 
+## Status Delete Federation
+
+- **The local delete commits FIRST and the `Delete` fans out from
+  `SendDeleteNoteJob` afterwards — and that job must never load the status it is
+  announcing the death of.** `database.deleteStatus` is a cascading hard delete,
+  so by the time the job runs the row (and its whole same-actor reply subtree) is
+  gone. `deleteStatusFromUserInput` (`lib/actions/deleteStatus.ts`) therefore
+  captures the audience before deleting and publishes it in the payload
+  (`{ actorId, statusId, to, cc }`), and `getFederatedStatusDeliveryInboxes`
+  takes `Pick<Status, 'to' | 'cc'>` rather than a whole `Status` so a caller
+  holding only that payload can still resolve inboxes. **Do not "unify" this job
+  onto `loadStatusAndActor`**: that is exactly the bug `sendUndoAnnounceJob` has
+  — `undoAnnounce` hard-deletes then enqueues, the job bails on `!status`, and
+  the `Undo` never federates. Every delivery test in
+  `lib/jobs/sendDeleteNoteJob.test.ts` uses a statusId that is deliberately NOT
+  in the database for that reason.
+- **The dedup id is `getHashFromString(`${statusId}#delete`)`, and the suffix is
+  correctness.** The queue deduplicates globally on `message.id` across job
+  names, with a window that outlives consumption, and `SendNoteJob` /
+  `SendUpdateNoteJob` already publish under the bare `getHashFromString(statusId)`
+  — without the suffix, deleting a status posted or edited inside that window is
+  silently dropped and never federates.
+- **The `publish` is wrapped in try/catch on purpose.** The hard delete has
+  already committed and cannot be undone, so a failed enqueue must not surface as
+  a failed request — that would tell the author their post is still there when it
+  is gone, and would skip the route's media cleanup. It is logged with a stack;
+  remote copies reconcile on their next fetch, which 404s.
+- Delivery errors never reach that catch: `postActivityToInbox` swallows every
+  network failure and returns `undefined`, so the activities `deleteStatus`
+  sender does not reject. A test that fails the _socket_ therefore proves nothing
+  about the job's per-inbox guard — mock the **sender** to reject, which is the
+  only seam that can.
+- Known gap, unchanged by the move to a job: a cascaded reply subtree is deleted
+  locally but only the top status's `Delete` federates.
+
 ## Better-auth Plugin Guidelines
 
 - **Do not register a better-auth plugin unless its required database tables exist** in the Knex migrations. The custom `knexAdapter` does not auto-create tables; missing tables will cause runtime errors.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -538,6 +538,23 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
 - **Internal API CORS:** Next.js API routes exclusively consumed by the internal web client (e.g., via `lib/client.ts`) do not require `OPTIONS` handlers or CORS preflight configurations, even if they use `apiResponse` with `allowedMethods`.
 - **Conditional Object Spreading:** Spreading `null` in object literals (e.g., `...(cond ? { ... } : null)`) is a deliberate, consistent no-op pattern used to cleanly omit keys and should not be flagged as confusing or replaced with `{}`.
 
+## Status delete federation
+
+- The local delete commits **first**; `SendDeleteNoteJob` federates the
+  `Delete`/`Tombstone` afterwards. Flag any change that reintroduces inline
+  fan-out ahead of `database.deleteStatus` — that blocked the response on remote
+  inboxes and let one failing server abort the local delete.
+- The job must **not** load the status: `database.deleteStatus` is a cascading
+  hard delete, so the audience travels in the job payload (`to`/`cc` captured
+  pre-delete) and `getFederatedStatusDeliveryInboxes` takes
+  `Pick<Status, 'to' | 'cc'>`. A "consistency" refactor onto `loadStatusAndActor`
+  silently stops delete federation — that is the live `sendUndoAnnounceJob` bug.
+- The dedup id must keep its `#delete` suffix; the bare status id collides with
+  `SendNoteJob`/`SendUpdateNoteJob` in the queue's global dedup window.
+- The activities `deleteStatus` sender never rejects (`postActivityToInbox`
+  swallows and returns `undefined`), so a per-inbox isolation test must mock the
+  sender, not the socket, or it asserts nothing.
+
 ## Link preview cards
 
 - A card is cached **per URL** in `link_previews` and mapped to a status by

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -542,8 +542,10 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
 
 - The local delete commits **first**; `SendDeleteNoteJob` federates the
   `Delete`/`Tombstone` afterwards. Flag any change that reintroduces inline
-  fan-out ahead of `database.deleteStatus` — that blocked the response on remote
-  inboxes and let one failing server abort the local delete.
+  fan-out ahead of `database.deleteStatus`: that made the response wait on every
+  remote inbox, and put inbox resolution ahead of the delete, so an error while
+  collecting them abandoned the delete entirely. (A failing remote server was
+  never the trigger — both the sender and `getActorPerson` swallow and return.)
 - The job must **not** load the status: `database.deleteStatus` is a cascading
   hard delete, so the audience travels in the job payload (`to`/`cc` captured
   pre-delete) and `getFederatedStatusDeliveryInboxes` takes

--- a/app/api/v1/accounts/outbox/route.test.ts
+++ b/app/api/v1/accounts/outbox/route.test.ts
@@ -9,6 +9,11 @@ import { DELETE, POST } from './route'
 
 const mockCreateNoteFromUserInput = vi.fn()
 const mockCreatePollFromUserInput = vi.fn()
+const mockDeleteStatusFromUserInput = vi.fn()
+vi.mock('@/lib/actions/deleteStatus', () => ({
+  deleteStatusFromUserInput: (...args: unknown[]) =>
+    mockDeleteStatusFromUserInput(...args)
+}))
 const mockResolveQuoteForCreate = vi.fn()
 const mockGetServerSession = vi.fn()
 vi.mock('@/lib/actions/createNote', () => ({
@@ -416,5 +421,28 @@ describe('DELETE /api/v1/accounts/outbox', () => {
     const res = await DELETE(req, { params: Promise.resolve({}) })
 
     expect(res.status).toBe(400)
+  })
+
+  // The other caller of the shared delete action, which owns the local delete
+  // and the federation enqueue. Only the wiring is asserted here; the ordering
+  // itself is covered in lib/actions/deleteStatus.test.ts.
+  it('hands a valid delete to the shared delete action', async () => {
+    mockDeleteStatusFromUserInput.mockResolvedValue(undefined)
+    const statusId = 'https://test.llun.dev/users/test1/statuses/delete-me'
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'DELETE',
+      body: JSON.stringify({ statusId }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://test.llun.dev'
+      }
+    })
+
+    const res = await DELETE(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(200)
+    expect(mockDeleteStatusFromUserInput).toHaveBeenCalledWith(
+      expect.objectContaining({ statusId, currentActor: seedActor1 })
+    )
   })
 })

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import {
   MAX_FEDERATION_MEDIA_ATTACHMENTS,
   MAX_PINNED_STATUSES,
@@ -68,10 +69,11 @@ vi.mock('@/lib/services/queue', async () => ({
   })
 }))
 
+// No `deleteStatus` here on purpose: status deletion federates through
+// SendDeleteNoteJob now, so the request path never reaches the sender.
 vi.mock('@/lib/activities', async () => ({
   sendLike: vi.fn().mockResolvedValue(undefined),
-  sendUndoLike: vi.fn().mockResolvedValue(undefined),
-  deleteStatus: vi.fn().mockResolvedValue(undefined)
+  sendUndoLike: vi.fn().mockResolvedValue(undefined)
 }))
 
 vi.mock('@/lib/services/medias', async (importOriginal) => ({
@@ -3167,6 +3169,30 @@ describe('GET /api/v1/statuses/[id]', () => {
         ),
         { params: Promise.resolve({ id: urlToId(statusId) }) }
       )
+
+    it('queues the federation delete with the audience the status had', async () => {
+      const { statusId } = await createNoteWithMedia('queues-federation')
+
+      const response = await deleteStatusRequest(statusId)
+
+      expect(response.status).toBe(200)
+      await expect(
+        database.getStatus({ statusId, withReplies: false })
+      ).resolves.toBeNull()
+      // The row is gone by now, so the job can only learn the audience from
+      // what the action captured into this payload.
+      expect(getQueue().publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: SEND_DELETE_NOTE_JOB_NAME,
+          data: {
+            actorId: ACTOR1_ID,
+            statusId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: []
+          }
+        })
+      )
+    })
 
     it('destroys media rows and storage files when delete_media is true', async () => {
       const { statusId, media } = await createNoteWithMedia('with-media')

--- a/lib/actions/deleteStatus.test.ts
+++ b/lib/actions/deleteStatus.test.ts
@@ -1,87 +1,124 @@
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
-import { deleteStatus } from '@/lib/activities'
 import { Database } from '@/lib/database/types'
-import { getFederatedStatusDeliveryInboxes } from '@/lib/services/federation/statusDelivery'
+import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 
-vi.mock('@/lib/activities', () => ({
-  deleteStatus: vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: vi.fn().mockReturnValue({
+    publish: vi.fn().mockResolvedValue(undefined)
+  })
 }))
 
-vi.mock('@/lib/services/federation/statusDelivery', () => ({
-  getFederatedStatusDeliveryInboxes: vi
-    .fn()
-    .mockResolvedValue(['https://remote.test/inbox'])
-}))
+const CURRENT_ACTOR = { id: 'https://llun.test/users/me' } as Actor
+
+const createDatabase = (status: Status | null) =>
+  ({
+    getStatus: vi.fn().mockResolvedValue(status),
+    deleteStatus: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as Database
 
 describe('deleteStatusFromUserInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('preserves direct status cc recipients on federated delete activities', async () => {
-    const currentActor = {
-      id: 'https://llun.test/users/me'
-    } as Actor
+  it('deletes the status locally before queueing the federation job', async () => {
     const status = {
       id: 'https://llun.test/users/me/statuses/direct-delete',
-      actorId: currentActor.id,
+      actorId: CURRENT_ACTOR.id,
       to: ['https://remote.test/users/primary'],
       cc: ['https://remote.test/users/copied']
     } as Status
-    const database = {
-      getStatus: vi.fn().mockResolvedValue(status),
-      deleteStatus: vi.fn().mockResolvedValue(undefined)
-    } as unknown as Database
+    const database = createDatabase(status)
+    const publish = vi.mocked(getQueue().publish)
 
     await deleteStatusFromUserInput({
-      currentActor,
+      currentActor: CURRENT_ACTOR,
       statusId: status.id,
       database
     })
 
-    expect(getFederatedStatusDeliveryInboxes).toHaveBeenCalledWith({
-      database,
-      currentActor,
-      status
-    })
-    expect(deleteStatus).toHaveBeenCalledWith({
-      currentActor,
-      inbox: 'https://remote.test/inbox',
-      statusId: status.id,
-      to: status.to,
-      cc: status.cc
-    })
     expect(database.deleteStatus).toHaveBeenCalledWith({
       statusId: status.id,
-      actorId: currentActor.id
+      actorId: CURRENT_ACTOR.id
     })
+    expect(publish).toHaveBeenCalledWith({
+      id: getHashFromString(`${status.id}#delete`),
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: CURRENT_ACTOR.id,
+        statusId: status.id,
+        to: status.to,
+        cc: status.cc
+      }
+    })
+
+    // The local delete has to win the race: the job resolves its delivery
+    // targets from the payload precisely because the row is already gone.
+    const deleteOrder = vi.mocked(database.deleteStatus).mock
+      .invocationCallOrder[0]
+    const publishOrder = publish.mock.invocationCallOrder[0]
+    expect(deleteOrder).toBeLessThan(publishOrder)
   })
 
-  it('does not send or delete statuses owned by a different actor', async () => {
-    const currentActor = {
-      id: 'https://llun.test/users/me'
-    } as Actor
+  it('does not delete or federate statuses owned by a different actor', async () => {
     const status = {
       id: 'https://llun.test/users/other/statuses/delete-attempt',
       actorId: 'https://llun.test/users/other',
       to: ['https://www.w3.org/ns/activitystreams#Public'],
       cc: []
     } as Status
-    const database = {
-      getStatus: vi.fn().mockResolvedValue(status),
-      deleteStatus: vi.fn().mockResolvedValue(undefined)
-    } as unknown as Database
+    const database = createDatabase(status)
 
     await deleteStatusFromUserInput({
-      currentActor,
+      currentActor: CURRENT_ACTOR,
       statusId: status.id,
       database
     })
 
-    expect(getFederatedStatusDeliveryInboxes).not.toHaveBeenCalled()
-    expect(deleteStatus).not.toHaveBeenCalled()
     expect(database.deleteStatus).not.toHaveBeenCalled()
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the status does not exist', async () => {
+    const database = createDatabase(null)
+
+    await deleteStatusFromUserInput({
+      currentActor: CURRENT_ACTOR,
+      statusId: 'https://llun.test/users/me/statuses/missing',
+      database
+    })
+
+    expect(database.deleteStatus).not.toHaveBeenCalled()
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('keeps the local delete when queueing the federation job fails', async () => {
+    const status = {
+      id: 'https://llun.test/users/me/statuses/queue-failure',
+      actorId: CURRENT_ACTOR.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: []
+    } as Status
+    const database = createDatabase(status)
+    vi.mocked(getQueue().publish).mockRejectedValueOnce(
+      new Error('Queue unavailable')
+    )
+
+    await expect(
+      deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+    ).resolves.toBeUndefined()
+
+    expect(database.deleteStatus).toHaveBeenCalledWith({
+      statusId: status.id,
+      actorId: CURRENT_ACTOR.id
+    })
   })
 })

--- a/lib/actions/deleteStatus.test.ts
+++ b/lib/actions/deleteStatus.test.ts
@@ -25,6 +25,13 @@ describe('deleteStatusFromUserInput', () => {
     vi.clearAllMocks()
   })
 
+  // vi.clearAllMocks() drops call history but keeps queued one-shot behaviour,
+  // so an unconsumed mockRejectedValueOnce would fire inside a later test's
+  // action and be swallowed by its catch.
+  afterEach(() => {
+    vi.mocked(getQueue().publish).mockReset().mockResolvedValue(undefined)
+  })
+
   it('deletes the status locally before queueing the federation job', async () => {
     const status = {
       id: 'https://llun.test/users/me/statuses/direct-delete',
@@ -116,6 +123,7 @@ describe('deleteStatusFromUserInput', () => {
       })
     ).resolves.toBeUndefined()
 
+    expect(vi.mocked(getQueue().publish)).toHaveBeenCalledTimes(1)
     expect(database.deleteStatus).toHaveBeenCalledWith({
       statusId: status.id,
       actorId: CURRENT_ACTOR.id

--- a/lib/actions/deleteStatus.ts
+++ b/lib/actions/deleteStatus.ts
@@ -1,9 +1,11 @@
-import { deleteStatus } from '@/lib/activities'
 import { Database } from '@/lib/database/types'
-import { getFederatedStatusDeliveryInboxes } from '@/lib/services/federation/statusDelivery'
+import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
 import { Actor } from '@/lib/types/domain/actor'
 import { normalizeActorId } from '@/lib/utils/activitypub'
-import { getVisibility } from '@/lib/utils/getVisibility'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
 
 interface DeleteStatusFromUserInputParams {
@@ -34,23 +36,36 @@ export const deleteStatusFromUserInput = async ({
       return
     }
 
-    const inboxes = await getFederatedStatusDeliveryInboxes({
-      database,
-      currentActor,
-      status: originalStatus
-    })
-    const isDirect =
-      getVisibility(originalStatus.to, originalStatus.cc) === 'direct'
-    await Promise.all(
-      inboxes.map((inbox) => {
-        return deleteStatus({
-          currentActor,
-          inbox,
-          statusId,
-          to: isDirect ? originalStatus.to : undefined,
-          cc: isDirect ? originalStatus.cc : undefined
-        })
-      })
-    )
+    // Delete locally first so the status leaves the author's timelines
+    // immediately, then federate the Tombstone in the background. Delivery used
+    // to run inline ahead of this, which made the request wait on every remote
+    // inbox (and left the status undeleted whenever one of them failed).
     await database.deleteStatus({ statusId, actorId: currentActor.id })
+
+    try {
+      await getQueue().publish({
+        // Suffixed because the queue deduplicates on this id across job names
+        // and the create/update jobs already publish under the bare status id.
+        // Without it, deleting a status posted or edited within the dedup
+        // window would be dropped and never federate.
+        id: getHashFromString(`${statusId}#delete`),
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        data: {
+          actorId: currentActor.id,
+          statusId,
+          // Captured here because the row above is already gone.
+          to: originalStatus.to,
+          cc: originalStatus.cc
+        }
+      })
+    } catch (error) {
+      // The local delete has committed and cannot be undone, so a failed
+      // enqueue must not surface as a failed delete — that would tell the
+      // author their post is still there when it is not. Remote copies
+      // reconcile on their next fetch, which 404s.
+      logger.error(
+        { statusId, actorId: currentActor.id, err: toLoggableError(error) },
+        'Failed to queue status delete federation'
+      )
+    }
   })

--- a/lib/actions/deleteStatus.ts
+++ b/lib/actions/deleteStatus.ts
@@ -38,8 +38,10 @@ export const deleteStatusFromUserInput = async ({
 
     // Delete locally first so the status leaves the author's timelines
     // immediately, then federate the Tombstone in the background. Delivery used
-    // to run inline ahead of this, which made the request wait on every remote
-    // inbox (and left the status undeleted whenever one of them failed).
+    // to run inline ahead of this, so the response waited on every remote inbox
+    // — and since resolving those inboxes also ran first, an error collecting
+    // them abandoned the delete entirely. (The sends themselves never rejected:
+    // postActivityToInbox swallows delivery failures.)
     await database.deleteStatus({ statusId, actorId: currentActor.id })
 
     try {

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -39,6 +39,7 @@ import {
   RELAY_ANNOUNCE_JOB_NAME,
   SEND_ANNOUNCE_JOB_NAME,
   SEND_BLOCK_JOB_NAME,
+  SEND_DELETE_NOTE_JOB_NAME,
   SEND_FLAG_JOB_NAME,
   SEND_NOTE_JOB_NAME,
   SEND_QUOTE_ACCEPT_JOB_NAME,
@@ -57,6 +58,7 @@ import { publishScheduledStatusJob } from './publishScheduledStatusJob'
 import { regenerateFitnessMapsJob } from './regenerateFitnessMapsJob'
 import { sendAnnounceJob } from './sendAnnounceJob'
 import { sendBlockJob } from './sendBlockJob'
+import { sendDeleteNoteJob } from './sendDeleteNoteJob'
 import { sendFlagJob } from './sendFlagJob'
 import { sendNoteJob } from './sendNoteJob'
 import { sendQuoteAcceptJob } from './sendQuoteAcceptJob'
@@ -99,6 +101,7 @@ export const JOBS: Record<string, JobHandle> = {
   [SEND_QUOTE_REVOKE_JOB_NAME]: sendQuoteRevokeJob,
   [HANDLE_QUOTE_REQUEST_JOB_NAME]: handleQuoteRequestJob,
   [SEND_UPDATE_NOTE_JOB_NAME]: sendUpdateNoteJob,
+  [SEND_DELETE_NOTE_JOB_NAME]: sendDeleteNoteJob,
   [SEND_UNDO_ANNOUNCE_JOB_NAME]: sendUndoAnnounceJob,
   [SEND_UNDO_FOLLOW_JOB_NAME]: sendUndoFollowJob,
   [SEND_UNBLOCK_JOB_NAME]: sendUnblockJob,

--- a/lib/jobs/names.ts
+++ b/lib/jobs/names.ts
@@ -19,6 +19,7 @@ export const IMPORT_FITNESS_FILES_JOB_NAME = 'ImportFitnessFilesJob'
 export const IMPORT_STRAVA_ACTIVITY_JOB_NAME = 'ImportStravaActivityJob'
 export const IMPORT_STRAVA_ARCHIVE_JOB_NAME = 'ImportStravaArchiveJob'
 export const SEND_UPDATE_NOTE_JOB_NAME = 'SendUpdateNoteJob'
+export const SEND_DELETE_NOTE_JOB_NAME = 'SendDeleteNoteJob'
 export const SEND_UNDO_ANNOUNCE_JOB_NAME = 'SendUndoAnnounceJob'
 export const GENERATE_FITNESS_HEATMAP_JOB_NAME = 'GenerateFitnessHeatmapJob'
 export const GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME =

--- a/lib/jobs/sendDeleteNoteJob.test.ts
+++ b/lib/jobs/sendDeleteNoteJob.test.ts
@@ -1,6 +1,8 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
+import { deleteStatus } from '@/lib/activities'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { JOBS } from '@/lib/jobs'
 import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { sendDeleteNoteJob } from '@/lib/jobs/sendDeleteNoteJob'
 import { expectCall, mockRequests } from '@/lib/stub/activities'
@@ -15,11 +17,28 @@ import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 enableFetchMocks()
 
+// Spy on the sender while keeping its real behaviour: the delivery assertions
+// below read the actual signed POSTs, but the per-inbox isolation case needs a
+// seam that can reject. postActivityToInbox swallows every network error, so
+// failing the socket (as an earlier version of that test did) never reaches the
+// job's own guard and proves nothing.
+vi.mock('@/lib/activities', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/activities')>()
+  return { ...actual, deleteStatus: vi.fn(actual.deleteStatus) }
+})
+
 const FOLLOWERS_SHARED_INBOX = 'https://somewhere.test/inbox'
 
-describe('Send delete note job', () => {
+const getRequestBody = (inbox: string) => {
+  const call = fetchMock.mock.calls.find((entry) => entry[0] === inbox)
+  if (!call) fail(`${inbox} request must exist`)
+  return JSON.parse(call[1]?.body as string)
+}
+
+describe('sendDeleteNoteJob', () => {
   const database = getTestSQLDatabase()
   let actor1: Actor | null = null
+  let realDeleteStatus: typeof deleteStatus
 
   beforeAll(async () => {
     await database.migrate()
@@ -28,6 +47,11 @@ describe('Send delete note job', () => {
       username: seedActor1.username,
       domain: seedActor1.domain
     })
+    const actual =
+      await vi.importActual<typeof import('@/lib/activities')>(
+        '@/lib/activities'
+      )
+    realDeleteStatus = actual.deleteStatus
   })
 
   afterAll(async () => {
@@ -38,10 +62,17 @@ describe('Send delete note job', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
     mockRequests(fetchMock)
+    // Restore the real sender: vi.clearAllMocks() drops call history but keeps
+    // whatever implementation a previous test installed.
+    vi.mocked(deleteStatus).mockImplementation(realDeleteStatus)
   })
 
-  // The status row is always gone by the time this job runs, so every case
-  // below deliberately uses a statusId that is not in the database.
+  it('is registered under its job name', () => {
+    expect(JOBS[SEND_DELETE_NOTE_JOB_NAME]).toBe(sendDeleteNoteJob)
+  })
+
+  // Every delivery case below deliberately uses a statusId that is not in the
+  // database: the row is always gone by the time this job runs.
   it('sends the delete activity for a status that no longer exists', async () => {
     if (!actor1) fail('Actor1 is required')
     const statusId = `${actor1.id}/statuses/already-deleted`
@@ -67,6 +98,29 @@ describe('Send delete note job', () => {
         type: 'Tombstone'
       }
     })
+  })
+
+  it('addresses a non-direct delete to the public audience rather than the original recipients', async () => {
+    if (!actor1) fail('Actor1 is required')
+    const statusId = `${actor1.id}/statuses/followers-only-deleted`
+
+    // Followers-only: the payload's `to` is the followers collection, so a
+    // dropped isDirect branch would leak it (and the raw cc) to every shared
+    // inbox and relay instead of sending the Public default.
+    await sendDeleteNoteJob(database, {
+      id: 'job-id',
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId,
+        to: [ACTOR1_FOLLOWER_URL],
+        cc: []
+      }
+    })
+
+    const body = getRequestBody(FOLLOWERS_SHARED_INBOX)
+    expect(body.to).toEqual([ACTIVITY_STREAM_PUBLIC])
+    expect(body.cc).toBeUndefined()
   })
 
   it('preserves the original recipients for a direct status', async () => {
@@ -98,7 +152,7 @@ describe('Send delete note job', () => {
 
     // A direct delete must not reach the follower audience.
     const followerCall = fetchMock.mock.calls.find(
-      (call) => call[0] === FOLLOWERS_SHARED_INBOX
+      (entry) => entry[0] === FOLLOWERS_SHARED_INBOX
     )
     expect(followerCall).toBeUndefined()
   })
@@ -118,28 +172,34 @@ describe('Send delete note job', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('delivers to the remaining inboxes when one inbox fails', async () => {
+  it('keeps delivering to the other inboxes when one send rejects', async () => {
     if (!actor1) fail('Actor1 is required')
     const statusId = `${actor1.id}/statuses/partial-failure`
-
-    fetchMock.mockResponse(async (req) => {
-      if (req.method === 'POST' && req.url === FOLLOWERS_SHARED_INBOX) {
+    vi.mocked(deleteStatus).mockImplementation(async (params) => {
+      if (params.inbox === FOLLOWERS_SHARED_INBOX) {
         throw new Error('Inbox unreachable')
       }
-      return { status: 202, body: '' }
+      return realDeleteStatus(params)
     })
 
-    await sendDeleteNoteJob(database, {
-      id: 'job-id',
-      name: SEND_DELETE_NOTE_JOB_NAME,
-      data: {
-        actorId: actor1.id,
-        statusId,
-        to: [ACTIVITY_STREAM_PUBLIC, EXTERNAL_ACTOR1],
-        cc: [ACTOR1_FOLLOWER_URL]
-      }
-    })
+    // Without the per-inbox guard the rejection escapes Promise.all and
+    // withSpan rethrows it, so resolving is itself the assertion.
+    await expect(
+      sendDeleteNoteJob(database, {
+        id: 'job-id',
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        data: {
+          actorId: actor1.id,
+          statusId,
+          to: [ACTIVITY_STREAM_PUBLIC, EXTERNAL_ACTOR1],
+          cc: [ACTOR1_FOLLOWER_URL]
+        }
+      })
+    ).resolves.toBeUndefined()
 
+    expect(vi.mocked(deleteStatus)).toHaveBeenCalledWith(
+      expect.objectContaining({ inbox: FOLLOWERS_SHARED_INBOX })
+    )
     expectCall(fetchMock, EXTERNAL_ACTOR1_INBOX, 'POST', {
       id: `${statusId}#delete`,
       type: 'Delete',

--- a/lib/jobs/sendDeleteNoteJob.test.ts
+++ b/lib/jobs/sendDeleteNoteJob.test.ts
@@ -1,0 +1,153 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { sendDeleteNoteJob } from '@/lib/jobs/sendDeleteNoteJob'
+import { expectCall, mockRequests } from '@/lib/stub/activities'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_FOLLOWER_URL, seedActor1 } from '@/lib/stub/seed/actor1'
+import {
+  EXTERNAL_ACTOR1,
+  EXTERNAL_ACTOR1_INBOX
+} from '@/lib/stub/seed/external1'
+import { Actor } from '@/lib/types/domain/actor'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+enableFetchMocks()
+
+const FOLLOWERS_SHARED_INBOX = 'https://somewhere.test/inbox'
+
+describe('Send delete note job', () => {
+  const database = getTestSQLDatabase()
+  let actor1: Actor | null = null
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    actor1 = await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockRequests(fetchMock)
+  })
+
+  // The status row is always gone by the time this job runs, so every case
+  // below deliberately uses a statusId that is not in the database.
+  it('sends the delete activity for a status that no longer exists', async () => {
+    if (!actor1) fail('Actor1 is required')
+    const statusId = `${actor1.id}/statuses/already-deleted`
+
+    await sendDeleteNoteJob(database, {
+      id: 'job-id',
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [ACTOR1_FOLLOWER_URL]
+      }
+    })
+
+    expectCall(fetchMock, FOLLOWERS_SHARED_INBOX, 'POST', {
+      id: `${statusId}#delete`,
+      type: 'Delete',
+      actor: actor1.id,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      object: {
+        id: statusId,
+        type: 'Tombstone'
+      }
+    })
+  })
+
+  it('preserves the original recipients for a direct status', async () => {
+    if (!actor1) fail('Actor1 is required')
+    const statusId = `${actor1.id}/statuses/direct-deleted`
+
+    await sendDeleteNoteJob(database, {
+      id: 'job-id',
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId,
+        to: [EXTERNAL_ACTOR1],
+        cc: []
+      }
+    })
+
+    expectCall(fetchMock, EXTERNAL_ACTOR1_INBOX, 'POST', {
+      id: `${statusId}#delete`,
+      type: 'Delete',
+      actor: actor1.id,
+      to: [EXTERNAL_ACTOR1],
+      cc: [],
+      object: {
+        id: statusId,
+        type: 'Tombstone'
+      }
+    })
+
+    // A direct delete must not reach the follower audience.
+    const followerCall = fetchMock.mock.calls.find(
+      (call) => call[0] === FOLLOWERS_SHARED_INBOX
+    )
+    expect(followerCall).toBeUndefined()
+  })
+
+  it('does nothing if actor is not found', async () => {
+    await sendDeleteNoteJob(database, {
+      id: 'job-id',
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: 'https://llun.test/users/not-exist-actor',
+        statusId: 'https://llun.test/users/not-exist-actor/statuses/post-1',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      }
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('delivers to the remaining inboxes when one inbox fails', async () => {
+    if (!actor1) fail('Actor1 is required')
+    const statusId = `${actor1.id}/statuses/partial-failure`
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.method === 'POST' && req.url === FOLLOWERS_SHARED_INBOX) {
+        throw new Error('Inbox unreachable')
+      }
+      return { status: 202, body: '' }
+    })
+
+    await sendDeleteNoteJob(database, {
+      id: 'job-id',
+      name: SEND_DELETE_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId,
+        to: [ACTIVITY_STREAM_PUBLIC, EXTERNAL_ACTOR1],
+        cc: [ACTOR1_FOLLOWER_URL]
+      }
+    })
+
+    expectCall(fetchMock, EXTERNAL_ACTOR1_INBOX, 'POST', {
+      id: `${statusId}#delete`,
+      type: 'Delete',
+      actor: actor1.id,
+      object: {
+        id: statusId,
+        type: 'Tombstone'
+      }
+    })
+  })
+})

--- a/lib/jobs/sendDeleteNoteJob.ts
+++ b/lib/jobs/sendDeleteNoteJob.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+
+import { deleteStatus } from '@/lib/activities'
+import { createJobHandle } from '@/lib/jobs/createJobHandle'
+import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getFederatedStatusDeliveryInboxes } from '@/lib/services/federation/statusDelivery'
+import { JobHandle } from '@/lib/services/queue/type'
+import { getVisibility } from '@/lib/utils/getVisibility'
+import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+import { withSpan } from '@/lib/utils/trace'
+
+export const JobData = z.object({
+  actorId: z.string(),
+  statusId: z.string(),
+  // The status's audience, captured by the action BEFORE the local delete.
+  // database.deleteStatus is a cascading hard delete, so by the time this job
+  // runs the row is gone: delivery targets and the direct-visibility to/cc
+  // preservation below must come from the payload. Loading the status here
+  // (loadStatusAndActor) would find nothing and silently skip federation.
+  to: z.string().array(),
+  cc: z.string().array()
+})
+
+// Fans a status Delete (Tombstone) out to the audience the status had when its
+// author deleted it. The actor is still loaded from the database because the
+// Delete has to be signed, and actors outlive their statuses.
+export const sendDeleteNoteJob: JobHandle = createJobHandle(
+  SEND_DELETE_NOTE_JOB_NAME,
+  async (database, message) => {
+    await withSpan('job', 'sendDeleteNote', {}, async (span) => {
+      const { actorId, statusId, to, cc } = JobData.parse(message.data)
+      span.setAttribute('actorId', actorId)
+      span.setAttribute('statusId', statusId)
+
+      const actor = await database.getActorFromId({ id: actorId })
+      if (!actor) {
+        span.recordException(new Error('Actor not found'))
+        return
+      }
+
+      const inboxes = await getFederatedStatusDeliveryInboxes({
+        database,
+        currentActor: actor,
+        status: { to, cc }
+      })
+
+      // Direct statuses keep their original recipients so the Delete reaches
+      // exactly who saw the status; everything else defaults to Public.
+      const isDirect = getVisibility(to, cc) === 'direct'
+      await Promise.all(
+        inboxes.map(async (inbox) => {
+          try {
+            await deleteStatus({
+              currentActor: actor,
+              inbox,
+              statusId,
+              to: isDirect ? to : undefined,
+              cc: isDirect ? cc : undefined
+            })
+          } catch (error) {
+            logger.error(
+              { inbox, statusId, err: toLoggableError(error) },
+              'Failed to send delete status'
+            )
+          }
+        })
+      )
+    })
+  }
+)

--- a/lib/jobs/sendDeleteNoteJob.ts
+++ b/lib/jobs/sendDeleteNoteJob.ts
@@ -35,7 +35,14 @@ export const sendDeleteNoteJob: JobHandle = createJobHandle(
 
       const actor = await database.getActorFromId({ id: actorId })
       if (!actor) {
+        // Terminal, not retryable: without the actor there is no key to sign
+        // with. Logged because the status row is already gone, so this is the
+        // only remaining record that a Delete was owed.
         span.recordException(new Error('Actor not found'))
+        logger.error(
+          { actorId, statusId },
+          'Cannot federate status delete: actor not found'
+        )
         return
       }
 

--- a/lib/services/federation/statusDelivery.ts
+++ b/lib/services/federation/statusDelivery.ts
@@ -16,15 +16,22 @@ const PUBLIC_AUDIENCES = new Set([
 
 const EXPLICIT_RECIPIENT_LOOKUP_CONCURRENCY = 8
 
+// Delivery targets depend on the audience alone, never on the rest of the
+// status. Accepting just those two fields lets a caller that no longer has the
+// row resolve inboxes from a captured audience — SendDeleteNoteJob runs after
+// the status has been hard-deleted. Every Status satisfies this structurally,
+// so existing callers pass through unchanged.
+type StatusAudience = Pick<Status, 'to' | 'cc'>
+
 const isFollowersAudience = (actorId: string) => actorId.endsWith('/followers')
 
-const hasFollowersAudience = (status: Status) =>
+const hasFollowersAudience = (status: StatusAudience) =>
   [...status.to, ...status.cc].some(isFollowersAudience)
 
-const hasPublicAudience = (status: Status) =>
+const hasPublicAudience = (status: StatusAudience) =>
   [...status.to, ...status.cc].some((actorId) => PUBLIC_AUDIENCES.has(actorId))
 
-const getExplicitRecipientActorIds = (status: Status) =>
+const getExplicitRecipientActorIds = (status: StatusAudience) =>
   [...new Set([...status.to, ...status.cc])].filter(
     (actorId) => !PUBLIC_AUDIENCES.has(actorId) && !isFollowersAudience(actorId)
   )
@@ -131,7 +138,7 @@ export const getFederatedStatusDeliveryInboxes = async ({
 }: {
   database: Database
   currentActor: Actor
-  status: Status
+  status: StatusAudience
 }) => {
   const inboxes: string[] = []
 


### PR DESCRIPTION
## Summary

Deleting a status ran the entire ActivityPub fan-out **inline, ahead of the local delete**. `deleteStatusFromUserInput` resolved every delivery inbox (followers + relays + explicit recipients, including live remote actor fetches for anyone not already in the local database), `Promise.all`'d a signed `Delete`/`Tombstone` POST to each one at a 10s timeout with a retry, and only then called `database.deleteStatus`.

Two consequences:

- **The post stayed on screen until every remote inbox had been contacted.** The delete dialog awaits the `DELETE` response before the timeline drops the row, so the author's own post remained visible for as long as the slowest server took to answer or time out.
- **The delete could be abandoned before it happened.** Inbox resolution ran ahead of `database.deleteStatus`, and that path throws — a database error while collecting followers, relays or recipients skipped the delete entirely, after Deletes had already gone out to remotes.

This makes the local delete happen first and moves delivery to a new `SendDeleteNoteJob`, matching what create (`SendNoteJob`), edit (`SendUpdateNoteJob`) and boost already do. Status deletion was the last status-lifecycle action still federating inline. The status now leaves the author's timelines as soon as the transaction commits.

Both delete entry points — `DELETE /api/v1/statuses/:id` and the legacy `DELETE /api/v1/accounts/outbox` — are fixed through the shared action, with no route logic changes. Media and fitness cleanup stay in the route, where the ids are already collected before the delete.

### The job cannot load the status it federates

`database.deleteStatus` is a cascading hard delete, so by the time the job runs the row is gone. The payload therefore carries the audience captured **before** the delete, and `getFederatedStatusDeliveryInboxes` was narrowed to accept just the `to` and `cc` fields — already all it read of the status — so no call site changed.

This is exactly what `sendUndoAnnounceJob` gets wrong today: `undoAnnounce` hard-deletes then enqueues, and the job bails on a missing status, so unboosts never federate. Noted here as a **pre-existing bug left for a follow-up PR** — it is not touched by this change.

### Two deliberate behaviour choices

- **Dedup id is `hash(statusId + '#delete')`, not `hash(statusId)`.** The queue deduplicates globally on message id across job names with a window that outlives consumption, and the create/update jobs already publish under the bare status id. Without the suffix, deleting a status that was posted or edited inside that window would be silently dropped and never federate.
- **The enqueue is wrapped in try/catch.** The local delete has already committed and cannot be undone, so surfacing a queue failure as a failed request would tell the author their post is still there when it is gone — and would skip the route's media cleanup. The failure is logged with a stack; remote copies reconcile on their next fetch, which 404s.

Under the default in-process queue (`NoQueue`), `publish` still runs the job inline, so a single-instance deployment continues to wait for fan-out — the same as create/edit/boost. What changes there regardless of backend: the delete has already committed first, inbox-resolution failures can no longer abandon it, and an inline failure can no longer fail the request. QStash deployments get the fully async path.

## Test plan

- **`lib/jobs/sendDeleteNoteJob.test.ts`** (new) — every delivery case deliberately uses a `statusId` that is **not** in the database, the regression guard for the whole design. Covers fan-out for a deleted status, direct statuses preserving their original `to`/`cc` (and not reaching the follower audience), non-direct statuses being addressed to Public instead of their raw audience, an unknown actor as a no-op, per-inbox failure isolation, and that the job is registered in the `JOBS` map.
- **`lib/actions/deleteStatus.test.ts`** (rewritten) — asserts the local delete is ordered *before* the publish via `invocationCallOrder`, the exact job payload, non-owner and missing-status no-ops, and that a rejecting `publish` still leaves the status deleted.
- **`app/api/v1/statuses/[id]/route.test.ts`** — added a route-level assertion that the job is queued with the pre-delete audience. The `deleteStatus` entry was dropped from the `@/lib/activities` mock, which now fails loudly if delivery ever creeps back into the request path.
- **`app/api/v1/accounts/outbox/route.test.ts`** — success-path coverage for the action's other caller, which previously only tested invalid JSON.

Full suite green: 869 files, 10,936 tests.

## Review

Two sub-agent review rounds (four reviewers, then three), each finding attacked by two independent skeptics. Round 1 refuted five design challenges as pre-existing or intentional, and found three of my own tests that **could not fail** — the per-inbox isolation test in particular, because `postActivityToInbox` swallows socket errors so the sender never rejects. All three now fail against a mutant of the code they guard. Round 2 produced no surviving findings, but did prompt a factual correction: a failing *remote server* was never able to abort the old local delete (the sender and `getActorPerson` both swallow) — only inbox resolution could, which is what the summary above and the docs now say. Details in the [round 1 comment](https://github.com/llun/activities.next/pull/1536#issuecomment-5415857719).

`AGENTS.md` and `REVIEW.md` gained a **Status Delete Federation** section recording the invariants, chiefly that this job must never load the status it federates.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: grepped `*.md` and `docs/` — nothing described the delete flow or enumerated jobs, so nothing went stale; added the new invariants to `AGENTS.md` / `REVIEW.md`
- [x] If migrations changed: n/a — no schema changes, payload-only job
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REnirYGfFfThi1SqsFX9zw