### PR TITLE
fix: match Mastodon anonymous fallback on optional auth and enrich trace spans

### DIFF
--- a/app/api/v1/accounts/[id]/media/route.test.ts
+++ b/app/api/v1/accounts/[id]/media/route.test.ts
@@ -194,7 +194,37 @@ describe('GET /api/v1/accounts/:id/media', () => {
   // The guard's own rejection paths return a bare apiErrorResponse, which
   // carries no CORS headers; a cross-origin caller would see an opaque browser
   // failure rather than the JSON error. `errorResponse` is what restores them.
-  it('keeps CORS headers on a guard-rejected response', async () => {
+  it('keeps CORS headers on a guard-rejected response (e.g. suspended actor)', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'read'
+    })
+    await database.setActorSuspended({
+      actorId: ACTOR1_ID,
+      suspended: true
+    })
+
+    try {
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(ACTOR1_ID)}/media`,
+          { method: 'GET', headers: { Authorization: 'Bearer suspended' } }
+        ),
+        { params: Promise.resolve({ id: urlToId(ACTOR1_ID) }) }
+      )
+
+      expect(response.status).toBe(403)
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy()
+    } finally {
+      await database.setActorSuspended({
+        actorId: ACTOR1_ID,
+        suspended: false
+      })
+    }
+  })
+
+  it('serves public media when an expired bearer token is provided (matching Mastodon)', async () => {
     mockStoredToken.mockResolvedValue({
       expiresAt: new Date(Date.now() - 60_000),
       referenceId: ACTOR1_ID,
@@ -203,14 +233,17 @@ describe('GET /api/v1/accounts/:id/media', () => {
 
     const response = await GET(
       new NextRequest(
-        `https://llun.test/api/v1/accounts/${urlToId(ACTOR1_ID)}/media`,
+        `https://llun.test/api/v1/accounts/${urlToId(ACTOR1_ID)}/media?limit=50`,
         { method: 'GET', headers: { Authorization: 'Bearer expired' } }
       ),
       { params: Promise.resolve({ id: urlToId(ACTOR1_ID) }) }
     )
 
-    expect(response.status).toBe(401)
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy()
+    expect(response.status).toBe(200)
+    const urls = await mediaUrls(response)
+    expect(urls).toContain(PUBLIC_MEDIA_URL)
+    expect(urls).not.toContain(FOLLOWERS_MEDIA_URL)
+    expect(urls).not.toContain(DIRECT_MEDIA_URL)
   })
 
   it('serves the owner their own private attachments', async () => {

--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -441,13 +441,19 @@ describe('GET /api/v1/accounts/lookup', () => {
     expect(await response.json()).toEqual(account)
   })
 
-  it('rejects an invalid bearer token even when the actor is stored locally', async () => {
+  it('serves a stored actor when an invalid bearer token is sent (matching Mastodon)', async () => {
     const storedActor = {
       id: 'https://remote.test/users/person',
       account: null,
       privateKey: ''
     }
     mockGetActorFromUsername.mockResolvedValue(storedActor)
+    mockGetMastodonActorFromId.mockResolvedValue({
+      id: 'https://remote.test/users/person',
+      username: 'person',
+      acct: 'person@remote.test',
+      url: 'https://remote.test/users/person'
+    } as MastodonActor)
     // Default mockStoredToken (null) makes any presented bearer invalid.
 
     const response = await GET(
@@ -457,13 +463,11 @@ describe('GET /api/v1/accounts/lookup', () => {
       )
     )
 
-    expect(response.status).toBe(401)
-    // The presented token is validated before any lookup work happens.
-    expect(mockGetActorFromUsername).not.toHaveBeenCalled()
-    expect(mockRecordActorIfNeeded).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalled()
   })
 
-  it('rejects bearer tokens without read account lookup scope before remote resolution', async () => {
+  it('refuses remote resolution with 404 for bearer tokens with insufficient scope', async () => {
     mockGetActorFromUsername.mockResolvedValue(null)
     mockStoredToken.mockResolvedValue({
       expiresAt: new Date(Date.now() + 60_000),
@@ -478,8 +482,41 @@ describe('GET /api/v1/accounts/lookup', () => {
       )
     )
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(404)
     expect(mockGetServerSession).not.toHaveBeenCalled()
     expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+  })
+
+  it('rejects a suspended actor with 403 even for stored lookups', async () => {
+    mockGetActorFromUsername.mockResolvedValue({
+      id: 'https://remote.test/users/person',
+      account: null,
+      privateKey: ''
+    })
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: 'https://llun.test/users/suspended-user',
+      scopes: 'read'
+    })
+    mockGetActorFromId.mockResolvedValue({
+      ...oauthActor,
+      id: 'https://llun.test/users/suspended-user',
+      suspendedAt: Date.now(),
+      account: {
+        id: 'account-suspended',
+        email: 'suspended@llun.test',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    } as unknown as Actor)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=person@remote.test',
+        { headers: { Authorization: 'Bearer suspended-token' } }
+      )
+    )
+
+    expect(response.status).toBe(403)
   })
 })

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from 'next/server'
 
-import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import {
+  getTestSQLDatabase,
+  getTestSQLDatabaseWithInstance
+} from '@/lib/database/testUtils'
 import { seedDatabase } from '@/lib/stub/database'
 import { statusPublicId } from '@/lib/stub/publicIds'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
@@ -17,8 +20,11 @@ vi.mock('@/lib/services/auth/getSession', () => ({
 }))
 
 let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+let mockKnex:
+  ReturnType<typeof getTestSQLDatabaseWithInstance>['instance'] | null = null
 vi.mock('@/lib/database', () => ({
-  getDatabase: () => mockDatabase
+  getDatabase: () => mockDatabase,
+  getKnex: () => mockKnex
 }))
 
 vi.mock('next/headers', () => ({
@@ -38,11 +44,12 @@ vi.mock('@/lib/config', () => ({
     allowEmails: [],
     host: 'llun.test',
     secretPhase: 'test-secret'
-  })
+  }),
+  getBaseURL: () => 'https://llun.test'
 }))
 
 describe('GET /api/v1/timelines/public', () => {
-  const database = getTestSQLDatabase()
+  const { database, instance } = getTestSQLDatabaseWithInstance()
   let publicStatus: Status
 
   beforeAll(async () => {
@@ -57,6 +64,7 @@ describe('GET /api/v1/timelines/public', () => {
       text: 'public timeline post'
     })
     mockDatabase = database
+    mockKnex = instance
   })
 
   afterAll(async () => {
@@ -387,6 +395,26 @@ describe('GET /api/v1/timelines/public', () => {
       expect(link).toContain('rel="next"')
       expect(link).toContain('remote=true')
       expect(link).not.toContain('local=true')
+    })
+
+    it('returns 200 OK as anonymous when an invalid or expired bearer token is sent (matching Mastodon)', async () => {
+      vi.spyOn(database, 'getTimeline').mockResolvedValue([publicStatus])
+
+      const req = new NextRequest('https://llun.test/api/v1/timelines/public', {
+        headers: {
+          Authorization: 'Bearer expired-or-invalid-token'
+        }
+      })
+
+      const response = await GET(req, {
+        params: Promise.resolve({})
+      })
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.map((status: { id: string }) => status.id)).toEqual([
+        await statusPublicId(database, publicStatus.id)
+      ])
     })
   })
 })

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -1435,6 +1435,84 @@ describe('OAuthGuard', () => {
         expect.objectContaining({ currentActor: null })
       )
     })
+
+    test('downgrades an expired bearer token to anonymous access (matching Mastodon)', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+      mockStoredTokens.set(hashToken('optional-expired-token'), {
+        token: hashToken('optional-expired-token'),
+        referenceId: PENDING_ACTOR_ID,
+        clientId: 'client-app-1',
+        expiresAt: new Date(Date.now() - 3600000),
+        scopes: JSON.stringify(['read'])
+      })
+
+      const guard = OptionalOAuthGuard([Scope.enum.read], mockHandler)
+      const response = await guard(
+        createRequest({ Authorization: 'Bearer optional-expired-token' }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currentActor: null })
+      )
+    })
+
+    test('downgrades a non-existent bearer token to anonymous access (matching Mastodon)', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const guard = OptionalOAuthGuard([Scope.enum.read], mockHandler)
+      const response = await guard(
+        createRequest({ Authorization: 'Bearer nonexistent-token' }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currentActor: null })
+      )
+    })
+
+    test('downgrades a malformed authorization header to anonymous access', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const guard = OptionalOAuthGuard([Scope.enum.read], mockHandler)
+      const response = await guard(
+        createRequest({ Authorization: 'NotBearer format' }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currentActor: null })
+      )
+    })
+
+    test('downgrades a token with insufficient scope to anonymous access on OptionalOAuthGuard', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+      mockStoredTokens.set(hashToken('optional-write-only-token'), {
+        token: hashToken('optional-write-only-token'),
+        referenceId: PENDING_ACTOR_ID,
+        clientId: 'client-app-1',
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['write'])
+      })
+
+      const guard = OptionalOAuthGuard([Scope.enum.read], mockHandler)
+      const response = await guard(
+        createRequest({ Authorization: 'Bearer optional-write-only-token' }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currentActor: null })
+      )
+    })
   })
 
   describe('OAuthAppGuard', () => {

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -22,6 +22,11 @@ import {
 } from '@/lib/utils/response'
 import { selectAccountActor } from '@/lib/utils/selectAccountActor'
 
+import {
+  annotateAuthAnonymous,
+  annotateAuthRejection,
+  annotateAuthSuccess
+} from './authTrace'
 import { hasSameOriginProof } from './sameOriginProof'
 import { hasGrantedScope } from './scopeHierarchy'
 import {
@@ -122,9 +127,18 @@ type ScopeMatchMode = 'all' | 'any'
 // token, a revoked one, a scope mismatch and a grant with no actor all look
 // identical. Record which check fired — never the token — so raising
 // `LOG_LEVEL` to debug is enough to diagnose one.
-const rejectBearer = (reason: string, statusCode: StatusCode) => {
+const rejectBearer = (
+  reason: string,
+  statusCode: StatusCode,
+  extra: Record<string, string | number | boolean | string[] | undefined> = {}
+) => {
+  annotateAuthRejection(reason, {
+    auth_type: 'bearer',
+    status: statusCode,
+    ...extra
+  })
   oauthLogger.debug(
-    { endpoint: 'guard', reason, status: statusCode },
+    { endpoint: 'guard', reason, status: statusCode, ...extra },
     `Bearer token rejected with ${statusCode}`
   )
   return apiErrorResponse(statusCode)
@@ -242,7 +256,10 @@ const resolveTokenContext = async ({
       if (!hasRequiredScopes({ grantedScopes: jwtScopes, scopes, matchMode })) {
         return {
           valid: false,
-          response: rejectBearer('insufficient_scope', 401)
+          response: rejectBearer('insufficient_scope', 401, {
+            required_scopes: scopes,
+            granted_scopes: jwtScopes
+          })
         }
       }
     }
@@ -280,7 +297,10 @@ const resolveTokenContext = async ({
       ) {
         return {
           valid: false,
-          response: rejectBearer('insufficient_scope', 401)
+          response: rejectBearer('insufficient_scope', 401, {
+            required_scopes: scopes,
+            granted_scopes: storedScopes
+          })
         }
       }
     }
@@ -391,7 +411,9 @@ const resolveAuthenticatedContext = async <P>({
       if (isActorModerationBlocked(parsedActor)) {
         return {
           authenticated: false,
-          response: rejectBearer('actor_moderation_blocked', 403)
+          response: rejectBearer('actor_moderation_blocked', 403, {
+            actor_id: parsedActor.id
+          })
         }
       }
       if (isActorConfirmationPending(parsedActor)) {
@@ -404,10 +426,20 @@ const resolveAuthenticatedContext = async <P>({
         if (unconfirmedAccount === 'reject') {
           return {
             authenticated: false,
-            response: rejectBearer('account_unconfirmed', 403)
+            response: rejectBearer('account_unconfirmed', 403, {
+              actor_id: parsedActor.id
+            })
           }
         }
       }
+
+      annotateAuthSuccess({
+        authType: 'bearer',
+        actorId: parsedActor.id,
+        clientId,
+        userId,
+        grantedScopes
+      })
 
       return {
         authenticated: true,
@@ -431,17 +463,35 @@ const resolveAuthenticatedContext = async <P>({
   }
 
   if (!hasSameOriginProof(req)) {
+    annotateAuthRejection('csrf_failed', {
+      auth_type: 'session',
+      status: 403
+    })
     return { authenticated: false, response: apiErrorResponse(403) }
   }
 
   const currentActor = await getActorFromSession(database, session)
   if (!currentActor) {
+    annotateAuthRejection('session_actor_not_found', {
+      auth_type: 'session',
+      status: 401
+    })
     return { authenticated: false, response: apiErrorResponse(401) }
   }
   if (isActorModerationBlocked(currentActor)) {
+    annotateAuthRejection('actor_moderation_blocked', {
+      auth_type: 'session',
+      status: 403,
+      actor_id: currentActor.id
+    })
     return { authenticated: false, response: apiErrorResponse(403) }
   }
   if (isActorConfirmationPending(currentActor)) {
+    annotateAuthRejection('account_unconfirmed', {
+      auth_type: 'session',
+      status: 403,
+      actor_id: currentActor.id
+    })
     if (unconfirmedAccount === 'anonymous') {
       return { authenticated: false }
     }
@@ -449,6 +499,11 @@ const resolveAuthenticatedContext = async <P>({
       return { authenticated: false, response: apiErrorResponse(403) }
     }
   }
+
+  annotateAuthSuccess({
+    authType: 'session',
+    actorId: currentActor.id
+  })
 
   return {
     authenticated: true,
@@ -474,6 +529,12 @@ const createOAuthGuard =
       unconfirmedAccount: options.unconfirmedAccount
     })
     if (!result.authenticated) {
+      if (!result.response) {
+        annotateAuthRejection('missing_credentials', {
+          status: 401,
+          required_scopes: scopes
+        })
+      }
       const response = result.response ?? apiErrorResponse(401)
       // Let CORS-enabled routes attach their allowed-method CORS headers to the
       // guard's 401/403/500 responses so cross-origin clients can read the
@@ -521,6 +582,10 @@ export const OAuthAppGuard =
 
     const authorizationToken = req.headers.get('Authorization')
     if (!isBearerAuthorizationHeader(authorizationToken)) {
+      annotateAuthRejection('missing_authorization_header', {
+        auth_type: 'bearer',
+        status: 401
+      })
       return fail(apiErrorResponse(401))
     }
 
@@ -579,6 +644,14 @@ export const OAuthAppGuard =
       return fail(apiErrorResponse(500))
     }
 
+    annotateAuthSuccess({
+      authType: 'bearer',
+      actorId: currentActor?.id ?? null,
+      clientId: client?.id ?? clientId,
+      userId,
+      grantedScopes
+    })
+
     return handle(req, {
       currentActor,
       client,
@@ -619,7 +692,7 @@ export const OptionalOAuthGuard =
       // Served WITHOUT its identity — neither refused nor accepted as itself.
       // Both alternatives are wrong here and the full argument lives in
       // AGENTS.md's "An Unconfirmed Account May Not Act"; the short of it is
-      // that refusing makes a valid token fail a read that succeeds with no
+      // that refusing made a valid token fail a read that succeeds with no
       // token, and accepting hands an unverified account real capability.
       unconfirmedAccount: 'anonymous'
     })
@@ -629,9 +702,19 @@ export const OptionalOAuthGuard =
     }
 
     if (result.response) {
-      return options.errorResponse
-        ? options.errorResponse(req, result.response.status as StatusCode)
-        : result.response
+      // Refuse moderation-blocked (suspended) actors with 403, and propagate server errors (500).
+      if (result.response.status === 403 || result.response.status >= 500) {
+        return options.errorResponse
+          ? options.errorResponse(req, result.response.status as StatusCode)
+          : result.response
+      }
+      // For 401 (invalid/expired/unrecognized token or no session actor),
+      // downgrade to anonymous rather than failing a public read that
+      // succeeds with no Authorization header at all (matching Mastodon's
+      // authorize_if_got_token! behavior).
+      annotateAuthAnonymous({ downgraded: true })
+    } else {
+      annotateAuthAnonymous({ downgraded: false })
     }
 
     const database = getDatabase()

--- a/lib/services/guards/authTrace.test.ts
+++ b/lib/services/guards/authTrace.test.ts
@@ -1,0 +1,89 @@
+import { trace } from '@opentelemetry/api'
+
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
+
+import {
+  annotateAuthAnonymous,
+  annotateAuthRejection,
+  annotateAuthSuccess
+} from './authTrace'
+
+describe('authTrace', () => {
+  let harness: ReturnType<typeof setupRecordingTracer>
+
+  beforeEach(() => {
+    harness = setupRecordingTracer()
+  })
+
+  afterEach(() => {
+    harness.cleanup()
+  })
+
+  describe('annotateAuthRejection', () => {
+    it('sets reject_reason and extra attributes on active recording span', async () => {
+      await trace.getTracer('test').startActiveSpan('testRoute', async () => {
+        annotateAuthRejection('token_expired', {
+          auth_type: 'bearer',
+          status: 401,
+          required_scopes: ['read', 'write']
+        })
+      })
+
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'auth.reject_reason': 'token_expired',
+        'auth.auth_type': 'bearer',
+        'auth.status': 401,
+        'auth.required_scopes': ['read', 'write']
+      })
+    })
+
+    it('does not throw when no span is active', () => {
+      expect(() => {
+        annotateAuthRejection('token_expired')
+      }).not.toThrow()
+    })
+  })
+
+  describe('annotateAuthSuccess', () => {
+    it('sets authentication success attributes on active recording span', async () => {
+      await trace.getTracer('test').startActiveSpan('testRoute', async () => {
+        annotateAuthSuccess({
+          authType: 'bearer',
+          actorId: 'https://llun.test/users/alice',
+          clientId: 'client-123',
+          userId: 'user-456',
+          grantedScopes: ['read', 'write']
+        })
+      })
+
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'auth.authenticated': true,
+        'auth.auth_type': 'bearer',
+        'auth.actor_id': 'https://llun.test/users/alice',
+        'auth.client_id': 'client-123',
+        'auth.user_id': 'user-456',
+        'auth.granted_scopes': 'read write'
+      })
+    })
+  })
+
+  describe('annotateAuthAnonymous', () => {
+    it('sets anonymous auth attributes on active recording span', async () => {
+      await trace.getTracer('test').startActiveSpan('testRoute', async () => {
+        annotateAuthAnonymous({
+          downgraded: true,
+          reason: 'token_not_found'
+        })
+      })
+
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'auth.auth_type': 'anonymous',
+        'auth.downgraded_from_invalid_token': true,
+        'auth.token_reject_reason': 'token_not_found'
+      })
+    })
+  })
+})

--- a/lib/services/guards/authTrace.ts
+++ b/lib/services/guards/authTrace.ts
@@ -1,0 +1,100 @@
+import { trace } from '@opentelemetry/api'
+
+const MAX_ATTRIBUTE_LENGTH = 500
+
+const bound = (value: string): string =>
+  value.length > MAX_ATTRIBUTE_LENGTH
+    ? value.slice(0, MAX_ATTRIBUTE_LENGTH)
+    : value
+
+/**
+ * Stamps an authentication rejection reason and optional diagnostic metadata
+ * onto the active OpenTelemetry span. If tracing is disabled or no span is
+ * recording, this is a no-op.
+ */
+export const annotateAuthRejection = (
+  reason: string,
+  extra: Record<string, string | number | boolean | string[] | undefined> = {}
+): void => {
+  try {
+    const span = trace.getActiveSpan()
+    if (!span || !span.isRecording()) return
+    span.setAttribute('auth.reject_reason', reason)
+    for (const [key, value] of Object.entries(extra)) {
+      if (value === undefined) continue
+      span.setAttribute(
+        `auth.${key}`,
+        typeof value === 'string'
+          ? bound(value)
+          : Array.isArray(value)
+            ? value.map((item) => bound(item))
+            : value
+      )
+    }
+  } catch {
+    // Tracing failures must never alter response handling
+  }
+}
+
+/**
+ * Stamps successful authentication metadata onto the active OpenTelemetry span.
+ */
+export const annotateAuthSuccess = ({
+  authType,
+  actorId,
+  clientId,
+  userId,
+  grantedScopes
+}: {
+  authType: 'bearer' | 'session'
+  actorId?: string | null
+  clientId?: string | null
+  userId?: string | null
+  grantedScopes?: string[] | null
+}): void => {
+  try {
+    const span = trace.getActiveSpan()
+    if (!span || !span.isRecording()) return
+    span.setAttribute('auth.authenticated', true)
+    span.setAttribute('auth.auth_type', authType)
+    if (actorId) {
+      span.setAttribute('auth.actor_id', bound(actorId))
+    }
+    if (clientId) {
+      span.setAttribute('auth.client_id', bound(clientId))
+    }
+    if (userId) {
+      span.setAttribute('auth.user_id', bound(userId))
+    }
+    if (grantedScopes && grantedScopes.length > 0) {
+      span.setAttribute('auth.granted_scopes', bound(grantedScopes.join(' ')))
+    }
+  } catch {
+    // Tracing failures must never alter response handling
+  }
+}
+
+/**
+ * Stamps anonymous authentication context onto the active OpenTelemetry span.
+ */
+export const annotateAuthAnonymous = ({
+  downgraded = false,
+  reason
+}: {
+  downgraded?: boolean
+  reason?: string
+} = {}): void => {
+  try {
+    const span = trace.getActiveSpan()
+    if (!span || !span.isRecording()) return
+    span.setAttribute('auth.auth_type', 'anonymous')
+    if (downgraded) {
+      span.setAttribute('auth.downgraded_from_invalid_token', true)
+    }
+    if (reason) {
+      span.setAttribute('auth.token_reject_reason', bound(reason))
+    }
+  } catch {
+    // Tracing failures must never alter response handling
+  }
+}

--- a/lib/utils/traceApiRoute.test.ts
+++ b/lib/utils/traceApiRoute.test.ts
@@ -29,7 +29,7 @@ describe('traceApiRoute', () => {
     vi.restoreAllMocks()
   })
 
-  it('wraps a successful route handler with tracing', async () => {
+  it('wraps a successful route handler with tracing and sets HTTP attributes', async () => {
     const handler = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {
         status: 200
@@ -37,12 +37,31 @@ describe('traceApiRoute', () => {
     )
 
     const wrapped = traceApiRoute('testRoute', handler)
-    const req = new NextRequest('http://localhost/api/test')
+    const req = new NextRequest('http://localhost/api/test?limit=100', {
+      headers: {
+        'user-agent': 'TestAgent/1.0'
+      }
+    })
     const context = { params: Promise.resolve({}) }
 
     const response = await wrapped(req, context)
 
     expect(handler).toHaveBeenCalledWith(req, context)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'http.request.method',
+      'GET'
+    )
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('url.path', '/api/test')
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('url.query', 'limit=100')
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'user_agent.original',
+      'TestAgent/1.0'
+    )
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'http.response.status_code',
+      200
+    )
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('http.status_code', 200)
     expect(mockSpan.setStatus).toHaveBeenCalledWith({
       code: SpanStatusCode.OK
     })

--- a/lib/utils/traceApiRoute.ts
+++ b/lib/utils/traceApiRoute.ts
@@ -28,18 +28,48 @@ export function traceApiRoute<P = unknown>(
   return (req: NextRequest, context: { params: Promise<P> }) => {
     return getTracer().startActiveSpan(`${op}.${name}`, async (span) => {
       try {
+        try {
+          const url = req.nextUrl ?? new URL(req.url, 'http://localhost')
+          span.setAttribute('http.request.method', req.method)
+          span.setAttribute('url.path', url.pathname)
+          const query = url.search
+            ? url.search.startsWith('?')
+              ? url.search.slice(1)
+              : url.search
+            : ''
+          if (query) {
+            span.setAttribute('url.query', query)
+          }
+          const userAgent = req.headers?.get?.('user-agent')
+          if (userAgent) {
+            span.setAttribute('user_agent.original', userAgent)
+          }
+        } catch {
+          // Tracing failures must never alter request handling
+        }
+
         if (addAttributes) {
-          const attributes = await addAttributes(req, context)
-          Object.entries(attributes).forEach(([key, value]) => {
-            if (value !== undefined) {
-              span.setAttribute(key, value)
-            }
-          })
+          try {
+            const attributes = await addAttributes(req, context)
+            Object.entries(attributes).forEach(([key, value]) => {
+              if (value !== undefined) {
+                span.setAttribute(key, value)
+              }
+            })
+          } catch {
+            // Tracing failures must never alter request handling
+          }
         }
 
         const response = await handler(req, context)
 
         const statusCode = response.status
+        try {
+          span.setAttribute('http.response.status_code', statusCode)
+          span.setAttribute('http.status_code', statusCode)
+        } catch {
+          // Tracing failures must never alter response handling
+        }
         if (statusCode >= 200 && statusCode < 400) {
           span.setStatus({ code: SpanStatusCode.OK })
         } else {


### PR DESCRIPTION
## Summary

- **Mastodon API compatibility for Optional OAuth (`OptionalOAuthGuard`)**:
  - When requests to public or optional-auth endpoints (e.g. `GET /api/v1/timelines/public`, `GET /api/v1/accounts/:id/media`, `GET /api/v1/accounts/lookup`) present an invalid, expired, or unscoped bearer token (such as a stale client token forwarded by a CDN/proxy), `OptionalOAuthGuard` now downgrades the 401 response to anonymous access (`currentActor: null`), allowing public requests to succeed with `200 OK`.
  - Matches Mastodon's `authorize_if_got_token!` upstream behavior where invalid tokens are treated as `nil` (`current_user = nil`) rather than failing public reads (*"a token must never make a request worse than sending none"*).
  - True security blocks (`403 Forbidden` for suspended actors and disabled accounts) and server errors (`500`) are preserved.

- **OpenTelemetry Trace Span Enrichment**:
  - Created `lib/services/guards/authTrace.ts` helper module to record semantic auth attributes on active spans (`auth.authenticated`, `auth.auth_type`, `auth.reject_reason`, `auth.actor_id`, `auth.client_id`, `auth.user_id`, `auth.granted_scopes`, `auth.downgraded_from_invalid_token`).
  - Stamped auth rejection, success, and downgrade attributes inside `OAuthGuard`, `OAuthAppGuard`, and `OptionalOAuthGuard`.
  - Enhanced `traceApiRoute.ts` to automatically record standard HTTP attributes on active spans (`http.request.method`, `url.path`, `url.query`, `user_agent.original`, `http.response.status_code`, `http.status_code`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
