### PR TITLE
fix: stack list header buttons onto new row on mobile

### DIFF
--- a/app/(timeline)/lists/ListsIndex.tsx
+++ b/app/(timeline)/lists/ListsIndex.tsx
@@ -113,8 +113,9 @@ export const ListsIndex: FC<ListsIndexProps> = ({ lists, collections }) => {
       <PageHeader
         title="Lists & Collections"
         description="Private curated timelines and shareable feeds you highlight"
+        stackActionsOnMobile
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <NewListButton variant="outline" />
             <NewCollectionButton />
           </div>

--- a/lib/components/page-header.test.tsx
+++ b/lib/components/page-header.test.tsx
@@ -40,4 +40,65 @@ describe('PageHeader', () => {
     expect(container.querySelector('.max-w-content')).not.toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'General' })).toBeInTheDocument()
   })
+
+  it('stacks actions on mobile when stackActionsOnMobile is true', () => {
+    const { container } = render(
+      <PageHeader
+        title="Lists & Collections"
+        description="Private curated timelines"
+        stackActionsOnMobile
+        actions={<button type="button">New list</button>}
+      />
+    )
+
+    const flexContainer = container.querySelector('.max-w-content > div')
+    expect(flexContainer).toHaveClass('flex-col')
+    expect(flexContainer).toHaveClass('sm:flex-row')
+    const actionWrapper = screen.getByRole('button', {
+      name: 'New list'
+    }).parentElement
+    expect(actionWrapper).toHaveClass('self-start')
+    expect(actionWrapper).toHaveClass('sm:self-center')
+  })
+
+  it('stacks actions on mobile in section mode when stackActionsOnMobile is true', () => {
+    const { container } = render(
+      <PageHeaderSectionProvider>
+        <PageHeader
+          title="Section"
+          description="Description"
+          stackActionsOnMobile
+          actions={<button type="button">Action</button>}
+        />
+      </PageHeaderSectionProvider>
+    )
+
+    const flexContainer = container.querySelector('.mb-6 > div')
+    expect(flexContainer).toHaveClass('flex-col')
+    expect(flexContainer).toHaveClass('sm:flex-row')
+    const actionWrapper = screen.getByRole('button', {
+      name: 'Action'
+    }).parentElement
+    expect(actionWrapper).toHaveClass('self-start')
+    expect(actionWrapper).toHaveClass('sm:self-center')
+  })
+
+  it('keeps actions inline by default when stackActionsOnMobile is not set', () => {
+    const { container } = render(
+      <PageHeader
+        title="Lists"
+        actions={<button type="button">Action</button>}
+      />
+    )
+
+    const flexContainer = container.querySelector('.max-w-content > div')
+    expect(flexContainer).toHaveClass('items-start')
+    expect(flexContainer).toHaveClass('justify-between')
+    expect(flexContainer).not.toHaveClass('flex-col')
+    const actionWrapper = screen.getByRole('button', {
+      name: 'Action'
+    }).parentElement
+    expect(actionWrapper).toHaveClass('self-center')
+    expect(actionWrapper).not.toHaveClass('self-start')
+  })
 })

--- a/lib/components/page-header.tsx
+++ b/lib/components/page-header.tsx
@@ -9,6 +9,7 @@ interface PageHeaderProps {
   description?: ReactNode
   actions?: ReactNode
   className?: string
+  stackActionsOnMobile?: boolean
 }
 
 // Break out of the content column (`max-w-content`) so the chrome spans the
@@ -69,7 +70,8 @@ export const PageHeader = ({
   title,
   description,
   actions,
-  className
+  className,
+  stackActionsOnMobile
 }: PageHeaderProps) => {
   const subnav = useContext(PageSubnavContext)
   const isSection = useContext(PageHeaderSectionContext)
@@ -77,7 +79,14 @@ export const PageHeader = ({
   if (isSection) {
     return (
       <div className={cn('mb-6', className)}>
-        <div className="flex items-start justify-between gap-4">
+        <div
+          className={cn(
+            'flex gap-4',
+            stackActionsOnMobile
+              ? 'flex-col sm:flex-row sm:items-start sm:justify-between'
+              : 'items-start justify-between'
+          )}
+        >
           <div className="min-w-0">
             <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
             {description && (
@@ -86,7 +95,18 @@ export const PageHeader = ({
               </div>
             )}
           </div>
-          {actions && <div className="shrink-0 self-center">{actions}</div>}
+          {actions && (
+            <div
+              className={cn(
+                'shrink-0',
+                stackActionsOnMobile
+                  ? 'self-start sm:self-center'
+                  : 'self-center'
+              )}
+            >
+              {actions}
+            </div>
+          )}
         </div>
         {subnav && <div className="mt-4">{subnav}</div>}
       </div>
@@ -102,7 +122,14 @@ export const PageHeader = ({
       style={breakoutStyle}
     >
       <div className="mx-auto max-w-content px-4 py-4">
-        <div className="flex items-start justify-between gap-4">
+        <div
+          className={cn(
+            'flex gap-4',
+            stackActionsOnMobile
+              ? 'flex-col sm:flex-row sm:items-start sm:justify-between'
+              : 'items-start justify-between'
+          )}
+        >
           <div className="min-w-0">
             <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
             {description && (
@@ -111,7 +138,18 @@ export const PageHeader = ({
               </div>
             )}
           </div>
-          {actions && <div className="shrink-0 self-center">{actions}</div>}
+          {actions && (
+            <div
+              className={cn(
+                'shrink-0',
+                stackActionsOnMobile
+                  ? 'self-start sm:self-center'
+                  : 'self-center'
+              )}
+            >
+              {actions}
+            </div>
+          )}
         </div>
         {subnav && <div className="mt-3">{subnav}</div>}
       </div>


### PR DESCRIPTION
## Summary

On mobile viewport sizes, the Lists & Collections header (`/lists`) squeezed the title and description into a narrow column because the "New list" and "New collection" action buttons were forced inline beside the description.

This change:
1. Adds `stackActionsOnMobile` prop to `PageHeader` in `@/lib/components/page-header.tsx`, allowing action buttons to wrap onto their own row on small screens (`flex-col sm:flex-row`).
2. Applies `stackActionsOnMobile` and `flex-wrap` to `ListsIndex.tsx`.
3. Adds unit tests covering `stackActionsOnMobile` behavior in `page-header.test.tsx`.

## Screenshots

- **Mobile View**: Action buttons ("New list" and "New collection") now render on a new row below the description, allowing the full title and description to fit cleanly.
- **Desktop View**: Unchanged, buttons remain aligned to the right side of the header.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)