### PR TITLE
Bump version to v1.150.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.149.21",
+  "version": "1.150.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.150.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.149.21`
- Base main SHA: `f12792f8999405ff9b0142071e441fa741d7e312`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
