### PR TITLE
Bump version to v1.148.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.2",
+  "version": "1.148.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.2`
- Base main SHA: `8b14cba72f7ad98fda5d90c1a6b1580d0cf93c62`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
