### PR TITLE
Bump version to v1.149.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.19",
+  "version": "1.149.20",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.20.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.19`
- Base main SHA: `0abe8e393a47f1c71e902c0f0e81319fef081824`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
