### PR TITLE
fix: stamp rejection reasons on all ActivityPub inbox failure spans

### DIFF
--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
+
 import { POST } from './route'
 
 const mockCanFederateWithDomain = vi.fn()
@@ -15,6 +17,20 @@ const mockDefaultActivityBody = Symbol('defaultActivityBody')
 let mockActivityBody: unknown = mockDefaultActivityBody
 let mockConsumeRequestBody = false
 let mockVerifiedSenderActorId = 'https://allowed.test/users/a'
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis()
+  }
+}))
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: mockLogger
+}))
 
 vi.mock('@/lib/services/federation/domainPolicy', () => ({
   canFederateWithDomain: (...params: unknown[]) =>
@@ -92,13 +108,20 @@ const createRequest = (actor: unknown) => {
 }
 
 describe('POST /api/inbox', () => {
+  let harness: ReturnType<typeof setupRecordingTracer>
+
   beforeEach(() => {
+    harness = setupRecordingTracer()
     vi.clearAllMocks()
     mockActivityBody = mockDefaultActivityBody
     mockConsumeRequestBody = false
     mockVerifiedSenderActorId = 'https://allowed.test/users/a'
     mockGetRelayByActorId.mockResolvedValue(null)
     mockGetModerationStatesForActors.mockResolvedValue(new Map())
+  })
+
+  afterEach(() => {
+    harness.cleanup()
   })
 
   describe('suspended remote sender', () => {
@@ -211,6 +234,13 @@ describe('POST /api/inbox', () => {
 
     expect(response.status).toBe(403)
     expect(mockPublish).not.toHaveBeenCalled()
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].name).toBe('api.sharedInbox')
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'domain_not_federatable',
+      'inbox.actor_id': 'https://blocked.test/users/a',
+      'inbox.sender_actor_id': 'https://allowed.test/users/a'
+    })
   })
 
   it.each([undefined, null, '', 42, {}])(
@@ -223,6 +253,12 @@ describe('POST /api/inbox', () => {
       expect(response.status).toBe(400)
       expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
       expect(mockPublish).not.toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].name).toBe('api.sharedInbox')
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'inbox.reject_reason': 'invalid_activity_body',
+        'inbox.sender_actor_id': 'https://allowed.test/users/a'
+      })
     }
   )
 
@@ -243,6 +279,10 @@ describe('POST /api/inbox', () => {
     expect(response.status).toBe(400)
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockPublish).not.toHaveBeenCalled()
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'invalid_activity_body'
+    })
   })
 
   it('uses the verified guard activity body after the request body is consumed', async () => {
@@ -269,6 +309,9 @@ describe('POST /api/inbox', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'CreateNoteJob' })
     )
+    expect(
+      harness.recordedSpans[0].attributes['inbox.reject_reason']
+    ).toBeUndefined()
   })
 
   it('enqueues activities whose actor is an object with an id', async () => {
@@ -374,5 +417,41 @@ describe('POST /api/inbox', () => {
 
     expect(response.status).toBe(202)
     expect(mockPublish).not.toHaveBeenCalled()
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].name).toBe('api.sharedInbox')
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'unsupported_activity_shape',
+      'inbox.activity_id': `${actor}/activities/unsupported-1`,
+      'inbox.activity_type': 'Dislike',
+      'inbox.sender_actor_id': actor
+    })
+  })
+
+  it('records exception, reject reason, and logs error when shared inbox handler throws', async () => {
+    mockPublish.mockRejectedValue(new Error('queue publish failed'))
+    mockCanFederateWithDomain.mockResolvedValue(true)
+
+    const response = await POST(createRequest('https://allowed.test/users/a'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(400)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].name).toBe('api.sharedInbox')
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'handler_exception',
+      'inbox.sender_actor_id': 'https://allowed.test/users/a'
+    })
+    expect(harness.recordedSpans[0].exception).toEqual(
+      new Error('queue publish failed')
+    )
+    expect(mockLogger.error).toHaveBeenCalledWith({
+      err: expect.any(Error),
+      message: 'Shared inbox handler threw',
+      senderActorId: 'https://allowed.test/users/a'
+    })
+    expect(mockLogger.error.mock.calls[0][0].err.message).toBe(
+      'queue publish failed'
+    )
   })
 })

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api'
+
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { StatusActivity } from '@/lib/activities/statusAction'
 import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
