### PR TITLE
Bump version to v1.148.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.10",
+  "version": "1.148.11",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.11.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.10`
- Base main SHA: `ee6e22b6da59303088393d8f29f8ac2377a10d99`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
