### PR TITLE
Bump version to v1.148.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.12",
+  "version": "1.148.13",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.13.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.12`
- Base main SHA: `87fa7ce418f79ab3ddf3a3627230e7b1718e3c89`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
