### PR TITLE
Bump version to v1.148.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.15",
+  "version": "1.148.16",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.148.16.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.148.15`
- Base main SHA: `ce85a8cb526321b6fd3214e10473ca97574ff7e1`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
