### PR TITLE
Bump version to v1.148.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.9",
+  "version": "1.148.10",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.10.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.9`
- Base main SHA: `7aeb8567cf6d426412279ea1676ca7bb5cfe3f5a`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
