### PR TITLE
Bump version to v1.148.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.7",
+  "version": "1.148.8",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.7`
- Base main SHA: `e63fd19fbbbcb9c779ba3c9b9fde3c3762bf4579`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
