### PR TITLE
none: stop the ImageUploadField focus tests racing the effect that moves focus

### DIFF
--- a/lib/components/settings/ImageUploadField.test.tsx
+++ b/lib/components/settings/ImageUploadField.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { uploadAttachment } from '@/lib/client'
 
@@ -143,8 +143,16 @@ describe('ImageUploadField', () => {
     await waitFor(() =>
       expect(getSubmittedValue(container, 'iconUrl')).toBe(MEDIA_URL)
     )
-    expect(document.activeElement).toBe(
-      screen.getByRole('button', { name: 'Upload Icon image' })
+    // Retried rather than asserted once, because the value landing does not
+    // mean the focus effect has run. React mutates the DOM during the commit
+    // and flushes passive effects afterwards, and `waitFor` polls a
+    // MutationObserver — so the hidden input's new value is observable in
+    // between, and a bare assertion here read `<body>` on CI while passing
+    // every time locally.
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole('button', { name: 'Upload Icon image' })
+      )
     )
   })
 
@@ -175,6 +183,12 @@ describe('ImageUploadField', () => {
     await waitFor(() =>
       expect(getSubmittedValue(container, 'iconUrl')).toBe(MEDIA_URL)
     )
+    // Retrying is no use for an assertion that nothing happened — it passes on
+    // the first poll — so this needs a barrier instead, and the value landing
+    // is not one for the reason above. Without flushing the effect the test
+    // still passes with the `document.body` guard deleted, i.e. it stops
+    // guarding anything on exactly the runs where the timing bites.
+    await act(async () => {})
     expect(document.activeElement).toBe(elsewhere)
     elsewhere.remove()
   })


### PR DESCRIPTION
## Why

`lib/components/settings/ImageUploadField.test.tsx` → `returns focus to Upload after an upload re-enables it` is flaky on CI. It failed **Test Shard 2 of 4** on #1592 (run 33058252485) with:

```
AssertionError: expected <body><div>…</div></body> to be <button data-slot="button" …>
```

`document.activeElement` was still `<body>` when the assertion ran. It passes 5/5 locally.

The test awaits one signal and asserts on a different one with zero margin:

```js
await waitFor(() =>
  expect(getSubmittedValue(container, 'iconUrl')).toBe(MEDIA_URL)
)
expect(document.activeElement).toBe(
  screen.getByRole('button', { name: 'Upload Icon image' })
)
```

The `waitFor` gates on the hidden input's **value**; the assertion is on **focus**. React mutates the DOM during the commit and flushes passive effects afterwards, and `waitFor` polls a MutationObserver — so the new value is observable in between, before the effect that restores focus has run. The CI DOM diff confirms this: the render had completed (remove button present, value populated), only focus had not been restored.

## What changed

**`returns focus to Upload after an upload re-enables it`** — the focus assertion moves inside `waitFor` so it retries. This keeps the guarantee the test documents (WCAG 2.4.3 focus restoration, per its own comment) while removing the race.

**`leaves focus alone when the user moved elsewhere during an upload`** — the sibling has the identical shape and is worse. It asserts that focus did **not** move, so retrying is no use: it passes on the first poll. Under the same timing it passed **with the component's `document.activeElement === document.body` guard deleted** — on exactly the runs where the race bites, it silently stopped guarding anything. It gets an `await act(async () => {})` barrier instead, the idiom already used 7× before focus assertions in `NavigationSettings.test.tsx`.

There is no `headerImageUrl` case in this file — `renderField` always renders `iconUrl`. The other three files with `activeElement` assertions (`NavigationSettings`, `link-preview-card`, `sidebar`) are clean: they assert synchronously after `fireEvent`, after `await act(...)`, or already inside `waitFor`.

The existing comment block explaining why the blur is driven explicitly (jsdom does not blur a focused element when it is disabled) is untouched — only the timing of the final assertions changed.

**Test-only change. No production code is touched.**

## Verification

Reproduced by wrapping the component's focus call in `setTimeout(…, 0)`, which forces the ordering CI hit — that yields the exact CI assertion against the old test. Both tests are revert-proofed:

| Sabotage | Old tests | New tests |
| --- | --- | --- |
| none | pass | pass (15/15 repeats) |
| focus deferred one tick | **test 1 fails** (exact CI error) | pass |
| `document.body` guard deleted | test 2 fails | test 2 fails |
| guard deleted **+** focus deferred | **test 2 passes vacuously** | — |
| focus restoration deleted entirely | — | test 1 fails |

One honest limitation: `act` does not flush a macrotask, so the sabotage that *exposes* test 2's vacuity is not one that *demonstrates* the repair. The repair rests on act's flush contract for passive effects. The race itself does not reproduce on a local machine at all — consistent with the 5/5 local passes.

Full gate green on this branch, rebased onto current `main`: `prettier` (clean), `yarn lint` (exit 0), `yarn typecheck` (exit 0), `yarn build` (exit 0), and all four CI shards (894 files) with `NODE_OPTIONS=--max-old-space-size=8192`.

`none:` prefix because a test-only change should not cut a release.

## Review note

**The sub-agent code review loop did not run.** This session is configured not to call the Agent tool, which is the inability exception in `AGENTS.md` → *When sub-agents are unavailable*. The diff was self-reviewed in one pass against `REVIEW.md` instead. Nothing here should be read as having been through the loop.

That self-review did turn up one pre-existing convention drift, deliberately left out of scope: both async tests hand-roll the promise-with-exposed-resolve pattern that `REVIEW.md` requires to use `createDeferred` from `@/lib/testing/deferred`. Tracked separately so this de-flake stays a minimal, fast-landing diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
