### PR TITLE
Bump version to v1.149.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.18",
+  "version": "1.149.19",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.19.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.18`
- Base main SHA: `1834c7c3ba2855286116305bed5172a9dec84b20`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
