### PR TITLE
Bump version to v1.149.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.2",
+  "version": "1.149.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.2`
- Base main SHA: `e4d16f951dfdb11d635918fb14119f9629471831`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
