### PR TITLE
fix: support Cloud Run serviceContext and robust stack trace extraction in logger

### DIFF
--- a/lib/utils/logger.test.ts
+++ b/lib/utils/logger.test.ts
@@ -44,8 +44,42 @@ describe('logger configuration and GCP formatters', () => {
     expect(bindings.serviceContext?.version).toBe(VERSION)
   })
 
-  it('formats severity and Error Reporting type when running in GCP', async () => {
-    process.env.K_SERVICE = 'test-service'
+  it('respects LOG_LEVEL environment variable', async () => {
+    process.env.LOG_LEVEL = 'debug'
+
+    const { logger } = await import('@/lib/utils/logger')
+    expect(logger.level).toBe('debug')
+  })
+
+  it('formats standard level object when not running in GCP', async () => {
+    delete process.env.K_SERVICE
+    delete process.env.GOOGLE_CLOUD_PROJECT
+    const logs: string[] = []
+
+    const { getLoggerOptions } = await import('@/lib/utils/logger')
+    const destination = {
+      write(chunk: string) {
+        logs.push(chunk)
+      }
+    }
+    const testLogger = pino(getLoggerOptions(), destination)
+
+    testLogger.warn('Non-GCP warning')
+    const warnEntry = JSON.parse(logs[0])
+    expect(warnEntry.level).toBe('warn')
+    expect(warnEntry.severity).toBeUndefined()
+    expect(warnEntry['@type']).toBeUndefined()
+
+    testLogger.error('Non-GCP error')
+    const errorEntry = JSON.parse(logs[1])
+    expect(errorEntry.level).toBe('error')
+    expect(errorEntry.severity).toBeUndefined()
+    expect(errorEntry['@type']).toBeUndefined()
+  })
+
+  it('formats severity and Error Reporting type when running in GCP via K_SERVICE or GOOGLE_CLOUD_PROJECT', async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'my-gcp-project'
+    delete process.env.K_SERVICE
     const logs: string[] = []
 
     const { getLoggerOptions } = await import('@/lib/utils/logger')

--- a/lib/utils/logger.test.ts
+++ b/lib/utils/logger.test.ts
@@ -1,0 +1,102 @@
+import pino from 'pino'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { VERSION } from '@/lib/utils/version'
+
+describe('logger configuration and GCP formatters', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.resetModules()
+  })
+
+  it('configures serviceContext with Cloud Run environment variables when present', async () => {
+    process.env.K_SERVICE = 'my-cloudrun-service'
+    process.env.K_REVISION = 'my-cloudrun-service-00001-abc'
+
+    const { logger } = await import('@/lib/utils/logger')
+    const bindings = logger.bindings() as {
+      serviceContext?: { service: string; version: string }
+    }
+
+    expect(bindings.serviceContext?.service).toBe('my-cloudrun-service')
+    expect(bindings.serviceContext?.version).toBe(
+      'my-cloudrun-service-00001-abc'
+    )
+  })
+
+  it('falls back to default service name and version when Cloud Run variables are unset', async () => {
+    delete process.env.K_SERVICE
+    delete process.env.K_REVISION
+
+    const { logger } = await import('@/lib/utils/logger')
+    const bindings = logger.bindings() as {
+      serviceContext?: { service: string; version: string }
+    }
+
+    expect(bindings.serviceContext?.service).toBe('activities.next')
+    expect(bindings.serviceContext?.version).toBe(VERSION)
+  })
+
+  it('formats severity and Error Reporting type when running in GCP', async () => {
+    process.env.K_SERVICE = 'test-service'
+    const logs: string[] = []
+
+    const { getLoggerOptions } = await import('@/lib/utils/logger')
+    const destination = {
+      write(chunk: string) {
+        logs.push(chunk)
+      }
+    }
+    const testLogger = pino(getLoggerOptions(), destination)
+
+    testLogger.warn('A warning message')
+    const warnEntry = JSON.parse(logs[0])
+    expect(warnEntry.severity).toBe('WARNING')
+    expect(warnEntry['@type']).toBeUndefined()
+
+    testLogger.error(new Error('An error occurred'), 'Operation failed')
+    const errorEntry = JSON.parse(logs[1])
+    expect(errorEntry.severity).toBe('ERROR')
+    expect(errorEntry['@type']).toBe(
+      'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent'
+    )
+    expect(errorEntry.stack_trace).toBeDefined()
+  })
+
+  it('extracts stack_trace from err, error, and direct stack properties', async () => {
+    process.env.K_SERVICE = 'test-service'
+    const logs: string[] = []
+
+    const { getLoggerOptions } = await import('@/lib/utils/logger')
+    const destination = {
+      write(chunk: string) {
+        logs.push(chunk)
+      }
+    }
+    const testLogger = pino(getLoggerOptions(), destination)
+
+    const testError = new Error('Test failure')
+
+    testLogger.error({ err: testError, message: 'Failed with err' })
+    const entryWithErr = JSON.parse(logs[0])
+    expect(entryWithErr.stack_trace).toBe(testError.stack)
+
+    testLogger.error({ error: testError, message: 'Failed with error' })
+    const entryWithError = JSON.parse(logs[1])
+    expect(entryWithError.stack_trace).toBe(testError.stack)
+
+    testLogger.error({
+      stack: 'custom-stack-trace',
+      message: 'Failed with stack'
+    })
+    const entryWithStack = JSON.parse(logs[2])
+    expect(entryWithStack.stack_trace).toBe('custom-stack-trace')
+  })
+})

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -1,8 +1,8 @@
-import pino, { Level } from 'pino'
+import pino, { Level, LoggerOptions } from 'pino'
 
 import { VERSION } from '@/lib/utils/version'
 
