### PR TITLE
fix: link ActorInfo's display name through the shared profile href

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1721,23 +1721,31 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   own. There is deliberately no prop for hiding one of the menu's own items;
   that is the per-page drift this whole section exists to prevent.
 - **Every author link in a post derives its href from `getActorProfileHref`
-  (`lib/components/posts/actor.tsx`), and each one degrades to plain text
-  where that answers `undefined`.** The three are the avatar (`ActorAvatar`),
-  the display name (`ActorInfo`) and the boosted-by line (`BoostStatus` in
-  `post.tsx`). A federated `preferredUsername` is a bare `z.string()` that
-  `recordActorIfNeeded` writes verbatim, so it can normalise to nothing — and
-  the mention built from one that does, `@@domain`, is a handle
-  `parseAccountHandle` rejects. `ActorInfo` therefore does **not** simply
-  render `getActorDisplayName(actor)` and `getActorMention(actor)`: when the
-  username normalises to empty it names the actor from the actor id instead,
-  the same three-part `handle`/`domain`/`href` the no-actor case has always
-  used, so its text and its destination stay in step with the avatar beside
-  it. Before this was shared, the avatar linked to `/@booster@domain` while
-  the display name right next to it linked to `/@@domain` — a 404 — with
-  **empty** link text, because `name || getDisplayUsername(username)` is `''`
-  for the same actor. Covered by the matrix in
-  `lib/components/posts/actor.test.tsx`; every case there passes against the
-  old code except the degenerate-username ones.
+  (`lib/components/posts/actor.tsx`), and each one degrades to unlinked
+  content where that answers `undefined`.** The three are the avatar
+  (`ActorAvatar`), the display name (`ActorInfo`) and the boosted-by line
+  (`BoostStatus` in `post.tsx`) — `ActorInfo` and `BoostStatus` fall back to
+  plain text, `ActorAvatar` falls back to an unlinked wrapper around the same
+  avatar (image or initials) it would otherwise link. A federated
+  `preferredUsername` is a bare `z.string()` that `recordActorIfNeeded` writes
+  verbatim, so it can normalise to nothing — and the mention built from one
+  that does, `@@domain`, is a handle `parseAccountHandle` rejects. `ActorInfo`
+  therefore does **not** simply render `getActorDisplayName(actor)` and
+  `getActorMention(actor)`: when the username normalises to empty, the
+  mention — and so both the href and the muted handle beside the name — falls
+  back to the actor id's `handle`/`domain`/`href` tuple, the same one the
+  no-actor case has always used, so the link's destination stays in step with
+  the avatar beside it. The name is a separate fallback chain,
+  `getActorDisplayName(actor) || idParts?.handle || ''`, that checks the
+  actor's own `name` first: a named actor with a degenerate username keeps its
+  name as the link text even though the mention under it switched to the
+  actor id, and only an actor with neither a name nor a usable username is
+  named from the actor-id handle too. Before this was shared, the avatar
+  linked to `/@booster@domain` while the display name right next to it linked
+  to `/@@domain` — a 404 — with **empty** link text, because
+  `name || getDisplayUsername(username)` is `''` for the same actor. Covered
+  by the matrix in `lib/components/posts/actor.test.tsx`; every case there
+  passes against the old code except the degenerate-username ones.
 
 ### Post media layout (`attachments.tsx`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1720,6 +1720,24 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   in the row a moment ago, so they stay nearest it) and **before** the menu's
   own. There is deliberately no prop for hiding one of the menu's own items;
   that is the per-page drift this whole section exists to prevent.
