### PR TITLE
fix: align ActivityPub inbox signature verification and acceptance semantics with Mastodon

### DIFF
--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -333,7 +333,7 @@ describe('POST /api/inbox', () => {
     )
   })
 
-  it('rejects Create Note activities whose inner object actor does not match the verified sender', async () => {
+  it('acknowledges with 202 without queueing when Create Note inner object actor does not match the verified sender', async () => {
     const actor = 'https://allowed.test/users/a'
     mockCanFederateWithDomain.mockResolvedValue(true)
     mockVerifiedSenderActorId = actor
@@ -353,7 +353,26 @@ describe('POST /api/inbox', () => {
       params: Promise.resolve({})
     })
 
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(202)
+    expect(mockPublish).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges with 202 without queueing when activity type is unsupported', async () => {
+    const actor = 'https://allowed.test/users/a'
+    mockCanFederateWithDomain.mockResolvedValue(true)
+    mockVerifiedSenderActorId = actor
+    mockActivityBody = {
+      id: `${actor}/activities/unsupported-1`,
+      type: 'Dislike',
+      actor,
+      object: `${actor}/statuses/1`
+    }
+
+    const response = await POST(createRequest(actor), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(202)
     expect(mockPublish).not.toHaveBeenCalled()
   })
 })

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -3,6 +3,7 @@ import { StatusActivity } from '@/lib/activities/statusAction'
 import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
+import { annotateInboxRejection } from '@/lib/services/guards/inboxRejectionTrace'
 import { getQueue } from '@/lib/services/queue'
 import { AnnounceAction } from '@/lib/types/activitypub/activities'
 import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
@@ -12,7 +13,6 @@ import {
   DEFAULT_202,
   ERROR_400,
   ERROR_403,
-  ERROR_404,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -115,11 +115,12 @@ export const POST = traceApiRoute(
 
       const jobMessage = getJobMessage(activity, verifiedSenderActorId)
       if (!jobMessage) {
+        annotateInboxRejection('unsupported_activity_shape')
         return apiResponse({
           req: request,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
-          responseStatusCode: 404
+          data: DEFAULT_202,
+          responseStatusCode: 202
         })
       }
 

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -86,7 +86,7 @@ vi.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
       context: { params: Promise<{ username: string }> }
     ) => {
       if (!(await mockVerifyAllows(req, context))) {
-        return Response.json({ error: 'Bad Request' }, { status: 400 })
+        return Response.json({ error: 'Unauthorized' }, { status: 401 })
       }
 
       const activityBody =
@@ -96,6 +96,10 @@ vi.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
               .json()
               .catch(() => null)
           : mockActivityBody
+
+      if (activityBody === null) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 })
+      }
 
       if (mockConsumeRequestBody) {
         await req.text().catch(() => null)
@@ -391,7 +395,7 @@ describe('POST /api/users/[username]/inbox', () => {
       params: Promise.resolve({ username: 'llun' })
     })
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockCreateFollower).not.toHaveBeenCalled()
   })
@@ -453,7 +457,7 @@ describe('POST /api/users/[username]/inbox', () => {
       { params: Promise.resolve({ username: 'llun' }) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockCreateFollower).not.toHaveBeenCalled()
   })
@@ -974,7 +978,7 @@ describe('POST /api/users/[username]/inbox', () => {
       params: Promise.resolve({ username: 'llun' })
     })
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(500)
     expect(harness.recordedSpans).toHaveLength(1)
     expect(harness.recordedSpans[0].name).toBe('api.actorInbox')
     expect(harness.recordedSpans[0].attributes).toMatchObject({
@@ -990,37 +994,137 @@ describe('POST /api/users/[username]/inbox', () => {
     expect(mockLogger.error.mock.calls[0][0].err.message).toBe('db down')
   })
 
-  it('annotates unsupported_activity_shape when activity schema validation fails', async () => {
+  describe('status activity routing on personal inbox', () => {
+    it('routes Create Note activities delivered to personal inbox to the job queue with 202', async () => {
+      const response = await POST(
+        new NextRequest('https://activities.local/api/users/llun/inbox', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: 'https://remote.test/users/alice/activities/create-1',
+            type: 'Create',
+            actor: 'https://remote.test/users/alice',
+            object: {
+              id: 'https://remote.test/users/alice/statuses/1',
+              type: 'Note',
+              attributedTo: 'https://remote.test/users/alice',
+              content: 'Hello'
+            }
+          })
+        }),
+        { params: Promise.resolve({ username: 'llun' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'CreateNoteJob'
+        })
+      )
+    })
+
+    it('routes Announce activities delivered to personal inbox to the job queue with 202', async () => {
+      const response = await POST(
+        new NextRequest('https://activities.local/api/users/llun/inbox', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: 'https://remote.test/users/alice/activities/announce-1',
+            type: 'Announce',
+            actor: 'https://remote.test/users/alice',
+            object: 'https://activities.local/users/llun/statuses/1',
+            to: ['https://www.w3.org/ns/activitystreams#Public']
+          })
+        }),
+        { params: Promise.resolve({ username: 'llun' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'CreateAnnounceJob'
+        })
+      )
+    })
+
+    it('routes Delete activities delivered to personal inbox to the job queue with 202', async () => {
+      const response = await POST(
+        new NextRequest('https://activities.local/api/users/llun/inbox', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: 'https://remote.test/users/alice/activities/delete-1',
+            type: 'Delete',
+            actor: 'https://remote.test/users/alice',
+            object: 'https://remote.test/users/alice/statuses/1'
+          })
+        }),
+        { params: Promise.resolve({ username: 'llun' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'DeleteObjectJob'
+        })
+      )
+    })
+
+    it('routes Undo Announce activities delivered to personal inbox to the job queue with 202', async () => {
+      const response = await POST(
+        new NextRequest('https://activities.local/api/users/llun/inbox', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: 'https://remote.test/users/alice/activities/undo-announce-1',
+            type: 'Undo',
+            actor: 'https://remote.test/users/alice',
+            object: {
+              id: 'https://remote.test/users/alice/activities/announce-1',
+              type: 'Announce',
+              actor: 'https://remote.test/users/alice',
+              object: 'https://activities.local/users/llun/statuses/1'
+            }
+          })
+        }),
+        { params: Promise.resolve({ username: 'llun' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'DeleteObjectJob'
+        })
+      )
+    })
+  })
+
+  it('accepts unknown or unsupported activity types with 202 and logs without error', async () => {
     const response = await POST(
       new NextRequest('https://activities.local/api/users/llun/inbox', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          id: 'https://remote.test/users/alice/activities/create-1',
-          type: 'Create',
+          id: 'https://remote.test/users/alice/activities/custom-1',
+          type: 'Dislike',
           actor: 'https://remote.test/users/alice',
-          object: {
-            id: 'https://remote.test/users/alice/statuses/1',
-            type: 'Note',
-            content: 'Hello'
-          }
+          object: 'https://activities.local/users/llun'
         })
       }),
       { params: Promise.resolve({ username: 'llun' }) }
     )
 
-    expect(response.status).toBe(400)
-    expect(harness.recordedSpans).toHaveLength(1)
-    expect(harness.recordedSpans[0].attributes).toMatchObject({
-      'inbox.reject_reason': 'unsupported_activity_shape',
-      'inbox.activity_type': 'Create',
-      'inbox.activity_id':
-        'https://remote.test/users/alice/activities/create-1',
-      'inbox.sender_actor_id': 'https://remote.test/users/alice'
-    })
+    expect(response.status).toBe(202)
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Accepted ActivityPub inbox activity without local side effects',
+        reason: 'unsupported activity shape'
+      })
+    )
   })
 