@@ -9,6 +11,7 @@ import { AnnounceAction } from '@/lib/types/activitypub/activities'
 import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   DEFAULT_202,
   ERROR_400,
@@ -16,6 +19,7 @@ import {
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { isRecord } from '@/lib/utils/typeGuards'
 
@@ -29,81 +33,59 @@ export const POST = traceApiRoute(
   'sharedInbox',
   ActivityPubVerifySenderGuard(
     async (request, { activityBody, database, verifiedSenderActorId }) => {
-      // Canonicalise the activity (and its embedded object) via JSON-LD
-      // compaction before matching on `type`/`object.type`, so dialect
-      // variations (array/IRI types, single vs array recipients, inline id
-      // references) collapse to the predictable shape the job matcher expects.
-      const body = await compactActivityPub(activityBody)
-      // Validate the sender identity from the original (pre-compaction) body. A
-      // malformed `actor` (empty string, number, bare object) must be rejected
-      // as a bad request rather than turned into a relative-reference artifact
-      // (e.g. `./`) by compaction's IRI resolution.
-      const actor = isRecord(activityBody)
-        ? extractActivityPubId(activityBody.actor)
-        : undefined
+      try {
+        // Canonicalise the activity (and its embedded object) via JSON-LD
+        // compaction before matching on `type`/`object.type`, so dialect
+        // variations (array/IRI types, single vs array recipients, inline id
+        // references) collapse to the predictable shape the job matcher expects.
+        const body = await compactActivityPub(activityBody)
+        // Validate the sender identity from the original (pre-compaction) body. A
+        // malformed `actor` (empty string, number, bare object) must be rejected
+        // as a bad request rather than turned into a relative-reference artifact
+        // (e.g. `./`) by compaction's IRI resolution.
+        const actor = isRecord(activityBody)
+          ? extractActivityPubId(activityBody.actor)
+          : undefined
 
-      // The guard enforces signed POST actors; keep route validation before casting unknown JSON.
-      if (
-        !isRecord(body) ||
-        typeof body.id !== 'string' ||
-        typeof body.type !== 'string' ||
-        !actor ||
-        !normalizeActorId(actor)
-      ) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
-        })
-      }
-      const activity = { ...body, actor } as unknown as StatusActivity
-      if (!(await canFederateWithDomain(database, activity.actor))) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_403,
-          responseStatusCode: 403
-        })
-      }
+        // The guard enforces signed POST actors; keep route validation before casting unknown JSON.
+        if (
+          !isRecord(body) ||
+          typeof body.id !== 'string' ||
+          typeof body.type !== 'string' ||
+          !actor ||
+          !normalizeActorId(actor)
+        ) {
+          annotateInboxRejection('invalid_activity_body', {
+            sender_actor_id: verifiedSenderActorId
+          })
+          return apiResponse({
+            req: request,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_400,
+            responseStatusCode: 400
+          })
+        }
+        const activity = { ...body, actor } as unknown as StatusActivity
+        if (!(await canFederateWithDomain(database, activity.actor))) {
+          annotateInboxRejection('domain_not_federatable', {
+            actor_id: activity.actor,
+            sender_actor_id: verifiedSenderActorId
+          })
+          return apiResponse({
+            req: request,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_403,
+            responseStatusCode: 403
+          })
+        }
 
