### PR TITLE
fix: confirm a gear component retire, and let it be undone

### DIFF
--- a/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
@@ -101,6 +101,13 @@ describe('GearComponentsCard', () => {
     mockRetireFitnessGearComponent.mockResolvedValue(
       createComponent({ removedAt: Date.UTC(2025, 5, 1) })
     )
+    // Without this default the unretire tests pass only on a neighbour's
+    // leaked implementation: `vi.clearAllMocks()` resets call history and
+    // leaves implementations in place, so whichever test last set one on this
+    // mock decides what the next test sees. Shuffled seeds 3, 8 and 10 failed.
+    mockUpdateFitnessGearComponent.mockResolvedValue(
+      createComponent({ removedAt: null })
+    )
   })
 
   it('renders the header with the installed count', () => {
@@ -416,6 +423,24 @@ describe('GearComponentsCard', () => {
 
     expect(await screen.findByText('Component not found')).toBeInTheDocument()
     expect(onChanged).not.toHaveBeenCalled()
+  })
+
+  // jsdom does no layout, so the wrap can only be asserted as the class that
+  // produces it. Below GEAR_TABLE_SNAP_WIDTH `dataColumnStyle` returns a FIXED
+  // panel, and an overhang there eats the value from the right and cannot be
+  // scrolled to under `x mandatory` — so a retired row's two actions must be
+  // able to wrap rather than spill.
+  it('lets the retired row actions wrap instead of overflowing', () => {
+    renderCard([createComponent({ removedAt: Date.UTC(2025, 5, 1) })])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+
+    const actions = screen
+      .getByRole('button', { name: 'Unretire Chain' })
+      .closest('div')
+    expect(actions).toHaveClass('flex-wrap')
   })
 
   it('offers both unretire and delete on a retired row', () => {

--- a/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
@@ -7,7 +7,8 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import {
   createFitnessGearComponent,
   deleteFitnessGearComponent,
-  retireFitnessGearComponent
+  retireFitnessGearComponent,
+  updateFitnessGearComponent
 } from '@/lib/client'
 import type { GearComponentEntity } from '@/lib/services/fitness-gears/gearEntities'
 
@@ -16,7 +17,8 @@ import { GearComponentsCard } from './GearComponentsCard'
 vi.mock('@/lib/client', () => ({
   createFitnessGearComponent: vi.fn(),
   deleteFitnessGearComponent: vi.fn(),
-  retireFitnessGearComponent: vi.fn()
+  retireFitnessGearComponent: vi.fn(),
+  updateFitnessGearComponent: vi.fn()
 }))
 
 const mockCreateFitnessGearComponent =
@@ -30,6 +32,10 @@ const mockDeleteFitnessGearComponent =
 const mockRetireFitnessGearComponent =
   retireFitnessGearComponent as jest.MockedFunction<
     typeof retireFitnessGearComponent
+  >
+const mockUpdateFitnessGearComponent =
+  updateFitnessGearComponent as jest.MockedFunction<
+    typeof updateFitnessGearComponent
   >
 
 const createComponent = (
@@ -277,6 +283,9 @@ describe('GearComponentsCard', () => {
     const onChanged = renderCard([createComponent()])
 
     fireEvent.click(screen.getByRole('button', { name: 'Retire Chain' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Confirm retire Chain' })
+    )
 
     await waitFor(() =>
       expect(mockRetireFitnessGearComponent).toHaveBeenCalledWith(
@@ -285,6 +294,141 @@ describe('GearComponentsCard', () => {
       )
     )
     expect(onChanged).toHaveBeenCalled()
+  })
+
+  // Retire closes the install window, so a stray click silently stops the part
+  // accruing distance — and it takes reading the table closely to notice.
+  it('does not retire on a single click', () => {
+    renderCard([createComponent()])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retire Chain' }))
+
+    expect(mockRetireFitnessGearComponent).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Confirm retire Chain' })
+    ).toBeInTheDocument()
+  })
+
+  it('disarms a pending retire when the button loses focus', () => {
+    renderCard([createComponent()])
+
+    const retire = screen.getByRole('button', { name: 'Retire Chain' })
+    fireEvent.click(retire)
+    fireEvent.blur(screen.getByRole('button', { name: 'Confirm retire Chain' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Retire Chain' })
+    ).toBeInTheDocument()
+    expect(mockRetireFitnessGearComponent).not.toHaveBeenCalled()
+  })
+
+  it('arms only one retire at a time', () => {
+    renderCard([
+      createComponent(),
+      createComponent({ id: 'component-2', componentType: 'Cassette' })
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retire Chain' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retire Cassette' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Retire Chain' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Confirm retire Cassette' })
+    ).toBeInTheDocument()
+  })
+
+  // Two confirm ids let an arm survive the flip: a row armed for Delete, then
+  // unretired, came back with Delete already armed — a one-click delete.
+  it('does not carry an arm across unretiring a row', async () => {
+    mockUpdateFitnessGearComponent.mockResolvedValue(
+      createComponent({ removedAt: null })
+    )
+    renderCard([createComponent({ removedAt: Date.UTC(2025, 5, 1) })])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(
+      screen.getByRole('button', { name: 'Confirm delete' })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unretire Chain' }))
+
+    await waitFor(() =>
+      expect(mockUpdateFitnessGearComponent).toHaveBeenCalled()
+    )
+    // Nothing is armed once the row changes which action it offers.
+    expect(screen.queryByRole('button', { name: 'Confirm delete' })).toBeNull()
+  })
+
+  // The server has always accepted `removedAt: null`; nothing in the UI called
+  // it, so a mis-retire was permanent.
+  it('unretires a retired component and refetches', async () => {
+    const onChanged = renderCard([
+      createComponent({ removedAt: Date.UTC(2025, 5, 1) })
+    ])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Unretire Chain' }))
+
+    await waitFor(() =>
+      expect(mockUpdateFitnessGearComponent).toHaveBeenCalledWith(
+        'gear-1',
+        'component-1',
+        { removedAt: null }
+      )
+    )
+    expect(onChanged).toHaveBeenCalled()
+  })
+
+  // Unlike Retire and Delete, Unretire is not armed: it restores state rather
+  // than destroying it, and a stray click is undone by one more click.
+  it('unretires on a single click', async () => {
+    renderCard([createComponent({ removedAt: Date.UTC(2025, 5, 1) })])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Unretire Chain' }))
+
+    await waitFor(() =>
+      expect(mockUpdateFitnessGearComponent).toHaveBeenCalled()
+    )
+  })
+
+  it('surfaces an unretire failure', async () => {
+    mockUpdateFitnessGearComponent.mockRejectedValue(
+      new Error('Component not found')
+    )
+    const onChanged = renderCard([
+      createComponent({ removedAt: Date.UTC(2025, 5, 1) })
+    ])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Unretire Chain' }))
+
+    expect(await screen.findByText('Component not found')).toBeInTheDocument()
+    expect(onChanged).not.toHaveBeenCalled()
+  })
+
+  it('offers both unretire and delete on a retired row', () => {
+    renderCard([createComponent({ removedAt: Date.UTC(2025, 5, 1) })])
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 1 retired component' })
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Unretire Chain' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
   })
 
   it('scopes the retire button accessible name to the component type', () => {
@@ -409,13 +553,20 @@ describe('GearComponentsCard', () => {
     const onChanged = renderCard([createComponent()])
 
     fireEvent.click(screen.getByRole('button', { name: 'Retire Chain' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Confirm retire Chain' })
+    )
 
     expect(
       await screen.findByText('Component already retired')
     ).toBeInTheDocument()
     expect(onChanged).not.toHaveBeenCalled()
-    // The row's own action comes back so the failure can be retried.
-    expect(screen.getByRole('button', { name: 'Retire Chain' })).toBeEnabled()
+    // The row's own action comes back so the failure can be retried — still
+    // armed, as Delete leaves itself, because the confirmation the user already
+    // gave was not the thing that failed. Leaving the row disarms it either way.
+    expect(
+      screen.getByRole('button', { name: 'Confirm retire Chain' })
+    ).toBeEnabled()
   })
 
   it('surfaces a delete failure', async () => {

--- a/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearComponentsCard.test.tsx
@@ -104,7 +104,8 @@ describe('GearComponentsCard', () => {
     // Without this default the unretire tests pass only on a neighbour's
     // leaked implementation: `vi.clearAllMocks()` resets call history and
     // leaves implementations in place, so whichever test last set one on this
-    // mock decides what the next test sees. Shuffled seeds 3, 8 and 10 failed.
+    // mock decides what the next test sees — including the rejection from
+    // "surfaces an unretire failure". Remove it and `--sequence.shuffle` fails.
     mockUpdateFitnessGearComponent.mockResolvedValue(
       createComponent({ removedAt: null })
     )
@@ -393,8 +394,11 @@ describe('GearComponentsCard', () => {
     expect(onChanged).toHaveBeenCalled()
   })
 
-  // Unlike Retire and Delete, Unretire is not armed: it restores state rather
-  // than destroying it, and a stray click is undone by one more click.
+  // Unretire is not armed. It is NOT the mirror of Retire — see the comment on
+  // `handleUnretire`: a delayed unretire credits every activity ridden while
+  // the part sat retired, and re-retiring does not take that back. It stays
+  // unarmed because arming adds friction to the misclick without preventing
+  // the misattribution.
   it('unretires on a single click', async () => {
     renderCard([createComponent({ removedAt: Date.UTC(2025, 5, 1) })])
 
@@ -440,7 +444,10 @@ describe('GearComponentsCard', () => {
     const actions = screen
       .getByRole('button', { name: 'Unretire Chain' })
       .closest('div')
-    expect(actions).toHaveClass('flex-wrap')
+    // Both tokens: `flex-wrap` does nothing without `display: flex`, and the
+    // enclosing `<td>` carries `whitespace-nowrap`, so a block container puts
+    // the two buttons on one line and overhangs the panel instead of wrapping.
+    expect(actions).toHaveClass('flex', 'flex-wrap')
   })
 
   it('offers both unretire and delete on a retired row', () => {

--- a/app/(timeline)/fitness/gear/[id]/GearComponentsCard.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearComponentsCard.tsx
@@ -216,10 +216,16 @@ export const GearComponentsCard: FC<Props> = ({
     }
   }
 
-  // Clearing `removedAt` reopens the install window, so the part resumes
-  // accruing distance from wherever it was added — the retire is undone, not
-  // recorded and reversed. The PATCH route already accepts `removedAt: null`;
-  // nothing in the UI called it before, which made a mis-retire permanent.
+  // Clearing `removedAt` reopens the ORIGINAL `[addedAt, now)` window. A
+  // component has one window and no per-period history, so this is not the
+  // mirror of Retire: undoing a retire seconds later credits nothing extra,
+  // but undoing one from last season credits every activity ridden while the
+  // part sat retired — and re-retiring does NOT take that back, because it
+  // only closes the window at the new now. Verified against the rollup query.
+  //
+  // Unretire is still unarmed. Arming it would add friction to the misclick
+  // this exists to recover from without preventing the misattribution, which
+  // the UI cannot distinguish from a legitimate refit anyway.
   const handleUnretire = async (componentId: string) => {
     setError(null)
     // The row is about to offer Retire instead of Delete; carrying an arm
@@ -603,7 +609,6 @@ export const GearComponentsCard: FC<Props> = ({
             // delete on the first click after the next "Show ...".
             onClick={() => {
               setShowRetired((current) => !current)
-              setConfirmingActionId(null)
               setConfirmingActionId(null)
             }}
           >

--- a/app/(timeline)/fitness/gear/[id]/GearComponentsCard.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearComponentsCard.tsx
@@ -15,7 +15,8 @@ import { useGearTableColumns } from '@/app/(timeline)/fitness/gear/useGearTableC
 import {
   createFitnessGearComponent,
   deleteFitnessGearComponent,
-  retireFitnessGearComponent
+  retireFitnessGearComponent,
+  updateFitnessGearComponent
 } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import { Card } from '@/lib/components/ui/card'
@@ -119,9 +120,19 @@ export const GearComponentsCard: FC<Props> = ({
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
-  // A second click on the same row's Delete confirms it — cheaper than a
-  // dialog for a row the user just retired, and still not a single misclick.
-  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
+  // A second click on the same row's Retire or Delete confirms it — cheaper
+  // than a dialog, and still not a single misclick. Retire arms too: it is not
+  // destructive the way Delete is, since the Unretire beside it puts the row
+  // back, but it closes the install window, so a stray click silently stops the
+  // part accruing distance and it takes reading the table closely to notice.
+  //
+  // ONE id, not one per action: a row offers exactly one confirmable action and
+  // `component.removedAt` decides which, so a single id makes "armed for the
+  // action this row no longer offers" unrepresentable. With two, unretiring a
+  // row armed for Delete left that arm set, and retiring it again brought the
+  // Delete button back already armed — a one-click delete, which is the hazard
+  // the disarm rules exist to prevent.
+  const [confirmingActionId, setConfirmingActionId] = useState<string | null>(
     null
   )
   const {
@@ -183,10 +194,16 @@ export const GearComponentsCard: FC<Props> = ({
   }
 
   const handleRetire = async (componentId: string) => {
+    if (confirmingActionId !== componentId) {
+      setConfirmingActionId(componentId)
+      return
+    }
+
     setError(null)
     setPendingActionId(componentId)
     try {
       await retireFitnessGearComponent(gearId, componentId)
+      setConfirmingActionId(null)
       onChanged()
     } catch (retireError) {
       setError(
@@ -199,9 +216,35 @@ export const GearComponentsCard: FC<Props> = ({
     }
   }
 
+  // Clearing `removedAt` reopens the install window, so the part resumes
+  // accruing distance from wherever it was added — the retire is undone, not
+  // recorded and reversed. The PATCH route already accepts `removedAt: null`;
+  // nothing in the UI called it before, which made a mis-retire permanent.
+  const handleUnretire = async (componentId: string) => {
+    setError(null)
+    // The row is about to offer Retire instead of Delete; carrying an arm
+    // across that flip is what the single id exists to prevent.
+    setConfirmingActionId(null)
+    setPendingActionId(componentId)
+    try {
+      await updateFitnessGearComponent(gearId, componentId, {
+        removedAt: null
+      })
+      onChanged()
+    } catch (unretireError) {
+      setError(
+        unretireError instanceof Error
+          ? unretireError.message
+          : 'Failed to unretire component.'
+      )
+    } finally {
+      setPendingActionId(null)
+    }
+  }
+
   const handleDelete = async (componentId: string) => {
-    if (confirmingDeleteId !== componentId) {
-      setConfirmingDeleteId(componentId)
+    if (confirmingActionId !== componentId) {
+      setConfirmingActionId(componentId)
       return
     }
 
@@ -209,7 +252,7 @@ export const GearComponentsCard: FC<Props> = ({
     setPendingActionId(componentId)
     try {
       await deleteFitnessGearComponent(gearId, componentId)
-      setConfirmingDeleteId(null)
+      setConfirmingActionId(null)
       onChanged()
     } catch (deleteError) {
       setError(
@@ -478,40 +521,69 @@ export const GearComponentsCard: FC<Props> = ({
                       className="px-3 py-2.5 pr-4 text-right align-top whitespace-nowrap"
                       style={dataColumnStyle(84)}
                     >
-                      {isRetired ? (
-                        <Button
-                          size="sm"
-                          type="button"
-                          variant="ghost"
-                          className="text-destructive"
-                          disabled={isPending}
-                          onClick={() => handleDelete(component.id)}
-                          // Leaving the button disarms it: an armed row that
-                          // stays armed is a destructive single click waiting
-                          // for whoever comes back to this table.
-                          onBlur={() => {
-                            if (confirmingDeleteId === component.id) {
-                              setConfirmingDeleteId(null)
+                      <div className="flex flex-wrap justify-end gap-1">
+                        {isRetired ? (
+                          <>
+                            <Button
+                              size="sm"
+                              type="button"
+                              variant="ghost"
+                              className="text-primary-text"
+                              aria-label={`Unretire ${component.componentType}`}
+                              disabled={isPending}
+                              onClick={() => handleUnretire(component.id)}
+                            >
+                              Unretire
+                            </Button>
+                            <Button
+                              size="sm"
+                              type="button"
+                              variant="ghost"
+                              className="text-destructive"
+                              disabled={isPending}
+                              onClick={() => handleDelete(component.id)}
+                              // Leaving the button disarms it: an armed row that
+                              // stays armed is a destructive single click waiting
+                              // for whoever comes back to this table.
+                              onBlur={() => {
+                                if (confirmingActionId === component.id) {
+                                  setConfirmingActionId(null)
+                                }
+                              }}
+                            >
+                              {confirmingActionId === component.id
+                                ? 'Confirm delete'
+                                : 'Delete'}
+                            </Button>
+                          </>
+                        ) : (
+                          <Button
+                            size="sm"
+                            type="button"
+                            variant="ghost"
+                            className="text-primary-text"
+                            aria-label={
+                              confirmingActionId === component.id
+                                ? `Confirm retire ${component.componentType}`
+                                : `Retire ${component.componentType}`
                             }
-                          }}
-                        >
-                          {confirmingDeleteId === component.id
-                            ? 'Confirm delete'
-                            : 'Delete'}
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          type="button"
-                          variant="ghost"
-                          className="text-primary-text"
-                          aria-label={`Retire ${component.componentType}`}
-                          disabled={isPending}
-                          onClick={() => handleRetire(component.id)}
-                        >
-                          Retire
-                        </Button>
-                      )}
+                            disabled={isPending}
+                            onClick={() => handleRetire(component.id)}
+                            // Same disarm rule as Delete: an armed row left
+                            // armed closes the next visitor's install window on
+                            // one click.
+                            onBlur={() => {
+                              if (confirmingActionId === component.id) {
+                                setConfirmingActionId(null)
+                              }
+                            }}
+                          >
+                            {confirmingActionId === component.id
+                              ? 'Confirm retire'
+                              : 'Retire'}
+                          </Button>
+                        )}
+                      </div>
                     </td>
                   </tr>
                 )
@@ -531,7 +603,8 @@ export const GearComponentsCard: FC<Props> = ({
             // delete on the first click after the next "Show ...".
             onClick={() => {
               setShowRetired((current) => !current)
-              setConfirmingDeleteId(null)
+              setConfirmingActionId(null)
+              setConfirmingActionId(null)
             }}
           >
             {showRetired


### PR DESCRIPTION
## Summary

Two problems with retiring a fitted component, from the review of #1530.

### Retire fired on one unconfirmed click

The adjacent Delete deliberately arms first and acts on the second click, with a rationale comment explaining why. Retire did not — and it is the *harder* of the two to notice going wrong. Delete removes a row you can see is gone; retire closes the install window silently, so the part stops accruing distance and nothing says so until someone reads the Retired column.

Retire now arms the same way, with both disarm rules Delete already had: leaving the button (`onBlur`), and hiding the retired rows.

### A misclick was unrecoverable from the UI

`PATCH /api/v1/fitness/gear/:id/components/:componentId` has always accepted `removedAt: null`, and `lib/client.ts` has always exported `updateFitnessGearComponent` — with **zero** callers outside its own definition and route tests. So the only way back from a mis-retire was the database.

Retired rows now carry an **Unretire** beside Delete, deliberately *not* armed.

Review round 1 corrected the reasoning I first gave for that, so it is worth stating precisely. Clearing `removedAt` reopens the **original** `[addedAt, now)` window, and a component has one window with no per-period history — so Unretire is *not* the mirror of Retire. Undoing a retire seconds later credits nothing extra. Undoing one from last season credits every activity ridden while the part sat retired, and **re-retiring does not take that back**, because it only closes the window at the new `now`. Verified against the rollup query with a throwaway database: a component retired at `2026-02-01` reading 10 km went to 30 km on unretire and stayed at 30 km after re-retiring.

It stays unarmed anyway. Arming it would add friction to the misclick this exists to recover from without preventing the misattribution — and the UI cannot tell a mistaken unretire from a legitimate refit of the same part, which is a real thing people do.

This is a pure UI change. `CreateFitnessGearComponentInput.removedAt` is already `number | null`, the request schema's `optionalEpochMilliseconds` is `.nullish()` (no `.transform()`, so the ordering trap does not apply), and the route's `removedAt <= addedAt` cross-check cannot trip when `removedAt` is null. `route.test.ts` already pins the server side.

### One armed id, not one per action

The obvious implementation adds `confirmingRetireId` beside `confirmingDeleteId`. That is wrong: a row armed for Delete and then unretired keeps that arm, and retiring it again brings Delete back **already armed** — a one-click delete, which is the exact hazard the disarm rules exist to prevent.

A row offers exactly one confirmable action and `removedAt` decides which, so there is one `confirmingActionId`. That makes the bad state unrepresentable rather than something to remember to clear, and preserves the existing "only one row armed at a time" invariant for free.

## Layout

The retired row's actions cell keeps its declared **84px** minimum rather than growing for the pair. Three reasons:

- A `<td>` minimum is per-row, but the column width is the max across rows — so a `isRetired ? 168 : 84` ternary is misleading: the installed rows' 84 is dead the moment one retired row is visible.
- The pair occupies ~185px anyway, so any smaller declared minimum never binds.
- 84 is quoted in **both** `AGENTS.md` and `CLAUDE.md` as one of the seven per-cell minimums summing to ~740px. Changing it silently makes both wrong; changing it honestly drags a two-file docs edit into a one-component PR.

`flex flex-wrap justify-end gap-1` is what handles the width. Below `GEAR_TABLE_SNAP_WIDTH` (480px) `dataColumnStyle` returns a *fixed* panel, and an overhang there eats the value from the right and cannot be scrolled to under `x mandatory` — so wrapping, not overflowing, is the behaviour that matters. Measured at 375px: the panel is 221px and Unretire (78px) + Delete (67px) sit on one line, right edges at 1376/1447 inside a cell ending at 1463. No overhang, no stacking needed; the wrap is insurance for narrower containers.

## Browser verification

Against a worktree-local SQLite `dev.sqlite3` on `localhost:3200` — never a remote database — with a seeded bike carrying one installed and one retired component.

| Check | Result |
| --- | --- |
| First click on Retire | arms to "Confirm retire", no request sent |
| Showing retired rows | disarms a pending confirm |
| Unretire | count 1→2 installed, row un-dims, action flips back to Retire |
| Full retire → unretire → retire | round-trips |
| Retired row actions | Unretire + Delete on one line, no overflow |
| Dark mode | reads correctly |
| 375px | both buttons on one line inside the cell |

## Testing

`yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test`, all green (884 files / 11,572 tests).

`GearComponentsCard.test.tsx` goes from 33 tests to 41. Two existing tests changed, because they pinned the single-click retire this PR removes.

Every new guard is **proved by reverting its subject**:

| Revert | Tests that fail |
| --- | --- |
| retire back to a single unconfirmed click | 5 |
| Unretire button removed | 4 |
| unretire sends something other than `removedAt: null` | 1 |
| retire `onBlur` disarm removed | 1 |
| `flex-wrap` dropped from the actions cell | 1 |
| unretire no longer clears the arm | 1 |
| `aria-label` loses the visible label | 5 |

That last one is WCAG 2.5.3 (Label in Name): the accessible name must *contain* the visible label, so the armed button is `Confirm retire <type>`, not `Confirm retiring <type>`.

## From review round 1

- **The new unretire tests were order-dependent.** `vi.clearAllMocks()` resets call history and leaves implementations in place, so with no `beforeEach` default for `updateFitnessGearComponent` they passed only on whichever neighbour had last set one — including the rejection from "surfaces an unretire failure". Removing the default and running under `--sequence.shuffle` fails; with it, every seed tried passes. (Round 2 noted that specific seed numbers are environment-dependent, so the claim is stated as the property rather than as particular seeds.) CI does not shuffle, so this would have sat latent.
- **The layout claim was asserted in this description and tested nowhere.** jsdom does no layout, so it is now pinned as the classes that produce it. Round 2 caught that asserting `flex-wrap` alone was not enough: `flex-wrap` does nothing without `display: flex`, and the enclosing `<td>` carries `whitespace-nowrap`, so dropping only `flex` gave a block container that put both buttons on one line and overhung the panel by 18px — measured in a browser — while the test still passed. It now asserts both tokens, and each drops independently to a failure.
- **A false claim survived in a second place.** Round 1 corrected the rationale comment in the component but left the identical retracted wording in the test file, 200 lines from its correction. Both now say the same true thing.
- A duplicated `setConfirmingActionId(null)`, left by collapsing two ids into one.

## Deliberately not in scope

- **Backdating a retire.** The API supports it — the PATCH route takes an arbitrary `removedAt` and already validates it against the stored `addedAt`, returning a real `422` with `removedAt must be after addedAt`. But a backdated retire silently rewrites derived distance history everywhere it is read (the gear page, the stat grid, the fitness overview), and it turns a one-click action into a form. Different blast radius, and it deserves its own change.
- **Guarding a future `addedAt`.** The inverted-window case the review notes named is **already handled**: `gearRequests.ts`'s `.refine` plus the route's cross-check against the stored other end. A future `addedAt` alone is not blocked, but that is arguably legitimate — planning a part swap — and it is not the same defect.
- **Per-period component history.** The gap-credit above is inherent to one `[addedAt, removedAt)` window per component; fixing it means recording install periods, which changes the schema and every rollup. Filed separately.
- **The gear-level Retire** in `GearDetailView` is also a single-click toggle. It is genuinely reversible in a way the component one was not — the same button unretires — so it does not share this defect, and changing it here would widen a one-component PR into the gear surface.
- **A better error than `404` when retiring an already-retired row.** Real, but the `404` is a deliberate outcome of a compare-and-swap: `retireFitnessGearComponent` predicates its `UPDATE` on `whereNull('removedAt')` so two concurrent requests produce one write, and 0 rows affected maps to null. Distinguishing "not found" from "already retired" means a second read to undo a design that is correct. With the two-click confirm and the row re-rendering as retired, the window is now narrow.
