### PR TITLE
fix: use headerHost and trusted host rules for API domain resolution

### DIFF
--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -452,4 +452,31 @@ describe('GET /api/v1/accounts/search', () => {
       exactActorIds: []
     })
   })
+
+  it('does not webfinger an unknown handle on a trusted local domain', async () => {
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetActorFromUsername.mockResolvedValue(null)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=unknown%40alias.llun.test&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'unknown',
+      domain: 'alias.llun.test'
+    })
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'unknown@alias.llun.test',
+      limit: 40,
+      offset: 0,
+      localDomain: 'llun.test',
+      exactActorIds: []
+    })
+  })
 })

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -47,7 +47,7 @@ vi.mock('@/lib/database', () => ({
 
 vi.mock('@/lib/config', () => ({
   getBaseURL: () => 'https://llun.test',
-  getConfig: () => ({ host: 'llun.test' })
+  getConfig: () => ({ host: 'llun.test', trustedHosts: ['alias.llun.test'] })
 }))
 
 vi.mock('better-auth/oauth2', () => ({
@@ -429,6 +429,27 @@ describe('GET /api/v1/accounts/search', () => {
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenLastCalledWith({
       ids: [resolvedActor.id, 'https://llun.test/users/charlie-brown']
+    })
+  })
+
+  it('scopes searchAccountIds localDomain to a trusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/accounts/search?q=runner', {
+        headers: {
+          Authorization: 'Bearer read-accounts-token',
+          'x-forwarded-host': 'alias.llun.test'
+        }
+      }),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'runner',
+      limit: 40,
+      offset: 0,
+      localDomain: 'alias.llun.test',
+      exactActorIds: []
     })
   })
 })

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
+import { getConfig } from '@/lib/config'
 import { localizeAccounts } from '@/lib/services/accounts/localizeAccount'
 import {
   recordRemoteActorBestEffort,
@@ -11,6 +12,7 @@ import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
+import { isOwnInstanceHost } from '@/lib/utils/host'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -105,7 +107,7 @@ export const GET = traceApiRoute(
             database,
             actor: storedExactActor
           })
