### PR TITLE
Bump version to v1.149.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.6",
+  "version": "1.149.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.6`
- Base main SHA: `fcbaf4344e4137e50fd0e021d6db1770d1029295`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
