### PR TITLE
Bump version to v1.149.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.9",
+  "version": "1.149.10",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.10.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.9`
- Base main SHA: `04402ed21b37a0ab9b072dcc69d961202a373d50`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
