### PR TITLE
Bump version to v1.150.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.150.3",
+  "version": "1.150.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.150.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.150.3`
- Base main SHA: `0515791a1f420a5299a875f04544e0612cab7083`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