-const levelToSeverity: Record<string, string> = {
+export const levelToSeverity: Record<string, string> = {
   trace: 'DEBUG',
   debug: 'DEBUG',
   info: 'INFO',
@@ -11,57 +11,72 @@ const levelToSeverity: Record<string, string> = {
   fatal: 'CRITICAL'
 }
 
-// Detect if running in GCP Cloud Run or other production environments
-const isGCP = Boolean(process.env.K_SERVICE || process.env.GOOGLE_CLOUD_PROJECT)
-const isDevelopment = process.env.NODE_ENV === 'development'
+export const getLoggerOptions = (): LoggerOptions => {
+  // Detect if running in GCP Cloud Run or other production environments
+  const isGCP = Boolean(
+    process.env.K_SERVICE || process.env.GOOGLE_CLOUD_PROJECT
+  )
+  const isDevelopment = process.env.NODE_ENV === 'development'
 
-const logger = pino({
-  enabled: true,
-  level: process.env.LOG_LEVEL ?? 'info',
-  base: {
-    serviceContext: {
-      service: 'activities.next',
-      version: VERSION
-    }
-  },
-  messageKey: 'message',
-  // Use pretty printing for local development, structured JSON for GCP
-  transport:
-    !isGCP && isDevelopment
-      ? {
-          target: 'pino-pretty',
-          options: {
-            colorize: true,
-            translateTime: 'HH:MM:ss',
-            ignore: 'pid,hostname,serviceContext'
-          }
-        }
-      : undefined,
-  formatters: {
-    level(label: string) {
-      // Only use GCP format when running in GCP
-      if (!isGCP) {
-        return { level: label }
+  return {
+    enabled: true,
+    level: process.env.LOG_LEVEL ?? 'info',
+    base: {
+      serviceContext: {
+        service: process.env.K_SERVICE || 'activities.next',
+        version: process.env.K_REVISION || VERSION
       }
-      const pinoLevel = label as Level
-      const severity = levelToSeverity[label] ?? 'INFO'
-      const typeProp =
-        pinoLevel === 'error' || pinoLevel === 'fatal'
-          ? {
-              '@type':
-                'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent'
-            }
-          : {}
-      return { severity, ...typeProp }
     },
+    messageKey: 'message',
+    // Use pretty printing for local development, structured JSON for GCP
+    transport:
+      !isGCP && isDevelopment
+        ? {
+            target: 'pino-pretty',
+            options: {
+              colorize: true,
+              translateTime: 'HH:MM:ss',
+              ignore: 'pid,hostname,serviceContext'
+            }
+          }
+        : undefined,
+    formatters: {
+      level(label: string) {
+        // Only use GCP format when running in GCP
+        if (!isGCP) {
+          return { level: label }
+        }
+        const pinoLevel = label as Level
+        const severity = levelToSeverity[label] ?? 'INFO'
+        const typeProp =
+          pinoLevel === 'error' || pinoLevel === 'fatal'
+            ? {
+                '@type':
+                  'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent'
+              }
+            : {}
+        return { severity, ...typeProp }
+      },
 
-    log(object) {
-      const logObject = object as { err?: Error }
-      const stackTrace = logObject.err?.stack
-      const stackProp = stackTrace ? { stack_trace: stackTrace } : {}
-      return { ...object, ...stackProp }
+      log(object) {
+        const logObject = object as {
+          err?: Error
+          error?: unknown
+          stack?: string
+        }
+        const errStack =
+          logObject.err?.stack ??
+          (logObject.error instanceof Error
+            ? logObject.error.stack
+            : undefined) ??
+          logObject.stack
+        const stackProp = errStack ? { stack_trace: errStack } : {}
+        return { ...object, ...stackProp }
+      }
     }
   }
-})
+}
+
+const logger = pino(getLoggerOptions())
 
 export { logger }


### PR DESCRIPTION
## Summary

- Bind `serviceContext.service` to `process.env.K_SERVICE || 'activities.next'` and `serviceContext.version` to `process.env.K_REVISION || VERSION` in `lib/utils/logger.ts`. When deployed to Cloud Run, this ensures Error Reporting groups error events under the exact Cloud Run service name shown in the Cloud Run Observability console rather than defaulting to the static `activities.next` string.
- Enhance the `log(object)` formatter in `logger.ts` to extract `stack_trace` from `err`, `error` (when an Error instance is provided), or `stack` properties. This ensures errors passed to `logger.error` are recognized and grouped by Google Cloud Error Reporting.
- Add unit tests in `lib/utils/logger.test.ts` covering Cloud Run environment variables fallback, GCP severity mapping, `@type` metadata, and stack trace formatting.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)