### PR TITLE
Bump version to v1.149.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.17",
+  "version": "1.149.18",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.18.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.17`
- Base main SHA: `63ae17dbfb8ca539d500f2c0366ed53a1e6fd0c7`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
