### PR TITLE
test: use enclosing backend in actor test fresh database helpers

### DIFF
--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -4,12 +4,14 @@ import knex, { Knex } from 'knex'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { type SQLActorDatabase } from '@/lib/database/sql/actor'
 import { CounterKey } from '@/lib/database/sql/utils/counter'
-import { SQLITE_MAX_BINDINGS } from '@/lib/database/sql/utils/knex'
+import {
+  SQLITE_MAX_BINDINGS,
+  getWhereInBatchSize
+} from '@/lib/database/sql/utils/knex'
 import {
   databaseBeforeAll,
   getTestDatabaseTable,
-  getTestSQLDatabase,
-  getTestSQLDatabaseWithInstance
+  getTestDatabaseWithInstance
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
 import {
@@ -36,30 +38,6 @@ import {
   isPublicId
 } from '@/lib/utils/publicId'
 import { urlToId } from '@/lib/utils/urlToId'
-
-const withFreshDatabase = async (
-  test: (database: Database) => Promise<void>
-) => {
-  const database = getTestSQLDatabase()
-  await database.migrate()
-  try {
-    await test(database)
-  } finally {
-    await database.destroy()
-  }
-}
-
-const withFreshDatabaseAndInstance = async (
-  test: (database: Database, instance: Knex) => Promise<void>
-) => {
-  const { database, instance } = getTestSQLDatabaseWithInstance()
-  await database.migrate()
-  try {
-    await test(database, instance)
-  } finally {
-    await database.destroy()
-  }
-}
 
 const createSigningAccount = async (
   database: Database,
@@ -94,7 +72,26 @@ describe('ActorDatabase', () => {
     await Promise.all(table.map((item) => item[1].destroy()))
   })
 
-  describe.each(table)('%s', (_, database) => {
+  describe.each(table)('%s', (backendName, database) => {
+    const withFreshDatabase = async (
+      test: (database: Database, instance: Knex) => Promise<void>
+    ) => {
+      const {
+        database: freshDatabase,
+        instance,
+        prepare
+      } = getTestDatabaseWithInstance(true, backendName)
+      await prepare()
+      await freshDatabase.migrate()
+      try {
+        await test(freshDatabase, instance)
+      } finally {
+        await freshDatabase.destroy()
+      }
+    }
+
+    const withFreshDatabaseAndInstance = withFreshDatabase
+
     // publicIds are minted at insert and random per run, so expectations read
     // them back off the stored row instead of hard-coding a literal.
     const getActorPublicId = async (actorId: string) => {
@@ -156,19 +153,6 @@ describe('ActorDatabase', () => {
     })
 
     describe('publicId', () => {
-      const withFreshDatabase = async (
-        test: (database: Database, instance: Knex) => Promise<void>
-      ) => {
-        const { database: freshDatabase, instance } =
-          getTestSQLDatabaseWithInstance()
-        await freshDatabase.migrate()
-        try {
-          await test(freshDatabase, instance)
-        } finally {
-          await freshDatabase.destroy()
-        }
-      }
-
       it('mints a v7 publicId at createActor whose timestamp matches createdAt', async () => {
         await withFreshDatabase(async (freshDatabase) => {
           const actorId = `https://${TEST_DOMAIN}/users/public-id-create-actor`
@@ -398,12 +382,12 @@ describe('ActorDatabase', () => {
           const bindingCounts = queries
             .filter(
               ({ sql }) =>
-                sql.includes('from `actors`') && sql.includes('`id` in')
+                /from [`"]actors[`"]/.test(sql) && /[`"]id[`"] in/.test(sql)
             )
             .map(({ bindings }) => bindings.length)
           expect(bindingCounts.length).toBeGreaterThan(1)
           expect(Math.max(...bindingCounts)).toBeLessThanOrEqual(
-            SQLITE_MAX_BINDINGS
+            getWhereInBatchSize(instance)
           )
           expect(map.size).toBe(1)
           expect(map.get(actorId)).toBeTruthy()

--- a/lib/database/testUtils.ts
+++ b/lib/database/testUtils.ts
@@ -181,9 +181,11 @@ export const databaseBeforeAll = async (table: TestDatabaseTable) => {
  * pg environment variables without ever opening a PostgreSQL connection. Use
  * this instead wherever the SQL under test has to agree across backends.
  */
-export const getTestDatabaseWithInstance = (isolated = false) => {
-  const type = process.env.TEST_DATABASE_TYPE
-  if (type !== 'pg') {
+export const getTestDatabaseWithInstance = (
+  isolated = false,
+  backend = process.env.TEST_DATABASE_TYPE
+) => {
+  if (backend !== 'pg') {
     const { database, instance } = getTestSQLDatabaseWithInstance()
     return { database, instance, prepare: noop as PrepareFunction }
   }


### PR DESCRIPTION
## Summary

`lib/database/sql/actor.test.ts` previously defined a local `withFreshDatabase` and `withFreshDatabaseAndInstance` calling `getTestSQLDatabase()` / `getTestSQLDatabaseWithInstance()`, which are SQLite-only. When running tests with `TEST_DATABASE_TYPE=pg`, the 24 tests calling `withFreshDatabase` reported as "pg" while secretly executing against SQLite in memory.

## Changes

1. **Test Utilities (`lib/database/testUtils.ts`)**:
   - Added an optional `backend` parameter to `getTestDatabaseWithInstance(isolated = false, backend = process.env.TEST_DATABASE_TYPE)` allowing callers to specify the backend explicitly.

2. **Actor SQL Test Suite (`lib/database/sql/actor.test.ts`)**:
   - Removed top-level SQLite-only `withFreshDatabase` and `withFreshDatabaseAndInstance` definitions.
   - Defined `withFreshDatabase` and `withFreshDatabaseAndInstance` inside `describe.each(table)('%s', (backendName, database) => {` using `getTestDatabaseWithInstance(true, backendName)`.
   - Removed duplicate shadow `withFreshDatabase` helper in `describe('publicId')`.
   - Updated `getActorPublicIds chunks a request wider than the SQLite bind limit` test to match identifier quotes dialect-agnostically (handling both SQLite backticks `` `actors` `` and PostgreSQL double quotes `"actors"`) and verify chunk sizes against `getWhereInBatchSize(instance)`.

## Verification

- **PostgreSQL 17**: Ran against local PostgreSQL 17 (`TEST_DATABASE_TYPE=pg TEST_DATABASE_HOST=127.0.0.1 TEST_DATABASE_USERNAME=postgres yarn test lib/database/sql/actor.test.ts`), all 83 tests passed.
- **SQLite**: Ran `yarn test lib/database/sql/actor.test.ts`, all 83 tests passed.
- **Connection Proof**: Ran with unreachable `TEST_DATABASE_HOST=127.0.0.2`, confirmed suite fails to connect rather than silently passing.
- **Pre-commit Gate**: `prettier` → `yarn lint` (0 errors) → `yarn typecheck` (0 errors) → `yarn build` (0 errors) → `yarn test` (12,086 tests passing).