### PR TITLE
Bump version to v1.149.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.12",
+  "version": "1.149.13",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.13.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.12`
- Base main SHA: `efc371e35e24635e66b89e1fef6205d186afe191`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
