### PR TITLE
Bump version to v1.149.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.20",
+  "version": "1.149.21",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.149.21.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.149.20`
- Base main SHA: `04219eff604398798a078a90c812d45fd4675bcb`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
