### PR TITLE
Bump version to v1.148.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.14",
+  "version": "1.148.15",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.15.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.14`
- Base main SHA: `eb532514cb77ca1a2e4c626616a41dfedb522871`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
