### PR TITLE
none: use the shared createDeferred across the remaining test files

### DIFF
--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -4,6 +4,7 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { createDeferred } from '@/lib/testing/deferred'
 import { Actor } from '@/lib/types/domain/actor'
 import { Client } from '@/lib/types/oauth2/client'
 
@@ -294,12 +295,8 @@ describe('AuthorizeCard', () => {
   })
 
   it('shows a denying label on the deny button only while denial is in flight', async () => {
-    let resolveFetch: (value: unknown) => void = () => {}
-    ;(global.fetch as jest.Mock).mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveFetch = resolve
-      })
-    )
+    const deferred = createDeferred<unknown>()
+    ;(global.fetch as jest.Mock).mockReturnValueOnce(deferred.promise)
 
     render(
       <AuthorizeCard
@@ -325,7 +322,7 @@ describe('AuthorizeCard', () => {
     expect(approveButton).toBeInTheDocument()
     expect(approveButton).toBeDisabled()
 
-    resolveFetch({
+    deferred.resolve({
       ok: true,
       json: async () => ({
         url: 'https://phanpy.local/?error=access_denied&state=return-state'
@@ -338,16 +335,12 @@ describe('AuthorizeCard', () => {
   })
 
   it('shows an approving label on the approve button only while approval is in flight', async () => {
-    let resolveFetch: (value: unknown) => void = () => {}
+    const deferred = createDeferred<unknown>()
     ;(global.fetch as jest.Mock)
       // persistSelectedActor() posts to /api/v1/actors/switch first.
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
       // The consent request stays pending so the loading label is observable.
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveFetch = resolve
-        })
-      )
+      .mockReturnValueOnce(deferred.promise)
 
     render(
       <AuthorizeCard
@@ -373,7 +366,7 @@ describe('AuthorizeCard', () => {
     expect(denyButton).toBeInTheDocument()
     expect(denyButton).toBeDisabled()
 
-    resolveFetch({
+    deferred.resolve({
       ok: true,
       json: async () => ({
         url: 'https://phanpy.local/?code=auth-code&state=return-state'

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -20,6 +20,7 @@ import {
   updateFitnessFileGear
 } from '@/lib/client'
 import type { GearEntity } from '@/lib/services/fitness-gears/gearEntities'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Status, StatusNote } from '@/lib/types/domain/status'
 import { loadMaplibreModule } from '@/lib/utils/maplibre'
@@ -2243,16 +2244,8 @@ describe('FitnessStatusDetail', () => {
       mockGetFitnessGearList.mockResolvedValue([
         buildGear({ id: 'gear-bike', name: 'Moots' })
       ])
-      let resolveUpdate: (file: {
-        id: string
-        gearId: string | null
-      }) => void = () => {}
-      mockUpdateFitnessFileGear.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            resolveUpdate = resolve
-          })
-      )
+      const deferred = createDeferred<{ id: string; gearId: string | null }>()
+      mockUpdateFitnessFileGear.mockImplementation(() => deferred.promise)
 
       renderDetail()
 
@@ -2274,7 +2267,7 @@ describe('FitnessStatusDetail', () => {
         'true'
       )
 
-      resolveUpdate({ id: 'fit-1', gearId: 'gear-bike' })
+      deferred.resolve({ id: 'fit-1', gearId: 'gear-bike' })
       await waitFor(() =>
         expect(
           within(menu).getByRole('menuitem', { name: 'Change gear' })
@@ -2323,13 +2316,8 @@ describe('FitnessStatusDetail', () => {
       // The status payload's single file is what renders first; the real list
       // arrives from `getFitnessFilesByStatus`, and here it lands while the
       // gear PATCH is still open.
-      let resolveFiles: (files: StatusFitnessFileItem[]) => void = () => {}
-      mockGetFitnessFilesByStatus.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            resolveFiles = resolve
-          })
-      )
+      const fileList = createDeferred<StatusFitnessFileItem[]>()
+      mockGetFitnessFilesByStatus.mockImplementation(() => fileList.promise)
       mockGetFitnessGearList.mockResolvedValue([
         buildGear({ id: 'gear-bike', name: 'Moots' })
       ])
@@ -2347,7 +2335,7 @@ describe('FitnessStatusDetail', () => {
       await expectGearLinkText('Moots')
 
       await act(async () => {
-        resolveFiles([
+        fileList.resolve([
           buildFitnessFile(),
           buildFitnessFile({
             id: 'fit-2',

--- a/app/(timeline)/account/sessions/AccountSessions.test.tsx
+++ b/app/(timeline)/account/sessions/AccountSessions.test.tsx
@@ -16,6 +16,7 @@ import {
   AccountSessions,
   SessionActor
 } from '@/app/(timeline)/account/sessions/AccountSessions'
+import { createDeferred } from '@/lib/testing/deferred'
 
 const deleteSession = vi.fn()
 const revokeOtherSessions = vi.fn()
@@ -302,13 +303,8 @@ describe('AccountSessions', () => {
   })
 
   it('disables every revoke control while a request is in flight', async () => {
-    let resolveRevoke: (value: boolean) => void = () => {}
-    revokeOtherSessions.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveRevoke = resolve
-        })
-    )
+    const deferred = createDeferred<boolean>()
+    revokeOtherSessions.mockImplementationOnce(() => deferred.promise)
     // A current session + one other (drives "Revoke all others") and an app
     // whose Revoke button stays mounted while the revoke-all is in flight.
     renderSessions({ sessions: oneOther, apps: [apps[0]] })
@@ -331,7 +327,7 @@ describe('AccountSessions', () => {
     fireEvent.click(appRevoke())
     expect(revokeConnectedApp).not.toHaveBeenCalled()
 
-    resolveRevoke(true)
+    deferred.resolve(true)
     await waitFor(() => expect(appRevoke()).not.toBeDisabled())
   })
 

--- a/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
+++ b/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
@@ -7,6 +7,7 @@ import { ReactNode } from 'react'
 
 import { CollectionMember } from '@/app/(timeline)/collections/CollectionEditor'
 import { getCollectionFeed, getCollectionTimeline } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { CollectionEntity } from '@/lib/types/mastodon/collection'
@@ -212,11 +213,8 @@ describe('CollectionDetail', () => {
   it('ignores a stale load-more response that resolves after a projection switch', async () => {
     // Hold the owner-feed load-more request open so it resolves AFTER the
     // projection switch — the requestId guard must drop its (now stale) result.
-    let resolveOwner: (value: unknown) => void = () => {}
-    const ownerPending = new Promise((resolve) => {
-      resolveOwner = resolve
-    })
-    ;(getCollectionTimeline as jest.Mock).mockReturnValue(ownerPending)
+    const ownerPending = createDeferred<unknown>()
+    ;(getCollectionTimeline as jest.Mock).mockReturnValue(ownerPending.promise)
 
     render(
       <CollectionDetail
@@ -236,7 +234,7 @@ describe('CollectionDetail', () => {
 
     // Now let the stale owner request resolve — it must NOT be applied.
     await act(async () => {
-      resolveOwner({
+      ownerPending.resolve({
         statuses: [{ id: 'owner-stale' }],
         nextMaxStatusId: null,
         prevMinStatusId: null

--- a/app/(timeline)/fitness/gear/GearListView.test.tsx
+++ b/app/(timeline)/fitness/gear/GearListView.test.tsx
@@ -12,6 +12,7 @@ import {
 
 import { createFitnessGear, getFitnessGearList } from '@/lib/client'
 import type { GearEntity } from '@/lib/services/fitness-gears/gearEntities'
+import { createDeferred } from '@/lib/testing/deferred'
 
 import { GearListView } from './GearListView'
 
@@ -278,7 +279,7 @@ describe('GearListView', () => {
 
   it('keeps the sections rendered while a refetch is in flight', async () => {
     mockCreateFitnessGear.mockResolvedValue(createGear())
-    let resolveRefetch: (gears: GearEntity[]) => void = () => {}
+    const deferred = createDeferred<GearEntity[]>()
     mockGetFitnessGearList
       .mockResolvedValueOnce([
         createGear(),
@@ -288,12 +289,7 @@ describe('GearListView', () => {
           retiredAt: Date.UTC(2023, 4, 1)
         })
       ])
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveRefetch = resolve
-          })
-      )
+      .mockImplementationOnce(() => deferred.promise)
     render(<GearListView />)
 
     // The expanded retired list is the state a "Loading..." swap would lose.
@@ -310,7 +306,7 @@ describe('GearListView', () => {
     expect(screen.getByRole('link', { name: 'Rocket' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Old racer' })).toBeInTheDocument()
 
-    resolveRefetch([createGear()])
+    deferred.resolve([createGear()])
     await waitFor(() =>
       expect(
         screen.queryByRole('link', { name: 'Old racer' })

--- a/app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx
@@ -8,6 +8,7 @@ import {
   type GearActivityStatusesPage,
   getFitnessGearActivities
 } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 
@@ -544,19 +545,15 @@ describe('GearActivitiesFeed', () => {
       renderFeed()
       await screen.findByRole('button', { name: 'Load more' })
 
-      let resolvePage: (value: GearActivityStatusesPage) => void = () => {}
-      mockGetFitnessGearActivities.mockReturnValueOnce(
-        new Promise<GearActivityStatusesPage>((resolve) => {
-          resolvePage = resolve
-        })
-      )
+      const deferred = createDeferred<GearActivityStatusesPage>()
+      mockGetFitnessGearActivities.mockReturnValueOnce(deferred.promise)
       act(() => scrollSentinelIntoView())
       act(() => scrollSentinelIntoView())
 
       expect(mockGetFitnessGearActivities).toHaveBeenCalledTimes(2)
 
       await act(async () => {
-        resolvePage(
+        deferred.resolve(
           page({ statuses: [createStatus('status-2', 'Evening ride')] })
         )
       })
@@ -564,18 +561,14 @@ describe('GearActivitiesFeed', () => {
     })
 
     it('is not armed while the first page is still loading', async () => {
-      let resolveFirst: (value: GearActivityStatusesPage) => void = () => {}
-      mockGetFitnessGearActivities.mockReturnValueOnce(
-        new Promise<GearActivityStatusesPage>((resolve) => {
-          resolveFirst = resolve
-        })
-      )
+      const deferred = createDeferred<GearActivityStatusesPage>()
+      mockGetFitnessGearActivities.mockReturnValueOnce(deferred.promise)
       renderFeed()
 
       expect(observe).not.toHaveBeenCalled()
 
       await act(async () => {
-        resolveFirst(
+        deferred.resolve(
           page({
             statuses: [createStatus('status-1', 'Morning ride')],
             hasMore: true,
@@ -593,10 +586,7 @@ describe('GearActivitiesFeed', () => {
     // `key`, so navigating between two gear pages swaps `gearId` on the SAME
     // instance rather than remounting.
     const renderThenSwitch = async () => {
-      let resolveStale: (value: GearActivityStatusesPage) => void = () => {}
-      const stalePage = new Promise<GearActivityStatusesPage>((resolve) => {
-        resolveStale = resolve
-      })
+      const stalePage = createDeferred<GearActivityStatusesPage>()
 
       mockGetFitnessGearActivities.mockResolvedValueOnce(
         page({
@@ -609,7 +599,7 @@ describe('GearActivitiesFeed', () => {
       const loadMore = await screen.findByRole('button', { name: 'Load more' })
 
       // "Load more" on gear A, still in flight when the gear changes.
-      mockGetFitnessGearActivities.mockReturnValueOnce(stalePage)
+      mockGetFitnessGearActivities.mockReturnValueOnce(stalePage.promise)
       fireEvent.click(loadMore)
 
       mockGetFitnessGearActivities.mockResolvedValueOnce(
@@ -633,10 +623,10 @@ describe('GearActivitiesFeed', () => {
         expect(screen.getByText('Gear B ride')).toBeInTheDocument()
       )
 
-      resolveStale(
+      stalePage.resolve(
         page({ statuses: [createStatus('a-2', 'Stale ride')], hasMore: true })
       )
-      await waitFor(() => expect(stalePage).resolves.toBeDefined())
+      await waitFor(() => expect(stalePage.promise).resolves.toBeDefined())
       return view
     }
 
@@ -717,12 +707,8 @@ describe('GearActivitiesFeed', () => {
       const view = renderFeed()
       await screen.findByRole('alert')
 
-      let resolveNext: (value: GearActivityStatusesPage) => void = () => {}
-      mockGetFitnessGearActivities.mockReturnValueOnce(
-        new Promise<GearActivityStatusesPage>((resolve) => {
-          resolveNext = resolve
-        })
-      )
+      const deferred = createDeferred<GearActivityStatusesPage>()
+      mockGetFitnessGearActivities.mockReturnValueOnce(deferred.promise)
       view.rerender(
         <GearActivitiesFeed
           gearId="gear-2"
@@ -738,7 +724,9 @@ describe('GearActivitiesFeed', () => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
       await act(async () => {
-        resolveNext(page({ statuses: [createStatus('b-1', 'Gear B ride')] }))
+        deferred.resolve(
+          page({ statuses: [createStatus('b-1', 'Gear B ride')] })
+        )
       })
       expect(screen.getByText('Gear B ride')).toBeInTheDocument()
     })
@@ -758,19 +746,15 @@ describe('GearActivitiesFeed', () => {
       const view = renderFeed()
       const loadMore = await screen.findByRole('button', { name: 'Load more' })
 
-      let resolveWalk: (value: GearActivityStatusesPage) => void = () => {}
-      mockGetFitnessGearActivities.mockReturnValueOnce(
-        new Promise<GearActivityStatusesPage>((resolve) => {
-          resolveWalk = resolve
-        })
-      )
+      const deferred = createDeferred<GearActivityStatusesPage>()
+      mockGetFitnessGearActivities.mockReturnValueOnce(deferred.promise)
       fireEvent.click(loadMore)
       expect(mockGetFitnessGearActivities).toHaveBeenCalledTimes(2)
 
       view.unmount()
       await act(async () => {
         // A postless page, which is what would otherwise keep the walk going.
-        resolveWalk(page({ hasMore: true, nextOffset: 40 }))
+        deferred.resolve(page({ hasMore: true, nextOffset: 40 }))
       })
 
       expect(mockGetFitnessGearActivities).toHaveBeenCalledTimes(2)

--- a/app/(timeline)/fitness/gear/[id]/GearDetailView.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearDetailView.test.tsx
@@ -19,6 +19,7 @@ import type {
   GearComponentEntity,
   GearEntity
 } from '@/lib/services/fitness-gears/gearEntities'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 
 import type { GearActivityFeedContext } from './GearActivitiesFeed'
@@ -424,13 +425,8 @@ describe('GearDetailView', () => {
   })
 
   it('disables the retire button while the change is in flight', async () => {
-    let resolveRetire: (gear: GearEntity) => void = () => {}
-    mockSetFitnessGearRetired.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveRetire = resolve
-        })
-    )
+    const deferred = createDeferred<GearEntity>()
+    mockSetFitnessGearRetired.mockImplementation(() => deferred.promise)
     render(<GearDetailView gearId="gear-1" feed={feed} />)
 
     const retire = await screen.findByRole('button', { name: 'Retire' })
@@ -438,7 +434,7 @@ describe('GearDetailView', () => {
 
     await waitFor(() => expect(retire).toBeDisabled())
 
-    resolveRetire(createGear({ retiredAt: Date.UTC(2026, 0, 1) }))
+    deferred.resolve(createGear({ retiredAt: Date.UTC(2026, 0, 1) }))
     await waitFor(() => expect(mockGetFitnessGearList).toHaveBeenCalledTimes(2))
   })
 
@@ -451,15 +447,10 @@ describe('GearDetailView', () => {
         removedAt: Date.UTC(2025, 5, 1)
       })
     ])
-    let resolveRefetch: (gears: GearEntity[]) => void = () => {}
+    const deferred = createDeferred<GearEntity[]>()
     mockGetFitnessGearList
       .mockResolvedValueOnce([createGear()])
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveRefetch = resolve
-          })
-      )
+      .mockImplementationOnce(() => deferred.promise)
     render(<GearDetailView gearId="gear-1" feed={feed} />)
 
     // Expand the retired rows: the child's own state is what a remount loses.
@@ -475,7 +466,7 @@ describe('GearDetailView', () => {
     expect(screen.getByText('Chain')).toBeInTheDocument()
     expect(screen.getByText('Cassette')).toBeInTheDocument()
 
-    resolveRefetch([createGear({ retiredAt: Date.UTC(2026, 0, 1) })])
+    deferred.resolve([createGear({ retiredAt: Date.UTC(2026, 0, 1) })])
     await screen.findByRole('button', { name: 'Unretire' })
   })
 

--- a/app/(timeline)/fitness/strava/StravaGearDefaultsSection.test.tsx
+++ b/app/(timeline)/fitness/strava/StravaGearDefaultsSection.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import { getFitnessGearList, updateFitnessGear } from '@/lib/client'
 import type { GearEntity } from '@/lib/services/fitness-gears/gearEntities'
+import { createDeferred } from '@/lib/testing/deferred'
 
 import {
   StravaGearDefaultsSection,
@@ -363,12 +364,8 @@ describe('StravaGearDefaultsSection', () => {
       defaultSports: []
     })
     mockGetFitnessGearList.mockResolvedValue([moots, giant])
-    let resolveSave: (gear: GearEntity) => void = () => {}
-    mockUpdateFitnessGear.mockReturnValue(
-      new Promise<GearEntity>((resolve) => {
-        resolveSave = resolve
-      })
-    )
+    const deferred = createDeferred<GearEntity>()
+    mockUpdateFitnessGear.mockReturnValue(deferred.promise)
 
     const elsewhere = document.createElement('button')
     elsewhere.textContent = 'Somewhere else'
@@ -386,7 +383,7 @@ describe('StravaGearDefaultsSection', () => {
 
     elsewhere.focus()
     await act(async () => {
-      resolveSave(giant)
+      deferred.resolve(giant)
     })
 
     expect(elsewhere).toHaveFocus()
@@ -464,12 +461,8 @@ describe('StravaGearDefaultsSection', () => {
       defaultSports: []
     })
     mockGetFitnessGearList.mockResolvedValue([moots, giant])
-    let resolveSave: (gear: GearEntity) => void = () => {}
-    mockUpdateFitnessGear.mockReturnValue(
-      new Promise<GearEntity>((resolve) => {
-        resolveSave = resolve
-      })
-    )
+    const deferred = createDeferred<GearEntity>()
+    mockUpdateFitnessGear.mockReturnValue(deferred.promise)
 
     render(<StravaGearDefaultsSection />)
 
@@ -487,7 +480,7 @@ describe('StravaGearDefaultsSection', () => {
     ).not.toHaveFocus()
 
     await act(async () => {
-      resolveSave(giant)
+      deferred.resolve(giant)
     })
 
     await waitFor(() =>

--- a/app/(timeline)/settings/blocks/BlocksList.test.tsx
+++ b/app/(timeline)/settings/blocks/BlocksList.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@testing-library/react'
 
 import { getBlocks, unblock } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 
 import { BlocksList } from './BlocksList'
@@ -69,12 +70,8 @@ describe('BlocksList', () => {
   })
 
   it('tracks pending unblock requests per account and clears loading on failure', async () => {
-    let resolveUnblock: (value: null) => void = () => undefined
-    unblockMock.mockReturnValueOnce(
-      new Promise<null>((resolve) => {
-        resolveUnblock = resolve
-      })
-    )
+    const deferred = createDeferred<null>()
+    unblockMock.mockReturnValueOnce(deferred.promise)
 
     render(
       <BlocksList accounts={[firstAccount, secondAccount]} nextMaxId={null} />
@@ -97,7 +94,7 @@ describe('BlocksList', () => {
     ).toBeEnabled()
 
     await act(async () => {
-      resolveUnblock(null)
+      deferred.resolve(null)
     })
 
     expect(await screen.findByRole('alert')).toHaveTextContent(

--- a/lib/components/fitness/useHeatmapTiles.test.ts
+++ b/lib/components/fitness/useHeatmapTiles.test.ts
@@ -9,6 +9,7 @@ import {
   TILE_EXTENT
 } from '@/lib/services/fitness-files/heatmapTiles/constants'
 import { encodeTile } from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
+import { createDeferred } from '@/lib/testing/deferred'
 
 import {
   MAX_TILES_PER_VIEW,
@@ -187,16 +188,11 @@ describe('useHeatmapTiles', () => {
   })
 
   it('keeps the previous geometry while the next viewport loads', async () => {
-    let release: (value: FitnessRouteHeatmapTileBatch) => void = () => {}
+    const deferred = createDeferred<FitnessRouteHeatmapTileBatch>()
     const fetchTiles = vi
       .fn()
       .mockImplementationOnce(async ({ tiles }) => batchOf(tiles))
-      .mockImplementationOnce(
-        () =>
-          new Promise<FitnessRouteHeatmapTileBatch>((resolve) => {
-            release = resolve
-          })
-      )
+      .mockImplementationOnce(() => deferred.promise)
     const { result } = renderHook(() =>
       useHeatmapTiles({ tileSource, fetchTiles })
     )
@@ -216,7 +212,7 @@ describe('useHeatmapTiles', () => {
 
     // Blanking here would read as breakage rather than loading.
     expect(result.current.runs).toBe(before)
-    act(() => release({ version: 3, tiles: {} }))
+    act(() => deferred.resolve({ version: 3, tiles: {} }))
   })
 
   it('restarts the view when the pyramid is rebuilt mid-load, rather than assembling half of it', async () => {

--- a/lib/components/layout/nav-preferences-context.test.tsx
+++ b/lib/components/layout/nav-preferences-context.test.tsx
@@ -9,6 +9,7 @@ import {
   useNavPreferences
 } from '@/lib/components/layout/nav-preferences-context'
 import { DEFAULT_NAV_ORDER } from '@/lib/services/navigation/navPreferences'
+import { createDeferred } from '@/lib/testing/deferred'
 
 const mockUpdate = vi.fn()
 vi.mock('@/lib/client', () => ({
@@ -101,13 +102,8 @@ describe('NavPreferencesProvider', () => {
   })
 
   it('coalesces edits made while a save is in flight into one trailing write', async () => {
-    let resolveFirst: (value: boolean) => void = () => {}
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveFirst = resolve
-        })
-    )
+    const deferred = createDeferred<boolean>()
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
 
     renderStore()
     click('hide favorites')
@@ -117,7 +113,7 @@ describe('NavPreferencesProvider', () => {
     // Only the first request has gone out so far.
     expect(mockUpdate).toHaveBeenCalledTimes(1)
     await act(async () => {
-      resolveFirst(true)
+      deferred.resolve(true)
     })
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2))
@@ -128,13 +124,8 @@ describe('NavPreferencesProvider', () => {
   })
 
   it('sends an edit that undoes an in-flight change', async () => {
-    let resolveFirst: (value: boolean) => void = () => {}
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveFirst = resolve
-        })
-    )
+    const deferred = createDeferred<boolean>()
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
 
     renderStore()
     click('hide favorites')
@@ -143,7 +134,7 @@ describe('NavPreferencesProvider', () => {
     click('show favorites')
 
     await act(async () => {
-      resolveFirst(true)
+      deferred.resolve(true)
     })
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2))
@@ -197,19 +188,14 @@ describe('NavPreferencesProvider', () => {
   })
 
   it('still saves an edit made after a failure that a later save recovered from', async () => {
-    let resolveFirst: (value: boolean) => void = () => {}
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveFirst = resolve
-        })
-    )
+    const deferred = createDeferred<boolean>()
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
 
     renderStore()
     click('hide favorites')
     click('hide bookmarks')
     await act(async () => {
-      resolveFirst(false)
+      deferred.resolve(false)
     })
     // The trailing save carries both hides and succeeds.
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2))
@@ -221,22 +207,17 @@ describe('NavPreferencesProvider', () => {
   })
 
   it('does not let a gesture that changed nothing undo a reset in flight', async () => {
-    let resolveReset: (value: boolean) => void = () => {}
+    const deferred = createDeferred<boolean>()
     renderStore({ order: ['settings', 'timeline'] })
 
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveReset = resolve
-        })
-    )
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
     click('reset')
     // A row picked up and dropped where it started, while the reset is still
     // in flight: it must not queue today's order over the reset's empty lists.
     click('commit')
 
     await act(async () => {
-      resolveReset(true)
+      deferred.resolve(true)
     })
     await act(async () => {})
 
@@ -268,37 +249,27 @@ describe('NavPreferencesProvider', () => {
   })
 
   it('keeps a reset queued behind an unrelated save that settles first', async () => {
-    let resolveHide: (value: boolean) => void = () => {}
+    const deferred = createDeferred<boolean>()
     renderStore({ order: ['settings', 'timeline'] })
 
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveHide = resolve
-        })
-    )
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
     click('hide favorites')
     // Queued behind the hide, so the hide landing must not be taken as the
     // account having settled what the reset is still owed.
     click('reset')
 
     await act(async () => {
-      resolveHide(true)
+      deferred.resolve(true)
     })
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2))
     expect(mockUpdate).toHaveBeenLastCalledWith({ navOrder: [], navHidden: [] })
   })
 
   it('still clears the stored lists when an edit made after a reset is undone', async () => {
-    let resolveReset: (value: boolean) => void = () => {}
+    const deferred = createDeferred<boolean>()
     renderStore({ order: ['settings', 'timeline'] })
 
-    mockUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveReset = resolve
-        })
-    )
+    mockUpdate.mockImplementationOnce(() => deferred.promise)
     click('reset')
     // An edit supersedes the reset, then the user takes it back. The navigation
     // is once again what reset produced, so the account should end up with the
@@ -307,7 +278,7 @@ describe('NavPreferencesProvider', () => {
     click('show favorites')
 
     await act(async () => {
-      resolveReset(true)
+      deferred.resolve(true)
     })
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2))
     expect(mockUpdate).toHaveBeenLastCalledWith({ navOrder: [], navHidden: [] })

--- a/lib/components/mute-action/mute-action.test.tsx
+++ b/lib/components/mute-action/mute-action.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@testing-library/react'
 
 import { mute, unmute } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 
 import { MuteAction } from './mute-action'
@@ -171,13 +172,8 @@ describe('MuteAction', () => {
   })
 
   it('keeps the dialog open and disables Cancel while a mute is in flight', async () => {
-    let resolveMute: (value: MastodonRelationship | null) => void = () =>
-      undefined
-    muteMock.mockReturnValueOnce(
-      new Promise<MastodonRelationship | null>((resolve) => {
-        resolveMute = resolve
-      })
-    )
+    const deferred = createDeferred<MastodonRelationship | null>()
+    muteMock.mockReturnValueOnce(deferred.promise)
 
     render(
       <MuteAction
@@ -205,7 +201,7 @@ describe('MuteAction', () => {
     ).toBeInTheDocument()
 
     await act(async () => {
-      resolveMute(relationship({ muting: true }))
+      deferred.resolve(relationship({ muting: true }))
     })
 
     await screen.findByRole('button', { name: 'Unmute' })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -950,12 +950,8 @@ describe('PostBox edit media', () => {
   })
 
   it('ignores reentrant submits while edit media upload is in flight', async () => {
-    let resolveUpdate: (value: Awaited<ReturnType<typeof updateNote>>) => void
-    updateNoteMock.mockReturnValue(
-      new Promise((resolve) => {
-        resolveUpdate = resolve
-      })
-    )
+    const deferred = createDeferred<Awaited<ReturnType<typeof updateNote>>>()
+    updateNoteMock.mockReturnValue(deferred.promise)
 
     const { container } = render(
       <PostBox
@@ -1000,7 +996,7 @@ describe('PostBox edit media', () => {
     })
 
     await act(async () => {
-      resolveUpdate!({
+      deferred.resolve({
         content: '<p>Original post text</p>',
         spoilerText: '',
         mediaAttachments: [],

--- a/lib/components/posts/actions/bookmark-button.test.tsx
+++ b/lib/components/posts/actions/bookmark-button.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { FC } from 'react'
 
 import { bookmarkStatus, undoBookmarkStatus } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
 
 import { BookmarkButton } from './bookmark-button'
@@ -134,11 +135,8 @@ describe('BookmarkButton', () => {
 
   it('auto-dismisses bookmark errors after a short delay', async () => {
     vi.useFakeTimers()
-    let resolveBookmark: (value: boolean) => void = () => {}
-    const bookmarkPromise = new Promise<boolean>((resolve) => {
-      resolveBookmark = resolve
-    })
-    ;(bookmarkStatus as jest.Mock).mockReturnValue(bookmarkPromise)
+    const deferred = createDeferred<boolean>()
+    ;(bookmarkStatus as jest.Mock).mockReturnValue(deferred.promise)
 
     try {
       render(<BookmarkAction status={status} />)
@@ -146,8 +144,8 @@ describe('BookmarkButton', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Bookmark' }))
 
       await act(async () => {
-        resolveBookmark(false)
-        await bookmarkPromise
+        deferred.resolve(false)
+        await deferred.promise
       })
 
       expect(screen.getByRole('alert')).toHaveTextContent(

--- a/lib/components/posts/actions/like-button.test.tsx
+++ b/lib/components/posts/actions/like-button.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import { likeStatus, undoLikeStatus } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
 
@@ -69,11 +70,8 @@ describe('LikeButton', () => {
   })
 
   it('disables while liking to avoid duplicate requests', async () => {
-    let resolveLike: (value: boolean) => void = () => {}
-    const likePromise = new Promise<boolean>((resolve) => {
-      resolveLike = resolve
-    })
-    ;(likeStatus as jest.Mock).mockReturnValue(likePromise)
+    const deferred = createDeferred<boolean>()
+    ;(likeStatus as jest.Mock).mockReturnValue(deferred.promise)
 
     render(<LikeButton currentActor={currentActor} status={status} />)
 
@@ -85,8 +83,8 @@ describe('LikeButton', () => {
     expect(likeStatus).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      resolveLike(true)
-      await likePromise
+      deferred.resolve(true)
+      await deferred.promise
     })
 
     expect(screen.getByRole('button', { name: 'Unlike, 1 like' })).toBeEnabled()

--- a/lib/components/posts/actions/reaction-button.test.tsx
+++ b/lib/components/posts/actions/reaction-button.test.tsx
@@ -8,6 +8,7 @@ import { FC } from 'react'
 import { ReactionButton } from '@/lib/components/posts/actions/reaction-button'
 import { ReactionRow } from '@/lib/components/posts/reaction-row'
 import { useReactionState } from '@/lib/components/posts/useReactionState'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { StatusNote } from '@/lib/types/domain/status'
 import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
@@ -184,12 +185,8 @@ describe('ReactionButton', () => {
   })
 
   it('keeps focus on the trigger across a picker-driven reaction', async () => {
-    let resolveRequest: (value: unknown) => void = () => {}
-    mockReactToStatus.mockReturnValue(
-      new Promise((resolve) => {
-        resolveRequest = resolve
-      })
-    )
+    const deferred = createDeferred<unknown>()
+    mockReactToStatus.mockReturnValue(deferred.promise)
 
     render(<Reactions currentActor={currentActor} status={statusWith([])} />)
     fireEvent.click(trigger())
@@ -206,7 +203,7 @@ describe('ReactionButton', () => {
     // in flight — disabling it here would blur it and reset the user's tab
     // position to the top of the document.
     await waitFor(() => expect(trigger()).toHaveFocus())
-    resolveRequest({ ok: true, reactions: [{ ...fire, count: 1, me: true }] })
+    deferred.resolve({ ok: true, reactions: [{ ...fire, count: 1, me: true }] })
     await waitFor(() => expect(mockReactToStatus).toHaveBeenCalledTimes(1))
     expect(trigger()).toHaveFocus()
   })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -19,6 +19,7 @@ import {
   likeStatus,
   reactToStatus
 } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import type { ActorProfile } from '@/lib/types/domain/actor'
 import {
   StatusAnnounce,
@@ -816,11 +817,8 @@ describe('Post', () => {
   })
 
   it('keeps pending like action state when the same status receives updated counts', async () => {
-    let resolveLike: (value: boolean) => void = () => {}
-    const likePromise = new Promise<boolean>((resolve) => {
-      resolveLike = resolve
-    })
-    ;(likeStatus as jest.Mock).mockReturnValue(likePromise)
+    const deferred = createDeferred<boolean>()
+    ;(likeStatus as jest.Mock).mockReturnValue(deferred.promise)
     const otherActor = {
       ...status.actor!,
       id: 'https://activities.local/users/other',
@@ -861,8 +859,8 @@ describe('Post', () => {
     expect(likeStatus).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      resolveLike(true)
-      await likePromise
+      deferred.resolve(true)
+      await deferred.promise
     })
 
     expect(
@@ -1927,12 +1925,8 @@ describe('Post', () => {
 
     it('disables the menu items whose write is already in flight', async () => {
       observeWidth(320)
-      let settleBookmark: (value: boolean) => void = () => {}
-      ;(bookmarkStatus as jest.Mock).mockReturnValue(
-        new Promise<boolean>((resolve) => {
-          settleBookmark = resolve
-        })
-      )
+      const bookmark = createDeferred<boolean>()
+      ;(bookmarkStatus as jest.Mock).mockReturnValue(bookmark.promise)
       ;(reactToStatus as jest.Mock).mockReturnValue(new Promise(() => {}))
       render(
         <Post
@@ -1973,7 +1967,7 @@ describe('Post', () => {
       // menu: Radix `aria-hidden`s the rest of the document while it is up, so
       // reopening would not find the ⋯ trigger.
       await act(async () => {
-        settleBookmark(true)
+        bookmark.resolve(true)
       })
       expect(
         within(menu).getByRole('menuitem', { name: 'Remove bookmark' })

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -11,6 +11,7 @@ import {
   ReactionState,
   useReactionState
 } from '@/lib/components/posts/useReactionState'
+import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
@@ -364,12 +365,8 @@ describe('ReactionRow', () => {
   })
 
   it('marks every chip busy while a reaction write is in flight', async () => {
-    let resolveRequest: (value: unknown) => void = () => {}
-    mockReactToStatus.mockReturnValue(
-      new Promise((resolve) => {
-        resolveRequest = resolve
-      })
-    )
+    const deferred = createDeferred<unknown>()
+    mockReactToStatus.mockReturnValue(deferred.promise)
 
     render(
       <Reactions
@@ -393,7 +390,7 @@ describe('ReactionRow', () => {
     fireEvent.click(other)
     expect(mockReactToStatus).toHaveBeenCalledTimes(1)
 
-    resolveRequest({ ok: true, reactions: [{ ...fire, count: 3, me: true }] })
+    deferred.resolve({ ok: true, reactions: [{ ...fire, count: 3, me: true }] })
     await waitFor(() =>
       expect(screen.getByLabelText('Remove 🔥 reaction, 3')).toHaveAttribute(
         'aria-disabled',

--- a/lib/components/posts/translation-context.test.tsx
+++ b/lib/components/posts/translation-context.test.tsx
@@ -9,6 +9,7 @@ import {
   getTranslationLanguages,
   translateStatus
 } from '@/lib/client'
+import { type Deferred, createDeferred } from '@/lib/testing/deferred'
 import { Translation } from '@/lib/types/mastodon/translation'
 
 import { useStatusTranslation } from './translation-context'
@@ -42,12 +43,12 @@ describe('useStatusTranslation', () => {
   })
 
   it('ignores an out-of-order response from a superseded target', async () => {
-    const resolvers: Record<string, (value: Translation) => void> = {}
+    const pending: Record<string, Deferred<Translation>> = {}
     ;(translateStatus as jest.Mock).mockImplementation(
-      ({ language }: { language: string }) =>
-        new Promise<Translation>((resolve) => {
-          resolvers[language] = resolve
-        })
+      ({ language }: { language: string }) => {
+        pending[language] = createDeferred<Translation>()
+        return pending[language].promise
+      }
     )
 
     const { result } = renderHook(() => useStatusTranslation('id-1', 'de'))
@@ -59,11 +60,11 @@ describe('useStatusTranslation', () => {
     expect(result.current.state).toBe('loading')
 
     // The superseded English request resolves last; it must not flip the UI.
-    act(() => resolvers.en(makeTranslation('en')))
+    act(() => pending.en.resolve(makeTranslation('en')))
     expect(result.current.state).toBe('loading')
 
     // The latest target (Spanish) wins and drives the visible state.
-    act(() => resolvers.es(makeTranslation('es')))
+    act(() => pending.es.resolve(makeTranslation('es')))
     await waitFor(() => expect(result.current.state).toBe('translated'))
     expect(result.current.target).toBe('es')
     expect(result.current.translation?.language).toBe('es')

--- a/lib/components/remote-follow/remote-follow-dialog.test.tsx
+++ b/lib/components/remote-follow/remote-follow-dialog.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { getRemoteFollowUrl } from '@/lib/client'
+import { type Deferred, createDeferred } from '@/lib/testing/deferred'
 
 import { RemoteFollowDialog } from './remote-follow-dialog'
 
@@ -125,12 +126,8 @@ describe('RemoteFollowDialog', () => {
   })
 
   it('does not navigate when the dialog is dismissed while the lookup is in flight', async () => {
-    let resolveLookup: (url: string) => void = () => undefined
-    getRemoteFollowUrlMock.mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveLookup = resolve
-      })
-    )
+    const deferred = createDeferred<string>()
+    getRemoteFollowUrlMock.mockReturnValue(deferred.promise)
     render(<RemoteFollowDialog targetHandle="local@llun.test" />)
     openDialog()
 
@@ -146,19 +143,15 @@ describe('RemoteFollowDialog', () => {
     })
 
     await act(async () => {
-      resolveLookup('https://remote.test/authorize_interaction?uri=x')
+      deferred.resolve('https://remote.test/authorize_interaction?uri=x')
     })
 
     expect(assign).not.toHaveBeenCalled()
   })
 
   it('leaves the form usable after a dismissed lookup resolves', async () => {
-    let resolveLookup: (url: string) => void = () => undefined
-    getRemoteFollowUrlMock.mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveLookup = resolve
-      })
-    )
+    const deferred = createDeferred<string>()
+    getRemoteFollowUrlMock.mockReturnValue(deferred.promise)
     render(<RemoteFollowDialog targetHandle="local@llun.test" />)
     openDialog()
 
@@ -170,7 +163,7 @@ describe('RemoteFollowDialog', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
     await act(async () => {
-      resolveLookup('https://remote.test/authorize_interaction?uri=x')
+      deferred.resolve('https://remote.test/authorize_interaction?uri=x')
     })
 
     openDialog()
@@ -182,12 +175,8 @@ describe('RemoteFollowDialog', () => {
   it('does not navigate when a dismissed lookup settles after the dialog is reopened', async () => {
     // Reopening to retry is the natural next move after giving up, and it must
     // not revive the lookup that was walked away from.
-    let resolveLookup: (url: string) => void = () => undefined
-    getRemoteFollowUrlMock.mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveLookup = resolve
-      })
-    )
+    const deferred = createDeferred<string>()
+    getRemoteFollowUrlMock.mockReturnValue(deferred.promise)
     render(<RemoteFollowDialog targetHandle="local@llun.test" />)
     openDialog()
 
@@ -203,7 +192,7 @@ describe('RemoteFollowDialog', () => {
     await screen.findByLabelText('Your address')
 
     await act(async () => {
-      resolveLookup('https://abandoned.test/authorize_interaction?uri=x')
+      deferred.resolve('https://abandoned.test/authorize_interaction?uri=x')
     })
 
     expect(assign).not.toHaveBeenCalled()
@@ -213,12 +202,12 @@ describe('RemoteFollowDialog', () => {
   })
 
   it('sends the visitor to the retried address, not the abandoned one', async () => {
-    const settle: Record<string, (url: string) => void> = {}
+    const pending: Record<string, Deferred<string>> = {}
     getRemoteFollowUrlMock.mockImplementation(
-      ({ account }: { account: string }) =>
-        new Promise<string>((resolve) => {
-          settle[account] = resolve
-        })
+      ({ account }: { account: string }) => {
+        pending[account] = createDeferred<string>()
+        return pending[account].promise
+      }
     )
     render(<RemoteFollowDialog targetHandle="local@llun.test" />)
     openDialog()
@@ -238,14 +227,14 @@ describe('RemoteFollowDialog', () => {
 
     // The abandoned lookup finishes first and must lose.
     await act(async () => {
-      settle['typo@wrong.test'](
+      pending['typo@wrong.test'].resolve(
         'https://wrong.test/authorize_interaction?uri=x'
       )
     })
     expect(assign).not.toHaveBeenCalled()
 
     await act(async () => {
-      settle['visitor@correct.test'](
+      pending['visitor@correct.test'].resolve(
         'https://correct.test/authorize_interaction?uri=x'
       )
     })
@@ -294,12 +283,8 @@ describe('RemoteFollowDialog', () => {
   it('does not navigate when the page is left while the lookup is in flight', async () => {
     // Radix pushes no history entry, so a browser or Android system Back
     // unmounts this without ever closing the dialog.
-    let resolveLookup: (url: string) => void = () => undefined
-    getRemoteFollowUrlMock.mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveLookup = resolve
-      })
-    )
+    const deferred = createDeferred<string>()
+    getRemoteFollowUrlMock.mockReturnValue(deferred.promise)
     const view = render(<RemoteFollowDialog targetHandle="local@llun.test" />)
     openDialog()
 
@@ -309,7 +294,7 @@ describe('RemoteFollowDialog', () => {
 
     view.unmount()
     await act(async () => {
-      resolveLookup('https://abandoned.test/authorize_interaction?uri=x')
+      deferred.resolve('https://abandoned.test/authorize_interaction?uri=x')
     })
 
     expect(assign).not.toHaveBeenCalled()

--- a/lib/components/settings/FitnessFileManagement.test.tsx
+++ b/lib/components/settings/FitnessFileManagement.test.tsx
@@ -4,6 +4,8 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { createDeferred } from '@/lib/testing/deferred'
+
 import { FitnessFileManagement } from './FitnessFileManagement'
 
 vi.mock('next/navigation', () => ({
@@ -209,11 +211,9 @@ describe('FitnessFileManagement', () => {
     })
 
     it('disables every retry button while a retry is in flight', async () => {
-      let resolveFetch: (value: unknown) => void = () => undefined
+      const deferred = createDeferred<unknown>()
       vi.spyOn(global, 'fetch').mockReturnValue(
-        new Promise((resolve) => {
-          resolveFetch = resolve
-        }) as unknown as Promise<Response>
+        deferred.promise as unknown as Promise<Response>
       )
 
       const baseFile = {
@@ -268,7 +268,7 @@ describe('FitnessFileManagement', () => {
         screen.getByRole('button', { name: 'Retry import' })
       ).toBeDisabled()
 
-      resolveFetch({
+      deferred.resolve({
         ok: true,
         json: async () => ({ batchId: 'strava-activity:A', retried: 1 })
       })

--- a/lib/hooks/useCopyToClipboard.test.ts
+++ b/lib/hooks/useCopyToClipboard.test.ts
@@ -3,6 +3,8 @@
  */
 import { act, renderHook, waitFor } from '@testing-library/react'
 
+import { createDeferred } from '@/lib/testing/deferred'
+
 import { useCopyToClipboard } from './useCopyToClipboard'
 
 const setClipboard = (writeText: ReturnType<typeof vi.fn> | undefined) => {
@@ -83,13 +85,8 @@ describe('useCopyToClipboard', () => {
   })
 
   it('does not flip copied when it unmounts while the write is in flight', async () => {
-    let resolveWrite: (() => void) | undefined
-    const writeText = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveWrite = resolve
-        })
-    )
+    const deferred = createDeferred<void>()
+    const writeText = vi.fn(() => deferred.promise)
     setClipboard(writeText)
 
     const { result, unmount } = renderHook(() => useCopyToClipboard())
@@ -100,7 +97,7 @@ describe('useCopyToClipboard', () => {
     // Unmount before the clipboard write resolves, then let it resolve.
     unmount()
     await act(async () => {
-      resolveWrite?.()
+      deferred.resolve()
       await copyPromise
     })
     // The guard skips setCopied after unmount — no act warning, no late update.

--- a/lib/services/actors/refreshRemoteActor.test.ts
+++ b/lib/services/actors/refreshRemoteActor.test.ts
@@ -1,5 +1,6 @@
 import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { Database } from '@/lib/database/types'
+import { createDeferred } from '@/lib/testing/deferred'
 import { Actor } from '@/lib/types/domain/actor'
 
 import {
@@ -165,12 +166,9 @@ describe('refreshKnownRemoteActor', () => {
 
   it('shares a single in-flight refresh across concurrent requests', async () => {
     const refreshedActor = { ...remoteActor, name: 'Refreshed' }
-    let resolveRefresh: (value: Actor) => void = () => {}
+    const deferred = createDeferred<Actor>()
     ;(recordActorIfNeeded as jest.Mock).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveRefresh = resolve
-        })
+      () => deferred.promise
     )
 
     const first = refreshKnownRemoteActor({
@@ -181,7 +179,7 @@ describe('refreshKnownRemoteActor', () => {
       database: mockDatabase,
       actor: remoteActor
     })
-    resolveRefresh(refreshedActor)
+    deferred.resolve(refreshedActor)
 
     await expect(first).resolves.toBe(refreshedActor)
     await expect(second).resolves.toBe(refreshedActor)


### PR DESCRIPTION
Follows #1603, which did this for `lib/components/settings/ImageUploadField.test.tsx`.

Twenty-three test files still hand-rolled the promise-with-exposed-resolve helper that `@/lib/testing/deferred` already exports — the same eight lines under a different local name each time. REVIEW.md's **Style, imports & tests** and AGENTS.md both name the helper directly, and `post-box`, `MessagesPage`, `SearchPageClient`, `FitnessHeatmapView` and `ImageUploadField` already import it.

Found with:

```
grep -rln "= resolve$" --include='*.test.ts' --include='*.test.tsx' . | grep -v node_modules
```

That grep now returns nothing.

## Behaviour-preserving

Every mock still returns a promise that stays **pending** until the test settles it — `createDeferred` is what makes that true, so no assertion about an in-flight state went vacuous.

No timing structure moved. The single `waitFor` / `act` / comment line anywhere in the diff is `expect(stalePage)` becoming `expect(stalePage.promise)` in `GearActivitiesFeed.test.tsx`, which the rename forced:

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -E 'waitFor|act\(async|// '
```

returns only that one pair. Verified further by sabotage: swapping the converted deferreds in `GearActivitiesFeed.test.tsx` for `Promise.resolve(...)` fails 3 tests, so the deferral is still load-bearing there. `nav-preferences-context.test.tsx` survives the same sabotage — but so does `main`'s hand-rolled version, checked directly, so that tolerance is pre-existing and not introduced here (its clicks all land in one tick, before any microtask flush).

## Two registry conversions

`translation-context.test.tsx` and `remote-follow-dialog.test.tsx` key their resolvers by language / account rather than holding one. Those now hold a `Record<string, Deferred<T>>` and mint a deferred per call, so each invocation still gets its own pending promise — a single shared deferred would have been a real behaviour change.

## Gate

`prettier --write .`, `yarn lint` (0 errors; no warning in any changed file), `yarn typecheck`, `yarn build`, `yarn test` — all clean. Full suite: **897 files / 11971 tests passed**.

## Follow-up: the grep misses a sibling variant

`= resolve$` does not catch hand-rolled promises that expose **`reject`** instead, which are the same eight lines and the same rule — `createDeferred` returns `{ promise, resolve, reject }`. Deliberately left out of this PR to keep it mechanical:

- `app/(timeline)/settings/mutes/MutesList.test.tsx`, `lib/components/block-action/block-action.test.tsx`, `lib/services/statuses/actorPublicStatusesCount.test.ts` — reject-only, not otherwise touched here
- reject twins inside files this PR does touch: `BlocksList`, `StravaGearDefaultsSection`, `GearActivitiesFeed`, `remote-follow-dialog`, and four in `FitnessStatusDetail`

One of them is **not** a mechanical swap and wants its own attention: `FitnessStatusDetail`'s `keeps both files' failures when each change fails in turn` arms `mockImplementation(() => new Promise(...))` and invokes it **twice**, so the mock re-arms with a fresh promise per call. A single reused deferred would hand the second call an already-rejected promise.

## Review

The sub-agent code-review loop did **not** run — this session is configured not to spawn sub-agents. Per AGENTS.md's *When sub-agents are unavailable*, I self-reviewed the diff in one pass against `REVIEW.md` instead (imports and sorting, test naming, the `createDeferred` rule itself, and no docs made stale — AGENTS.md and REVIEW.md describe the rule and its history, neither carries a file count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)