-      // Swallow activities from a suspended remote actor: acknowledge with 202
-      // but never queue them. A 403 would leak the moderation decision back to
-      // the sender.
-      const senderStates = await database.getModerationStatesForActors({
-        actorIds: [verifiedSenderActorId]
-      })
-      if (senderStates.get(verifiedSenderActorId)?.suspendedAt) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: DEFAULT_202,
-          responseStatusCode: 202
+        // Swallow activities from a suspended remote actor: acknowledge with 202
+        // but never queue them. A 403 would leak the moderation decision back to
+        // the sender.
+        const senderStates = await database.getModerationStatesForActors({
+          actorIds: [verifiedSenderActorId]
         })
-      }
-
-      // A relay forwards third-party posts as an Announce signed by the relay
-      // itself (so the signer === actor check already passed). When the verified
-      // sender is an accepted relay, route its Announce to the relay-ingest job
-      // (which re-fetches the wrapped note from origin and federates it) instead
-      // of the normal boost path — we never want a relay-attributed Announce row.
-      if (activity.type === AnnounceAction) {
-        const relay = await database.getRelayByActorId({
-          actorId: verifiedSenderActorId
-        })
-        // Any Announce from a KNOWN relay is relay traffic, never a normal
-        // boost. Accepted relays are ingested into the Federated timeline; a
-        // known-but-not-accepted relay (pending/rejected/unsubscribed) is
-        // acknowledged without falling through to the boost path, so it can
-        // never create a relay-attributed Announce row.
-        if (relay) {
-          if (relay.state === 'accepted') {
-            await getQueue().publish({
-              id: getHashFromString(activity.id),
-              name: RELAY_ANNOUNCE_JOB_NAME,
-              data: activity
-            })
-          }
+        if (senderStates.get(verifiedSenderActorId)?.suspendedAt) {
           return apiResponse({
             req: request,
             allowedMethods: CORS_HEADERS,
@@ -111,26 +93,79 @@ export const POST = traceApiRoute(
             responseStatusCode: 202
           })
         }
-      }
 
-      const jobMessage = getJobMessage(activity, verifiedSenderActorId)
-      if (!jobMessage) {
-        annotateInboxRejection('unsupported_activity_shape')
+        // A relay forwards third-party posts as an Announce signed by the relay
+        // itself (so the signer === actor check already passed). When the verified
+        // sender is an accepted relay, route its Announce to the relay-ingest job
+        // (which re-fetches the wrapped note from origin and federates it) instead
+        // of the normal boost path — we never want a relay-attributed Announce row.
+        if (activity.type === AnnounceAction) {
+          const relay = await database.getRelayByActorId({
+            actorId: verifiedSenderActorId
+          })
+          // Any Announce from a KNOWN relay is relay traffic, never a normal
+          // boost. Accepted relays are ingested into the Federated timeline; a
+          // known-but-not-accepted relay (pending/rejected/unsubscribed) is
+          // acknowledged without falling through to the boost path, so it can
+          // never create a relay-attributed Announce row.
+          if (relay) {
+            if (relay.state === 'accepted') {
+              await getQueue().publish({
+                id: getHashFromString(activity.id),
+                name: RELAY_ANNOUNCE_JOB_NAME,
+                data: activity
+              })
+            }
+            return apiResponse({
+              req: request,
+              allowedMethods: CORS_HEADERS,
+              data: DEFAULT_202,
+              responseStatusCode: 202
+            })
+          }
+        }
+
+        const jobMessage = getJobMessage(activity, verifiedSenderActorId)
+        if (!jobMessage) {
+          annotateInboxRejection('unsupported_activity_shape', {
+            activity_id: activity.id,
+            activity_type: activity.type,
+            sender_actor_id: verifiedSenderActorId
+          })
+          return apiResponse({
+            req: request,
+            allowedMethods: CORS_HEADERS,
+            data: DEFAULT_202,
+            responseStatusCode: 202
+          })
+        }
+
+        await getQueue().publish(jobMessage)
         return apiResponse({
           req: request,
           allowedMethods: CORS_HEADERS,
           data: DEFAULT_202,
           responseStatusCode: 202
         })
+      } catch (error) {
+        const span = trace.getActiveSpan()
+        const err = error instanceof Error ? error : new Error(String(error))
+        span?.recordException(err)
+        annotateInboxRejection('handler_exception', {
+          sender_actor_id: verifiedSenderActorId
+        })
+        logger.error({
+          err: toLoggableError(error),
+          message: 'Shared inbox handler threw',
+          senderActorId: verifiedSenderActorId
+        })
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
       }
-
-      await getQueue().publish(jobMessage)
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: DEFAULT_202,
-        responseStatusCode: 202
-      })
     },
     CORS_HEADERS
   )

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -206,6 +206,10 @@ export const POST = traceApiRoute(
                 : context.verifiedSenderActorId
 
             if (!(await canFederateWithDomain(database, activityActor))) {
+              annotateInboxRejection('domain_not_federatable', {
+                actor_id: activityActor,
+                sender_actor_id: context.verifiedSenderActorId
+              })
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
@@ -328,13 +332,18 @@ export const POST = traceApiRoute(
                   activity: acceptFollow.data,
                   database
                 })
-                if (!follow)
+                if (!follow) {
+                  annotateInboxRejection('follow_request_not_found', {
+                    activity_id: activity.id,
+                    sender_actor_id: context.verifiedSenderActorId
+                  })
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
                     data: ERROR_404,
                     responseStatusCode: 404
                   })