+- **Every author link in a post derives its href from `getActorProfileHref`
+  (`lib/components/posts/actor.tsx`), and each one degrades to plain text
+  where that answers `undefined`.** The three are the avatar (`ActorAvatar`),
+  the display name (`ActorInfo`) and the boosted-by line (`BoostStatus` in
+  `post.tsx`). A federated `preferredUsername` is a bare `z.string()` that
+  `recordActorIfNeeded` writes verbatim, so it can normalise to nothing — and
+  the mention built from one that does, `@@domain`, is a handle
+  `parseAccountHandle` rejects. `ActorInfo` therefore does **not** simply
+  render `getActorDisplayName(actor)` and `getActorMention(actor)`: when the
+  username normalises to empty it names the actor from the actor id instead,
+  the same three-part `handle`/`domain`/`href` the no-actor case has always
+  used, so its text and its destination stay in step with the avatar beside
+  it. Before this was shared, the avatar linked to `/@booster@domain` while
+  the display name right next to it linked to `/@@domain` — a 404 — with
+  **empty** link text, because `name || getDisplayUsername(username)` is `''`
+  for the same actor. Covered by the matrix in
+  `lib/components/posts/actor.test.tsx`; every case there passes against the
+  old code except the degenerate-username ones.
 
 ### Post media layout (`attachments.tsx`)
 

--- a/lib/components/posts/actor.test.tsx
+++ b/lib/components/posts/actor.test.tsx
@@ -92,3 +92,162 @@ describe('post author links', () => {
     )
   })
 })
