### PR TITLE
Bump version to v1.148.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.147.0",
+  "version": "1.148.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.147.0`
- Base main SHA: `8c46380bc53384c633b13bffba3f7ff9099ea5c6`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
