### PR TITLE
Bump version to v1.149.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.8",
+  "version": "1.149.9",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.9.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.8`
- Base main SHA: `09fd90e86416a43491db4c264cd81b2156cc3949`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
