### PR TITLE
Bump version to v1.151.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.150.4",
+  "version": "1.151.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.151.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.150.4`
- Base main SHA: `bf9bf911456e34c6c9e5bad8b5abbcee26d483db`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
