### PR TITLE
Fix ActivityPub Accept header missing profile parameter

### DIFF
--- a/lib/activities/activityPubHeaders.test.ts
+++ b/lib/activities/activityPubHeaders.test.ts
@@ -35,7 +35,7 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toEqual({
-      accept: 'application/activity+json, application/ld+json'
+      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
     })
   })
 
@@ -57,7 +57,7 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      accept: 'application/activity+json, application/ld+json',
+      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
       host: 'remote.test',
       signature: expect.stringContaining('headers="(request-target) host date"')
     })
@@ -80,7 +80,7 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      accept: 'application/activity+json, application/ld+json',
+      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
       'content-type': 'application/activity+json',
       digest: expect.stringMatching(/^SHA-256=/),
       signature: expect.stringContaining(

--- a/lib/activities/activityPubHeaders.test.ts
+++ b/lib/activities/activityPubHeaders.test.ts
@@ -35,7 +35,8 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toEqual({
-      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      accept:
+        'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
     })
   })
 
@@ -57,7 +58,8 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+      accept:
+        'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
       host: 'remote.test',
       signature: expect.stringContaining('headers="(request-target) host date"')
     })
@@ -80,7 +82,8 @@ describe('activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+      accept:
+        'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
       'content-type': 'application/activity+json',
       digest: expect.stringMatching(/^SHA-256=/),
       signature: expect.stringContaining(

--- a/lib/activities/constants.ts
+++ b/lib/activities/constants.ts
@@ -1,2 +1,3 @@
-export const DEFAULT_ACCEPT = 'application/activity+json, application/ld+json'
+export const DEFAULT_ACCEPT =
+  'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
 export const DEFAULT_SHORT_REQUEST_TIMEOUT = 100


### PR DESCRIPTION
Update the `DEFAULT_ACCEPT` header in `lib/activities/constants.ts` to include the `profile` parameter for `application/ld+json`, which is required by the ActivityPub specification. Also update the corresponding tests in `lib/activities/activityPubHeaders.test.ts`.

---
*PR created automatically by Jules for task [11445290154134245206](https://jules.google.com/task/11445290154134245206) started by @llun*