### PR TITLE
Bump version to v1.148.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.11",
+  "version": "1.148.12",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.12.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.11`
- Base main SHA: `9ab6cef965f970d6f802ad851acd29ec273aead4`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
