### PR TITLE
Bump version to v1.149.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.148.17",
+  "version": "1.149.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.148.17`
- Base main SHA: `c7afeed3e00f8d8fb7ddeed19af7766e41c9f0fb`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
