### PR TITLE
Bump version to v1.149.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.10",
+  "version": "1.149.11",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.11.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.10`
- Base main SHA: `dcc4f05fc5ded4fd00b4904730252b362696051a`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
