### PR TITLE
Bump version to v1.150.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.150.2",
+  "version": "1.150.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.150.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.150.2`
- Base main SHA: `eac8f82051f39c670bcdf767cadf0b39fbfbc554`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
