### PR TITLE
fix: use request headerHost for account lookup domain resolution

### DIFF
--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -42,7 +42,7 @@ vi.mock('@/lib/database', () => ({
 
 vi.mock('@/lib/config', () => ({
   getBaseURL: () => 'https://llun.test',
-  getConfig: () => ({ host: 'llun.test' })
+  getConfig: () => ({ host: 'llun.test', trustedHosts: ['custom.llun.test'] })
 }))
 
 vi.mock('better-auth/oauth2', () => ({
@@ -107,6 +107,48 @@ describe('GET /api/v1/accounts/lookup', () => {
       username: 'test1',
       domain: 'llun.test'
     })
+  })
+
+  it('uses headerHost for local lookup when handle has no domain', async () => {
+    const actor = { id: 'https://custom.llun.test/users/null' }
+    const account = { id: 'null', username: 'null', acct: 'null' }
+    mockGetActorFromUsername.mockResolvedValue(actor)
+    mockGetMastodonActorFromId.mockResolvedValue(account)
+
+    const response = await GET(
+      new NextRequest(
+        'https://custom.llun.test/api/v1/accounts/lookup?acct=null',
+        {
+          headers: { host: 'custom.llun.test' }
+        }
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'custom.llun.test'
+    })
+  })
+
+  it('does not remotely resolve handles for trusted instance domains', async () => {
+    mockGetActorFromUsername.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: 'https://llun.test/users/oauth-user',
+      scopes: 'read'
+    })
+    mockGetActorFromId.mockResolvedValue(oauthActor)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=missing@custom.llun.test&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      )
+    )
+
+    expect(response.status).toBe(404)
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
   })
 
   it('rejects handles with more than one username/domain separator', async () => {

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -19,6 +19,7 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { isOwnInstanceHost } from '@/lib/utils/host'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -96,8 +97,8 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
       responseStatusCode: 400
     })
 
-  const config = getConfig()
-  const handle = parseAccountHandle(acct, config.host)
+  const host = headerHost(req.headers)
+  const handle = parseAccountHandle(acct, host)
 
   if (!handle)
     return apiResponse({
@@ -176,7 +177,7 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
     if (!isInternal && (await getRemoteFetchAuth()).authorized) {
       actor = await refreshKnownRemoteActor({ database, actor })
     }
-  } else if (resolve && domain !== config.host) {
+  } else if (resolve && !isOwnInstanceHost(domain, getConfig())) {
     // An invalid bearer already returned above, so an unauthorized viewer
     // here is credential-less and gets the same 404 an unresolvable handle
     // would.
@@ -215,6 +216,6 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data: localizeAccount(mastodonActor, headerHost(req.headers))
+    data: localizeAccount(mastodonActor, host)
   })
 })


### PR DESCRIPTION
## Summary

Fixes 404 errors on `GET /api/v1/accounts/lookup?acct=<username>` for handles without an explicit `@domain` suffix when accessed via trusted alternative domains or reverse proxies (such as CloudFront).

## Cause & Root Problem

When `GET /api/v1/accounts/lookup` resolved an account handle without an explicit `@domain` part (e.g. `acct=null`), it defaulted the domain using `config.host` (`getConfig().host`) instead of the request host `headerHost(req.headers)`.

In setups where a reverse proxy (e.g. CloudFront for `llun.dev`) routes requests to an origin running with a different default host (e.g. `cloudrun.llun.social`), or on multi-domain instances where actors exist under trusted alternative domains:
1. `parseAccountHandle(acct, config.host)` constructed `{ username: 'null', domain: 'cloudrun.llun.social' }`.
2. The database lookup searched for `domain = 'cloudrun.llun.social'` instead of `domain = 'llun.dev'`.
3. The lookup returned `null` and resulted in a `404 Not Found`.
4. Additionally, the `resolve=true` branch used `domain !== config.host` rather than `isOwnInstanceHost(domain, getConfig())`, which could erroneously trigger remote WebFinger lookups for trusted local domains.

## Fix

1. In `app/api/v1/accounts/lookup/route.ts`:
   - Resolve `host = headerHost(req.headers)` and pass it to `parseAccountHandle(acct, host)`.
   - Update the remote WebFinger check to `!isOwnInstanceHost(domain, getConfig())`.
   - Reuse `host` for `localizeAccount(mastodonActor, host)`.
2. In `app/api/v1/accounts/lookup/route.test.ts`:
   - Added test verifying that account lookup without a domain uses `headerHost` from request headers.
   - Added test verifying that accounts on trusted instance domains are not remotely resolved.

## Verification

- `yarn run prettier --write .` passed.
- `yarn lint` passed (0 errors, 72 warnings).
- `yarn typecheck` passed (0 errors).
- `yarn build` passed.
- `yarn test` passed (913 test files, 12,298 tests passed).
