### PR TITLE
Bump version to v1.149.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.0",
+  "version": "1.149.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.0`
- Base main SHA: `d0bb5554bde44d9baced80dc8f7fd73f28901289`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