+                }
                 return apiResponse({
                   req,
                   allowedMethods: CORS_HEADERS,
@@ -375,13 +384,18 @@ export const POST = traceApiRoute(
                   activity: rejectFollow.data,
                   database
                 })
-                if (!follow)
+                if (!follow) {
+                  annotateInboxRejection('follow_request_not_found', {
+                    activity_id: activity.id,
+                    sender_actor_id: context.verifiedSenderActorId
+                  })
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
                     data: ERROR_404,
                     responseStatusCode: 404
                   })
+                }
                 return apiResponse({
                   req,
                   allowedMethods: CORS_HEADERS,
@@ -394,13 +408,18 @@ export const POST = traceApiRoute(
                   followRequest: activity as FollowRequest,
                   database
                 })
-                if (!follow)
+                if (!follow) {
+                  annotateInboxRejection('follow_creation_failed', {
+                    activity_id: activity.id,
+                    sender_actor_id: context.verifiedSenderActorId
+                  })
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
                     data: ERROR_404,
                     responseStatusCode: 404
                   })
+                }
                 return apiResponse({
                   req,
                   allowedMethods: CORS_HEADERS,
@@ -414,13 +433,18 @@ export const POST = traceApiRoute(
                   activity,
                   targetActorId: actor.id
                 })
-                if (!block)
+                if (!block) {
+                  annotateInboxRejection('block_failed', {
+                    activity_id: activity.id,
+                    sender_actor_id: context.verifiedSenderActorId
+                  })
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
                     data: ERROR_404,
                     responseStatusCode: 404
                   })
