### PR TITLE
fix: stamp a rejection reason on every ActivityPub inbox trace span

### DIFF
--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
 import { HANDLE_QUOTE_REQUEST_JOB_NAME } from '@/lib/jobs/names'
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
 
 import { POST } from './route'
 
@@ -41,6 +42,20 @@ let mockActor: MockActor = {
   username: 'llun',
   type: 'Person'
 }
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis()
+  }
+}))
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: mockLogger
+}))
 
 vi.mock('@/lib/services/queue', () => ({
   getQueue: vi.fn().mockReturnValue({
@@ -201,7 +216,10 @@ const createActorInboxActivityRequest = (type: string) =>
   })
 
 describe('POST /api/users/[username]/inbox', () => {
+  let harness: ReturnType<typeof setupRecordingTracer>
+
   beforeEach(() => {
+    harness = setupRecordingTracer()
     vi.clearAllMocks()
     mockActor = {
       id: 'https://activities.local/users/llun',
@@ -236,6 +254,10 @@ describe('POST /api/users/[username]/inbox', () => {
     })
     mockActivityBody = mockDefaultActivityBody
     mockConsumeRequestBody = false
+  })
+
+  afterEach(() => {
+    harness.cleanup()
   })
 
   it('returns 202 without side effects when the verified sender actor is suspended', async () => {
@@ -943,5 +965,96 @@ describe('POST /api/users/[username]/inbox', () => {
       actorId: 'https://remote.test/users/alice',
       statusId: 'https://activities.local/users/llun/statuses/1'
     })
+  })
+
+  it('records exception, reject reason, and logs error when an action throws', async () => {
+    mockCreateFollower.mockRejectedValue(new Error('db down'))
+
+    const response = await POST(createFollowRequest('llun'), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(400)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].name).toBe('api.actorInbox')
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'handler_exception',
+      'inbox.sender_actor_id': 'https://remote.test/users/alice'
+    })
+    expect(harness.recordedSpans[0].exception).toEqual(new Error('db down'))
+    expect(mockLogger.error).toHaveBeenCalledWith({
+      err: expect.any(Error),
+      message: 'ActivityPub inbox handler threw',
+      senderActorId: 'https://remote.test/users/alice'
+    })
+    expect(mockLogger.error.mock.calls[0][0].err.message).toBe('db down')
+  })
+
+  it('annotates unsupported_activity_shape when activity schema validation fails', async () => {
+    const response = await POST(
+      new NextRequest('https://activities.local/api/users/llun/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: 'https://remote.test/users/alice/activities/create-1',
+          type: 'Create',
+          actor: 'https://remote.test/users/alice',
+          object: {
+            id: 'https://remote.test/users/alice/statuses/1',
+            type: 'Note',
+            content: 'Hello'
+          }
+        })
+      }),
+      { params: Promise.resolve({ username: 'llun' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'unsupported_activity_shape',
+      'inbox.activity_type': 'Create',
+      'inbox.activity_id':
+        'https://remote.test/users/alice/activities/create-1',
+      'inbox.sender_actor_id': 'https://remote.test/users/alice'
+    })
+  })
+
+  it('annotates unsupported_activity_shape with string array activity_type', async () => {
+    const response = await POST(
+      new NextRequest('https://activities.local/api/users/llun/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: 'https://remote.test/users/alice/activities/custom-1',
+          type: ['Create', 'https://example.com/Custom'],
+          actor: 'https://remote.test/users/alice',
+          object: 'https://activities.local/users/llun'
+        })
+      }),
+      { params: Promise.resolve({ username: 'llun' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'unsupported_activity_shape',
+      'inbox.activity_type': ['Create', 'https://example.com/Custom'],
+      'inbox.activity_id':
+        'https://remote.test/users/alice/activities/custom-1',
+      'inbox.sender_actor_id': 'https://remote.test/users/alice'
+    })
+  })
+
+  it('does not annotate inbox.reject_reason on a valid accepted activity', async () => {
+    const response = await POST(createFollowRequest('llun'), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(202)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(
+      harness.recordedSpans[0].attributes['inbox.reject_reason']
+    ).toBeUndefined()
   })
 })

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -1,3 +1,4 @@
+import { trace } from '@opentelemetry/api'
 import { z } from 'zod'
 
 import { acceptFollowRequest } from '@/lib/actions/acceptFollowRequest'
