### PR TITLE
none: use the shared createDeferred in the ImageUploadField focus tests

### DIFF
--- a/lib/components/settings/ImageUploadField.test.tsx
+++ b/lib/components/settings/ImageUploadField.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { uploadAttachment } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 
 import { ImageUploadField } from './ImageUploadField'
 
@@ -120,12 +121,8 @@ describe('ImageUploadField', () => {
     // pass with the fix removed. The blur is driven explicitly instead, and
     // what is actually under test is the restoration: focus sitting on the body
     // when an upload finishes is returned to Upload.
-    let resolveUpload: (value: UploadResult) => void = () => {}
-    vi.mocked(uploadAttachment).mockReturnValue(
-      new Promise<UploadResult>((resolve) => {
-        resolveUpload = resolve
-      })
-    )
+    const deferred = createDeferred<UploadResult>()
+    vi.mocked(uploadAttachment).mockReturnValue(deferred.promise)
 
     const { container } = renderField(null)
     const fileInput =
@@ -138,7 +135,7 @@ describe('ImageUploadField', () => {
     // leaves behind when it disables the button that held it.
     expect(document.activeElement).toBe(document.body)
 
-    resolveUpload(uploadResult)
+    deferred.resolve(uploadResult)
 
     await waitFor(() =>
       expect(getSubmittedValue(container, 'iconUrl')).toBe(MEDIA_URL)
@@ -159,12 +156,8 @@ describe('ImageUploadField', () => {
   it('leaves focus alone when the user moved elsewhere during an upload', async () => {
     // The effect only reclaims focus that fell to the body, so someone who
     // tabbed on while the upload ran is not yanked back to it.
-    let resolveUpload: (value: UploadResult) => void = () => {}
-    vi.mocked(uploadAttachment).mockReturnValue(
-      new Promise<UploadResult>((resolve) => {
-        resolveUpload = resolve
-      })
-    )
+    const deferred = createDeferred<UploadResult>()
+    vi.mocked(uploadAttachment).mockReturnValue(deferred.promise)
 
     const { container } = renderField(null)
     const elsewhere = document.createElement('button')
@@ -178,7 +171,7 @@ describe('ImageUploadField', () => {
     })
 
     elsewhere.focus()
-    resolveUpload(uploadResult)
+    deferred.resolve(uploadResult)
 
     await waitFor(() =>
       expect(getSubmittedValue(container, 'iconUrl')).toBe(MEDIA_URL)


### PR DESCRIPTION
Both async tests in `lib/components/settings/ImageUploadField.test.tsx` hand-rolled the same promise-with-exposed-resolve helper that `@/lib/testing/deferred` already exports. REVIEW.md → "Style, imports & tests" names this directly:

> A test that needs to control **when** an awaited call settles imports `createDeferred` from `@/lib/testing/deferred` rather than hand-rolling another promise-with-exposed-resolve helper (the same eight lines had been copied into four files under three names).

`post-box`, `MessagesPage`, `SearchPageClient` and `FitnessHeatmapView` were already on the helper; these two were the stragglers in this file. `deferred` as the binding name follows `FitnessHeatmapView.test.tsx`, which uses it verbatim wherever a test has only one.

## Behaviour-preserving

The mock still returns a promise that settles only when the test says so, and **the timing structure around each settle is untouched**. Both structures from #1601 survive with their explanatory comments intact:

- `returns focus to Upload after an upload re-enables it` keeps its `await waitFor(...)` around the focus assertion (the CI flake on Test Shard 2 of 4).
- `leaves focus alone when the user moved elsewhere during an upload` keeps its `await act(async () => {})` barrier (the vacuous assertion).

Net: 7 insertions, 14 deletions, one file.

## Verification

Rebased onto `main` after #1601 merged, so this sits directly on top of the timing fix rather than duplicating it.

- `yarn vitest run lib/components/settings/ImageUploadField.test.tsx` — 9 passed.
- **Revert-proof.** Temporarily deleting the `if (document.activeElement === document.body)` guard from `lib/components/settings/ImageUploadField.tsx:56` fails `leaves focus alone when the user moved elsewhere during an upload` at the `expect(document.activeElement).toBe(elsewhere)` assertion — the Upload button had taken focus. Guard restored; the diff touches only the test file.
- Full gate on Node 24 / yarn: `prettier --check` clean, `yarn lint` exit 0 (pre-existing warnings only, none in this file), `yarn typecheck` exit 0, `yarn build` exit 0, `yarn test` 897 files / 11,971 tests passed.

## Review

**The sub-agent code-review loop did not run on this PR.** This session is configured not to call the Agent tool unless the user asks for it, which is the inability case in AGENTS.md → "When sub-agents are unavailable". A single self-review pass against REVIEW.md was done instead; no findings. Treat this as unreviewed by the loop, not as a clean loop result.

## Follow-up, not in scope

23 other test files still hand-roll the same pattern (`BlocksList`, `GearListView`, `GearDetailView`, `GearActivitiesFeed`, `StravaGearDefaultsSection` and others). Converting them is mechanical but touches a lot of surface, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)