### PR TITLE
Bump version to v1.148.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.6",
+  "version": "1.148.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.6`
- Base main SHA: `3eab18e5279507d3801d064dd387d30db9a76876`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