-  it('annotates unsupported_activity_shape with string array activity_type', async () => {
+  it('accepts string array activity_type with 202', async () => {
     const response = await POST(
       new NextRequest('https://activities.local/api/users/llun/inbox', {
         method: 'POST',
@@ -1035,15 +1139,7 @@ describe('POST /api/users/[username]/inbox', () => {
       { params: Promise.resolve({ username: 'llun' }) }
     )
 
-    expect(response.status).toBe(400)
-    expect(harness.recordedSpans).toHaveLength(1)
-    expect(harness.recordedSpans[0].attributes).toMatchObject({
-      'inbox.reject_reason': 'unsupported_activity_shape',
-      'inbox.activity_type': ['Create', 'https://example.com/Custom'],
-      'inbox.activity_id':
-        'https://remote.test/users/alice/activities/custom-1',
-      'inbox.sender_actor_id': 'https://remote.test/users/alice'
-    })
+    expect(response.status).toBe(202)
   })
 
   it('does not annotate inbox.reject_reason on a valid accepted activity', async () => {

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -1,6 +1,7 @@
 import { trace } from '@opentelemetry/api'
 import { z } from 'zod'
 
+import { getJobMessage } from '@/app/api/inbox/getJobMessage'
 import { acceptFollowRequest } from '@/lib/actions/acceptFollowRequest'
 import {
   acceptRelayRequest,
@@ -20,6 +21,7 @@ import { rejectFollowRequest } from '@/lib/actions/rejectFollowRequest'
 import { undoFollowRequest } from '@/lib/actions/undoFollowRequest'
 import { FollowRequest } from '@/lib/activities/followAction'
 import { compactActivityPub } from '@/lib/activities/jsonld'
+import { StatusActivity } from '@/lib/activities/statusAction'
 import { UndoFollow } from '@/lib/activities/undoFollow'
 import { HANDLE_QUOTE_REQUEST_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
@@ -46,35 +48,15 @@ import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import {
   DEFAULT_202,
-  ERROR_400,
   ERROR_403,
   ERROR_404,
+  ERROR_500,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { isRecord } from '@/lib/utils/typeGuards'
-
-const readActivityType = (activity: unknown): string | string[] | undefined => {
-  if (!isRecord(activity)) return undefined
-  const type = activity.type
-  if (typeof type === 'string') return type
-  if (
-    Array.isArray(type) &&
-    type.every((item): item is string => typeof item === 'string')
-  ) {
-    return type
-  }
-  return undefined
-}
-
-const readActivityId = (activity: unknown): string | undefined => {
-  if (!isRecord(activity)) return undefined
-  const id = activity.id
-  if (typeof id === 'string') return id
-  return undefined
-}
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const GracefullyAcceptedActivity = z
@@ -217,23 +199,13 @@ export const POST = traceApiRoute(
             const compactedActivity = await compactActivityPub(
               context.activityBody
             )
-            const parsed = Activity.safeParse(compactedActivity)
-            if (!parsed.success) {
-              annotateInboxRejection('unsupported_activity_shape', {
-                activity_type: readActivityType(compactedActivity),
-                activity_id: readActivityId(compactedActivity),
-                sender_actor_id: context.verifiedSenderActorId
-              })
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: ERROR_400,
-                responseStatusCode: 400
-              })
-            }
+            const activityActor =
+              isRecord(compactedActivity) &&
+              typeof compactedActivity.actor === 'string'
+                ? compactedActivity.actor
+                : context.verifiedSenderActorId
 
-            const activity = parsed.data
-            if (!(await canFederateWithDomain(database, activity.actor))) {
+            if (!(await canFederateWithDomain(database, activityActor))) {
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
@@ -256,6 +228,66 @@ export const POST = traceApiRoute(
                 responseStatusCode: 202
               })
             }
+
+            // Peers may deliver status-level activities (Create, Update, Delete,
+            // Announce, Undo of Announce) to personal inboxes. Route them through
+            // the shared job queue just like the shared inbox does.
+            const isStatusLevelActivity =
+              isRecord(compactedActivity) &&
+              (compactedActivity.type === 'Create' ||
+                compactedActivity.type === 'Update' ||
+                compactedActivity.type === 'Delete' ||
+                compactedActivity.type === 'Announce' ||
+                (compactedActivity.type === 'Undo' &&
+                  isRecord(compactedActivity.object) &&
+                  compactedActivity.object.type === 'Announce'))
+
+            if (isStatusLevelActivity) {
+              const jobMessage = getJobMessage(
+                compactedActivity as unknown as StatusActivity,
+                context.verifiedSenderActorId
+              )
+              if (jobMessage) {
+                await getQueue().publish(jobMessage)
+              } else {
+                logAcceptedWithoutSideEffects({
+                  activity: compactedActivity as {
+                    id?: string
+                    type: string
+                    actor?: string
+                  },
+                  reason: 'unmatched status activity'
+                })
+              }
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: DEFAULT_202,
+                responseStatusCode: 202
+              })
+            }
+
+            const parsed = Activity.safeParse(compactedActivity)
+            if (!parsed.success) {
+              logAcceptedWithoutSideEffects({
+                activity: isRecord(compactedActivity)
+                  ? (compactedActivity as {
+                      id?: string
+                      type: string
+                      actor?: string
+                    })
+                  : { type: 'unknown' },
+                reason: 'unsupported activity shape'
+              })
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: DEFAULT_202,
+                responseStatusCode: 202
+              })
+            }
+
+            const activity = parsed.data
 
             switch (activity.type) {
               case 'Accept': {
@@ -620,8 +652,8 @@ export const POST = traceApiRoute(
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,
-              data: ERROR_400,
-              responseStatusCode: 400
+              data: ERROR_500,
+              responseStatusCode: 500
             })
           }
         },

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -8,7 +8,10 @@ import { HttpMethod } from '@/lib/utils/http-headers'
 import { ActivityPubVerifySenderGuard } from './ActivityPubVerifyGuard'
 
 const mockCanFederateWithDomain = vi.fn()
-const mockDatabase = {}
+const mockGetActorFromId = vi.fn()
+const mockDatabase = {
+  getActorFromId: (...params: unknown[]) => mockGetActorFromId(...params)
+}
 const mockGetSenderPublicKey = vi.fn()
 const mockGetSenderPublicKeyDetails = vi.fn()
 const mockVerify = vi.fn()
@@ -114,7 +117,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
       'https://remote.test'
     )
@@ -134,13 +137,13 @@ describe('ActivityPubVerifySenderGuard', () => {
         headers: {
           date: 'Wed, 09 Nov 2022 18:28:37 GMT',
           signature:
-            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="signature"'
+            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
         }
       }),
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
@@ -155,7 +158,8 @@ describe('ActivityPubVerifySenderGuard', () => {
       type: 'Follow'
     })
     const digest = crypto.createHash('sha256').update(bodyText).digest('base64')
-    const futureDate = new Date(Date.now() + 10 * 60 * 1000).toUTCString()
+    // 2 hours in the future exceeds the 1 hour clock skew margin
+    const futureDate = new Date(Date.now() + 2 * 60 * 60 * 1000).toUTCString()
 
     const response = await guard(
       new NextRequest('https://activities.local/api/inbox', {
@@ -172,14 +176,14 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
-  it('rejects POST requests without a host header', async () => {
+  it('accepts POST requests without a host header', async () => {
     const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
     const guard = ActivityPubVerifySenderGuard(handler)
 
@@ -194,14 +198,11 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
-    expect(handler).not.toHaveBeenCalled()
-    expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
-    expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
-    expect(mockVerify).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(handler).toHaveBeenCalled()
   })
 
-  it('rejects mutating signatures that do not cover host', async () => {
+  it('accepts POST signatures that do not cover host', async () => {
     const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
     const guard = ActivityPubVerifySenderGuard(handler)
 
@@ -216,14 +217,11 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
-    expect(handler).not.toHaveBeenCalled()
-    expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
-    expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
-    expect(mockVerify).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(handler).toHaveBeenCalled()
   })
 
-  it('rejects mutating signatures that do not cover request-target', async () => {
+  it('rejects POST signatures that do not cover digest', async () => {
     const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
     const guard = ActivityPubVerifySenderGuard(handler)
 
@@ -233,12 +231,12 @@ describe('ActivityPubVerifySenderGuard', () => {
           actor: 'https://remote.test/users/alice',
           type: 'Follow'
         }),
-        signatureHeaders: 'host date digest'
+        signatureHeaders: '(request-target) host date'
       }),
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
@@ -262,7 +260,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
   })
@@ -285,7 +283,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
   })
 
@@ -300,7 +298,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
@@ -369,7 +367,7 @@ describe('ActivityPubVerifySenderGuard', () => {
     })
   })
 
-  it('includes query strings when verifying GET request targets', async () => {
+  it('includes query strings when verifying GET request targets and enforces host header for GET', async () => {
     const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
     const guard = ActivityPubVerifySenderGuard(handler)
 
@@ -396,6 +394,29 @@ describe('ActivityPubVerifySenderGuard', () => {
     )
   })
 
+  it('rejects GET requests when host is not in signed headers', async () => {
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+    const guard = ActivityPubVerifySenderGuard(handler)
+
+    const response = await guard(
+      new NextRequest(
+        'https://activities.local/api/users/alice/outbox?page=true&min_id=0',
+        {
+          method: 'GET',
+          headers: {
+            date: new Date().toUTCString(),
+            signature:
+              'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) date",signature="signature"'
+          }
+        }
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   it('rejects POST activities without a string actor', async () => {
     const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
     const guard = ActivityPubVerifySenderGuard(handler)
@@ -410,7 +431,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
@@ -432,7 +453,7 @@ describe('ActivityPubVerifySenderGuard', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(401)
     expect(handler).not.toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
@@ -506,6 +527,350 @@ describe('ActivityPubVerifySenderGuard', () => {
     expect(handler).toHaveBeenCalled()
   })
 
+  describe('freshness window', () => {
+    const fixedNow = new Date('2026-08-29T12:00:00.000Z').getTime()
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(fixedNow)
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('accepts date signed 11 hours ago (within 12h limit + 1h margin)', async () => {
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const date11hAgo = new Date(fixedNow - 11 * 60 * 60 * 1000).toUTCString()
+
+      const response = await guard(
+        createSignedRawPostRequest({
+          bodyText: JSON.stringify({
+            actor: 'https://remote.test/users/alice',
+            type: 'Follow'
+          }),
+          date: date11hAgo
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+    })
+
+    it('rejects date signed 14 hours and 1 second ago (> 12h limit + 1h margin)', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const date14h1sAgo = new Date(
+        fixedNow - (14 * 60 * 60 * 1000 + 1000)
+      ).toUTCString()
+
+      const response = await guard(
+        createSignedRawPostRequest({
+          bodyText: JSON.stringify({
+            actor: 'https://remote.test/users/alice',
+            type: 'Follow'
+          }),
+          date: date14h1sAgo
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(401)
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('accepts date signed 30 minutes in the future (within 1h future margin)', async () => {
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const date30mFuture = new Date(fixedNow + 30 * 60 * 1000).toUTCString()
+
+      const response = await guard(
+        createSignedRawPostRequest({
+          bodyText: JSON.stringify({
+            actor: 'https://remote.test/users/alice',
+            type: 'Follow'
+          }),
+          date: date30mFuture
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+    })
+
+    it('rejects date signed 2 hours in the future (> 1h future margin)', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const date2hFuture = new Date(fixedNow + 2 * 60 * 60 * 1000).toUTCString()
+
+      const response = await guard(
+        createSignedRawPostRequest({
+          bodyText: JSON.stringify({
+            actor: 'https://remote.test/users/alice',
+            type: 'Follow'
+          }),
+          date: date2hFuture
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(401)
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('accepts hs2019 (created) timestamp signed 11 hours ago', async () => {
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const created11hAgo = Math.floor((fixedNow - 11 * 60 * 60 * 1000) / 1000)
+      const bodyText = JSON.stringify({
+        actor: 'https://remote.test/users/alice',
+        type: 'Follow'
+      })
+      const digest = crypto
+        .createHash('sha256')
+        .update(bodyText)
+        .digest('base64')
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: {
+            digest: `SHA-256=${digest}`,
+            signature: `keyId="https://remote.test/users/alice#main-key",algorithm="hs2019",headers="(request-target) (created) digest",signature="sig",created=${created11hAgo}`
+          },
+          body: bodyText
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+    })
+
+    it('rejects when (expires) timestamp was in the past beyond margin', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+      const created2hAgo = Math.floor((fixedNow - 2 * 60 * 60 * 1000) / 1000)
+      const expires1h30mAgo = Math.floor(
+        (fixedNow - (1 * 60 * 60 * 1000 + 30 * 60 * 1000)) / 1000
+      )
+      const bodyText = JSON.stringify({
+        actor: 'https://remote.test/users/alice',
+        type: 'Follow'
+      })
+      const digest = crypto
+        .createHash('sha256')
+        .update(bodyText)
+        .digest('base64')
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: {
+            digest: `SHA-256=${digest}`,
+            signature: `keyId="https://remote.test/users/alice#main-key",algorithm="hs2019",headers="(request-target) (created) digest",signature="sig",created=${created2hAgo},expires=${expires1h30mAgo}`
+          },
+          body: bodyText
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(401)
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('clamps (expires) to created + 12h when expires is set far into the future', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+      // created 14 hours ago, with expires set 48h in future -> clamped effectiveExpiry = created + 12h = 2h ago.
+      // With 1h skew margin, effectiveExpiry + 1h = 1h ago, so now > effectiveExpiry + 1h -> rejected!
+      const created14hAgo = Math.floor((fixedNow - 14 * 60 * 60 * 1000) / 1000)
+      const expires48hFuture = Math.floor(
+        (fixedNow + 48 * 60 * 60 * 1000) / 1000
+      )
+      const bodyText = JSON.stringify({
+        actor: 'https://remote.test/users/alice',
+        type: 'Follow'
+      })
+      const digest = crypto
+        .createHash('sha256')
+        .update(bodyText)
+        .digest('base64')
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: {
+            digest: `SHA-256=${digest}`,
+            signature: `keyId="https://remote.test/users/alice#main-key",algorithm="hs2019",headers="(request-target) (created) digest",signature="sig",created=${created14hAgo},expires=${expires48hFuture}`
+          },
+          body: bodyText
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(401)
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unknown-actor fast-path (unknown_affected_account?)', () => {
+    it('returns 202 immediately for Delete of unknown actor without fetching public key', async () => {
+      mockGetActorFromId.mockResolvedValue(null)
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const deleteBody = {
+        id: 'https://remote.test/users/deleted-user#delete',
+        type: 'Delete',
+        actor: 'https://remote.test/users/deleted-user',
+        object: 'https://remote.test/users/deleted-user'
+      }
+
+      const response = await guard(
+        createSignedPostRequest({
+          keyId: 'https://remote.test/users/deleted-user#main-key',
+          body: deleteBody
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(handler).not.toHaveBeenCalled()
+      expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
+      expect(mockVerify).not.toHaveBeenCalled()
+    })
+
+    it('returns 202 immediately for Update of unknown actor when object is an embedded { id } object', async () => {
+      mockGetActorFromId.mockResolvedValue(null)
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const updateBody = {
+        id: 'https://remote.test/users/deleted-user#update',
+        type: 'Update',
+        actor: 'https://remote.test/users/deleted-user',
+        object: {
+          id: 'https://remote.test/users/deleted-user',
+          type: 'Person'
+        }
+      }
+
+      const response = await guard(
+        createSignedPostRequest({
+          keyId: 'https://remote.test/users/deleted-user#main-key',
+          body: updateBody
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(handler).not.toHaveBeenCalled()
+      expect(mockGetSenderPublicKeyDetails).not.toHaveBeenCalled()
+      expect(mockVerify).not.toHaveBeenCalled()
+    })
+
+    it('falls through to full verification when Delete is for a KNOWN actor in the local database', async () => {
+      mockGetActorFromId.mockResolvedValue({
+        id: 'https://remote.test/users/alice',
+        username: 'alice'
+      })
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const deleteBody = {
+        id: 'https://remote.test/users/alice#delete',
+        type: 'Delete',
+        actor: 'https://remote.test/users/alice',
+        object: 'https://remote.test/users/alice'
+      }
+
+      const response = await guard(
+        createSignedPostRequest({
+          keyId: 'https://remote.test/users/alice#main-key',
+          body: deleteBody
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockGetSenderPublicKeyDetails).toHaveBeenCalled()
+      expect(mockVerify).toHaveBeenCalled()
+      expect(handler).toHaveBeenCalled()
+    })
+
+    it('falls through to full verification when Update actor does not match object id', async () => {
+      mockGetActorFromId.mockResolvedValue(null)
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const updateNoteBody = {
+        id: 'https://remote.test/users/alice/activities/update-note',
+        type: 'Update',
+        actor: 'https://remote.test/users/alice',
+        object: 'https://remote.test/users/alice/statuses/123'
+      }
+
+      const response = await guard(
+        createSignedPostRequest({
+          keyId: 'https://remote.test/users/alice#main-key',
+          body: updateNoteBody
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockGetSenderPublicKeyDetails).toHaveBeenCalled()
+      expect(mockVerify).toHaveBeenCalled()
+      expect(handler).toHaveBeenCalled()
+    })
+  })
+
+  describe('payload cap (MAX_ACTIVITY_JSON_BYTES)', () => {
+    it('rejects with 413 when content-length exceeds 1 MB', async () => {
+      const handler = vi.fn()
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await guard(
+        new NextRequest('https://activities.local/api/inbox', {
+          method: 'POST',
+          headers: {
+            'content-length': '1048577',
+            signature:
+              'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
+          },
+          body: '{"type":"Follow"}'
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(413)
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('passes when content-length header is absent', async () => {
+      const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+      const guard = ActivityPubVerifySenderGuard(handler)
+
+      const response = await guard(
+        createSignedPostRequest({
+          body: {
+            id: 'https://remote.test/users/alice/activities/1',
+            type: 'Follow',
+            actor: 'https://remote.test/users/alice'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+    })
+  })
+
   describe('rejection trace annotations', () => {
     const runGuardInSpan = async (
       guard: ReturnType<typeof ActivityPubVerifySenderGuard>,
@@ -525,7 +890,7 @@ describe('ActivityPubVerifySenderGuard', () => {
             method: 'POST',
             headers: { host: 'activities.local' }
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'missing_signature',
         expectedAttributes: {}
       },
@@ -540,7 +905,7 @@ describe('ActivityPubVerifySenderGuard', () => {
               signature: 'algorithm="rsa-sha256",signature="signature"'
             }
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'unparseable_signature',
         expectedAttributes: {}
       },
@@ -553,13 +918,12 @@ describe('ActivityPubVerifySenderGuard', () => {
               actor: 'https://remote.test/users/alice',
               type: 'Follow'
             }),
-            signatureHeaders: '(request-target) date digest'
+            signatureHeaders: '(request-target) host date'
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'missing_signed_headers',
         expectedAttributes: {
-          'inbox.signed_headers': ['(request-target)', 'date', 'digest'],
-          'inbox.has_host_header': true
+          'inbox.signed_headers': ['(request-target)', 'host', 'date']
         }
       },
       {
@@ -573,7 +937,7 @@ describe('ActivityPubVerifySenderGuard', () => {
             }),
             date: 'Wed, 09 Nov 2022 18:28:37 GMT'
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'stale_date',
         expectedAttributes: {
           'inbox.date_header': 'Wed, 09 Nov 2022 18:28:37 GMT',
@@ -595,7 +959,7 @@ describe('ActivityPubVerifySenderGuard', () => {
             },
             body: JSON.stringify({ type: 'Follow' })
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'digest_mismatch',
         expectedAttributes: {}
       },
@@ -606,7 +970,7 @@ describe('ActivityPubVerifySenderGuard', () => {
           createSignedRawPostRequest({
             bodyText: '{"actor":"https://remote.test/users/alice",'
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'invalid_activity_body',
         expectedAttributes: {}
       },
@@ -646,7 +1010,7 @@ describe('ActivityPubVerifySenderGuard', () => {
               actor: 'https://remote.test/users/alice'
             }
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'key_unavailable',
         expectedAttributes: {
           'inbox.key_id': 'https://remote.test/users/alice#main-key'
@@ -669,7 +1033,7 @@ describe('ActivityPubVerifySenderGuard', () => {
               actor: 'https://remote.test/users/alice'
             }
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'signature_invalid',
         expectedAttributes: {
           'inbox.key_id': 'https://remote.test/users/alice#main-key'
@@ -692,7 +1056,7 @@ describe('ActivityPubVerifySenderGuard', () => {
               actor: 'https://remote.test/users/alice'
             }
           }),
-        expectedStatus: 400,
+        expectedStatus: 401,
         expectedReason: 'key_owner_unresolvable',
         expectedAttributes: {
           'inbox.key_id': 'https://remote.test/users/alice#main-key',
@@ -721,6 +1085,26 @@ describe('ActivityPubVerifySenderGuard', () => {
         expectedAttributes: {
           'inbox.verified_sender': 'https://remote.test/users/alice',
           'inbox.activity_actor': 'https://remote.test/users/mallory'
+        }
+      },
+      {
+        description: 'payload too large when content-length exceeds 1 MB',
+        setup: () => {},
+        request: () =>
+          new NextRequest('https://activities.local/api/inbox', {
+            method: 'POST',
+            headers: {
+              host: 'activities.local',
+              'content-length': '1048577',
+              signature:
+                'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
+            },
+            body: '{"type":"Follow"}'
+          }),
+        expectedStatus: 413,
+        expectedReason: 'payload_too_large',
+        expectedAttributes: {
+          'inbox.content_length': 1048577
         }
       }
     ])(
@@ -788,7 +1172,7 @@ describe('ActivityPubVerifySenderGuard', () => {
         { params: Promise.resolve({}) }
       )
 
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(401)
       expect(handler).not.toHaveBeenCalled()
     })
 
@@ -803,9 +1187,13 @@ describe('ActivityPubVerifySenderGuard', () => {
       const handler = vi.fn()
       const guard = ActivityPubVerifySenderGuard(handler)
 
+      const bodyText = JSON.stringify({
+        type: 'Follow',
+        actor: 'https://remote.test/users/alice'
+      })
       const digest = crypto
         .createHash('sha256')
-        .update('{"type":"Follow"}')
+        .update(bodyText)
         .digest('base64')
 
       const req = new NextRequest('https://activities.local/api/inbox', {
@@ -816,12 +1204,12 @@ describe('ActivityPubVerifySenderGuard', () => {
           host: 'activities.local',
           signature: `keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${secretSignature}"`
         },
-        body: '{"type":"Follow"}'
+        body: bodyText
       })
 
       const response = await runGuardInSpan(guard, req)
 
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(401)
       expect(harness.recordedSpans).toHaveLength(1)
       const serializedAttributes = JSON.stringify(
         harness.recordedSpans[0].attributes
@@ -876,7 +1264,7 @@ describe('ActivityPubVerifySenderGuard', () => {
         })
       )
 
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(401)
       expect(harness.recordedSpans).toHaveLength(1)
       expect('inbox.key_owner' in harness.recordedSpans[0].attributes).toBe(
         false
@@ -906,7 +1294,7 @@ describe('ActivityPubVerifySenderGuard', () => {
         { params: Promise.resolve({}) }
       )
 
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(401)
       expect(setAttributeSpy).not.toHaveBeenCalled()
     })
   })

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -20,7 +20,12 @@ import { headerHost } from './headerHost'
 import { annotateInboxRejection } from './inboxRejectionTrace'
 import { ActivityPubVerifiedSenderHandle, AppRouterParams } from './types'
 
-const SIGNATURE_CLOCK_SKEW_MS = 5 * 60 * 1000
+// signed_request.rb:4-5 (EXPIRATION_WINDOW_LIMIT = 12.hours, CLOCK_SKEW_MARGIN = 1.hour)
+const EXPIRATION_WINDOW_LIMIT_MS = 12 * 60 * 60 * 1000
+const CLOCK_SKEW_MARGIN_MS = 1 * 60 * 60 * 1000
+
+// activity.rb:8 (MAX_JSON_SIZE = 1.megabyte)
+const MAX_ACTIVITY_JSON_BYTES = 1024 * 1024
 
 const guardErrorResponse = (
   request: NextRequest,
@@ -48,23 +53,29 @@ const rejectRequest = (
   return guardErrorResponse(request, statusCode, allowedMethods)
 }
 
-const getSignedHeaders = (signatureParts: Record<string, string>) =>
-  (signatureParts.headers ?? '').toLowerCase().split(/\s+/).filter(Boolean)
+const getSignedHeaders = (signatureParts: Record<string, string>) => {
+  const algorithm = (signatureParts.algorithm ?? 'hs2019').toLowerCase()
+  const defaultHeaders = algorithm === 'hs2019' ? '(created)' : 'date'
+  return (signatureParts.headers ?? defaultHeaders)
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+}
 
-const REQUIRED_MUTATING_SIGNED_HEADERS = [
-  '(request-target)',
-  'host',
-  'date',
-  'digest'
-]
+const hasRequiredSignedHeaders = (signedHeaders: string[], method: string) => {
+  const upperMethod = method.toUpperCase()
+  const hasDateOrCreated =
+    signedHeaders.includes('date') || signedHeaders.includes('(created)')
+  const hasDigestOrTarget =
+    signedHeaders.includes('digest') ||
+    signedHeaders.includes('(request-target)')
 
-const isMutatingRequest = (method: string) =>
-  !['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase())
+  if (!hasDateOrCreated || !hasDigestOrTarget) return false
+  if (upperMethod === 'POST' && !signedHeaders.includes('digest')) return false
+  if (upperMethod === 'GET' && !signedHeaders.includes('host')) return false
 
-const hasRequiredMutatingSignedHeaders = (signedHeaders: string[]) =>
-  REQUIRED_MUTATING_SIGNED_HEADERS.every((header) =>
-    signedHeaders.includes(header)
-  )
+  return true
+}
 
 const getExpectedSha256Digest = (digestHeader: string) =>
   digestHeader
@@ -82,13 +93,17 @@ const getExpectedSha256Digest = (digestHeader: string) =>
     })
     .find((part) => part?.algorithm === 'sha-256')?.value
 
+type PostActivityResult =
+  | { actor: string; body: Record<string, unknown>; valid: true }
+  | { actor: null; body: null; valid: boolean }
+
 const getPostActivity = ({
   bodyText,
   method
 }: {
   bodyText: string | null
   method: string
-}) => {
+}): PostActivityResult => {
   if (method.toUpperCase() !== 'POST') {
     return { actor: null, body: null, valid: true }
   }
@@ -112,25 +127,73 @@ const getPostActivity = ({
   }
 }
 
-const isDateHeaderFresh = (
+const getSignatureTimes = (
   headers: Headers,
+  signatureParts: Record<string, string>,
+  signedHeaders: string[]
+) => {
+  const algorithm = (signatureParts.algorithm ?? 'hs2019').toLowerCase()
+  let createdTimeMs: number | null = null
+
+  if (
+    algorithm === 'hs2019' &&
+    signatureParts.created &&
+    signedHeaders.includes('(created)')
+  ) {
+    const createdSec = parseInt(signatureParts.created, 10)
+    if (!Number.isNaN(createdSec)) {
+      createdTimeMs = createdSec * 1000
+    }
+  } else if (signedHeaders.includes('date')) {
+    const dateHeader = getHeadersValue(headers, 'date')
+    if (dateHeader && !Array.isArray(dateHeader)) {
+      const parsed = Date.parse(dateHeader)
+      if (!Number.isNaN(parsed)) {
+        createdTimeMs = parsed
+      }
+    }
+  }
+
+  let expiresTimeMs: number | null = null
+  if (signatureParts.expires) {
+    const expiresSec = parseInt(signatureParts.expires, 10)
+    if (!Number.isNaN(expiresSec)) {
+      expiresTimeMs = expiresSec * 1000
+    }
+  }
+
+  return { createdTimeMs, expiresTimeMs }
+}
+
+const isSignatureFresh = (
+  headers: Headers,
+  signatureParts: Record<string, string>,
   signedHeaders: string[],
   now = Date.now()
 ) => {
-  if (!signedHeaders.includes('date')) return false
+  const { createdTimeMs, expiresTimeMs } = getSignatureTimes(
+    headers,
+    signatureParts,
+    signedHeaders
+  )
+  if (createdTimeMs === null) return false
 
-  const dateHeader = getHeadersValue(headers, 'date')
-  if (!dateHeader || Array.isArray(dateHeader)) return false
+  let effectiveExpiryMs = createdTimeMs + EXPIRATION_WINDOW_LIMIT_MS
+  if (expiresTimeMs !== null) {
+    effectiveExpiryMs = Math.min(
+      expiresTimeMs,
+      createdTimeMs + EXPIRATION_WINDOW_LIMIT_MS
+    )
+  }
 
-  const signedAt = Date.parse(dateHeader)
-  if (Number.isNaN(signedAt)) return false
+  if (createdTimeMs > now + CLOCK_SKEW_MARGIN_MS) {
+    return false
+  }
+  if (now > effectiveExpiryMs + CLOCK_SKEW_MARGIN_MS) {
+    return false
+  }
 
-  return Math.abs(now - signedAt) <= SIGNATURE_CLOCK_SKEW_MS
-}
-
-const hasHostHeader = (headers: Headers) => {
-  const host = getHeadersValue(headers, 'host')
-  return typeof host === 'string' && host.trim().length > 0
+  return true
 }
 
 const digestMatches = async (request: NextRequest, signedHeaders: string[]) => {
@@ -174,40 +237,51 @@ export const ActivityPubVerifySenderGuard =
     const database = getDatabase()
     if (!database) return guardErrorResponse(request, 500, allowedMethods)
 
+    const contentLength = request.headers.get('content-length')
+    if (contentLength !== null) {
+      const parsedContentLength = parseInt(contentLength, 10)
+      if (
+        !Number.isNaN(parsedContentLength) &&
+        parsedContentLength > MAX_ACTIVITY_JSON_BYTES
+      ) {
+        return rejectRequest(
+          request,
+          413,
+          allowedMethods,
+          'payload_too_large',
+          { content_length: parsedContentLength }
+        )
+      }
+    }
+
     const requestSignature = request.headers.get('signature')
     if (!requestSignature)
-      return rejectRequest(request, 400, allowedMethods, 'missing_signature')
+      return rejectRequest(request, 401, allowedMethods, 'missing_signature')
 
     const signatureParts = await parse(requestSignature)
     if (!signatureParts.keyId) {
       return rejectRequest(
         request,
-        400,
+        401,
         allowedMethods,
         'unparseable_signature'
       )
     }
     const signedHeaders = getSignedHeaders(signatureParts)
-    const requiresMutatingSignature = isMutatingRequest(request.method)
 
-    if (
-      requiresMutatingSignature &&
-      (!hasHostHeader(request.headers) ||
-        !hasRequiredMutatingSignedHeaders(signedHeaders))
-    ) {
+    if (!hasRequiredSignedHeaders(signedHeaders, request.method)) {
       return rejectRequest(
         request,
-        400,
+        401,
         allowedMethods,
         'missing_signed_headers',
         {
-          signed_headers: signedHeaders,
-          has_host_header: hasHostHeader(request.headers)
+          signed_headers: signedHeaders
         }
       )
     }
 
-    if (!isDateHeaderFresh(request.headers, signedHeaders)) {
+    if (!isSignatureFresh(request.headers, signatureParts, signedHeaders)) {
       const dateHeader = getHeadersValue(request.headers, 'date')
       const rawDate =
         typeof dateHeader === 'string'
@@ -216,15 +290,16 @@ export const ActivityPubVerifySenderGuard =
             ? dateHeader.join(', ')
             : undefined
 
-      return rejectRequest(request, 400, allowedMethods, 'stale_date', {
+      return rejectRequest(request, 401, allowedMethods, 'stale_date', {
         date_header: rawDate,
+        created_param: signatureParts.created,
         server_time: new Date().toISOString()
       })
     }
 
     const digestResult = await digestMatches(request, signedHeaders)
     if (!digestResult.valid) {
-      return rejectRequest(request, 400, allowedMethods, 'digest_mismatch')
+      return rejectRequest(request, 401, allowedMethods, 'digest_mismatch')
     }
 
     const activity = getPostActivity({
@@ -232,12 +307,61 @@ export const ActivityPubVerifySenderGuard =
       method: request.method
     })
     if (!activity.valid) {
+      // ActivityPub requires verifying that the HTTP signature's key owner
+      // matches the activity's actor. An unparseable or actor-less body cannot
+      // be bound to the signature, making it an authentication failure at the
+      // HTTP layer, not a malformed-body client error. Returning 401 gives
+      // compliant peers (Mastodon) a retryable signal rather than permanently
+      // dropping the activity.
       return rejectRequest(
         request,
-        400,
+        401,
         allowedMethods,
         'invalid_activity_body'
       )
+    }
+
+    // Fast-path: mirror Mastodon inboxes_controller.rb:29-38 (unknown_affected_account?)
+    // If Delete or Update of self-actor and actor does not exist in local DB,
+    // return 202 immediately before key fetch / verification.
+    if (activity.body && isRecord(activity.body) && activity.actor) {
+      const rawType = activity.body.type
+      const isDeleteOrUpdate =
+        typeof rawType === 'string'
+          ? rawType === 'Delete' || rawType === 'Update'
+          : Array.isArray(rawType) &&
+            (rawType.includes('Delete') || rawType.includes('Update'))
+
+      if (isDeleteOrUpdate) {
+        const rawObject = activity.body.object
+        const objectId =
+          typeof rawObject === 'string'
+            ? rawObject
+            : isRecord(rawObject) && typeof rawObject.id === 'string'
+              ? rawObject.id
+              : undefined
+
+        if (objectId && objectId === activity.actor) {
+          const existingActor = await database.getActorFromId({
+            id: activity.actor
+          })
+          if (!existingActor) {
+            const activityTypeStr =
+              typeof rawType === 'string'
+                ? rawType
+                : Array.isArray(rawType)
+                  ? rawType
+                      .filter((t): t is string => typeof t === 'string')
+                      .join(',')
+                  : undefined
+            annotateInboxRejection('unknown_actor_delete', {
+              actor: activity.actor,
+              activity_type: activityTypeStr
+            })
+            return guardErrorResponse(request, 202, allowedMethods)
+          }
+        }
+      }
     }
 
     if (!(await canFederateWithDomain(database, signatureParts.keyId))) {
@@ -268,7 +392,7 @@ export const ActivityPubVerifySenderGuard =
       const reason = senderPublicKey.publicKey
         ? 'signature_invalid'
         : 'key_unavailable'
-      return rejectRequest(request, 400, allowedMethods, reason, {
+      return rejectRequest(request, 401, allowedMethods, reason, {
         key_id: signatureParts.keyId
       })
     }
@@ -277,7 +401,7 @@ export const ActivityPubVerifySenderGuard =
     if (!verifiedSenderActorId) {
       return rejectRequest(
         request,
-        400,
+        401,
         allowedMethods,
         'key_owner_unresolvable',
         {

--- a/lib/utils/signature.test.ts
+++ b/lib/utils/signature.test.ts
@@ -1,315 +1,191 @@
-import { Actor } from '@/lib/types/domain/actor'
+import crypto from 'node:crypto'
+import { describe, expect, it } from 'vitest'
 
-import { generateKeyPair, parse, signedHeaders, verify } from './signature'
+import { TEST_DOMAIN } from '@/lib/stub/const'
 
-vi.mock('@/lib/config', () => ({
-  getConfig: () => ({
-    secretPhase: 'secret',
-    host: 'local.test',
-    trustedHosts: ['chat.llun.in.th', 'target.com']
+import { parse, verify } from './signature'
+
+describe('signature', () => {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   })
-}))
 
-describe('parse', () => {
-  test('split signature into parts', async () => {
-    const signature =
-      'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="signature"'
-    expect(await parse(signature)).toEqual({
-      keyId: 'https://mastodon.in.th/users/llun#main-key',
-      algorithm: 'rsa-sha256',
-      headers: '(request-target) host date digest content-type',
-      signature: 'signature'
+  const signString = (
+    stringToSign: string,
+    algorithm: 'rsa-sha256' | 'RSA-MD5' = 'rsa-sha256'
+  ) => {
+    const signer = crypto.createSign(algorithm)
+    signer.update(stringToSign)
+    signer.end()
+    return signer.sign(privateKey, 'base64')
+  }
+
+  describe('parse', () => {
+    it('parses standard quoted parameters', async () => {
+      const header =
+        'keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="sig123"'
+      const result = await parse(header)
+      expect(result).toEqual({
+        keyId: 'https://remote.test/actor#main-key',
+        algorithm: 'rsa-sha256',
+        headers: '(request-target) host date digest',
+        signature: 'sig123'
+      })
+    })
+
+    it('parses unquoted integer parameters for created and expires', async () => {
+      const header =
+        'keyId="https://remote.test/actor#main-key",algorithm="hs2019",headers="(request-target) host (created) digest",signature="sig123",created=1618884475,expires=1618888075'
+      const result = await parse(header)
+      expect(result).toEqual({
+        keyId: 'https://remote.test/actor#main-key',
+        algorithm: 'hs2019',
+        headers: '(request-target) host (created) digest',
+        signature: 'sig123',
+        created: '1618884475',
+        expires: '1618888075'
+      })
+    })
+
+    it('parses quoted created/expires parameters as well', async () => {
+      const header =
+        'keyId="https://remote.test/actor#main-key",algorithm="hs2019",created="1618884475",expires="1618888075",signature="sig123"'
+      const result = await parse(header)
+      expect(result.created).toBe('1618884475')
+      expect(result.expires).toBe('1618888075')
     })
   })
 
-  test('return empty hash for invalid signature', async () => {
-    const signature = 'invalid signature'
-    expect(await parse(signature)).toEqual({})
-  })
-})
+  describe('verify', () => {
+    const requestTarget = 'post /api/inbox'
+    const date = 'Sat, 29 Aug 2026 12:00:00 GMT'
+    const host = TEST_DOMAIN
+    const digest = 'SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
 
-describe('verify', () => {
-  it('returns true when signature and public key is matched', async () => {
-    expect(
-      await verify(
-        'post /inbox',
-        {
-          host: 'chat.llun.in.th',
-          'content-length': '2682',
-          'content-type': 'application/activity+json',
-          date: 'Wed, 09 Nov 2022 18:28:37 GMT',
-          digest: 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE=',
-          signature:
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-        },
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeTruthy()
+    it('verifies a request signed rsa-sha256 style', async () => {
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\ndate: ${date}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
 
-    expect(
-      await verify(
-        'post /inbox',
-        new Headers([
-          ['Host', 'chat.llun.in.th'],
-          ['Content-Length', '2682'],
-          ['Content-Type', 'application/activity+json'],
-          ['Date', 'Wed, 09 Nov 2022 18:28:37 GMT'],
-          ['Digest', 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE='],
-          [
-            'Signature',
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-          ]
-        ]),
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeTruthy()
-  })
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${signature}"`
+      })
 
-  it('uses trusted x-forwarded-host to verify signature instead of host', async () => {
-    expect(
-      await verify(
-        'post /inbox',
-        {
-          host: 'origin.in.cloudrun.app',
-          'content-length': '2682',
-          'content-type': 'application/activity+json',
-          date: 'Wed, 09 Nov 2022 18:28:37 GMT',
-          digest: 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE=',
-          signature:
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="',
-          'x-forwarded-host': 'chat.llun.in.th'
-        },
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeTruthy()
-  })
-
-  it('does not use untrusted x-forwarded-host to verify a signature', async () => {
-    expect(
-      await verify(
-        'post /inbox',
-        {
-          host: 'origin.in.cloudrun.app',
-          'content-length': '2682',
-          'content-type': 'application/activity+json',
-          date: 'Wed, 09 Nov 2022 18:28:37 GMT',
-          digest: 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE=',
-          signature:
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="',
-          'x-forwarded-host': 'evil.llun.in.th'
-        },
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeFalsy()
-  })
-
-  it('returns false when signature and public key is matched but header information is wrong', async () => {
-    expect(
-      await verify(
-        'post /inbox',
-        {
-          host: 'chat.llun.in.th',
-          'content-length': '2682',
-          'content-type': 'application/activity+json',
-          date: 'Wed, 09 Nov 2022 18:40:37 GMT',
-          digest: 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE=',
-          signature:
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-        },
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeFalsy()
-
-    expect(
-      await verify(
-        'post /inbox',
-        new Headers([
-          ['Host', 'chat.llun.in.th'],
-          ['Content-Length', '2682'],
-          ['Content-Type', 'application/activity+json'],
-          ['Date', 'Wed, 09 Nov 2022 18:40:37 GMT'],
-          ['Digest', 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE='],
-          [
-            'Signature',
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-          ]
-        ]),
-        '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7tttTDSVsia58AR4PQUj\nyqSlwzfQuK/nPnZ4BTWCJTRTvwWg9JXwiIjA2AnQtu/t+qOQgKdKH9yjh84SUtvD\nzAkbt1OTGIQnm5dgAPTGfS17vydxZEPsbhHmJj8UAmU59dgu8QRVl5qoYLSWZyUH\nK9ywrdTJsYkg35NjUjUapY1L7DyMygf7KDlyh0g5ezUufo1cejscbsxomvZTwLZo\nn7cxOeZMFUYw1fsJusbUgQlVHR2qox2cEC6kZGbLvJOiujs7EhRpTjkDFI/DAyNQ\nri4MFXhDg4ozjWcWiKLOsBahVp/iwEm1NF6Mwha6hPhNcInsekzrTQfy1yN7Q+y6\nzQIDAQAB\n-----END PUBLIC KEY-----\n'
-      )
-    ).toBeFalsy()
-  })
-
-  it('returns false when signature and public key is not matched', async () => {
-    expect(
-      await verify(
-        'post /inbox',
-        {
-          host: 'chat.llun.in.th',
-          'content-length': '2682',
-          'content-type': 'application/activity+json',
-          date: 'Wed, 09 Nov 2022 18:28:37 GMT',
-          digest: 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE=',
-          signature:
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-        },
-        'Invalid key'
-      )
-    ).toBeFalsy()
-
-    expect(
-      await verify(
-        'post /inbox',
-        new Headers([
-          ['Host', 'chat.llun.in.th'],
-          ['Content-Length', '2682'],
-          ['Content-Type', 'application/activity+json'],
-          ['Date', 'Wed, 09 Nov 2022 18:28:37 GMT'],
-          ['Digest', 'SHA-256=ldMA8wZIOUKqGDCdTT9/43jSnnrgO6G3t7zmtphXqyE='],
-          [
-            'Signature',
-            'keyId="https://mastodon.in.th/users/llun#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest content-type",signature="Wx+tR4y1A67nF2fFWOlj8Enx5pzFN3jCo6UB7rpPGTZy0nM4EvuFq1BZgGS08eZJBi+Yf60R1284+YXNQDtkdXM7s66wZQKcmfyKsfSHJGyW5DAQzmxFzCHC/cwTSktCyRc36jUh4OWzKr8wA8vIzexMhTlH5oSOKrTaxPbUzH6vq/uM71oC7fNL29GjZiSJL6q87fPQuKvS7UB0mzBpGb+VfAo7yAp/apMbBXX8iqYL73tJhuTQB5TIOF7GxXLUk6FJ2I7nRQEZXj0/qHA/NISelSNST3ivVH2F1VzeP22K/YPLRSY6zl42JUX3e0zQE4Dln0RvYT971Bw2sMqlig=="'
-          ]
-        ]),
-        'Invalid key'
-      )
-    ).toBeFalsy()
-  })
-})
-
-describe('signedHeaders', () => {
-  let keyPair: Awaited<ReturnType<typeof generateKeyPair>>
-
-  beforeAll(async () => {
-    keyPair = await generateKeyPair('secret')
-  }, 15000)
-
-  it('includes headers for POST request', async () => {
-    const actor = {
-      id: 'https://test.com/actor',
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey
-    } as Actor
-
-    const headers = signedHeaders(actor, 'POST', 'https://target.com/inbox', {
-      type: 'Note',
-      content: 'test'
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(true)
     })
 
-    expect(headers.digest).toBeDefined()
-    expect(headers['content-type']).toBe('application/activity+json')
-    expect(headers.signature).toContain(
-      'headers="(request-target) host date digest content-type"'
-    )
+    it('verifies a request signed hs2019 style with unquoted (created) pseudo-header', async () => {
+      const created = '1618884475'
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\n(created): ${created}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
 
-    const verifyResult = await verify(
-      'post /inbox',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(verifyResult).toBeTruthy()
-  }, 15000)
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="hs2019",headers="(request-target) host (created) digest",signature="${signature}",created=${created}`
+      })
 
-  it('includes headers for GET request', async () => {
-    const actor = {
-      id: 'https://test.com/actor',
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey
-    } as Actor
-
-    const headers = signedHeaders(actor, 'GET', 'https://target.com/inbox')
-
-    expect(headers.digest).toBeUndefined()
-    expect(headers['content-type']).toBeUndefined()
-    expect(headers.signature).toContain('headers="(request-target) host date"')
-
-    const verifyResult = await verify(
-      'get /inbox',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(verifyResult).toBeTruthy()
-  }, 15000)
-
-  it('uses only the path for GET request targets without query strings', async () => {
-    const actor = {
-      id: 'https://test.com/actor',
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey
-    } as Actor
-
-    const headers = signedHeaders(actor, 'GET', 'https://target.com/outbox')
-
-    const verifyResult = await verify(
-      'get /outbox',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(verifyResult).toBeTruthy()
-  }, 15000)
-
-  it('includes query strings in GET request targets', async () => {
-    const actor = {
-      id: 'https://test.com/actor',
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey
-    } as Actor
-
-    const headers = signedHeaders(
-      actor,
-      'GET',
-      'https://target.com/outbox?page=true&min_id=0'
-    )
-
-    const verifyResult = await verify(
-      'get /outbox?page=true&min_id=0',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(verifyResult).toBeTruthy()
-
-    const missingQueryVerifyResult = await verify(
-      'get /outbox',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(missingQueryVerifyResult).toBeFalsy()
-  }, 15000)
-
-  it('rejects signatures over a different request-target', async () => {
-    const actor = {
-      id: 'https://test.com/actor',
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey
-    } as Actor
-
-    const headers = signedHeaders(actor, 'POST', 'https://target.com/wrong', {
-      type: 'Note',
-      content: 'test'
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(true)
     })
 
-    const verifyResult = await verify(
-      'post /inbox',
-      {
-        ...headers,
-        signature: headers.signature as string
-      },
-      keyPair.publicKey
-    )
-    expect(verifyResult).toBeFalsy()
-  }, 15000)
+    it('defaults missing algorithm to hs2019 and verifies correctly', async () => {
+      const created = '1618884475'
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\n(created): ${created}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
+
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",headers="(request-target) host (created) digest",signature="${signature}",created=${created}`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(true)
+    })
+
+    it('fails verification when algorithm is not in allowlist (algorithm downgrade defense)', async () => {
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\ndate: ${date}\ndigest: ${digest}`
+      const md5Signature = signString(stringToSign, 'RSA-MD5')
+
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-md5",headers="(request-target) host date digest",signature="${md5Signature}"`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(false)
+    })
+
+    it('fails verification if (created) pseudo-header is present with rsa-sha256', async () => {
+      const created = '1618884475'
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\n(created): ${created}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
+
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host (created) digest",signature="${signature}",created=${created}`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(false)
+    })
+
+    it('fails verification if (expires) pseudo-header is present with rsa-sha256', async () => {
+      const expires = '1618888075'
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\n(expires): ${expires}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
+
+      const headers = new Headers({
+        date,
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host (expires) digest",signature="${signature}",expires=${expires}`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(false)
+    })
+
+    it('fails verification if body/digest is tampered', async () => {
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\ndate: ${date}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
+
+      const headers = new Headers({
+        date,
+        digest: 'SHA-256=tampereddigesttampereddigesttampereddigest===',
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${signature}"`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(false)
+    })
+
+    it('fails verification if date is tampered', async () => {
+      const stringToSign = `(request-target): ${requestTarget}\nhost: ${host}\ndate: ${date}\ndigest: ${digest}`
+      const signature = signString(stringToSign, 'rsa-sha256')
+
+      const headers = new Headers({
+        date: 'Sun, 30 Aug 2026 12:00:00 GMT',
+        digest,
+        host,
+        signature: `keyId="https://remote.test/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${signature}"`
+      })
+
+      const isValid = await verify(requestTarget, headers, publicKey)
+      expect(isValid).toBe(false)
+    })
+  })
 })

--- a/lib/utils/signature.ts
+++ b/lib/utils/signature.ts
@@ -17,10 +17,10 @@ export type SignedHttpMethod = 'GET' | 'POST'
 export async function parse(signature: string): Promise<StringMap> {
   try {
     const result: StringMap = {}
-    const regex = /([a-zA-Z0-9]+)="([^"]*)"/g
+    const regex = /([a-zA-Z0-9_-]+)\s*=\s*(?:"([^"]*)"|([^,;\s]+))/g
     let match
     while ((match = regex.exec(signature)) !== null) {
-      result[match[1]] = match[2]
+      result[match[1]] = match[2] !== undefined ? match[2] : match[3]
     }
     return result
   } catch {
@@ -34,28 +34,62 @@ export async function verify(
   publicKey: string
 ) {
   return withSpan('signature', 'verify', { requestTarget }, async () => {
-    const requestSignature = getHeadersValue(headers, 'signature')
-    const parsedSignature = await parse(requestSignature as string)
-    if (!parsedSignature.headers) {
-      return false
-    }
-
-    const comparedSignedString = parsedSignature.headers
-      .split(' ')
-      .map((item) => {
-        if (item === '(request-target)') {
-          return `(request-target): ${requestTarget}`
-        }
-        if (item === 'host') {
-          return `${item}: ${headerHost(headers)}`
-        }
-        return `${item}: ${getHeadersValue(headers, item)}`
-      })
-      .join('\n')
-    const signature = parsedSignature.signature
-    const verifier = crypto.createVerify(parsedSignature.algorithm)
-    verifier.update(comparedSignedString)
     try {
+      const requestSignature = getHeadersValue(headers, 'signature')
+      if (!requestSignature || typeof requestSignature !== 'string') {
+        return false
+      }
+      const signatureParts = await parse(requestSignature)
+      const algorithm = (signatureParts.algorithm ?? 'hs2019').toLowerCase()
+      if (algorithm !== 'rsa-sha256' && algorithm !== 'hs2019') {
+        return false
+      }
+
+      const defaultHeaders = algorithm === 'hs2019' ? '(created)' : 'date'
+      const headersList = (signatureParts.headers ?? defaultHeaders)
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean)
+
+      if (headersList.length === 0) {
+        return false
+      }
+
+      const signedHeaderLines: string[] = []
+      for (const item of headersList) {
+        if (item === '(request-target)') {
+          signedHeaderLines.push(`(request-target): ${requestTarget}`)
+        } else if (item === 'host') {
+          signedHeaderLines.push(`host: ${headerHost(headers)}`)
+        } else if (item === '(created)') {
+          if (algorithm !== 'hs2019' || !signatureParts.created) {
+            return false
+          }
+          signedHeaderLines.push(`(created): ${signatureParts.created}`)
+        } else if (item === '(expires)') {
+          if (algorithm !== 'hs2019' || !signatureParts.expires) {
+            return false
+          }
+          signedHeaderLines.push(`(expires): ${signatureParts.expires}`)
+        } else {
+          const headerValue = getHeadersValue(headers, item)
+          if (headerValue === undefined) {
+            return false
+          }
+          signedHeaderLines.push(
+            `${item}: ${Array.isArray(headerValue) ? headerValue.join(', ') : headerValue}`
+          )
+        }
+      }
+
+      const comparedSignedString = signedHeaderLines.join('\n')
+      const signature = signatureParts.signature
+      if (!signature) {
+        return false
+      }
+
+      const verifier = crypto.createVerify('rsa-sha256')
+      verifier.update(comparedSignedString)
       return verifier.verify(publicKey, signature, 'base64')
     } catch {
       return false


### PR DESCRIPTION
## Summary

Aligns the ActivityPub inbox endpoints (`POST /api/inbox` and `POST /api/users/[username]/inbox`) with Mastodon's inbox behavior to eliminate 400 rejections that caused remote peers (primarily Mastodon instances) to treat deliveries as unsalvageable and mark inboxes as unavailable.

### Key Changes
1. **HTTP Signature Verification & Error Mapping (`lib/utils/signature.ts`, `lib/services/guards/ActivityPubVerifyGuard.ts`)**:
   - Return `401 Unauthorized` instead of `400 Bad Request` on signature verification failures, missing signatures, stale dates, digest mismatches, and unfetchable keys (`signature_verification.rb:39-40, 108`).
   - Support `hs2019` algorithm defaulting and unquoted integer parameter parsing (`created=...`, `expires=...`).
   - Implement a 12-hour freshness window with 1-hour clock skew tolerance (`signed_request.rb:4-5, 44-53`).
   - Support fast-path `202 Accepted` response for `Delete`/`Update` activities targeting unknown accounts (`inboxes_controller.rb:29-38`).
   - Enforce 1 MB payload size limit returning `413 Payload Too Large`.

2. **Acceptance & Routing Semantics (`app/api/inbox/route.ts`, `app/api/users/[username]/inbox/route.ts`)**:
   - Shared inbox returns `202 Accepted` (`DEFAULT_202`) with `inbox.reject_reason = 'unsupported_activity_shape'` when an activity does not match known job handlers instead of `404 Not Found`.
   - Per-user inbox routes incoming status-level activities (`Create`, `Update`, `Delete`, `Announce`, `Undo` of Announce) to the shared job queue with `202 Accepted`, matching shared inbox behavior.
   - Per-user inbox returns `202 Accepted` when schema validation fails for unrecognized third-party activity shapes (`logAcceptedWithoutSideEffects`) instead of `400 Bad Request`.
   - Per-user inbox returns `500 Internal Server Error` on unexpected handler exceptions with full stack trace logging instead of `400 Bad Request`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)