### PR TITLE
Bump version to v1.147.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.146.2",
+  "version": "1.147.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.147.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.146.2`
- Base main SHA: `bda2ae2af1dc58ab10986e731a9bdd5d86288b99`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
