### PR TITLE
Bump version to v1.149.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.1",
+  "version": "1.149.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.1`
- Base main SHA: `8f42e5afd83f48382d69ad7504ae9bab6edeb6f8`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