-        } else {
+        } else if (!isOwnInstanceHost(handle.domain, getConfig())) {
           const actorId = await getWebfingerSelf({
             account: `${handle.username}@${handle.domain}`
           })

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
-import { getConfig } from '@/lib/config'
 import { localizeAccounts } from '@/lib/services/accounts/localizeAccount'
 import {
   recordRemoteActorBestEffort,
@@ -70,14 +69,13 @@ export const GET = traceApiRoute(
       }
 
       const query = q.trim()
-      const localDomain = getConfig().host
       const accessDomain = headerHost(req.headers)
       const getSearchParams = (exactActorIds: string[] = []) => {
         return {
           q: query,
           limit,
           offset,
-          localDomain,
+          localDomain: accessDomain,
           exactActorIds,
           ...(following ? { followingActorId: context.currentActor.id } : {})
         }

--- a/app/api/v1/actors/domains/route.test.ts
+++ b/app/api/v1/actors/domains/route.test.ts
@@ -100,11 +100,11 @@ describe('GET /api/v1/actors/domains', () => {
     }
   })
 
-  it('returns host from config', async () => {
+  it('returns trusted host rules when allowActorDomains is not set', async () => {
     mockGetConfig.mockReturnValue({
-      host: 'main.test',
-      allowEmails: [],
-      allowActorDomains: ['allowed.test']
+      host: 'llun.test',
+      trustedHosts: ['alias.llun.test', 'other.llun.test'],
+      allowEmails: []
     })
 
     const response = await GET(createRequest(), {
@@ -113,6 +113,30 @@ describe('GET /api/v1/actors/domains', () => {
 
     const data = await response.json()
     expect(response.status).toBe(200)
-    expect(data.host).toBe('main.test')
+    expect(data.domains).toEqual([
+      'llun.test',
+      'alias.llun.test',
+      'other.llun.test'
+    ])
+    expect(data.host).toBe('llun.test')
+  })
+
+  it('returns host from request headers', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'main.test',
+      trustedHosts: ['alias.main.test'],
+      allowEmails: []
+    })
+
+    const response = await GET(
+      new NextRequest('https://main.test/api/v1/actors/domains', {
+        headers: { 'x-forwarded-host': 'alias.main.test' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    const data = await response.json()
+    expect(response.status).toBe(200)
+    expect(data.host).toBe('alias.main.test')
   })
 })

--- a/app/api/v1/actors/domains/route.ts
+++ b/app/api/v1/actors/domains/route.ts
@@ -2,7 +2,9 @@ import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { getResolvedServerSettings } from '@/lib/services/serverSettings'
+import { getTrustedHostRules } from '@/lib/utils/host'
 import { apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
@@ -13,14 +15,14 @@ export const GET = traceApiRoute(
     const { federation } = await getResolvedServerSettings()
     const allowedDomains = federation.allowActorDomains.length
       ? federation.allowActorDomains
-      : [config.host]
+      : getTrustedHostRules(config)
 
     return apiResponse({
       req,
       allowedMethods: ['GET'],
       data: {
         domains: allowedDomains,
-        host: config.host
+        host: headerHost(req.headers)
       }
     })
   })

--- a/app/api/v1/actors/route.test.ts
+++ b/app/api/v1/actors/route.test.ts
@@ -99,6 +99,26 @@ describe('POST /api/v1/actors', () => {
     }
   })
 
+  it('allows creating an actor on a trusted host when allowActorDomains is not set', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      trustedHosts: ['alias.llun.test'],
+      allowEmails: []
+    })
+
+    const response = await POST(
+      createRequest({
+        username: 'newactor-trusted',
+        domain: 'alias.llun.test'
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    const data = await response.json()
+    expect(response.status).toBe(200)
+    expect(data.domain).toBe('alias.llun.test')
+  })
+
   it('falls back to the current actor domain when none is provided', async () => {
     mockGetConfig.mockReturnValue({
       host: 'llun.test',

--- a/app/api/v1/actors/route.ts
+++ b/app/api/v1/actors/route.ts
@@ -7,6 +7,7 @@ import { localUsernameSchema } from '@/lib/services/accounts/localUsername'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getResolvedServerSettings } from '@/lib/services/serverSettings'
+import { getTrustedHostRules } from '@/lib/utils/host'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -75,7 +76,7 @@ export const POST = traceApiRoute(
       parsed.data.domain ?? currentActor.domain ?? headerHost(req.headers)
     const allowedDomains = federation.allowActorDomains.length
       ? federation.allowActorDomains
-      : [config.host]
+      : getTrustedHostRules(config)
 
     if (!allowedDomains.includes(domain)) {
       return apiResponse({

--- a/app/api/v1/directory/route.test.ts
+++ b/app/api/v1/directory/route.test.ts
@@ -10,7 +10,10 @@ const mockCurrentActor = {
 }
 
 vi.mock('@/lib/config', () => ({
-  getConfig: () => ({ host: 'local.test' })
+  getConfig: () => ({
+    host: 'local.test',
+    trustedHosts: ['alias.local.test']
+  })
 }))
 
 vi.mock('@/lib/services/guards/OAuthGuard', () => ({
@@ -125,6 +128,23 @@ describe('GET /api/v1/directory', () => {
     expect(response.status).toBe(200)
     expect(mockDatabase.getLocalMastodonActors).toHaveBeenCalledWith(
       expect.objectContaining({ local: expectedLocal })
+    )
+  })
+
+  it('passes request headerHost as localDomain when x-forwarded-host is present', async () => {
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/directory?local=true', {
+        headers: { 'x-forwarded-host': 'alias.local.test' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getLocalMastodonActors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localDomain: 'alias.local.test',
+        local: true
+      })
     )
   })
 })

--- a/app/api/v1/directory/route.ts
+++ b/app/api/v1/directory/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
-import { getConfig } from '@/lib/config'
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -44,7 +44,7 @@ export const GET = traceApiRoute(
 
     const { offset, limit, order, local } = parsed.data
     const actors = await database.getLocalMastodonActors({
-      localDomain: getConfig().host,
+      localDomain: headerHost(req.headers),
       limit,
       offset,
       order,

--- a/app/api/v1/instance/peers/route.test.ts
+++ b/app/api/v1/instance/peers/route.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getInstancePeers: vi.fn()
+}
+
+let databasePresent: typeof mockDatabase | null = mockDatabase
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => databasePresent
+}))
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.test',
+    trustedHosts: ['alias.llun.test']
+  })
+}))
+
+const params = { params: Promise.resolve({}) }
+
+describe('GET /api/v1/instance/peers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    databasePresent = mockDatabase
+    mockDatabase.getInstancePeers.mockResolvedValue([
+      'remote1.test',
+      'remote2.test'
+    ])
+  })
+
+  it('returns peers excluding the canonical host by default', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/peers'),
+      params
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getInstancePeers).toHaveBeenCalledWith({
+      localDomain: 'llun.test'
+    })
+    const data = await response.json()
+    expect(data).toEqual(['remote1.test', 'remote2.test'])
+  })
+
+  it('returns peers excluding a trusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/peers', {
+        headers: { 'x-forwarded-host': 'alias.llun.test' }
+      }),
+      params
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getInstancePeers).toHaveBeenCalledWith({
+      localDomain: 'alias.llun.test'
+    })
+  })
+
+  it('returns 500 when database is not available', async () => {
+    databasePresent = null
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/peers'),
+      params
+    )
+
+    expect(response.status).toBe(500)
+  })
+})

