### PR TITLE
Bump version to v1.146.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.146.0",
+  "version": "1.146.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.146.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.146.0`
- Base main SHA: `11f778a497e93c42701baeaa3b6da37cd4926993`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
