### PR TITLE
Bump version to v1.149.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.3",
+  "version": "1.149.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.3`
- Base main SHA: `9ea94016411e677ea06b007b12c1ad038264ce01`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