--- a/app/api/v1/instance/peers/route.ts
+++ b/app/api/v1/instance/peers/route.ts
@@ -1,5 +1,5 @@
-import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_500,
@@ -28,7 +28,7 @@ export const GET = traceApiRoute('getInstancePeers', async (req) => {
   }
 
   const peers = await database.getInstancePeers({
-    localDomain: getConfig().host
+    localDomain: headerHost(req.headers)
   })
   return apiResponse({
     req,

--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -83,6 +83,25 @@ describe('GET /api/v1/instance', () => {
     })
   })
 
+  it('passes the request domain to getInstanceStats', async () => {
+    const peersSpy = vi
+      .spyOn(database, 'getInstancePeers')
+      .mockResolvedValue([])
+    try {
+      await GET(
+        new NextRequest('https://llun.test/api/v1/instance', {
+          headers: { 'x-forwarded-host': 'alias.llun.test' }
+        }),
+        params
+      )
+      expect(peersSpy).toHaveBeenCalledWith({
+        localDomain: 'alias.llun.test'
+      })
+    } finally {
+      peersSpy.mockRestore()
+    }
+  })
+
   it('ignores an untrusted forwarded host', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v1/instance', {

--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -45,7 +45,7 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
   }
 
   const [stats, contactAccount, serverSettings] = await Promise.all([
-    getInstanceStats(database, config.host),
+    getInstanceStats(database, domain),
     getInstanceContactAccount(database),
     getResolvedServerSettings(database)
   ])

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -91,6 +91,25 @@ describe('GET /api/v2/instance', () => {
     })
   })
 
