### PR TITLE
Bump version to v1.151.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.151.0",
+  "version": "1.151.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.151.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.151.0`
- Base main SHA: `1c2f67ea232b707bd22f34195811ca5fcf1e9e04`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