@@ -28,6 +29,7 @@ import {
   OnlyLocalUserGuard,
   OnlyLocalUserGuardParams
 } from '@/lib/services/guards/OnlyLocalUserGuard'
+import { annotateInboxRejection } from '@/lib/services/guards/inboxRejectionTrace'
 import { getQueue } from '@/lib/services/queue'
 import {
   Accept,
@@ -50,7 +52,29 @@ import {
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { isRecord } from '@/lib/utils/typeGuards'
+
+const readActivityType = (activity: unknown): string | string[] | undefined => {
+  if (!isRecord(activity)) return undefined
+  const type = activity.type
+  if (typeof type === 'string') return type
+  if (
+    Array.isArray(type) &&
+    type.every((item): item is string => typeof item === 'string')
+  ) {
+    return type
+  }
+  return undefined
+}
+
+const readActivityId = (activity: unknown): string | undefined => {
+  if (!isRecord(activity)) return undefined
+  const id = activity.id
+  if (typeof id === 'string') return id
+  return undefined
+}
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const GracefullyAcceptedActivity = z
@@ -195,6 +219,11 @@ export const POST = traceApiRoute(
             )
             const parsed = Activity.safeParse(compactedActivity)
             if (!parsed.success) {
+              annotateInboxRejection('unsupported_activity_shape', {
+                activity_type: readActivityType(compactedActivity),
+                activity_id: readActivityId(compactedActivity),
+                sender_actor_id: context.verifiedSenderActorId
+              })
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
@@ -575,7 +604,19 @@ export const POST = traceApiRoute(
                   responseStatusCode: 202
                 })
             }
-          } catch {
+          } catch (error) {
+            const span = trace.getActiveSpan()
+            const err =
+              error instanceof Error ? error : new Error(String(error))
+            span?.recordException(err)
+            annotateInboxRejection('handler_exception', {
+              sender_actor_id: context.verifiedSenderActorId
+            })
+            logger.error({
+              err: toLoggableError(error),
+              message: 'ActivityPub inbox handler threw',
+              senderActorId: context.verifiedSenderActorId
+            })
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -854,5 +854,60 @@ describe('ActivityPubVerifySenderGuard', () => {
       expect(typeof keyIdAttr).toBe('string')
       expect((keyIdAttr as string).length).toBe(500)
     })
+
+    it('skips undefined extra attributes without stamping them on the span', async () => {
+      mockGetSenderPublicKeyDetails.mockResolvedValue({
+        owner: null,
+        publicKey: ''
+      })
+      mockVerify.mockResolvedValue(false)
+
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await runGuardInSpan(
+        guard,
+        createSignedPostRequest({
+          body: {
+            id: 'https://remote.test/users/alice/activities/1',
+            type: 'Follow',
+            actor: 'https://remote.test/users/alice'
+          }
+        })
+      )
+
+      expect(response.status).toBe(400)
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect('inbox.key_owner' in harness.recordedSpans[0].attributes).toBe(
+        false
+      )
+    })
+
+    it('does not set attributes when the active span is not recording', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const setAttributeSpy = vi.fn()
+      const nonRecordingSpan = {
+        isRecording: () => false,
+        setAttribute: setAttributeSpy,
+        setStatus: vi.fn()
+      }
+
+      vi.spyOn(trace, 'getActiveSpan').mockReturnValue(
+        nonRecordingSpan as never
+      )
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: { host: 'activities.local' }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(400)
+      expect(setAttributeSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -1,6 +1,8 @@
+import { trace } from '@opentelemetry/api'
 import { NextRequest } from 'next/server'
 import crypto from 'node:crypto'
 
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
 import { HttpMethod } from '@/lib/utils/http-headers'
 
 import { ActivityPubVerifySenderGuard } from './ActivityPubVerifyGuard'
@@ -40,19 +42,21 @@ const createSignedRawPostRequest = ({
   bodyText,
   keyId = 'https://remote.test/users/alice#main-key',
   signatureHeaders = '(request-target) host date digest',
-  host = 'activities.local'
+  host = 'activities.local',
+  date = new Date().toUTCString()
 }: {
   bodyText: string
   keyId?: string
   signatureHeaders?: string
   host?: string
+  date?: string
 }) => {
   const digest = crypto.createHash('sha256').update(bodyText).digest('base64')
 
   return new NextRequest('https://activities.local/api/inbox', {
     method: 'POST',
     headers: {
-      date: new Date().toUTCString(),
+      date,
       digest: `SHA-256=${digest}`,
       ...(host ? { host } : {}),
       signature: `keyId="${keyId}",algorithm="rsa-sha256",headers="${signatureHeaders}",signature="signature"`
@@ -74,7 +78,10 @@ const createSignedPostRequest = ({
   })
 
 describe('ActivityPubVerifySenderGuard', () => {
+  let harness: ReturnType<typeof setupRecordingTracer>
+
   beforeEach(() => {
+    harness = setupRecordingTracer()
     vi.clearAllMocks()
     mockCanFederateWithDomain.mockResolvedValue(true)
     mockGetSenderPublicKey.mockResolvedValue('public-key')
@@ -83,6 +90,10 @@ describe('ActivityPubVerifySenderGuard', () => {
       publicKey: 'public-key'
     })
     mockVerify.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    harness.cleanup()
   })
 
   it('returns CORS headers on verification errors when methods are provided', async () => {
@@ -493,5 +504,355 @@ describe('ActivityPubVerifySenderGuard', () => {
 
     expect(response.status).toBe(200)
     expect(handler).toHaveBeenCalled()
+  })
+
+  describe('rejection trace annotations', () => {
+    const runGuardInSpan = async (
+      guard: ReturnType<typeof ActivityPubVerifySenderGuard>,
+      req: NextRequest
+    ) => {
+      return trace.getTracer('test').startActiveSpan('api.inbox', async () => {
+        return guard(req, { params: Promise.resolve({}) })
+      })
+    }
+
+    it.each([
+      {
+        description: 'missing signature header',
+        setup: () => {},
+        request: () =>
+          new NextRequest('https://activities.local/api/inbox', {
+            method: 'POST',
+            headers: { host: 'activities.local' }
+          }),
+        expectedStatus: 400,
+        expectedReason: 'missing_signature',
+        expectedAttributes: {}
+      },
+      {
+        description: 'unparseable signature header without keyId',
+        setup: () => {},
+        request: () =>
+          new NextRequest('https://activities.local/api/inbox', {
+            method: 'POST',
+            headers: {
+              host: 'activities.local',
+              signature: 'algorithm="rsa-sha256",signature="signature"'
+            }
+          }),
+        expectedStatus: 400,
+        expectedReason: 'unparseable_signature',
+        expectedAttributes: {}
+      },
+      {
+        description: 'missing required signed headers',
+        setup: () => {},
+        request: () =>
+          createSignedRawPostRequest({
+            bodyText: JSON.stringify({
+              actor: 'https://remote.test/users/alice',
+              type: 'Follow'
+            }),
+            signatureHeaders: '(request-target) date digest'
+          }),
+        expectedStatus: 400,
+        expectedReason: 'missing_signed_headers',
+        expectedAttributes: {
+          'inbox.signed_headers': ['(request-target)', 'date', 'digest'],
+          'inbox.has_host_header': true
+        }
+      },
+      {
+        description: 'stale date header',
+        setup: () => {},
+        request: () =>
+          createSignedRawPostRequest({
+            bodyText: JSON.stringify({
+              actor: 'https://remote.test/users/alice',
+              type: 'Follow'
+            }),
+            date: 'Wed, 09 Nov 2022 18:28:37 GMT'
+          }),
+        expectedStatus: 400,
+        expectedReason: 'stale_date',
+        expectedAttributes: {
+          'inbox.date_header': 'Wed, 09 Nov 2022 18:28:37 GMT',
+          'inbox.server_time': expect.any(String)
+        }
+      },
+      {
+        description: 'mismatched digest header',
+        setup: () => {},
+        request: () =>
+          new NextRequest('https://activities.local/api/inbox', {
+            method: 'POST',
+            headers: {
+              host: 'activities.local',
+              date: new Date().toUTCString(),
+              digest: 'SHA-256=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+              signature:
+                'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
+            },
+            body: JSON.stringify({ type: 'Follow' })
+          }),
+        expectedStatus: 400,
+        expectedReason: 'digest_mismatch',
+        expectedAttributes: {}
+      },
+      {
+        description: 'invalid activity body JSON',
+        setup: () => {},
+        request: () =>
+          createSignedRawPostRequest({
+            bodyText: '{"actor":"https://remote.test/users/alice",'
+          }),
+        expectedStatus: 400,
+        expectedReason: 'invalid_activity_body',
+        expectedAttributes: {}
+      },
+      {
+        description: 'domain not federatable',
+        setup: () => {
+          mockCanFederateWithDomain.mockResolvedValue(false)
+        },
+        request: () =>
+          createSignedPostRequest({
+            body: {
+              id: 'https://remote.test/users/alice/activities/1',
+              type: 'Follow',
+              actor: 'https://remote.test/users/alice'
+            }
+          }),
+        expectedStatus: 403,
+        expectedReason: 'domain_not_federatable',
+        expectedAttributes: {
+          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+        }
+      },
+      {
+        description: 'key unavailable when sender public key details are empty',
+        setup: () => {
+          mockGetSenderPublicKeyDetails.mockResolvedValue({
+            owner: null,
+            publicKey: ''
+          })
+          mockVerify.mockResolvedValue(false)
+        },
+        request: () =>
+          createSignedPostRequest({
+            body: {
+              id: 'https://remote.test/users/alice/activities/1',
+              type: 'Follow',
+              actor: 'https://remote.test/users/alice'
+            }
+          }),
+        expectedStatus: 400,
+        expectedReason: 'key_unavailable',
+        expectedAttributes: {
+          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+        }
+      },
+      {
+        description: 'signature invalid when public key is present',
+        setup: () => {
+          mockGetSenderPublicKeyDetails.mockResolvedValue({
+            owner: 'https://remote.test/users/alice',
+            publicKey: 'public-key'
+          })
+          mockVerify.mockResolvedValue(false)
+        },
+        request: () =>
+          createSignedPostRequest({
+            body: {
+              id: 'https://remote.test/users/alice/activities/1',
+              type: 'Follow',
+              actor: 'https://remote.test/users/alice'
+            }
+          }),
+        expectedStatus: 400,
+        expectedReason: 'signature_invalid',
+        expectedAttributes: {
+          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+        }
+      },
+      {
+        description: 'key owner unresolvable to a valid actor id',
+        setup: () => {
+          mockGetSenderPublicKeyDetails.mockResolvedValue({
+            owner: '_:b0',
+            publicKey: 'public-key'
+          })
+          mockVerify.mockResolvedValue(true)
+        },
+        request: () =>
+          createSignedPostRequest({
+            body: {
+              id: 'https://remote.test/users/alice/activities/1',
+              type: 'Follow',
+              actor: 'https://remote.test/users/alice'
+            }
+          }),
+        expectedStatus: 400,
+        expectedReason: 'key_owner_unresolvable',
+        expectedAttributes: {
+          'inbox.key_id': 'https://remote.test/users/alice#main-key',
+          'inbox.key_owner': '_:b0'
+        }
+      },
+      {
+        description: 'sender actor mismatch with activity actor',
+        setup: () => {
+          mockGetSenderPublicKeyDetails.mockResolvedValue({
+            owner: 'https://remote.test/users/alice',
+            publicKey: 'public-key'
+          })
+          mockVerify.mockResolvedValue(true)
+        },
+        request: () =>
+          createSignedPostRequest({
+            body: {
+              id: 'https://remote.test/users/mallory/activities/1',
+              type: 'Follow',
+              actor: 'https://remote.test/users/mallory'
+            }
+          }),
+        expectedStatus: 403,
+        expectedReason: 'sender_actor_mismatch',
+        expectedAttributes: {
+          'inbox.verified_sender': 'https://remote.test/users/alice',
+          'inbox.activity_actor': 'https://remote.test/users/mallory'
+        }
+      }
+    ])(
+      'annotates $expectedReason for $description',
+      async ({
+        setup,
+        request,
+        expectedStatus,
+        expectedReason,
+        expectedAttributes
+      }) => {
+        setup()
+        const handler = vi.fn()
+        const guard = ActivityPubVerifySenderGuard(handler)
+
+        const response = await runGuardInSpan(guard, request())
+
+        expect(response.status).toBe(expectedStatus)
+        expect(handler).not.toHaveBeenCalled()
+        expect(harness.recordedSpans).toHaveLength(1)
+        expect(harness.recordedSpans[0].attributes['inbox.reject_reason']).toBe(
+          expectedReason
+        )
+        if (Object.keys(expectedAttributes).length > 0) {
+          expect(harness.recordedSpans[0].attributes).toMatchObject(
+            expectedAttributes
+          )
+        }
+      }
+    )
+
+    it('does not set reject_reason on a fully valid request', async () => {
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await runGuardInSpan(
+        guard,
+        createSignedPostRequest({
+          body: {
+            id: 'https://remote.test/users/alice/activities/1',
+            type: 'Follow',
+            actor: 'https://remote.test/users/alice'
+          }
+        })
+      )
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(
+        harness.recordedSpans[0].attributes['inbox.reject_reason']
+      ).toBeUndefined()
+    })
+
+    it('returns the rejection status without throwing when no span is active', async () => {
+      harness.cleanup()
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: { host: 'activities.local' }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(400)
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('never attaches the raw signature string to span attributes', async () => {
+      const secretSignature = 'super-secret-signature-string-12345'
+      mockGetSenderPublicKeyDetails.mockResolvedValue({
+        owner: 'https://remote.test/users/alice',
+        publicKey: 'public-key'
+      })
+      mockVerify.mockResolvedValue(false)
+
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const digest = crypto
+        .createHash('sha256')
+        .update('{"type":"Follow"}')
+        .digest('base64')
+
+      const req = new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          date: new Date().toUTCString(),
+          digest: `SHA-256=${digest}`,
+          host: 'activities.local',
+          signature: `keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${secretSignature}"`
+        },
+        body: '{"type":"Follow"}'
+      })
+
+      const response = await runGuardInSpan(guard, req)
+
+      expect(response.status).toBe(400)
+      expect(harness.recordedSpans).toHaveLength(1)
+      const serializedAttributes = JSON.stringify(
+        harness.recordedSpans[0].attributes
+      )
+      expect(serializedAttributes).not.toContain(secretSignature)
+    })
+
+    it('truncates oversized attributes to 500 characters', async () => {
+      const longKeyId = 'https://remote.test/users/alice#' + 'a'.repeat(600)
+      mockCanFederateWithDomain.mockResolvedValue(false)
+
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await runGuardInSpan(
+        guard,
+        createSignedPostRequest({
+          keyId: longKeyId,
+          body: {
+            id: 'https://remote.test/users/alice/activities/1',
+            type: 'Follow',
+            actor: 'https://remote.test/users/alice'
+          }
+        })
+      )
+
+      expect(response.status).toBe(403)
+      expect(harness.recordedSpans).toHaveLength(1)
+      const keyIdAttr = harness.recordedSpans[0].attributes['inbox.key_id']
+      expect(typeof keyIdAttr).toBe('string')
+      expect((keyIdAttr as string).length).toBe(500)
+    })
   })
 })

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -17,6 +17,7 @@ import { isRecord } from '@/lib/utils/typeGuards'
 
 import { getSenderPublicKeyDetails } from './getSenderPublicKey'
 import { headerHost } from './headerHost'
+import { annotateInboxRejection } from './inboxRejectionTrace'
 import { ActivityPubVerifiedSenderHandle, AppRouterParams } from './types'
 
 const SIGNATURE_CLOCK_SKEW_MS = 5 * 60 * 1000
@@ -34,6 +35,17 @@ const guardErrorResponse = (
     data: codeMap[statusCode],
     responseStatusCode: statusCode
   })
+}
+
+const rejectRequest = (
+  request: NextRequest,
+  statusCode: StatusCode,
+  allowedMethods: HttpMethod[] | undefined,
+  reason: string,
+  extra?: Record<string, string | number | boolean | string[] | undefined>
+) => {
+  annotateInboxRejection(reason, extra)
+  return guardErrorResponse(request, statusCode, allowedMethods)
 }
 
 const getSignedHeaders = (signatureParts: Record<string, string>) =>
@@ -164,11 +176,16 @@ export const ActivityPubVerifySenderGuard =
 
     const requestSignature = request.headers.get('signature')
     if (!requestSignature)
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(request, 400, allowedMethods, 'missing_signature')
 
     const signatureParts = await parse(requestSignature)
     if (!signatureParts.keyId) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(
+        request,
+        400,
+        allowedMethods,
+        'unparseable_signature'
+      )
     }
     const signedHeaders = getSignedHeaders(signatureParts)
     const requiresMutatingSignature = isMutatingRequest(request.method)
@@ -178,16 +195,36 @@ export const ActivityPubVerifySenderGuard =
       (!hasHostHeader(request.headers) ||
         !hasRequiredMutatingSignedHeaders(signedHeaders))
     ) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(
+        request,
+        400,
+        allowedMethods,
+        'missing_signed_headers',
+        {
+          signed_headers: signedHeaders,
+          has_host_header: hasHostHeader(request.headers)
+        }
+      )
     }
 
     if (!isDateHeaderFresh(request.headers, signedHeaders)) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      const dateHeader = getHeadersValue(request.headers, 'date')
+      const rawDate =
+        typeof dateHeader === 'string'
+          ? dateHeader
+          : Array.isArray(dateHeader)
+            ? dateHeader.join(', ')
+            : undefined
+
+      return rejectRequest(request, 400, allowedMethods, 'stale_date', {
+        date_header: rawDate,
+        server_time: new Date().toISOString()
+      })
     }
 
     const digestResult = await digestMatches(request, signedHeaders)
     if (!digestResult.valid) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(request, 400, allowedMethods, 'digest_mismatch')
     }
 
     const activity = getPostActivity({
@@ -195,11 +232,24 @@ export const ActivityPubVerifySenderGuard =
       method: request.method
     })
     if (!activity.valid) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(
+        request,
+        400,
+        allowedMethods,
+        'invalid_activity_body'
+      )
     }
 
     if (!(await canFederateWithDomain(database, signatureParts.keyId))) {
-      return guardErrorResponse(request, 403, allowedMethods)
+      return rejectRequest(
+        request,
+        403,
+        allowedMethods,
+        'domain_not_federatable',
+        {
+          key_id: signatureParts.keyId
+        }
+      )
     }
 
     const host = headerHost(request.headers)
