### PR TITLE
Bump version to v1.149.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.15",
+  "version": "1.149.16",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.16.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.15`
- Base main SHA: `b10709123585eb4ac51d7527e26fbf981ec35dc3`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
