### PR TITLE
fix: consume verification code before redirecting authenticated session

### DIFF
--- a/app/(nosidebar)/auth/confirmation/page.test.tsx
+++ b/app/(nosidebar)/auth/confirmation/page.test.tsx
@@ -1,0 +1,143 @@
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+
+import Page from './page'
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+const redirectMock = vi.fn((path: string) => path)
+vi.mock('next/navigation', () => ({
+  redirect: (path: string) => redirectMock(path)
+}))
+
+const aSession = { user: { email: 'rider@example.com' } } as Awaited<
+  ReturnType<typeof getServerAuthSession>
+>
+
+describe('/auth/confirmation page', () => {
+  const verifyAccountMock = vi.fn()
+  const mockDatabase = {
+    verifyAccount: verifyAccountMock
+  } as unknown as Database
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getDatabase).mockReturnValue(mockDatabase)
+  })
+
+  it('consumes the verification code even when an active session exists (avoids stuck unconfirmed accounts on repoint/rotation)', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+    verifyAccountMock.mockResolvedValue({ id: 'account-1' })
+
+    const element = await Page({
+      searchParams: Promise.resolve({ verificationCode: 'valid-code' })
+    })
+
+    expect(verifyAccountMock).toHaveBeenCalledWith({
+      verificationCode: 'valid-code'
+    })
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toEqual(<h1>Your account is verified</h1>)
+  })
+
+  it('shows invalid verification code when code fails verification even with an active session', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+    verifyAccountMock.mockResolvedValue(null)
+
+    const element = await Page({
+      searchParams: Promise.resolve({ verificationCode: 'bad-code' })
+    })
+
+    expect(verifyAccountMock).toHaveBeenCalledWith({
+      verificationCode: 'bad-code'
+    })
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toEqual(<h1>Invalid verification code</h1>)
+  })
+
+  it('redirects to home when an active session exists and no verification code is present', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({
+      searchParams: Promise.resolve({})
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock).toHaveBeenCalledWith('/')
+    expect(verifyAccountMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to home when an active session exists and verification code is empty', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({
+      searchParams: Promise.resolve({ verificationCode: '' })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock).toHaveBeenCalledWith('/')
+    expect(verifyAccountMock).not.toHaveBeenCalled()
+  })
+
+  it('consumes the verification code for a logged-out visitor', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+    verifyAccountMock.mockResolvedValue({ id: 'account-1' })
+
+    const element = await Page({
+      searchParams: Promise.resolve({ verificationCode: 'valid-code' })
+    })
+
+    expect(verifyAccountMock).toHaveBeenCalledWith({
+      verificationCode: 'valid-code'
+    })
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toEqual(<h1>Your account is verified</h1>)
+  })
+
+  it('picks the first code when verificationCode is an array', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+    verifyAccountMock.mockResolvedValue({ id: 'account-1' })
+
+    const element = await Page({
+      searchParams: Promise.resolve({
+        verificationCode: ['first-code', 'second-code']
+      })
+    })
+
+    expect(verifyAccountMock).toHaveBeenCalledWith({
+      verificationCode: 'first-code'
+    })
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toEqual(<h1>Your account is verified</h1>)
+  })
+
+  it('shows invalid verification code when logged out with no verification code', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+
+    const element = await Page({
+      searchParams: Promise.resolve({})
+    })
+
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(verifyAccountMock).not.toHaveBeenCalled()
+    expect(element).toEqual(<h1>Invalid verification code</h1>)
+  })
+
+  it('throws an error when database is not available', async () => {
+    vi.mocked(getDatabase).mockReturnValue(null)
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+
+    await expect(
+      Page({
+        searchParams: Promise.resolve({ verificationCode: 'valid-code' })
+      })
+    ).rejects.toThrow('Database is not available')
+  })
+})

--- a/app/(nosidebar)/auth/confirmation/page.tsx
+++ b/app/(nosidebar)/auth/confirmation/page.tsx
@@ -26,14 +26,16 @@ const Page: FC<Props> = async ({ searchParams }) => {
   ])
 
   if (!database) throw new Error('Database is not available')
-  if (session && session.user) {
-    return redirect('/')
-  }
 
   const { verificationCode } = await searchParams
   const code = Array.isArray(verificationCode)
     ? verificationCode[0]
     : verificationCode
+
+  if (!code && session && session.user) {
+    return redirect('/')
+  }
+
   const isAccountVerify = Boolean(await isVerify(database, code))
 
   return (


### PR DESCRIPTION
## Summary

`app/(nosidebar)/auth/confirmation/page.tsx` was redirecting to `/` whenever an active cookie session existed *before* checking and consuming the `verificationCode` query param.

### Reachability Analysis
While `databaseHooks.session.create.before` (`canCreateSessionForAccount`) prevents creating new sessions for unconfirmed accounts, hitting `/auth/confirmation?verificationCode=...` while holding a session occurs in reachable scenarios:
1. **Same-account email repoint/rotation**: When an account updates its email via `POST /api/v1/emails/confirmations`, `repointUnconfirmedAccountEmail` marks the account unconfirmed (`emailVerified: false`, `verifiedAt: null`, `verificationCode: '...'`), but does not delete existing sessions from the database (unlike password reset). The account is now pending confirmation while retaining an active cookie session. Clicking the confirmation link redirected to `/`, where `AuthenticatedGuard` 403s on every route, leaving the account locked with no way to confirm.
2. **Cross-account browser session**: If a user is already signed in (e.g. User A) in a browser and opens a confirmation link for User B (or an alt/test account), the previous code redirected User A to `/` without consuming User B's verification code.

### Fix
- Reordered operations in `app/(nosidebar)/auth/confirmation/page.tsx` so the verification code is extracted and consumed first via `database.verifyAccount({ verificationCode: code })`.
- Retained the redirect to `/` when an active session exists and no verification code query param is present.
- Added unit tests pinning this behavior in `app/(nosidebar)/auth/confirmation/page.test.tsx`.

### Cache / State Invalidation
No session or actor cache invalidation is required: Better Auth sessions store token metadata rather than verification state; React `cache()` is per-request scoped; and guards reload the account freshly from the database on subsequent requests.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