@@ -209,22 +259,48 @@ export const ActivityPubVerifySenderGuard =
       database,
       signatureParts.keyId
     )
-    if (
-      !(await verify(requestTarget, request.headers, senderPublicKey.publicKey))
-    ) {
-      return guardErrorResponse(request, 400, allowedMethods)
+    const isSignatureVerified = await verify(
+      requestTarget,
+      request.headers,
+      senderPublicKey.publicKey
+    )
+    if (!isSignatureVerified) {
+      const reason = senderPublicKey.publicKey
+        ? 'signature_invalid'
+        : 'key_unavailable'
+      return rejectRequest(request, 400, allowedMethods, reason, {
+        key_id: signatureParts.keyId
+      })
     }
 
     const verifiedSenderActorId = normalizeActorId(senderPublicKey.owner)
     if (!verifiedSenderActorId) {
-      return guardErrorResponse(request, 400, allowedMethods)
+      return rejectRequest(
+        request,
+        400,
+        allowedMethods,
+        'key_owner_unresolvable',
+        {
+          key_id: signatureParts.keyId,
+          key_owner: senderPublicKey.owner ?? undefined
+        }
+      )
     }
 
     if (activity.actor) {
       const normalizedActor = normalizeActorId(activity.actor)
 
       if (verifiedSenderActorId !== normalizedActor) {
-        return guardErrorResponse(request, 403, allowedMethods)
+        return rejectRequest(
+          request,
+          403,
+          allowedMethods,
+          'sender_actor_mismatch',
+          {
+            verified_sender: verifiedSenderActorId,
+            activity_actor: normalizedActor ?? undefined
+          }
+        )
       }
     }
 

--- a/lib/services/guards/inboxRejectionTrace.ts
+++ b/lib/services/guards/inboxRejectionTrace.ts
@@ -1,0 +1,39 @@
+import { trace } from '@opentelemetry/api'
+
+const MAX_ATTRIBUTE_LENGTH = 500
+
+const bound = (value: string): string =>
+  value.length > MAX_ATTRIBUTE_LENGTH
+    ? value.slice(0, MAX_ATTRIBUTE_LENGTH)
+    : value
+
+/**
+ * Stamps the rejection reason for an ActivityPub inbox request onto the
+ * request's existing traceApiRoute span (api.sharedInbox /
+ * api.actorInbox). Never creates a span; a missing or non-recording
+ * active span makes this a no-op, matching the repo-wide "tracing off is
+ * free" rule in lib/utils/trace.ts.
+ */
+export const annotateInboxRejection = (
+  reason: string,
+  extra: Record<string, string | number | boolean | string[] | undefined> = {}
+): void => {
+  try {
+    const span = trace.getActiveSpan()
+    if (!span || !span.isRecording()) return
+    span.setAttribute('inbox.reject_reason', reason)
+    for (const [key, value] of Object.entries(extra)) {
+      if (value === undefined) continue
+      span.setAttribute(
+        `inbox.${key}`,
+        typeof value === 'string'
+          ? bound(value)
+          : Array.isArray(value)
+            ? value.map((item) => bound(item))
+            : value
+      )
+    }
+  } catch {
+    // Tracing failures must never alter response handling
+  }
+}

--- a/lib/testing/recordingTracer.ts
+++ b/lib/testing/recordingTracer.ts
@@ -1,0 +1,178 @@
+import {
+  Context,
+  ContextManager,
+  ROOT_CONTEXT,
+  Span,
+  SpanContext,
+  SpanOptions,
+  SpanStatus,
+  TraceFlags,
+  Tracer,
+  TracerProvider,
+  context,
+  trace
+} from '@opentelemetry/api'
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export class AsyncLocalStorageContextManager implements ContextManager {
+  private _storage = new AsyncLocalStorage<Context>()
+
+  active(): Context {
+    return this._storage.getStore() ?? ROOT_CONTEXT
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    ctx: Context,
+    fn: (...args: A) => ReturnType<F>,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    return this._storage.run(ctx, () => fn.apply(thisArg, args))
+  }
+
+  bind<T>(_context: Context, target: T): T {
+    return target
+  }
+
+  enable(): this {
+    return this
+  }
+
+  disable(): this {
+    this._storage.disable()
+    return this
+  }
+}
+
+export interface RecordedSpan {
+  name: string
+  spanId: string
+  parentSpanId?: string
+  attributes: Record<string, unknown>
+  status?: SpanStatus
+  exception?: Error
+  ended: boolean
+}
+
+export function createRecordingTracerProvider() {
+  const recordedSpans: RecordedSpan[] = []
+  let spanIdCounter = 0
+
+  class FakeSpan implements Span {
+    readonly spanContextValue: SpanContext
+    private _rec: RecordedSpan
+
+    constructor(name: string, options?: SpanOptions, parentContext?: Context) {
+      const parentSpan = parentContext
+        ? trace.getSpan(parentContext)
+        : undefined
+      const id = String(++spanIdCounter).padStart(16, '0')
+      this.spanContextValue = {
+        traceId:
+          parentSpan?.spanContext().traceId ??
+          '11111111111111111111111111111111',
+        spanId: id,
+        traceFlags: TraceFlags.SAMPLED
+      }
+      this._rec = {
+        name,
+        spanId: id,
+        parentSpanId: parentSpan?.spanContext().spanId,
+        attributes: { ...(options?.attributes ?? {}) },
+        ended: false
+      }
+      recordedSpans.push(this._rec)
+    }
+
+    spanContext(): SpanContext {
+      return this.spanContextValue
+    }
+    setAttribute(key: string, value: unknown): this {
+      this._rec.attributes[key] = value
+      return this
+    }
+    setAttributes(attributes: Record<string, unknown>): this {
+      Object.assign(this._rec.attributes, attributes)
+      return this
+    }
+    addEvent(): this {
+      return this
+    }
+    addLink(): this {
+      return this
+    }
+    addLinks(): this {
+      return this
+    }
+    setStatus(status: SpanStatus): this {
+      this._rec.status = status
+      return this
+    }
+    updateName(name: string): this {
+      this._rec.name = name
+      return this
+    }
+    end(): void {
+      this._rec.ended = true
+    }
+    isRecording(): boolean {
+      return true
+    }
+    recordException(exception: Error): void {
+      this._rec.exception = exception
+    }
+  }
+
+  class FakeTracer implements Tracer {
+    startSpan(name: string, options?: SpanOptions, ctx?: Context): Span {
+      return new FakeSpan(name, options, ctx ?? context.active())
+    }
+    startActiveSpan<F extends (span: Span) => unknown>(
+      name: string,
+      optionsOrFn: SpanOptions | F,
+      contextOrFn?: Context | F,
+      maybeFn?: F
+    ): ReturnType<F> {
+      let fn: F
+      let options: SpanOptions | undefined
+      let ctx: Context | undefined
+
+      if (typeof optionsOrFn === 'function') {
+        fn = optionsOrFn
+      } else if (typeof contextOrFn === 'function') {
+        fn = contextOrFn
+        options = optionsOrFn
+      } else {
+        fn = maybeFn!
+        options = optionsOrFn
+        ctx = contextOrFn
+      }
+
+      const activeCtx = ctx ?? context.active()
+      const span = new FakeSpan(name, options, activeCtx)
+      const newCtx = trace.setSpan(activeCtx, span)
+      return context.with(newCtx, () => fn(span)) as ReturnType<F>
+    }
+  }
+
+  const provider: TracerProvider = {
+    getTracer: () => new FakeTracer()
+  }
+
+  return { provider, recordedSpans }
+}
+
+export function setupRecordingTracer() {
+  const contextManager = new AsyncLocalStorageContextManager()
+  contextManager.enable()
+  context.setGlobalContextManager(contextManager)
+  const fake = createRecordingTracerProvider()
+  trace.setGlobalTracerProvider(fake.provider)
+  return {
+    recordedSpans: fake.recordedSpans,
+    cleanup: () => {
+      trace.disable()
+      context.disable()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stamps a machine-readable rejection reason onto the active OpenTelemetry trace span (`api.sharedInbox` / `api.actorInbox`) on every 400 and 403 path across `ActivityPubVerifyGuard.ts` and `app/api/users/[username]/inbox/route.ts`.

This provides observability into the production spike of inbox 400 responses without modifying any wire behavior or HTTP responses.

### Key Changes
- Created `lib/services/guards/inboxRejectionTrace.ts` exporting `annotateInboxRejection(reason, extra)` which stamps `inbox.reject_reason` and prefixed diagnostic attributes (`inbox.<key>`) onto the active OpenTelemetry span.
- Routed every early-return rejection in `ActivityPubVerifySenderGuard` through `rejectRequest` to annotate reasons (including the `key_unavailable` vs `signature_invalid` distinction) while preserving identical return values and status codes.
- Added rejection annotation on unsupported activity schema failure in `app/api/users/[username]/inbox/route.ts` with defensive length-bounded `activity_type` and `activity_id` extraction.
- Replaced the blanket catch in `app/api/users/[username]/inbox/route.ts` to record span exception, annotate `handler_exception`, and log error via `logger.error` with normalized `toLoggableError(error)`.
- Added shared test tracer helper `lib/testing/recordingTracer.ts` and comprehensive unit tests covering all 11 reason matrix rows, negative success cases, no-span resilience, signature redaction hygiene, and attribute length bounding.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)