### PR TITLE
Bump version to v1.148.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.5",
+  "version": "1.148.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.5`
- Base main SHA: `994425f90042c18ffa8e2be6ac87490780ac7b40`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
