### PR TITLE
feat: enrich inbox rejection OpenTelemetry span annotations

### DIFF
--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -239,7 +239,10 @@ describe('POST /api/inbox', () => {
     expect(harness.recordedSpans[0].attributes).toMatchObject({
       'inbox.reject_reason': 'domain_not_federatable',
       'inbox.actor_id': 'https://blocked.test/users/a',
-      'inbox.sender_actor_id': 'https://allowed.test/users/a'
+      'inbox.sender_actor_id': 'https://allowed.test/users/a',
+      'inbox.activity_id': 'https://blocked.test/users/a/activities/create-1',
+      'inbox.activity_type': 'Create',
+      'inbox.activity_object_id': 'https://blocked.test/users/a/statuses/1'
     })
   })
 
@@ -423,6 +426,7 @@ describe('POST /api/inbox', () => {
       'inbox.reject_reason': 'unsupported_activity_shape',
       'inbox.activity_id': `${actor}/activities/unsupported-1`,
       'inbox.activity_type': 'Dislike',
+      'inbox.activity_object_id': `${actor}/statuses/1`,
       'inbox.sender_actor_id': actor
     })
   })
@@ -440,7 +444,10 @@ describe('POST /api/inbox', () => {
     expect(harness.recordedSpans[0].name).toBe('api.sharedInbox')
     expect(harness.recordedSpans[0].attributes).toMatchObject({
       'inbox.reject_reason': 'handler_exception',
-      'inbox.sender_actor_id': 'https://allowed.test/users/a'
+      'inbox.sender_actor_id': 'https://allowed.test/users/a',
+      'inbox.activity_id': 'https://allowed.test/users/a/activities/create-1',
+      'inbox.activity_type': 'Create',
+      'inbox.error': 'queue publish failed'
     })
     expect(harness.recordedSpans[0].exception).toEqual(
       new Error('queue publish failed')

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -5,7 +5,10 @@ import { StatusActivity } from '@/lib/activities/statusAction'
 import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
-import { annotateInboxRejection } from '@/lib/services/guards/inboxRejectionTrace'
+import {
+  annotateInboxRejection,
+  getActivityTraceAttributes
+} from '@/lib/services/guards/inboxRejectionTrace'
 import { getQueue } from '@/lib/services/queue'
 import { AnnounceAction } from '@/lib/types/activitypub/activities'
 import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
@@ -56,7 +59,8 @@ export const POST = traceApiRoute(
           !normalizeActorId(actor)
         ) {
           annotateInboxRejection('invalid_activity_body', {
-            sender_actor_id: verifiedSenderActorId
+            sender_actor_id: verifiedSenderActorId,
+            ...getActivityTraceAttributes(activityBody)
           })
           return apiResponse({
             req: request,
@@ -69,7 +73,8 @@ export const POST = traceApiRoute(
         if (!(await canFederateWithDomain(database, activity.actor))) {
           annotateInboxRejection('domain_not_federatable', {
             actor_id: activity.actor,
-            sender_actor_id: verifiedSenderActorId
+            sender_actor_id: verifiedSenderActorId,
+            ...getActivityTraceAttributes(activity)
           })
           return apiResponse({
             req: request,
@@ -128,9 +133,8 @@ export const POST = traceApiRoute(
         const jobMessage = getJobMessage(activity, verifiedSenderActorId)
         if (!jobMessage) {
           annotateInboxRejection('unsupported_activity_shape', {
-            activity_id: activity.id,
-            activity_type: activity.type,
-            sender_actor_id: verifiedSenderActorId
+            sender_actor_id: verifiedSenderActorId,
+            ...getActivityTraceAttributes(activity)
           })
           return apiResponse({
             req: request,
@@ -152,7 +156,9 @@ export const POST = traceApiRoute(
         const err = error instanceof Error ? error : new Error(String(error))
         span?.recordException(err)
         annotateInboxRejection('handler_exception', {
-          sender_actor_id: verifiedSenderActorId
+          sender_actor_id: verifiedSenderActorId,
+          ...getActivityTraceAttributes(activityBody),
+          error: err.message
         })
         logger.error({
           err: toLoggableError(error),

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -1153,4 +1153,56 @@ describe('POST /api/users/[username]/inbox', () => {
       harness.recordedSpans[0].attributes['inbox.reject_reason']
     ).toBeUndefined()
   })
+
+  it('annotates sender_actor_mismatch and activity attributes on Undo Follow mismatch', async () => {
+    const response = await POST(
+      new NextRequest('https://activities.local/api/users/llun/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: 'https://remote.test/users/alice/activities/undo-1',
+          type: 'Undo',
+          actor: 'https://remote.test/users/alice',
+          object: {
+            id: 'https://remote.test/users/mallory/follows/1',
+            type: 'Follow',
+            actor: 'https://remote.test/users/mallory',
+            object: 'https://activities.local/users/llun'
+          }
+        })
+      }),
+      { params: Promise.resolve({ username: 'llun' }) }
+    )
+
+    expect(response.status).toBe(403)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'sender_actor_mismatch',
+      'inbox.verified_sender': 'https://remote.test/users/alice',
+      'inbox.activity_actor': 'https://remote.test/users/mallory',
+      'inbox.activity_id': 'https://remote.test/users/alice/activities/undo-1',
+      'inbox.activity_type': 'Undo',
+      'inbox.activity_object_id': 'https://remote.test/users/mallory/follows/1',
+      'inbox.activity_object_type': 'Follow'
+    })
+  })
+
+  it('annotates domain_not_federatable with activity metadata in actor inbox', async () => {
+    mockCanFederateWithDomain.mockResolvedValue(false)
+
+    const response = await POST(createFollowRequest('llun'), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(403)
+    expect(harness.recordedSpans).toHaveLength(1)
+    expect(harness.recordedSpans[0].attributes).toMatchObject({
+      'inbox.reject_reason': 'domain_not_federatable',
+      'inbox.actor_id': 'https://remote.test/users/alice',
+      'inbox.sender_actor_id': 'https://remote.test/users/alice',
+      'inbox.activity_id': 'https://remote.test/users/alice/follows/1',
+      'inbox.activity_type': 'Follow',
+      'inbox.activity_object_id': 'https://activities.local/users/llun'
+    })
+  })
 })

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -31,7 +31,10 @@ import {
   OnlyLocalUserGuard,
   OnlyLocalUserGuardParams
 } from '@/lib/services/guards/OnlyLocalUserGuard'
-import { annotateInboxRejection } from '@/lib/services/guards/inboxRejectionTrace'
+import {
+  annotateInboxRejection,
+  getActivityTraceAttributes
+} from '@/lib/services/guards/inboxRejectionTrace'
 import { getQueue } from '@/lib/services/queue'
 import {
   Accept,
@@ -208,7 +211,8 @@ export const POST = traceApiRoute(
             if (!(await canFederateWithDomain(database, activityActor))) {
               annotateInboxRejection('domain_not_federatable', {
                 actor_id: activityActor,
-                sender_actor_id: context.verifiedSenderActorId
+                sender_actor_id: context.verifiedSenderActorId,
+                ...getActivityTraceAttributes(compactedActivity)
               })
               return apiResponse({
                 req,
@@ -334,8 +338,8 @@ export const POST = traceApiRoute(
                 })
                 if (!follow) {
                   annotateInboxRejection('follow_request_not_found', {
-                    activity_id: activity.id,
-                    sender_actor_id: context.verifiedSenderActorId
+                    sender_actor_id: context.verifiedSenderActorId,
+                    ...getActivityTraceAttributes(activity)
                   })
                   return apiResponse({
                     req,
@@ -386,8 +390,8 @@ export const POST = traceApiRoute(
                 })
                 if (!follow) {
                   annotateInboxRejection('follow_request_not_found', {
-                    activity_id: activity.id,
-                    sender_actor_id: context.verifiedSenderActorId
+                    sender_actor_id: context.verifiedSenderActorId,
+                    ...getActivityTraceAttributes(activity)
                   })
                   return apiResponse({
                     req,
@@ -410,8 +414,8 @@ export const POST = traceApiRoute(
                 })
                 if (!follow) {
                   annotateInboxRejection('follow_creation_failed', {
-                    activity_id: activity.id,
-                    sender_actor_id: context.verifiedSenderActorId
+                    sender_actor_id: context.verifiedSenderActorId,
+                    ...getActivityTraceAttributes(activity)
                   })
                   return apiResponse({
                     req,
@@ -435,8 +439,8 @@ export const POST = traceApiRoute(
                 })
                 if (!block) {
                   annotateInboxRejection('block_failed', {
-                    activity_id: activity.id,
-                    sender_actor_id: context.verifiedSenderActorId
+                    sender_actor_id: context.verifiedSenderActorId,
+                    ...getActivityTraceAttributes(activity)
                   })
                   return apiResponse({
                     req,
@@ -512,6 +516,7 @@ export const POST = traceApiRoute(
                   if (!actorIdsMatch(activity.actor, undoFollow.data.actor)) {
                     annotateInboxRejection('sender_actor_mismatch', {
                       verified_sender: activity.actor,
+                      ...getActivityTraceAttributes(activity),
                       activity_actor: undoFollow.data.actor
                     })
                     return apiResponse({
@@ -531,8 +536,8 @@ export const POST = traceApiRoute(
                   })
                   if (!result) {
                     annotateInboxRejection('undo_follow_not_found', {
-                      activity_id: activity.id,
-                      sender_actor_id: context.verifiedSenderActorId
+                      sender_actor_id: context.verifiedSenderActorId,
+                      ...getActivityTraceAttributes(activity)
                     })
                     return apiResponse({
                       req,
@@ -602,6 +607,7 @@ export const POST = traceApiRoute(
                   if (!actorIdsMatch(activity.actor, undoBlock.data.actor)) {
                     annotateInboxRejection('sender_actor_mismatch', {
                       verified_sender: activity.actor,
+                      ...getActivityTraceAttributes(activity),
                       activity_actor: undoBlock.data.actor
                     })
                     return apiResponse({
@@ -620,8 +626,8 @@ export const POST = traceApiRoute(
                   })
                   if (!result) {
                     annotateInboxRejection('undo_block_not_found', {
-                      activity_id: activity.id,
-                      sender_actor_id: context.verifiedSenderActorId
+                      sender_actor_id: context.verifiedSenderActorId,
+                      ...getActivityTraceAttributes(activity)
                     })
                     return apiResponse({
                       req,
@@ -684,7 +690,9 @@ export const POST = traceApiRoute(
               error instanceof Error ? error : new Error(String(error))
             span?.recordException(err)
             annotateInboxRejection('handler_exception', {
-              sender_actor_id: context.verifiedSenderActorId
+              sender_actor_id: context.verifiedSenderActorId,
+              ...getActivityTraceAttributes(context.activityBody),
+              error: err.message
             })
             logger.error({
               err: toLoggableError(error),

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -990,7 +990,10 @@ describe('ActivityPubVerifySenderGuard', () => {
         expectedStatus: 403,
         expectedReason: 'domain_not_federatable',
         expectedAttributes: {
-          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+          'inbox.key_id': 'https://remote.test/users/alice#main-key',
+          'inbox.activity_id': 'https://remote.test/users/alice/activities/1',
+          'inbox.activity_type': 'Follow',
+          'inbox.activity_actor': 'https://remote.test/users/alice'
         }
       },
       {
@@ -1013,7 +1016,10 @@ describe('ActivityPubVerifySenderGuard', () => {
         expectedStatus: 401,
         expectedReason: 'key_unavailable',
         expectedAttributes: {
-          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+          'inbox.key_id': 'https://remote.test/users/alice#main-key',
+          'inbox.activity_id': 'https://remote.test/users/alice/activities/1',
+          'inbox.activity_type': 'Follow',
+          'inbox.activity_actor': 'https://remote.test/users/alice'
         }
       },
       {
@@ -1036,7 +1042,10 @@ describe('ActivityPubVerifySenderGuard', () => {
         expectedStatus: 401,
         expectedReason: 'signature_invalid',
         expectedAttributes: {
-          'inbox.key_id': 'https://remote.test/users/alice#main-key'
+          'inbox.key_id': 'https://remote.test/users/alice#main-key',
+          'inbox.activity_id': 'https://remote.test/users/alice/activities/1',
+          'inbox.activity_type': 'Follow',
+          'inbox.activity_actor': 'https://remote.test/users/alice'
         }
       },
       {
@@ -1060,7 +1069,10 @@ describe('ActivityPubVerifySenderGuard', () => {
         expectedReason: 'key_owner_unresolvable',
         expectedAttributes: {
           'inbox.key_id': 'https://remote.test/users/alice#main-key',
-          'inbox.key_owner': '_:b0'
+          'inbox.key_owner': '_:b0',
+          'inbox.activity_id': 'https://remote.test/users/alice/activities/1',
+          'inbox.activity_type': 'Follow',
+          'inbox.activity_actor': 'https://remote.test/users/alice'
         }
       },
       {
@@ -1077,14 +1089,19 @@ describe('ActivityPubVerifySenderGuard', () => {
             body: {
               id: 'https://remote.test/users/mallory/activities/1',
               type: 'Follow',
-              actor: 'https://remote.test/users/mallory'
+              actor: 'https://remote.test/users/mallory',
+              object: 'https://activities.local/users/bob'
             }
           }),
         expectedStatus: 403,
         expectedReason: 'sender_actor_mismatch',
         expectedAttributes: {
+          'inbox.key_id': 'https://remote.test/users/alice#main-key',
           'inbox.verified_sender': 'https://remote.test/users/alice',
-          'inbox.activity_actor': 'https://remote.test/users/mallory'
+          'inbox.activity_actor': 'https://remote.test/users/mallory',
+          'inbox.activity_id': 'https://remote.test/users/mallory/activities/1',
+          'inbox.activity_type': 'Follow',
+          'inbox.activity_object_id': 'https://activities.local/users/bob'
         }
       },
       {

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -17,7 +17,10 @@ import { isRecord } from '@/lib/utils/typeGuards'
 
 import { getSenderPublicKeyDetails } from './getSenderPublicKey'
 import { headerHost } from './headerHost'
-import { annotateInboxRejection } from './inboxRejectionTrace'
+import {
+  annotateInboxRejection,
+  getActivityTraceAttributes
+} from './inboxRejectionTrace'
 import { ActivityPubVerifiedSenderHandle, AppRouterParams } from './types'
 
 // signed_request.rb:4-5 (EXPIRATION_WINDOW_LIMIT = 12.hours, CLOCK_SKEW_MARGIN = 1.hour)
@@ -95,7 +98,8 @@ const getExpectedSha256Digest = (digestHeader: string) =>
 
 type PostActivityResult =
   | { actor: string; body: Record<string, unknown>; valid: true }
-  | { actor: null; body: null; valid: boolean }
+  | { actor: null; body: Record<string, unknown> | null; valid: false }
+  | { actor: null; body: null; valid: true }
 
 const getPostActivity = ({
   bodyText,
@@ -118,7 +122,7 @@ const getPostActivity = ({
 
     const actor = extractActivityPubId(body.actor)
     if (!actor || !normalizeActorId(actor)) {
-      return { actor: null, body: null, valid: false }
+      return { actor: null, body, valid: false }
     }
 
     return { actor, body: { ...body, actor }, valid: true }
@@ -317,7 +321,11 @@ export const ActivityPubVerifySenderGuard =
         request,
         401,
         allowedMethods,
-        'invalid_activity_body'
+        'invalid_activity_body',
+        {
+          key_id: signatureParts.keyId,
+          ...getActivityTraceAttributes(activity.body)
+        }
       )
     }
 
@@ -356,7 +364,8 @@ export const ActivityPubVerifySenderGuard =
                   : undefined
             annotateInboxRejection('unknown_actor_delete', {
               actor: activity.actor,
-              activity_type: activityTypeStr
+              activity_type: activityTypeStr,
+              ...getActivityTraceAttributes(activity.body)
             })
             return guardErrorResponse(request, 202, allowedMethods)
           }
@@ -371,7 +380,8 @@ export const ActivityPubVerifySenderGuard =
         allowedMethods,
         'domain_not_federatable',
         {
-          key_id: signatureParts.keyId
+          key_id: signatureParts.keyId,
+          ...getActivityTraceAttributes(activity.body)
         }
       )
     }
@@ -393,7 +403,8 @@ export const ActivityPubVerifySenderGuard =
         ? 'signature_invalid'
         : 'key_unavailable'
       return rejectRequest(request, 401, allowedMethods, reason, {
-        key_id: signatureParts.keyId
+        key_id: signatureParts.keyId,
+        ...getActivityTraceAttributes(activity.body)
       })
     }
 
@@ -406,7 +417,8 @@ export const ActivityPubVerifySenderGuard =
         'key_owner_unresolvable',
         {
           key_id: signatureParts.keyId,
-          key_owner: senderPublicKey.owner ?? undefined
+          key_owner: senderPublicKey.owner ?? undefined,
+          ...getActivityTraceAttributes(activity.body)
         }
       )
     }
@@ -421,7 +433,9 @@ export const ActivityPubVerifySenderGuard =
           allowedMethods,
           'sender_actor_mismatch',
           {
+            key_id: signatureParts.keyId,
             verified_sender: verifiedSenderActorId,
+            ...getActivityTraceAttributes(activity.body),
             activity_actor: normalizedActor ?? undefined
           }
         )

--- a/lib/services/guards/inboxRejectionTrace.test.ts
+++ b/lib/services/guards/inboxRejectionTrace.test.ts
@@ -1,0 +1,147 @@
+import { trace } from '@opentelemetry/api'
+
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
+
+import {
+  annotateInboxRejection,
+  getActivityTraceAttributes
+} from './inboxRejectionTrace'
+
+describe('inboxRejectionTrace', () => {
+  let harness: ReturnType<typeof setupRecordingTracer>
+
+  beforeEach(() => {
+    harness = setupRecordingTracer()
+  })
+
+  afterEach(() => {
+    harness.cleanup()
+  })
+
+  describe('getActivityTraceAttributes', () => {
+    it('returns empty object for non-record bodies', () => {
+      expect(getActivityTraceAttributes(null)).toEqual({})
+      expect(getActivityTraceAttributes(undefined)).toEqual({})
+      expect(getActivityTraceAttributes('string')).toEqual({})
+      expect(getActivityTraceAttributes(123)).toEqual({})
+      expect(getActivityTraceAttributes([])).toEqual({})
+    })
+
+    it('extracts activity metadata for a standard Create activity with nested object', () => {
+      const body = {
+        id: 'https://writing.exchange/users/ninetiger/statuses/12345/activity',
+        type: 'Create',
+        actor: 'https://writing.exchange/users/ninetiger',
+        object: {
+          id: 'https://writing.exchange/users/ninetiger/statuses/12345',
+          type: 'Note'
+        }
+      }
+
+      expect(getActivityTraceAttributes(body)).toEqual({
+        activity_id:
+          'https://writing.exchange/users/ninetiger/statuses/12345/activity',
+        activity_type: 'Create',
+        activity_actor: 'https://writing.exchange/users/ninetiger',
+        activity_object_id:
+          'https://writing.exchange/users/ninetiger/statuses/12345',
+        activity_object_type: 'Note',
+        activity_target_id: undefined
+      })
+    })
+
+    it('extracts string object URI for Delete or Announce activities', () => {
+      const body = {
+        id: 'https://remote.test/users/alice/activities/delete-1',
+        type: 'Delete',
+        actor: 'https://remote.test/users/alice',
+        object: 'https://remote.test/users/alice/statuses/1'
+      }
+
+      expect(getActivityTraceAttributes(body)).toEqual({
+        activity_id: 'https://remote.test/users/alice/activities/delete-1',
+        activity_type: 'Delete',
+        activity_actor: 'https://remote.test/users/alice',
+        activity_object_id: 'https://remote.test/users/alice/statuses/1',
+        activity_object_type: undefined,
+        activity_target_id: undefined
+      })
+    })
+
+    it('extracts target and array types correctly', () => {
+      const body = {
+        id: 'https://remote.test/users/alice/activities/add-1',
+        type: ['Add', 'CustomActivity'],
+        actor: { id: 'https://remote.test/users/alice' },
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: ['Note', 'Article']
+        },
+        target: 'https://remote.test/users/alice/collections/featured'
+      }
+
+      expect(getActivityTraceAttributes(body)).toEqual({
+        activity_id: 'https://remote.test/users/alice/activities/add-1',
+        activity_type: 'Add,CustomActivity',
+        activity_actor: 'https://remote.test/users/alice',
+        activity_object_id: 'https://remote.test/users/alice/statuses/1',
+        activity_object_type: 'Note,Article',
+        activity_target_id:
+          'https://remote.test/users/alice/collections/featured'
+      })
+    })
+
+    it('extracts target when target is an object with id', () => {
+      const body = {
+        id: 'https://remote.test/users/alice/activities/1',
+        type: 'Follow',
+        actor: 'https://remote.test/users/alice',
+        object: 'https://local.test/users/bob',
+        target: { id: 'https://local.test/users/bob/inbox' }
+      }
+
+      expect(getActivityTraceAttributes(body)).toEqual({
+        activity_id: 'https://remote.test/users/alice/activities/1',
+        activity_type: 'Follow',
+        activity_actor: 'https://remote.test/users/alice',
+        activity_object_id: 'https://local.test/users/bob',
+        activity_object_type: undefined,
+        activity_target_id: 'https://local.test/users/bob/inbox'
+      })
+    })
+  })
+
+  describe('annotateInboxRejection', () => {
+    it('sets reject_reason and extra attributes on the active recording span', async () => {
+      await trace
+        .getTracer('test')
+        .startActiveSpan('api.sharedInbox', async () => {
+          annotateInboxRejection('sender_actor_mismatch', {
+            verified_sender: 'https://mstdn.social/users/grickle',
+            ...getActivityTraceAttributes({
+              id: 'https://writing.exchange/users/ninetiger/statuses/123/activity',
+              type: 'Create',
+              actor: 'https://writing.exchange/users/ninetiger',
+              object: {
+                id: 'https://writing.exchange/users/ninetiger/statuses/123',
+                type: 'Note'
+              }
+            })
+          })
+        })
+
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'inbox.reject_reason': 'sender_actor_mismatch',
+        'inbox.verified_sender': 'https://mstdn.social/users/grickle',
+        'inbox.activity_id':
+          'https://writing.exchange/users/ninetiger/statuses/123/activity',
+        'inbox.activity_type': 'Create',
+        'inbox.activity_actor': 'https://writing.exchange/users/ninetiger',
+        'inbox.activity_object_id':
+          'https://writing.exchange/users/ninetiger/statuses/123',
+        'inbox.activity_object_type': 'Note'
+      })
+    })
+  })
+})

--- a/lib/services/guards/inboxRejectionTrace.ts
+++ b/lib/services/guards/inboxRejectionTrace.ts
@@ -1,11 +1,72 @@
 import { trace } from '@opentelemetry/api'
 
+import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
+import { isRecord } from '@/lib/utils/typeGuards'
+
 const MAX_ATTRIBUTE_LENGTH = 500
 
 const bound = (value: string): string =>
   value.length > MAX_ATTRIBUTE_LENGTH
     ? value.slice(0, MAX_ATTRIBUTE_LENGTH)
     : value
+
+/**
+ * Extracts standard ActivityPub trace attributes from an activity payload.
+ */
+export const getActivityTraceAttributes = (
+  body: unknown
+): Record<string, string | undefined> => {
+  if (!isRecord(body)) return {}
+
+  const activityId =
+    typeof body.id === 'string' ? extractActivityPubId(body.id) : undefined
+
+  const activityType =
+    typeof body.type === 'string'
+      ? body.type
+      : Array.isArray(body.type)
+        ? body.type.filter((t): t is string => typeof t === 'string').join(',')
+        : undefined
+
+  const rawActor = extractActivityPubId(body.actor)
+  const activityActor = rawActor
+    ? (normalizeActorId(rawActor) ?? rawActor)
+    : undefined
+
+  let objectId: string | undefined
+  let objectType: string | undefined
+
+  if (typeof body.object === 'string') {
+    objectId = extractActivityPubId(body.object)
+  } else if (isRecord(body.object)) {
+    if (typeof body.object.id === 'string') {
+      objectId = extractActivityPubId(body.object.id)
+    }
+    if (typeof body.object.type === 'string') {
+      objectType = body.object.type
+    } else if (Array.isArray(body.object.type)) {
+      objectType = body.object.type
+        .filter((t): t is string => typeof t === 'string')
+        .join(',')
+    }
+  }
+
+  let targetId: string | undefined
+  if (typeof body.target === 'string') {
+    targetId = extractActivityPubId(body.target)
+  } else if (isRecord(body.target) && typeof body.target.id === 'string') {
+    targetId = extractActivityPubId(body.target.id)
+  }
+
+  return {
+    activity_id: activityId,
+    activity_type: activityType,
+    activity_actor: activityActor,
+    activity_object_id: objectId,
+    activity_object_type: objectType,
+    activity_target_id: targetId
+  }
+}
 
 /**
  * Stamps the rejection reason for an ActivityPub inbox request onto the


### PR DESCRIPTION
## Summary
Enriches OpenTelemetry trace span annotations for ActivityPub inbox rejections (such as `sender_actor_mismatch`, `domain_not_federatable`, `invalid_activity_body`, `unsupported_activity_shape`, and `handler_exception`) across `ActivityPubVerifyGuard`, `/api/inbox`, and `/api/users/[username]/inbox`.

## Problem & Background
When an incoming ActivityPub HTTP request to `/inbox` or `/@username/inbox` fails verification or route processing (for example returning HTTP 403 `sender_actor_mismatch`), the span previously recorded only `inbox.reject_reason`, `inbox.verified_sender`, and `inbox.activity_actor`.

Because the activity payload metadata was discarded during rejection:
- It was impossible to know which activity was rejected (no `activity_id` or `activity_type` such as `Create`, `Announce`, `Update`, `Delete`, `Like`, `Undo`).
- It was impossible to know which target object was referenced (no `activity_object_id` or `activity_object_type`).
- It was impossible to see which cryptographic key ID signed the HTTP request (no `key_id`).

## Changes
- **ActivityPub Trace Helper** (`lib/services/guards/inboxRejectionTrace.ts`):
  - Added `getActivityTraceAttributes(body)` helper to extract `activity_id`, `activity_type`, `activity_actor`, `activity_object_id`, `activity_object_type`, and `activity_target_id` from activity JSON payloads.
  - Added unit tests in `lib/services/guards/inboxRejectionTrace.test.ts`.
- **ActivityPub Verification Guard** (`lib/services/guards/ActivityPubVerifyGuard.ts`):
  - Updated `getPostActivity` to preserve parsed JSON `body` even when actor normalization fails so `invalid_activity_body` rejections can still capture available activity metadata.
  - Attached `key_id: signatureParts.keyId` on signature, domain, and sender rejections.
  - Attached `getActivityTraceAttributes(activity.body)` to `sender_actor_mismatch`, `domain_not_federatable`, `signature_invalid`, `key_unavailable`, `key_owner_unresolvable`, and `invalid_activity_body`.
- **Shared Inbox Route** (`app/api/inbox/route.ts`):
  - Enriched span annotations for `invalid_activity_body`, `domain_not_federatable`, `unsupported_activity_shape`, and `handler_exception` (including `inbox.error`).
- **Actor Inbox Route** (`app/api/users/[username]/inbox/route.ts`):
  - Enriched span annotations for `domain_not_federatable`, `sender_actor_mismatch` (Undo Follow/Block), `follow_request_not_found`, `follow_creation_failed`, `block_failed`, `undo_follow_not_found`, `undo_block_not_found`, and `handler_exception` (including `inbox.error`).

## Trace Attributes Comparison

### Before
```json
{
  "name": "api.sharedInbox",
  "attributes": [
    { "key": "inbox.reject_reason", "value": { "stringValue": "sender_actor_mismatch" } },
    { "key": "inbox.verified_sender", "value": { "stringValue": "https://mstdn.social/users/grickle" } },
    { "key": "inbox.activity_actor", "value": { "stringValue": "https://writing.exchange/users/ninetiger" } }
  ]
}
```

### After
```json
{
  "name": "api.sharedInbox",
  "attributes": [
    { "key": "inbox.reject_reason", "value": { "stringValue": "sender_actor_mismatch" } },
    { "key": "inbox.key_id", "value": { "stringValue": "https://mstdn.social/users/grickle#main-key" } },
    { "key": "inbox.verified_sender", "value": { "stringValue": "https://mstdn.social/users/grickle" } },
    { "key": "inbox.activity_actor", "value": { "stringValue": "https://writing.exchange/users/ninetiger" } },
    { "key": "inbox.activity_id", "value": { "stringValue": "https://writing.exchange/users/ninetiger/statuses/12345/activity" } },
    { "key": "inbox.activity_type", "value": { "stringValue": "Create" } },
    { "key": "inbox.activity_object_id", "value": { "stringValue": "https://writing.exchange/users/ninetiger/statuses/12345" } },
    { "key": "inbox.activity_object_type", "value": { "stringValue": "Note" } }
  ]
}
```

## Verification
- `yarn run prettier --write .` (clean)
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (clean production build)
- `yarn test` (all 907 test suites / 12,229 tests passed)