+
+// A federated `preferredUsername` is a bare `z.string()` (see
+// `lib/types/activitypub/actor.ts`) that `recordActorIfNeeded` writes verbatim,
+// so a remote server can hand us one that normalises to nothing at all.
+const degenerateActor: ActorProfile = {
+  ...actor,
+  id: 'https://remote.example/users/booster',
+  username: '@',
+  domain: 'remote.example',
+  name: undefined
+}
+
+const namedDegenerateActor: ActorProfile = {
+  ...degenerateActor,
+  name: 'Test Actor'
+}
+
+describe('ActorInfo', () => {
+  it.each([
+    {
+      description: 'links the actor mention for a usable username',
+      props: { actor, actorId: 'https://llun.test/users/test' },
+      href: '/@test@llun.test',
+      text: 'Test Actor@test@llun.test'
+    },
+    {
+      description: 'names an unnamed actor by its username',
+      props: {
+        actor: { ...actor, name: undefined },
+        actorId: 'https://llun.test/users/test'
+      },
+      href: '/@test@llun.test',
+      text: 'test@test@llun.test'
+    },
+    {
+      description: 'keeps the actor mention when the actor id is opaque',
+      props: {
+        actor,
+        actorId: 'https://llun.test/users/8b1f0d6c-6a1e-4f0a-9d3b-2c5e7f0a1b2c'
+      },
+      href: '/@test@llun.test',
+      text: 'Test Actor@test@llun.test'
+    },
+    {
+      description: 'falls back to the actor id for a degenerate username',
+      props: {
+        actor: degenerateActor,
+        actorId: 'https://remote.example/users/booster'
+      },
+      href: '/@booster@remote.example',
+      text: '@booster@remote.example'
+    },
+    {
+      description: 'keeps the name but takes the mention from the actor id',
+      props: {
+        actor: namedDegenerateActor,
+        actorId: 'https://remote.example/users/booster'
+      },
+      href: '/@booster@remote.example',
+      text: 'Test Actor@remote.example'
+    },
+    {
+      description:
+        'reads the handle from the status url when the actor id is opaque too',
+      props: {
+        actor: degenerateActor,
+        actorId:
+          'https://remote.example/users/did:plc:5rkxs2rkfhyqvyzsxtlfvdhr',
+        statusUrl: 'https://remote.example/@booster/109'
+      },
+      href: '/@booster@remote.example',
+      text: '@booster@remote.example'
+    },
+    {
+      description: 'renders the actor id handle when the actor is missing',
+      props: { actorId: 'https://llun.test/users/test' },
+      href: '/@test@llun.test',
+      text: '@test@llun.test'
+    }
+  ])('$description', ({ props, href, text }) => {
+    const { container } = render(<ActorInfo {...props} />)
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', href)
+    expect(container.textContent).toBe(text)
+  })
+
+  it.each([
+    {
+      description: 'a degenerate username and an opaque actor id',
+      props: {
+        actor: degenerateActor,
+        actorId: 'https://remote.example/users/did:plc:5rkxs2rkfhyqvyzsxtlfvdhr'
+      },
+      text: '@remote.example'
+    },
+    {
+      description:
+        'a named actor with a degenerate username and an opaque actor id',
+      props: {
+        actor: namedDegenerateActor,
+        actorId: 'https://remote.example/users/did:plc:5rkxs2rkfhyqvyzsxtlfvdhr'
+      },
+      text: 'Test Actor'
+    },
+    {
+      description: 'no actor and an opaque actor id',
+      props: {
+        actorId: 'https://remote.example/users/did:plc:5rkxs2rkfhyqvyzsxtlfvdhr'
+      },
+      text: '@remote.example'
+    },
+    {
+      description: 'a degenerate username and no actor id to fall back on',
+      props: { actor: degenerateActor, actorId: '' },
+      text: '@'
+    }
+  ])('renders plain text and no link for $description', ({ props, text }) => {
+    const { container } = render(<ActorInfo {...props} />)
+
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(container.textContent).toBe(text)
+  })
+
+  it('renders nothing without an actor or an actor id', () => {
+    const { container } = render(<ActorInfo />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('ActorAvatar', () => {
+  it.each([
+    {
+      description: 'the actor name',
+      props: { actor, actorId: 'https://llun.test/users/test' },
+      initials: 'TA'
+    },
+    {
+      description: 'the actor username when it has no name',
+      props: {
+        actor: { ...actor, name: undefined },
+        actorId: 'https://llun.test/users/test'
+      },
+      initials: 'T'
+    },
+    {
+      description: 'the actor id handle when there is no actor',
+      props: { actorId: 'https://llun.test/users/test' },
+      initials: 'T'
+    }
+  ])(
+    'builds the fallback initials from $description',
+    ({ props, initials }) => {
+      render(<ActorAvatar {...props} />)
+
+      expect(screen.getByText(initials)).toBeInTheDocument()
+    }
+  )
+})

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -149,12 +149,12 @@ const getActorIdParts = (
 const getActorIdHandle = (actorId: string, statusUrl?: string | null) =>
   getActorIdParts(actorId, statusUrl).handle
 
-// The profile page an actor links to. Callers that need only the href — the
-// avatar below, and the boosted-by line in `post.tsx` — share this instead of
-// re-deriving it. Falls through to the actor-id path when the actor is
-// present but its username normalises to empty (e.g. a federated
-// `preferredUsername` of just `@` characters), so the href is never built
-// from a mention with an empty local part — otherwise undefined when the
+// The profile page an actor links to, shared by every author link in a post —
+// the avatar below, `ActorInfo`'s display name, and the boosted-by line in
+// `post.tsx` — instead of each re-deriving it. Falls through to the actor-id
+// path when the actor is present but its username normalises to empty (e.g. a
+// federated `preferredUsername` of just `@` characters), so the href is never
+// built from a mention with an empty local part — otherwise undefined when the
 // actor id also carries no usable handle (an opaque `did:`/UUID username),
 // which is the case those callers render as plain text rather than as a link
 // to nowhere.
@@ -179,14 +179,13 @@ export const getActorIdMention = (
 }
 
 // The name a caller shows beside (or instead of) `getActorProfileHref`'s
-// destination: `name || getDisplayUsername(username)`. `ActorAvatar`'s
-// initials and `ActorInfo`'s display name compute this same composition
-// inline today rather than calling this helper: converging them needs a
-// third fallback branch there for a degenerate username, plus its own
-// test matrix, so they still duplicate it.
+// destination: `name || getDisplayUsername(username)`.
 // Undefined when there is no actor to name, mirroring `getActorProfileHref`'s
-// own `undefined` for "nothing to link"; a caller with a fallback of its own
-// (`BoostStatus` reads the actor id instead) chains it with `||`.
+// own `undefined` for "nothing to link". It is empty — not undefined — for an
+// actor that exists but has neither a name nor a username that normalises to
+// anything, so every caller needs a fallback of its own and chains it with
+// `||`: `BoostStatus` and `ActorInfo` read the actor id, `ActorAvatar` draws
+// no initials.
 export const getActorDisplayName = (
   actor?: ActorProfile | null
 ): string | undefined =>
@@ -204,7 +203,7 @@ export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
 
   const href = getActorProfileHref(actor, actorId, statusUrl)
   const initials = actor
-    ? getInitials(actor.name || getDisplayUsername(actor.username) || '')
+    ? getInitials(getActorDisplayName(actor) || '')
     : getInitials(getActorIdHandle(actorId || '', statusUrl))
 
   const avatar = (
@@ -228,44 +227,36 @@ export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
 export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
-  if (!actor) {
-    const { handle, domain, href } = getActorIdParts(actorId || '', statusUrl)
-    return (
-      <div
-        className="flex min-w-0 max-w-full items-center gap-1"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {href ? (
-          <Link
-            href={href}
-            prefetch={false}
-            className="font-semibold hover:underline truncate"
-          >
-            {handle}
-          </Link>
-        ) : (
-          <span className="font-semibold truncate">{handle}</span>
-        )}
-        <span className="text-muted-foreground truncate">{domain}</span>
-      </div>
-    )
-  }
+  const href = getActorProfileHref(actor, actorId, statusUrl)
+  // The actor's own mention is only usable while its username normalises to
+  // something: `@@domain` is a handle `parseAccountHandle` rejects, and the
+  // name beside it would be empty too. So an actor with a degenerate
+  // `preferredUsername` is named from the actor id instead — the same place
+  // `getActorProfileHref` has already sent the link, and the same parts the
+  // no-actor case has always used.
+  const mention =
+    actor && getDisplayUsername(actor.username) ? getActorMention(actor) : null
+  const idParts = mention ? null : getActorIdParts(actorId || '', statusUrl)
+  const name = getActorDisplayName(actor) || idParts?.handle || ''
+  const mutedHandle = mention ?? idParts?.domain ?? ''
 
   return (
     <div
       className="flex min-w-0 max-w-full items-center gap-1"
       onClick={(e) => e.stopPropagation()}
     >
-      <Link
-        href={`/${getActorMention(actor)}`}
-        prefetch={false}
-        className="font-semibold hover:underline truncate"
-      >
-        {actor.name || getDisplayUsername(actor.username)}
-      </Link>
-      <span className="text-muted-foreground truncate">
-        {getActorMention(actor)}
-      </span>
+      {href ? (
+        <Link
+          href={href}
+          prefetch={false}
+          className="font-semibold hover:underline truncate"
+        >
+          {name}
+        </Link>
+      ) : (
+        <span className="font-semibold truncate">{name}</span>
+      )}
+      <span className="text-muted-foreground truncate">{mutedHandle}</span>
     </div>
   )
 }

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -36,6 +36,12 @@ const getDisplayUsername = (username: string) =>
 const getActorMention = (actor: ActorProfile) =>
   `@${getDisplayUsername(actor.username)}@${actor.domain}`
 
+// The actor's own mention is only usable while its username normalises to
+// something: `@@domain` is a handle `parseAccountHandle` rejects, so an actor
+// with a degenerate `preferredUsername` has no mention to offer here.
+const getUsableActorMention = (actor?: ActorProfile | null): string | null =>
+  actor && getDisplayUsername(actor.username) ? getActorMention(actor) : null
+
 const getProfileHandleFromParts = (parts: string[]) => {
   const profileIndex = parts.indexOf('profile')
   const profileHandle = parts[profileIndex + 1]
@@ -156,16 +162,16 @@ const getActorIdHandle = (actorId: string, statusUrl?: string | null) =>
 // federated `preferredUsername` of just `@` characters), so the href is never
 // built from a mention with an empty local part — otherwise undefined when the
 // actor id also carries no usable handle (an opaque `did:`/UUID username),
-// which is the case those callers render as plain text rather than as a link
-// to nowhere.
+// which is the case those callers render as unlinked content rather than a
+// link to nowhere: plain text in `ActorInfo` and `BoostStatus`, an unlinked
+// avatar (image or initials) in `ActorAvatar`.
 export const getActorProfileHref = (
   actor?: ActorProfile | null,
   actorId?: string,
   statusUrl?: string | null
 ): string | undefined => {
-  if (actor && getDisplayUsername(actor.username)) {
-    return `/${getActorMention(actor)}`
-  }
+  const mention = getUsableActorMention(actor)
+  if (mention) return `/${mention}`
   if (!actorId) return undefined
   return getActorIdParts(actorId, statusUrl).href
 }
@@ -229,13 +235,16 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
 
   const href = getActorProfileHref(actor, actorId, statusUrl)
   // The actor's own mention is only usable while its username normalises to
-  // something: `@@domain` is a handle `parseAccountHandle` rejects, and the
-  // name beside it would be empty too. So an actor with a degenerate
-  // `preferredUsername` is named from the actor id instead — the same place
-  // `getActorProfileHref` has already sent the link, and the same parts the
-  // no-actor case has always used.
-  const mention =
-    actor && getDisplayUsername(actor.username) ? getActorMention(actor) : null
+  // something: `@@domain` is a handle `parseAccountHandle` rejects. So an
+  // actor with a degenerate `preferredUsername` gets its mention (and href)
+  // from the actor id instead — the same tuple `getActorProfileHref` has
+  // already sent the link to, and the same parts the no-actor case has
+  // always used. The *name* is a separate fallback chain that checks the
+  // actor's own `name` first (see `getActorDisplayName`), so a named actor
+  // keeps its name as the link text even though the mention beneath it
+  // switched to the actor id; only an actor with neither a name nor a usable
+  // username is named from the actor-id handle too.
+  const mention = getUsableActorMention(actor)
   const idParts = mention ? null : getActorIdParts(actorId || '', statusUrl)
   const name = getActorDisplayName(actor) || idParts?.handle || ''
   const mutedHandle = mention ?? idParts?.domain ?? ''

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -234,10 +234,8 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   const href = getActorProfileHref(actor, actorId, statusUrl)
-  // `name` and `mention` are independent fallback chains, so they can
-  // disagree: a named actor whose username normalises to empty keeps its own
-  // name while its mention and href come from the actor id. See "Status Posts
-  // & Actions" in AGENTS.md.
+  // `name` and `mention` are independent fallback chains and can disagree.
+  // See "Status Posts & Actions" in AGENTS.md for the case breakdown.
   const mention = getUsableActorMention(actor)
   const idParts = mention ? null : getActorIdParts(actorId || '', statusUrl)
   const name = getActorDisplayName(actor) || idParts?.handle || ''

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -234,16 +234,10 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   const href = getActorProfileHref(actor, actorId, statusUrl)
-  // The actor's own mention is only usable while its username normalises to
-  // something: `@@domain` is a handle `parseAccountHandle` rejects. So an
-  // actor with a degenerate `preferredUsername` gets its mention (and href)
-  // from the actor id instead — the same tuple `getActorProfileHref` has
-  // already sent the link to, and the same parts the no-actor case has
-  // always used. The *name* is a separate fallback chain that checks the
-  // actor's own `name` first (see `getActorDisplayName`), so a named actor
-  // keeps its name as the link text even though the mention beneath it
-  // switched to the actor id; only an actor with neither a name nor a usable
-  // username is named from the actor-id handle too.
+  // `name` and `mention` are independent fallback chains, so they can
+  // disagree: a named actor whose username normalises to empty keeps its own
+  // name while its mention and href come from the actor id. See "Status Posts
+  // & Actions" in AGENTS.md.
   const mention = getUsableActorMention(actor)
   const idParts = mention ? null : getActorIdParts(actorId || '', statusUrl)
   const name = getActorDisplayName(actor) || idParts?.handle || ''

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -97,9 +97,9 @@ export const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
   const actorName =
     getActorDisplayName(status.actor) || getActorIdMention(status.actorId)
   // Can be undefined — see `getActorProfileHref`'s doc comment for exactly
-  // when, since it is not simply "no boost actor row". `ActorInfo`'s
-  // actor-present branch links unconditionally instead of falling back, so
-  // it does not share this behaviour.
+  // when, since it is not simply "no boost actor row". `ActorInfo` reads the
+  // same helper for the header author and degrades to plain text the same way,
+  // so the two links in a boosted post's header agree on what is linkable.
   const profileHref = getActorProfileHref(status.actor, status.actorId)
 
   return (


### PR DESCRIPTION
## What

`ActorInfo`'s actor-present branch built both halves of the author link straight from the actor:

```
href = `/${getActorMention(actor)}`
text = actor.name || getDisplayUsername(actor.username)
```

For a federated actor whose `preferredUsername` normalises to empty — the literal `@` — both collapse at once. The href becomes `/@@domain`, which `parseAccountHandle` rejects (it strips one leading `@`, splits on `@`, and refuses an empty username), so it 404s. The text becomes `''`, so the link is invisible: a zero-width anchor with an empty accessible name.

`preferredUsername` is a bare `z.string()` with no shape check (`lib/types/activitypub/actor.ts`) and `recordActorIfNeeded` writes it verbatim, so any remote server can produce this.

#1606 fixed exactly this for the **sibling** element: `getActorProfileHref` falls through to the actor-id-derived href when the actor's username normalises to empty, and `ActorAvatar` calls it. `ActorInfo` did not, so the avatar and the display name in the same post header linked to two different places for such an actor. Converging them was deferred there because it is not a pure substitution.

## How

- `ActorInfo` reads `getActorProfileHref(actor, actorId, statusUrl)` and renders a `<span>` rather than a `<Link>` when it answers `undefined` — the way its own no-actor branch already did.
- The **third fallback branch**: `getActorDisplayName(actor)` is `''`, not `undefined`, for the degenerate actor, so the name falls through to the actor-id-derived `handle`. The muted text beside it falls through to that same derivation's `domain`, because the actor's own mention is `@@domain` there too — and that fallback is gated on the **username**, not on the display name, so an actor that has a name but a degenerate username keeps its name and still gets a usable mention beside it.
- Those two conditions are now the same condition, which collapses `ActorInfo`'s two branches into one: `getActorDisplayName(actor) || idParts?.handle` covers "no actor" and "degenerate actor" identically, since the helper answers `undefined` for the first and `''` for the second.
- `getUsableActorMention` (added in review, see below) is the one spelling of "does this actor have a usable mention". `getActorProfileHref` and `ActorInfo` both read it, so the predicate that decides the fallback exists once rather than twice.
- `ActorAvatar`'s initials call `getActorDisplayName(actor) || ''` instead of recomposing `name || getDisplayUsername(username)` inline. Pure substitution — the `|| ''` is kept because the helper's return type is `string | undefined`.
- `statusUrl` now reaches the actor-present path, so a degenerate username whose actor id is *also* opaque (`did:`/UUID) can still be rescued by the handle in the status URL.

## Tests

`lib/components/posts/actor.test.tsx` gains a matrix over (actor present/absent) × (username degenerate/normal) × (actor id opaque/usable), asserting the href **and** the exact rendered text (`container.textContent`, not a substring match — `toHaveTextContent` would pass on `Test Actor@@remote.example`).

Written first and watched fail. Against `main`, 6 of the 20 cases fail and each fails for the right reason:

| Case | Failure on `main` |
| --- | --- |
| degenerate username, usable actor id | `href="/@@remote.example"`, expected `/@booster@remote.example` |
| degenerate username + name, usable actor id | same href; text `Test Actor@@remote.example` |
| degenerate username, status url rescue | same href |
| degenerate username, opaque actor id (×2, named and unnamed) | link rendered where plain text is expected |
| degenerate username, no actor id | link to `/@` rendered where plain text is expected |

The other 14 pass on both sides, and that is deliberate: they pin the behaviour this change must **not** move (a normal actor, an unnamed actor, an opaque actor id that the actor mention wins over, the no-actor branch, and `ActorAvatar`'s three initials paths, which are a pure refactor).

The matrix also proved sufficient under mutation: dropping `getUsableActorMention`'s `actor &&` guard, weakening it to `actor ? … : null`, inverting its ternary, and dropping `getActorProfileHref`'s early return each fail 3–17 of the 20 cases. No mutant survived.

## Verification

Full gate green at every commit: `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` (898 files / 12,015 tests).

Checked in a browser against a local SQLite instance, light and dark, with two seeded remote actors carrying `preferredUsername: '@'` — one named, one not — posting into the home timeline.

Before, on `main`:

| element | href | text |
| --- | --- | --- |
| avatar | `/@namedbooster@named.example` | `NB` |
| display name | `/@@named.example` | `Named Booster` |
| avatar | `/@booster@degenerate.example` | — |
| display name | `/@@degenerate.example` | *(empty)* |

`http://localhost:3100/@@degenerate.example` renders the app's 404 page, confirming the destination.

After:

| element | href | text |
| --- | --- | --- |
| avatar | `/@namedbooster@named.example` | `NB` |
| display name | `/@namedbooster@named.example` | `Named Booster` |
| avatar | `/@booster@degenerate.example` | — |
| display name | `/@booster@degenerate.example` | `@booster` |

Every ordinary actor on the same timeline (local `testuser`, remote `mira` and `rico`) renders byte-identically before and after — avatar and display name both pointing at the same `/@user@domain`. No console errors, no hydration warnings.

## Known gap, deliberately not widened here

`ActorAvatar`'s initials stay a pure substitution, so the degenerate unnamed actor's avatar still falls back to an empty string rather than to the actor-id handle. That is unchanged from `main` and from #1606; giving the avatar the same third fallback is a separate decision about the avatar's own fallback text, not about this link.

## Docs

`AGENTS.md` → **Status Posts & Actions**: a bullet recording that all three author links in a post derive their href from `getActorProfileHref`, and that each degrades to **unlinked content** where it answers `undefined` — plain text for `ActorInfo` and `BoostStatus`, an unlinked avatar for `ActorAvatar`. It also records why `ActorInfo` cannot simply render `getActorDisplayName` + `getActorMention`, and that the name and the mention are separate fallback chains that can disagree.

Stale comments corrected in the same PR: `getActorDisplayName`'s doc said `ActorAvatar` and `ActorInfo` still duplicate its composition; `BoostStatus`'s said `ActorInfo` links unconditionally; and `getActorProfileHref`'s tail said all its callers degrade to "plain text", which was never true of the avatar.

## Review

The sub-agent code-review loop ran **5 rounds**, ending on a clean one. Six findings across rounds 1–4, each confirmed by an adversarial verifier before being posted, each fixed, replied to and resolved; round 5 surfaced nothing. One further finding was refuted and never posted.

| Round | Found |
| --- | --- |
| 1 | `AGENTS.md` overclaimed that a degenerate actor is named from the actor id — untrue when it has a `name`; "degrades to plain text" was false for `ActorAvatar`; the usable-mention predicate was spelled twice |
| 2 | round 1's own fix had put one explanation in three places — the `parseAccountHandle` sentence in two code comments, and the name-fallback paragraph in both the code and `AGENTS.md` |
| 3 | the surviving comment still restated the bullet it pointed at, and "its mention and href come from the actor id" was loose — `mutedHandle` is `idParts.domain` alone |
| 4 | the count in this very section: it read "5 findings" while six threads stood resolved |
| 5 | nothing — the round that stopped the loop |

Round 3's thread bundles two findings — the scope and correctness lenses reached the same clause by different routes — so six threads carry seven lens findings.

The refuted one: `getActorProfileHref` short-circuits on `!actorId` before consulting `statusUrl`, while `ActorInfo`'s `idParts` consults it regardless — so in principle a degenerate actor with no `actorId` but a rescuable `statusUrl` would render a handle with no link. Unreachable: `Status.actor` is only non-null when it was looked up *by* that same `actorId`, so `actor` truthy with `actorId` falsy cannot occur.

Rounds 2 and 3 are worth noting as a pattern — a round whose job is fixing duplicated prose is the round most likely to create more of it, because the fixer is holding the corrected wording and looking for somewhere to put it. Both were settled by deleting rather than rewording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



