### PR TITLE
Bump version to v1.149.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.16",
+  "version": "1.149.17",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.17.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.16`
- Base main SHA: `0026ce4d772a592d079612e7f51036026678295b`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