+                }
                 return apiResponse({
                   req,
                   allowedMethods: CORS_HEADERS,
@@ -486,6 +510,10 @@ export const POST = traceApiRoute(
                 const undoFollow = Follow.safeParse(undoObject)
                 if (undoFollow.success) {
                   if (!actorIdsMatch(activity.actor, undoFollow.data.actor)) {
+                    annotateInboxRejection('sender_actor_mismatch', {
+                      verified_sender: activity.actor,
+                      activity_actor: undoFollow.data.actor
+                    })
                     return apiResponse({
                       req,
                       allowedMethods: CORS_HEADERS,
@@ -501,13 +529,18 @@ export const POST = traceApiRoute(
                       object: undoFollow.data
                     } as UndoFollow
                   })
-                  if (!result)
+                  if (!result) {
+                    annotateInboxRejection('undo_follow_not_found', {
+                      activity_id: activity.id,
+                      sender_actor_id: context.verifiedSenderActorId
+                    })
                     return apiResponse({
                       req,
                       allowedMethods: CORS_HEADERS,
                       data: ERROR_404,
                       responseStatusCode: 404
                     })
+                  }
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
@@ -567,6 +600,10 @@ export const POST = traceApiRoute(
                 const undoBlock = Block.safeParse(undoObject)
                 if (undoBlock.success) {
                   if (!actorIdsMatch(activity.actor, undoBlock.data.actor)) {
+                    annotateInboxRejection('sender_actor_mismatch', {
+                      verified_sender: activity.actor,
+                      activity_actor: undoBlock.data.actor
+                    })
                     return apiResponse({
                       req,
                       allowedMethods: CORS_HEADERS,
@@ -581,13 +618,18 @@ export const POST = traceApiRoute(
                     object: undoBlock.data,
                     targetActorId: actor.id
                   })
-                  if (!result)
+                  if (!result) {
+                    annotateInboxRejection('undo_block_not_found', {
+                      activity_id: activity.id,
+                      sender_actor_id: context.verifiedSenderActorId
+                    })
                     return apiResponse({
                       req,
                       allowedMethods: CORS_HEADERS,
                       data: ERROR_404,
                       responseStatusCode: 404
                     })
+                  }
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,

--- a/lib/services/guards/OnlyLocalUserGuard.test.ts
+++ b/lib/services/guards/OnlyLocalUserGuard.test.ts
@@ -1,3 +1,4 @@
+import { trace } from '@opentelemetry/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getTestSQLDatabaseWithInstance } from '@/lib/database/testUtils'
@@ -5,6 +6,7 @@ import { FEDERATION_SIGNING_ACTOR_USERNAME } from '@/lib/services/federation/ins
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
 
 import { OnlyLocalUserGuard } from './OnlyLocalUserGuard'
 
@@ -423,6 +425,71 @@ describe('OnlyLocalUserGuard', () => {
       expect(mockHandler).not.toHaveBeenCalled()
 
       mockDatabase = originalDb
+    })
+  })
+
+  describe('rejection trace annotations', () => {
+    let harness: ReturnType<typeof setupRecordingTracer>
+
+    beforeEach(() => {
+      harness = setupRecordingTracer()
+    })
+
+    afterEach(() => {
+      harness.cleanup()
+    })
+
+    const runGuardInSpan = async (
+      guard: ReturnType<typeof OnlyLocalUserGuard>,
+      req: NextRequest,
+      username: string
+    ) => {
+      return trace
+        .getTracer('test')
+        .startActiveSpan('api.actorInbox', async () => {
+          return guard(req, { params: Promise.resolve({ username }) })
+        })
+    }
+
+    it('annotates local_actor_not_found when user does not exist', async () => {
+      const guard = OnlyLocalUserGuard(mockHandler)
+      const req = createRequest()
+      const response = await runGuardInSpan(guard, req, 'nonexistent')
+
+      expect(response.status).toBe(404)
+      expect(mockHandler).not.toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'inbox.reject_reason': 'local_actor_not_found',
+        'inbox.username': 'nonexistent'
+      })
+    })
+
+    it('annotates local_actor_suspended when local actor is suspended', async () => {
+      const actor = await database.getActorFromUsername({
+        username: seedActor1.username,
+        domain: 'llun.test'
+      })
+      await database.setActorSuspended({ actorId: actor!.id, suspended: true })
+
+      try {
+        const guard = OnlyLocalUserGuard(mockHandler)
+        const req = createRequest()
+        const response = await runGuardInSpan(guard, req, seedActor1.username)
+
+        expect(response.status).toBe(410)
+        expect(mockHandler).not.toHaveBeenCalled()
+        expect(harness.recordedSpans).toHaveLength(1)
+        expect(harness.recordedSpans[0].attributes).toMatchObject({
+          'inbox.reject_reason': 'local_actor_suspended',
+          'inbox.username': seedActor1.username
+        })
+      } finally {
+        await database.setActorSuspended({
+          actorId: actor!.id,
+          suspended: false
+        })
+      }
     })
   })
 })

--- a/lib/services/guards/OnlyLocalUserGuard.ts
+++ b/lib/services/guards/OnlyLocalUserGuard.ts
@@ -11,6 +11,7 @@ import { normalizeUsername } from '@/lib/utils/normalizeUsername'
 import { apiErrorResponse } from '@/lib/utils/response'
 
 import { headerHost } from './headerHost'
+import { annotateInboxRejection } from './inboxRejectionTrace'
 import { AppRouterParams } from './types'
 
 export type OnlyLocalUserGuardParams = {
@@ -58,6 +59,7 @@ export const OnlyLocalUserGuard =
       actor?.account ||
       (options.allowFederationSigningActor && isFederationSigningActor(actor))
     if (!actor || !isAllowedActor) {
+      annotateInboxRejection('local_actor_not_found', { username })
       return apiErrorResponse(404)
     }
 
@@ -110,6 +112,7 @@ export const OnlyLocalUserGuard =
       isFederationSigningActorIdUsername(normalizeUsername(username)) &&
       !isFederationSigningActor(actor)
     ) {
+      annotateInboxRejection('local_actor_not_found', { username })
       return apiErrorResponse(404)
     }
 
@@ -117,6 +120,7 @@ export const OnlyLocalUserGuard =
     // following, per-user inbox, statuses) responds 410 Gone. Silenced actors
     // still resolve — silence only hides their statuses from public timelines.
     if (actor.suspendedAt) {
+      annotateInboxRejection('local_actor_suspended', { username })
       return apiErrorResponse(410)
     }
 


### PR DESCRIPTION
## Summary

Ensures all failure and error return paths in the shared ActivityPub inbox (`/api/inbox`), per-user inbox (`/api/users/[username]/inbox`), and local actor guards (`OnlyLocalUserGuard`) stamp an `inbox.reject_reason` and contextual attributes onto the active OpenTelemetry trace span.

### Problem
Previously, while `ActivityPubVerifySenderGuard` stamped rejection reasons for HTTP signature verification failures, failures occurring inside the route handlers (e.g. invalid activity payload shape after compaction in `/api/inbox`, blocked federation domains, unresolvable follow/block records, or unhandled handler exceptions) returned HTTP 4xx without calling `annotateInboxRejection`. Because HTTP 4xx responses are not JavaScript runtime errors, `traceApiRoute` marked the span status as `STATUS_CODE_ERROR` (`HTTP 400`/`HTTP 404`) without any exception stack trace or rejection reason attributes, making it difficult to debug why an inbox request failed.

### Changes
- **`app/api/inbox/route.ts`**:
  - Annotated `inbox.reject_reason: 'invalid_activity_body'` when activity payload structure is invalid after compaction.
  - Annotated `inbox.reject_reason: 'domain_not_federatable'` when federation domain check fails.
  - Annotated `inbox.reject_reason: 'unsupported_activity_shape'` when `getJobMessage` returns `null`.
  - Added try/catch block around handler execution to record exceptions with `span.recordException`, log via `logger.error`, and annotate `inbox.reject_reason: 'handler_exception'`.
- **`app/api/users/[username]/inbox/route.ts`**:
  - Annotated `inbox.reject_reason` for domain federation blocks, missing follow/block targets, and undo sender mismatches / missing targets.
- **`lib/services/guards/OnlyLocalUserGuard.ts`**:
  - Annotated `inbox.reject_reason: 'local_actor_not_found'` when local actor lookup 404s.
  - Annotated `inbox.reject_reason: 'local_actor_suspended'` when local actor is suspended (410).
- **Tests**:
  - Added test suites in `app/api/inbox/route.test.ts` and `lib/services/guards/OnlyLocalUserGuard.test.ts` verifying trace span annotations across all rejection and error scenarios.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
