### PR TITLE
test: de-flake the actor outbox load-more assertions

### DIFF
--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -2,7 +2,13 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved
+} from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { getActorStatuses } from '@/lib/client'
@@ -221,11 +227,17 @@ describe('ActorTimelines', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-    await waitFor(() => {
-      expect(getActorStatusesMock).toHaveBeenCalledWith({
-        actorId: 'https://remote.example/users/actor',
-        pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
-      })
+    // Wait on the append landing in the DOM, not on the request being made:
+    // the call happens synchronously inside the click, so a `waitFor` on the
+    // mock settles before the response resolves, and the commit lands one
+    // macrotask later — the very boundary testing-library's own drain awaits.
+    // A bare DOM assertion after that `waitFor` therefore has no retry window
+    // and loses the race under a loaded machine.
+    await screen.findByText('https://remote.example/statuses/older')
+
+    expect(getActorStatusesMock).toHaveBeenCalledWith({
+      actorId: 'https://remote.example/users/actor',
+      pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
     })
     expect(
       screen.getAllByText('https://remote.example/statuses/older')
@@ -269,9 +281,9 @@ describe('ActorTimelines', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-    await waitFor(() => {
-      expect(getActorStatusesMock).toHaveBeenCalledTimes(2)
-    })
+    await screen.findByText('https://remote.example/statuses/oldest')
+
+    expect(getActorStatusesMock).toHaveBeenCalledTimes(2)
     expect(getActorStatusesMock).toHaveBeenNthCalledWith(1, {
       actorId: 'https://remote.example/users/actor',
       pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
@@ -310,11 +322,11 @@ describe('ActorTimelines', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-    await waitFor(() => {
-      expect(getActorStatusesMock).toHaveBeenCalledWith({
-        actorId: 'https://remote.example/users/actor',
-        pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
-      })
+    await screen.findByText('https://remote.example/statuses/first-post')
+
+    expect(getActorStatusesMock).toHaveBeenCalledWith({
+      actorId: 'https://remote.example/users/actor',
+      pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
     })
     expect(
       screen.getAllByText('https://remote.example/statuses/first-post')
@@ -376,9 +388,15 @@ describe('ActorTimelines', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-    await waitFor(() => {
-      expect(getActorStatusesMock).toHaveBeenCalledTimes(1)
-    })
+    // Nothing is appended here, so the settled state is the control itself
+    // going away. It reads "Loading..." while the request is in flight, which
+    // means the "Load more" assertion below would pass mid-flight too — wait
+    // for the in-flight control to be removed first so it asserts the end state.
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('button', { name: 'Loading...' })
+    )
+
+    expect(getActorStatusesMock).toHaveBeenCalledTimes(1)
     expect(
       screen.queryByRole('button', { name: 'Load more' })
     ).not.toBeInTheDocument()


### PR DESCRIPTION
## Problem

`app/(timeline)/[actor]/ActorTimelines.test.tsx` → **"loads and appends older actor statuses from the next outbox page"** fails intermittently in a full `yarn test` run:

```
TestingLibraryElementError: Unable to find an element with the text:
https://remote.example/statuses/older
```

It passes in isolation and on an immediate re-run — timing-sensitive, not deterministic. Pre-existing; the file was last touched in #1283, and this is unrelated to any current PR.

## Root cause

`waitFor` gated on the mock being **called**, then the DOM was asserted outside any retry window:

```js
await waitFor(() => {
  expect(getActorStatusesMock).toHaveBeenCalledWith({ ... })   // the CALL
})
expect(screen.getAllByText('…/statuses/older')).toHaveLength(1) // the RENDER
```

`loadMoreStatuses` invokes `getActorStatuses` synchronously, before its first `await`, and `fireEvent.click` is wrapped in a **synchronous** `act()` — so the mock has already been called by the time `waitFor` runs its **first** check. `waitFor` settles immediately, and testing-library's `asyncWrapper` then drains with a bare `setTimeout(0)` (it deliberately disables the act environment for `waitFor`/`findBy*`).

Measured where the commit actually lands, by probing the ticks after the click:

```
microtask0..5 = false   macrotask0 = true   macrotask1..3 = true
```

The append commits in the **first macrotask** — the same boundary the drain awaits. The assertion therefore had **zero scheduling margin**: any perturbation that pushes the commit past that one timer (an OS preemption under a fully parallel 884-file suite) makes `getAllByText` throw. That is the reported failure.

An earlier hypothesis — that burning CPU *before* `waitFor` would lose the race — was **falsified**: 0/300 iterations reproduced it, even under 14 concurrent CPU hogs. The busy-wait ran before the drain timer was registered, so it was irrelevant. The perturbation has to land after that timer exists.

## Fix

Wait on the **render**, then assert. Per the #1331 lesson, `toHaveLength` stays *outside* the retrying block — an exact count inside `waitFor` can be permanently unsatisfiable — so the shape is `await screen.findByText(...)` followed by the count/argument assertions.

Four tests in the file had this shape:

| Test | Change |
| --- | --- |
| loads and appends older actor statuses… | `findByText('…/older')` before the assertions |
| continues to the next cursor when an outbox page has no renderable statuses | `findByText('…/oldest')`; `toHaveBeenCalledTimes(2)` moved out of `waitFor` |
| shows load more when the initial actor page has no renderable statuses | `findByText('…/first-post')` before the assertions |
| stops loading when an empty outbox page repeats the same cursor | `waitForElementToBeRemoved` on the in-flight control |

The last one has no appended content to wait for, and its `queryByRole('button', { name: 'Load more' })` assertion **passed mid-flight too** — the control reads `Loading...` while the request is in flight, so "no Load more button" was true both during and after the load. Verified directly: under the perturbation below, the pre-fix version of that test passed while the component was still loading. It now waits for the in-flight control to be removed, so it asserts the end state.

"shows a retryable error when loading older statuses fails" is deliberately left alone — its `waitFor` already gates on the DOM (`getByRole('alert')`), and the `toBeEnabled()` that follows reads state committed in the same batch.

## Proof

**1. The failure mode, demonstrated.** A scratch copy of the file with every mocked resolution deferred one macrotask past the drain (a `then` that fires on `setImmediate` after burning 3 ms, modelling a busy machine) — run against the **pre-fix** file at `HEAD`:

```
× loads and appends older actor statuses from the next outbox page
  → Unable to find an element with the text: https://remote.example/statuses/older
× shows load more when the initial actor page has no renderable statuses
  → Unable to find an element with the text: https://remote.example/statuses/first-post
  Tests  2 failed | 15 passed (17)
```

The reported error, reproduced verbatim — plus a second sibling the report predicted.

**2. The fix survives it.** Same perturbation, post-fix file: **17 passed (17)**.

**3. The fixed tests still catch real regressions.** Independent breaks of `ActorTimelines.tsx` (reverted afterwards; only the test file is in this diff):

- `appendUniqueStatuses` silently drops the new page → **3 failed** (all three `findByText` tests)
- `setCurrentStatusPagination` never advances the cursor → **2 failed** (the "Load more" retires and "stops loading" tests)
- the multi-page loop capped at one iteration → **1 failed** ("continues to the next cursor…")

So the waits are load-bearing, not just tolerant. `waitForElementToBeRemoved` also cannot pass vacuously: it throws if its target is already absent at call time, confirmed by patching the button to never render `Loading...`.

## Not touched

The same *syntactic* shape — `waitFor` on a mock, then a bare DOM assertion — appears elsewhere: `MessagesPage.test.tsx:367`, `mute-action.test.tsx:162`, `FitnessHeatmapView.test.tsx:947`, `MutesList.test.tsx:88`, `BlocksList.test.tsx:131`, `AnnouncementBanner.test.tsx:179`. Each was checked, and **none is actually vulnerable to this race**:

- `MessagesPage` and `mute-action` — the follow-ups read state that is either already rendered, or gated behind a still-unresolved `createDeferred`, or re-queried with a retrying `findByRole`.
- `MutesList` / `BlocksList` — each is immediately followed by a *second* `waitFor` that gates on the real DOM removal.
- `FitnessHeatmapView` — `handleRegionRemoved` applies its `setHeatmaps` update optimistically *before* its own `await`, so the DOM is final inside the click's own `act()` batch.
- `AnnouncementBanner` — the render happens inside `await act(async () => …)`, which drains the microtask `mockResolvedValue` resolves on and flushes the commit before any assertion runs. Probed 6/6 under 12 concurrent CPU hogs: the commit had already landed every time `waitFor` ran.

That last one is close to the general rule, stated precisely: **an awaited `act(async …)` drains work reachable through microtasks — including an already-resolved `mockResolvedValue` — and flushes the resulting commit before returning; `fireEvent.click`'s *synchronous* `act` drains nothing.** The four tests fixed here start their async work from a synchronous `fireEvent.click`, so nothing drains the continuation before `waitFor`'s immediate pass.

The caveat matters for anyone applying this elsewhere: an awaited async `act` is *not* a barrier for a resolution deferred behind a real macrotask (a timer, or a promise resolved later by the test), because `recursivelyFlushAsyncActWork` returns as soon as the act queue is empty and does not wait for work that has not been queued yet. Every mock in the list above resolves on a pure microtask chain, which is why the rule holds for all of them.

So no follow-up sweep is owed. An earlier draft of this section claimed these were the same defect and "worth a separate sweep" — that was wrong, and the review loop caught it.

## Review

Sub-agent review loop, round 1: correctness, testing, quality, scope/regression and design-system lenses, with every candidate finding put through the adversarial verifier.

- correctness, testing, design-system — no findings. The testing lens independently reproduced all three revert-proofs.
- quality — flagged `getAllByText(X).toHaveLength(1)` as redundant after `findByText(X)` (which throws on multiple matches). Verifier CONFIRMED the redundancy. Kept deliberately: `findByText`'s uniqueness guarantee is an incidental library detail a reader shouldn't have to know, while `toHaveLength(1)` states the test's actual claim and stays parallel with the neighbouring `toHaveLength(2)` two-panel test. See the thread.
- scope/regression — no code findings; caught the inaccurate "Not touched" claim in an earlier draft of this body, now corrected above.

## Gate

`prettier --write .` → `yarn lint` (0 errors) → `yarn typecheck` (clean) → `yarn build` → `yarn test`: **884 files / 11564 tests passed**.

No production code changed; no migrations, config, or UI.
