### PR TITLE
Bump version to v1.148.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.0",
+  "version": "1.148.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.0`
- Base main SHA: `e663078c31e9d8e4c39a7dff93d55a2c20942c43`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