+  it('passes the request domain to getInstanceStats', async () => {
+    const peersSpy = vi
+      .spyOn(database, 'getInstancePeers')
+      .mockResolvedValue([])
+    try {
+      await GET(
+        new NextRequest('https://llun.test/api/v2/instance', {
+          headers: { 'x-forwarded-host': 'alias.llun.test' }
+        }),
+        params
+      )
+      expect(peersSpy).toHaveBeenCalledWith({
+        localDomain: 'alias.llun.test'
+      })
+    } finally {
+      peersSpy.mockRestore()
+    }
+  })
+
   it('ignores an untrusted forwarded host', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v2/instance', {

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -50,7 +50,7 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
     }
   }
   const [stats, contactAccount, serverSettings] = await Promise.all([
-    getInstanceStats(database, config.host),
+    getInstanceStats(database, domain),
     getInstanceContactAccount(database),
     getResolvedServerSettings(database)
   ])

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -74,7 +74,7 @@ vi.mock('@/lib/database', () => ({
 
 vi.mock('@/lib/config', () => ({
   getBaseURL: () => 'https://llun.test',
-  getConfig: () => ({ host: 'llun.test' })
+  getConfig: () => ({ host: 'llun.test', trustedHosts: ['alias.llun.test'] })
 }))
 
 vi.mock('better-auth/oauth2', () => ({
@@ -208,7 +208,8 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 3,
-      offset: 0
+      offset: 0,
+      localDomain: 'llun.test'
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',
@@ -252,6 +253,7 @@ describe('GET /api/v2/search', () => {
       q: 'trail',
       limit: 2,
       offset: 0,
+      localDomain: 'llun.test',
       followingActorId: oauthActor.id
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
@@ -419,7 +421,8 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 20,
-      offset: 0
+      offset: 0,
+      localDomain: 'llun.test'
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',
@@ -443,6 +446,7 @@ describe('GET /api/v2/search', () => {
       q: 'trail',
       limit: 20,
       offset: 0,
+      localDomain: 'llun.test',
       followingActorId: oauthActor.id
     })
   })
@@ -478,7 +482,8 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 20,
-      offset: 0
+      offset: 0,
+      localDomain: 'llun.test'
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',
@@ -1183,6 +1188,64 @@ describe('GET /api/v2/search', () => {
     })
   })
 
+  it('resolves bare username queries against the request accessDomain', async () => {
+    const localActor = {
+      id: 'https://alias.llun.test/users/runner',
+      account: { id: 'account-id' },
+      privateKey: 'private-key'
+    }
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetActorFromUsername.mockResolvedValue(localActor)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=runner&type=accounts&resolve=true',
+        {
+          headers: {
+            Authorization: 'Bearer read-search-token',
+            'x-forwarded-host': 'alias.llun.test'
+          }
+        }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'runner',
+      domain: 'alias.llun.test'
+    })
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'runner',
+      limit: 20,
+      offset: 0,
+      localDomain: 'alias.llun.test'
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: [localActor.id]
+    })
+  })
+
+  it('does not webfinger an unknown handle on a trusted local domain', async () => {
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetActorFromUsername.mockResolvedValue(null)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=unknown%40alias.llun.test&type=accounts&resolve=true',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'unknown',
+      domain: 'alias.llun.test'
+    })
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+  })
+
   it('does not resolve account URLs after the first page', async () => {
     const accountUrl = 'http://remote.test/users/resolved'
 
@@ -1316,7 +1379,8 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 40,
-      offset: 0
+      offset: 0,
+      localDomain: 'llun.test'
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -34,6 +34,7 @@ import {
 } from '@/lib/utils/accountHandle'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { clampedLimit } from '@/lib/utils/clampedLimit'
+import { isOwnInstanceHost } from '@/lib/utils/host'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import {
@@ -268,7 +269,8 @@ const resolveAccountId = async ({
   query,
   resolve,
   following,
-  signingActor
+  signingActor,
+  accessDomain
 }: {
   database: Database
   currentActor: Actor | null
@@ -276,6 +278,7 @@ const resolveAccountId = async ({
   resolve: boolean
   following: boolean
   signingActor?: Actor
+  accessDomain: string
 }) => {
   if (!resolve) return null
 
@@ -323,7 +326,7 @@ const resolveAccountId = async ({
 
   const handle = query.includes('@')
     ? parseAccountHandle(query)
-    : { username: query, domain: getConfig().host }
+    : { username: query, domain: accessDomain }
   if (!handle) return null
 
   let actor = await database.getActorFromUsername(handle)
@@ -331,7 +334,10 @@ const resolveAccountId = async ({
     // Same refresh as the URL branch: handle searches with resolve=true are
     // how apps open remote profiles, and the header is built from this result.
     actor = await refreshKnownRemoteActor({ database, actor, signingActor })
-  } else if (query.includes('@')) {
+  } else if (
+    query.includes('@') &&
+    !isOwnInstanceHost(handle.domain, getConfig())
+  ) {
     const actorId = await getWebfingerSelf({
       account: `${handle.username}@${handle.domain}`
     })
@@ -424,7 +430,8 @@ const searchAccounts = async ({
   query,
   limit,
   offset,
-  signingActor
+  signingActor,
+  accessDomain
 }: {
   database: Database
   currentActor: Actor | null
@@ -433,6 +440,7 @@ const searchAccounts = async ({
   limit: number
   offset: number
   signingActor?: Actor
+  accessDomain: string
 }) => {
   const [resolvedAccountId, indexedIds] = await Promise.all([
     offset === 0
@@ -442,13 +450,15 @@ const searchAccounts = async ({
           query,
           resolve: params.resolve ?? false,
           following: params.following ?? false,
-          signingActor
+          signingActor,
+          accessDomain
         })
       : Promise.resolve(null),
     database.searchAccountIds({
       q: query,
       limit,
       offset,
+      localDomain: accessDomain,
       ...(params.following && currentActor
         ? { followingActorId: currentActor.id }
         : {})
@@ -638,6 +648,7 @@ export const GET = traceApiRoute(
       // user-scoped (`currentActor`) and are untouched. Resolution is
       // best-effort: a missing/failed signer degrades to an unsigned fetch
       // rather than failing the whole search.
+      const accessDomain = headerHost(req.headers)
       const requiresRemoteSigner = params.resolve === true && offset === 0
       const signingActor = requiresRemoteSigner
         ? await getFederationSigningActor(database).catch((error) => {
@@ -659,7 +670,8 @@ export const GET = traceApiRoute(
               query,
               limit,
               offset,
-              signingActor
+              signingActor,
+              accessDomain
             })
           : [],
         includeHashtags
@@ -698,7 +710,7 @@ export const GET = traceApiRoute(
         req,
         allowedMethods: CORS_HEADERS,
         data: {
-          accounts: localizeAccounts(accounts, headerHost(req.headers)),
+          accounts: localizeAccounts(accounts, accessDomain),
           statuses,
           hashtags
         }


### PR DESCRIPTION
## Summary
Audits and updates API endpoints to use \`headerHost(req.headers)\` and instance trusted host rules (\`isOwnInstanceHost\` / \`getTrustedHostRules\`) instead of static \`config.host\` / \`getConfig().host\` for request-time domain resolution, filtering, and validation.

### Changes
1. **\`app/api/v2/search/route.ts\`**:
   - Threaded \`accessDomain = headerHost(req.headers)\` down to \`searchAccounts\` and \`resolveAccountId\`.
   - Updated \`resolveAccountId\` bare-username domain default to use \`accessDomain\`.
   - Added \`!isOwnInstanceHost(handle.domain, getConfig())\` guard to prevent outbound WebFinger calls against local/trusted domains when an actor does not exist.
   - Passed \`localDomain: accessDomain\` to \`database.searchAccountIds(...)\`.
2. **\`app/api/v1/accounts/search/route.ts\`**:
   - Passed \`localDomain: accessDomain\` to \`database.searchAccountIds(...)\`.
3. **\`app/api/v1/directory/route.ts\`**:
   - Passed \`localDomain: headerHost(req.headers)\` to \`database.getLocalMastodonActors(...)\`.
4. **\`app/api/v1/actors/route.ts\` & \`app/api/v1/actors/domains/route.ts\`**:
   - Updated \`allowedDomains\` fallback from \`[config.host]\` to \`getTrustedHostRules(config)\`.
   - Updated \`GET /api/v1/actors/domains\` response \`host\` to \`headerHost(req.headers)\`.
5. **\`app/api/v1/instance/peers/route.ts\`**:
   - Passed \`localDomain: headerHost(req.headers)\` to \`database.getInstancePeers(...)\`.
6. **\`app/api/v1/instance/route.ts\` & \`app/api/v2/instance/route.ts\`**:
   - Passed \`domain = headerHost(req.headers)\` to \`getInstanceStats(database, domain)\`.

### Test Coverage & Verification
- Updated and added unit test cases covering default host and trusted forwarded hosts (\`x-forwarded-host\`).
- Full quality gate passed:
  - \`yarn run prettier --write .\` (green)
  - \`yarn lint\` (green, 0 errors)
  - \`yarn typecheck\` (green)
  - \`yarn build\` (green)
  - \`yarn test\` (green, 914 test files passed, 12,320 tests passed)