### PR TITLE
feat: show redirect page for logged-out visitors on non-local user handles

### DIFF
--- a/app/(timeline)/[actor]/ActorRedirectCard.test.tsx
+++ b/app/(timeline)/[actor]/ActorRedirectCard.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ActorRedirectCard } from './ActorRedirectCard'
+
+describe('ActorRedirectCard', () => {
+  it('renders the redirect card with host, target link, and actor handle', () => {
+    render(
+      <ActorRedirectCard
+        host="llun.social"
+        targetUrl="https://pouet.chapril.org/@clairenony"
+        domain="pouet.chapril.org"
+        username="clairenony"
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('If you trust this link, click it to continue.')
+    ).toBeInTheDocument()
+
+    const buttonLink = screen.getByRole('link', {
+      name: /continue to pouet\.chapril\.org/i
+    })
+    expect(buttonLink).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony'
+    )
+    expect(buttonLink).toHaveAttribute('rel', 'noopener noreferrer')
+
+    const rawLink = screen.getByRole('link', {
+      name: 'https://pouet.chapril.org/@clairenony'
+    })
+    expect(rawLink).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony'
+    )
+
+    expect(
+      screen.getByText('@clairenony@pouet.chapril.org · external profile')
+    ).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/ActorRedirectCard.tsx
+++ b/app/(timeline)/[actor]/ActorRedirectCard.tsx
@@ -57,7 +57,7 @@ export const ActorRedirectCard: FC<ActorRedirectCardProps> = ({
           <a
             href={targetUrl}
             rel="noopener noreferrer"
-            className="text-primary hover:underline break-all text-center text-xs font-medium max-w-[360px]"
+            className="text-primary-text hover:underline break-all text-center text-xs font-medium max-w-[360px]"
           >
             {targetUrl}
           </a>

--- a/app/(timeline)/[actor]/ActorRedirectCard.tsx
+++ b/app/(timeline)/[actor]/ActorRedirectCard.tsx
@@ -1,0 +1,75 @@
+import { ExternalLink } from 'lucide-react'
+import { FC } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface ActorRedirectCardProps {
+  host: string
+  targetUrl: string
+  domain: string
+  username: string
+}
+
+export const ActorRedirectCard: FC<ActorRedirectCardProps> = ({
+  host,
+  targetUrl,
+  domain,
+  username
+}) => {
+  return (
+    <div className="flex flex-1 items-center justify-center p-4 sm:p-6">
+      <div
+        className={cn(
+          'bg-card flex w-full flex-col items-center rounded-xl border px-[22px] py-7 text-center shadow-sm',
+          'sm:max-w-[480px] sm:px-10 sm:py-11'
+        )}
+      >
+        {/* Eyebrow pill */}
+        <div className="bg-background text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
+          <ExternalLink className="size-[13px]" aria-hidden="true" />
+          <span>Redirect · external profile</span>
+        </div>
+
+        {/* Hero icon */}
+        <div className="text-primary mb-1 mt-4 sm:mt-[22px]">
+          <ExternalLink className="size-16 sm:size-[88px]" aria-hidden="true" />
+        </div>
+
+        {/* Title */}
+        <h1 className="mt-3 text-xl font-semibold leading-[1.25] tracking-[-0.01em] text-pretty sm:mt-4 sm:text-2xl">
+          You are leaving {host}
+        </h1>
+
+        {/* Body */}
+        <p className="text-muted-foreground mt-2.5 max-w-[380px] text-sm leading-[1.6] text-pretty sm:text-[15px]">
+          If you trust this link, click it to continue.
+        </p>
+
+        {/* Action button & target link */}
+        <div className="mt-6 flex w-full flex-col items-center gap-3">
+          <Button asChild className="w-full sm:w-auto">
+            <a href={targetUrl} rel="noopener noreferrer">
+              Continue to {domain}
+              <ExternalLink className="ml-2 h-4 w-4" />
+            </a>
+          </Button>
+          <a
+            href={targetUrl}
+            rel="noopener noreferrer"
+            className="text-primary hover:underline break-all text-center text-xs font-medium max-w-[360px]"
+          >
+            {targetUrl}
+          </a>
+        </div>
+
+        {/* Monospace technical detail */}
+        <div className="mt-[22px] w-full border-t pt-4 sm:mt-7">
+          <code className="text-muted-foreground font-mono text-xs">
+            @{username}@{domain} · external profile
+          </code>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(timeline)/[actor]/followers/page.test.tsx
+++ b/app/(timeline)/[actor]/followers/page.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { notFound, redirect } from 'next/navigation'
+
+import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+
+const mockDatabase = {
+  getFollowers: vi.fn(),
+  getActorFromId: vi.fn()
+}
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+  redirect: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/FollowList', () => ({
+  FollowList: () => <div data-testid="follow-list" />
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getFollowListBlockedActorIds', () => ({
+  getFollowListBlockedActorIds: vi.fn().mockResolvedValue([])
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+const mockRedirect = vi.mocked(redirect)
+const mockNotFound = vi.mocked(notFound)
+
+describe('[actor] followers page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+  })
+
+  it('redirects logged-out visitors on non-local actor to the main actor profile', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+
+    await Page({
+      params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+    })
+
+    expect(mockRedirect).toHaveBeenCalledWith('/@clairenony@pouet.chapril.org')
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  it('calls notFound for local actor when profile is not found', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue(null)
+
+    await Page({
+      params: Promise.resolve({ actor: '@unknown@llun.social' })
+    })
+
+    expect(mockNotFound).toHaveBeenCalled()
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+})

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { FC } from 'react'
 
 import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
@@ -10,6 +10,7 @@ import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { Button } from '@/lib/components/ui/button'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
 import { Actor, ActorProfile } from '@/lib/types/domain/actor'
 import { Follow } from '@/lib/types/domain/follow'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
@@ -40,7 +41,7 @@ const Page: FC<Props> = async ({ params }) => {
   if (parts.length !== 2) {
     return notFound()
   }
-  const actorDomain = parts[1]
+  const [actorUsername, actorDomain] = parts
 
   const actorProfile = await getProfileData(
     database,
@@ -49,6 +50,10 @@ const Page: FC<Props> = async ({ params }) => {
     { currentActor }
   )
   if (!actorProfile) {
+    const isLocal = await isLocalFederationDomain(database, actorDomain)
+    if (!isLoggedIn && !isLocal) {
+      return redirect(`/@${actorUsername}@${actorDomain}`)
+    }
     return notFound()
   }
 

--- a/app/(timeline)/[actor]/following/page.test.tsx
+++ b/app/(timeline)/[actor]/following/page.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { notFound, redirect } from 'next/navigation'
+
+import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+
+const mockDatabase = {
+  getFollowing: vi.fn(),
+  getActorFromId: vi.fn()
+}
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+  redirect: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/FollowList', () => ({
+  FollowList: () => <div data-testid="follow-list" />
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getFollowListBlockedActorIds', () => ({
+  getFollowListBlockedActorIds: vi.fn().mockResolvedValue([])
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+const mockRedirect = vi.mocked(redirect)
+const mockNotFound = vi.mocked(notFound)
+
+describe('[actor] following page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+  })
+
+  it('redirects logged-out visitors on non-local actor to the main actor profile', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+
+    await Page({
+      params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+    })
+
+    expect(mockRedirect).toHaveBeenCalledWith('/@clairenony@pouet.chapril.org')
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  it('calls notFound for local actor when profile is not found', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue(null)
+
+    await Page({
+      params: Promise.resolve({ actor: '@unknown@llun.social' })
+    })
+
+    expect(mockNotFound).toHaveBeenCalled()
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+})

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { FC } from 'react'
 
 import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
@@ -10,6 +10,7 @@ import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { Button } from '@/lib/components/ui/button'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
 import { Actor, ActorProfile } from '@/lib/types/domain/actor'
 import { Follow } from '@/lib/types/domain/follow'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
@@ -40,7 +41,7 @@ const Page: FC<Props> = async ({ params }) => {
   if (parts.length !== 2) {
     return notFound()
   }
-  const actorDomain = parts[1]
+  const [actorUsername, actorDomain] = parts
 
   const actorProfile = await getProfileData(
     database,
@@ -49,6 +50,10 @@ const Page: FC<Props> = async ({ params }) => {
     { currentActor }
   )
   if (!actorProfile) {
+    const isLocal = await isLocalFederationDomain(database, actorDomain)
+    if (!isLoggedIn && !isLocal) {
+      return redirect(`/@${actorUsername}@${actorDomain}`)
+    }
     return notFound()
   }
 

--- a/app/(timeline)/[actor]/page.redirect.test.tsx
+++ b/app/(timeline)/[actor]/page.redirect.test.tsx
@@ -18,7 +18,8 @@ vi.mock('@/lib/config', () => ({
   getConfig: () => ({
     host: 'llun.social',
     mediaStorage: null
-  })
+  }),
+  getBaseURL: () => 'https://llun.social'
 }))
 
 vi.mock('@/lib/database', () => ({

--- a/app/(timeline)/[actor]/page.redirect.test.tsx
+++ b/app/(timeline)/[actor]/page.redirect.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { getProfileData } from './getProfileData'
+import Page, { generateMetadata } from './page'
+
+const mockDatabase = {}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  })
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('./getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('./ActorTimelines', () => ({
+  ActorTimelines: () => <div data-testid="actor-timelines" />
+}))
+
+vi.mock('./ProfileHeaderImage', () => ({
+  ProfileHeaderImage: () => <div data-testid="header-image" />
+}))
+
+vi.mock('./ProfileRelationshipActions', () => ({
+  ProfileRelationshipActions: () => <div data-testid="relationship-actions" />
+}))
+
+vi.mock('@/lib/services/mastodon/getMastodonFeaturedTag', () => ({
+  getMastodonFeaturedTag: vi.fn()
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+const mockNotFound = vi.mocked(notFound)
+
+describe('[actor] page redirects and non-local handles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+  })
+
+  it('renders ActorRedirectCard for a non-local user when logged out', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+    })
+    render(element)
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('If you trust this link, click it to continue.')
+    ).toBeInTheDocument()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to pouet\.chapril\.org/i
+    })
+    expect(continueLink).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony'
+    )
+    expect(continueLink).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  it('calls notFound for an unknown local user when logged out', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue(null)
+
+    await Page({
+      params: Promise.resolve({ actor: '@unknown@llun.social' })
+    })
+
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+
+  it('calls notFound for invalid actor handle parameter', async () => {
+    await Page({
+      params: Promise.resolve({ actor: 'invalid' })
+    })
+
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+
+  describe('generateMetadata', () => {
+    it('sets canonical link and noindex robots for logged-out non-local actor', async () => {
+      mockGetServerAuthSession.mockResolvedValue(null)
+      mockIsLocalFederationDomain.mockResolvedValue(false)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @clairenony@pouet.chapril.org',
+        robots: { index: false, follow: false },
+        alternates: {
+          canonical: 'https://pouet.chapril.org/@clairenony'
+        }
+      })
+    })
+
+    it('sets standard metadata for local actor', async () => {
+      mockGetServerAuthSession.mockResolvedValue(null)
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@localuser@llun.social' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @localuser@llun.social'
+      })
+    })
+  })
+})

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -11,10 +11,12 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
+import { ActorRedirectCard } from './ActorRedirectCard'
 import { ActorTimelines } from './ActorTimelines'
 import { ProfileHeaderImage } from './ProfileHeaderImage'
 import { ProfileRelationshipActions } from './ProfileRelationshipActions'
@@ -38,8 +40,30 @@ export const generateMetadata = async ({
   params
 }: Props): Promise<Metadata> => {
   const { actor } = await params
+  const decodedActorHandle = decodeURIComponent(actor)
+  const parts = decodedActorHandle.split('@').slice(1)
+  if (parts.length === 2) {
+    const [username, domain] = parts
+    const database = getDatabase()
+    if (database) {
+      const session = await getServerAuthSession()
+      const isLoggedIn = Boolean(session?.user?.email)
+      const isLocal = await isLocalFederationDomain(database, domain)
+      if (!isLoggedIn && !isLocal) {
+        const targetUrl = `https://${domain}/@${username}`
+        return {
+          title: `Activities.next: ${decodedActorHandle}`,
+          robots: { index: false, follow: false },
+          alternates: {
+            canonical: targetUrl
+          }
+        }
+      }
+    }
+  }
+
   return {
-    title: `Activities.next: ${decodeURIComponent(actor)}`
+    title: `Activities.next: ${decodedActorHandle}`
   }
 }
 
@@ -56,7 +80,7 @@ const Page: FC<Props> = async ({ params }) => {
   if (parts.length !== 2) {
     return notFound()
   }
-  const actorDomain = parts[1]
+  const [actorUsername, actorDomain] = parts
 
   // Resolve the viewer's actor for relationship/ownership checks, settings, and
   // timeline rendering. Remote-fetch signing is handled inside getProfileData
@@ -73,6 +97,20 @@ const Page: FC<Props> = async ({ params }) => {
     { currentActor }
   )
   if (!actorProfile) {
+    const isLocal = await isLocalFederationDomain(database, actorDomain)
+    if (!isLoggedIn && !isLocal) {
+      const bareHost = host.includes('://') ? new URL(host).host : host
+      const targetUrl = `https://${actorDomain}/@${actorUsername}`
+      return (
+        <ActorRedirectCard
+          host={bareHost}
+          targetUrl={targetUrl}
+          domain={actorDomain}
+          username={actorUsername}
+        />
+      )
+    }
+
     return notFound()
   }
 


### PR DESCRIPTION
## Summary

When logged-out visitors land on a non-local user handle (such as `/@clairenony@pouet.chapril.org`), Activities.next previously returned a 404 Not Found error because remote profiles are only fetched and rendered in-app for authenticated users.

This PR adds a Mastodon-compatible redirect interstitial page styled consistently with the Activities.next error-page component (`lib/components/error-page.tsx`), informing the visitor that they are leaving the instance and providing a direct link to the account on its origin server (`https://pouet.chapril.org/@clairenony`).

## Changes
- **`ActorRedirectCard`**: Created error-page-styled card displaying "You are leaving {host}", "If you trust this link, click it to continue.", primary CTA button, raw link, and footer detail.
- **`app/(timeline)/[actor]/page.tsx`**: Render `ActorRedirectCard` for logged-out non-local handles when `!actorProfile`. Set `robots: { index: false, follow: false }` and canonical alternate metadata.
- **Followers & Following sub-routes**: Redirect logged-out visitors on non-local handles to the main profile route.
- **Tests**: Added unit and server component tests for `ActorRedirectCard`, `[actor]/page.tsx`, `followers/page.tsx`, and `following/page.tsx`.

## Verification
- `yarn run prettier --write .` (Passed)
- `yarn lint` (Passed)
- `yarn typecheck` (Passed)
- `yarn build` (Passed)
- `yarn test` (Passed 12,334 tests across 918 files)