### PR TITLE
Bump version to v1.146.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.146.1",
+  "version": "1.146.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.146.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.146.1`
- Base main SHA: `0bb5cc39f90cdf6282f645fa600468b356ace651`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
