### PR TITLE
fix: preserve media description and prevent file name as default alt text

### DIFF
--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -456,7 +456,7 @@ describe('POST /api/v1/statuses', () => {
     expect(mastodonStatus.media_attachments[0]).toMatchObject({
       type: 'image',
       url: 'https://llun.test/api/v1/files/medias/form-status-photo.webp',
-      description: 'form-status-photo.png'
+      description: ''
     })
 
     const attachments = await database.getAttachmentsWithMedia({
@@ -465,7 +465,7 @@ describe('POST /api/v1/statuses', () => {
     expect(attachments).toHaveLength(1)
     expect(attachments[0]).toMatchObject({
       mediaId: String(media!.id),
-      name: 'form-status-photo.png'
+      name: ''
     })
   })
 

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1041,7 +1041,7 @@ describe('client uploadAttachment presigned completion', () => {
       )
     ).resolves.toMatchObject({
       id: 'media-1',
-      name: 'photo.png'
+      name: ''
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(5)
@@ -1124,6 +1124,31 @@ describe('client uploadAttachment presigned completion', () => {
       '/api/v1/accounts/media/media-1',
       expect.objectContaining({ method: 'DELETE' })
     )
+  })
+
+  it('returns media description from upload response instead of file name on direct upload', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(null), { status: 404 })
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        id: 'media-123',
+        type: 'image',
+        mime_type: 'image/png',
+        url: 'https://llun.test/files/123.png',
+        preview_url: null,
+        meta: { original: { width: 100, height: 100 } },
+        description: 'AI alt description'
+      }),
+      { status: 200 }
+    )
+
+    const result = await uploadAttachment(
+      new File(['test'], 'photo.png', { type: 'image/png' })
+    )
+
+    expect(result).toMatchObject({
+      id: 'media-123',
+      name: 'AI alt description'
+    })
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1822,7 +1822,7 @@ export const uploadAttachment = async (
       posterUrl: media.preview_url,
       width: media.meta.original.width,
       height: media.meta.original.height,
-      name: file.name
+      name: media.description ?? undefined
     }
   }
 
@@ -1838,10 +1838,7 @@ export const uploadAttachment = async (
     return null
   }
 
-  return {
-    ...completion.completed,
-    name: file.name
-  }
+  return completion.completed
 }
 
 interface GetActorMediaParams {

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -552,9 +552,12 @@ export const PostBox: FC<Props> = ({
           dispatch(updateAttachment(attachment.id, restoredAttachment))
           const reason =
             error instanceof Error && error.message ? `: ${error.message}` : ''
-          throw new Error(`Fail to upload ${attachment.name}${reason}`, {
-            cause: error
-          })
+          throw new Error(
+            `Fail to upload ${attachment.file?.name ?? attachment.name ?? 'file'}${reason}`,
+            {
+              cause: error
+            }
+          )
         }
       })
     )
@@ -1325,7 +1328,7 @@ export const PostBox: FC<Props> = ({
             return (
               <button
                 type="button"
-                aria-label={`Remove media ${item.name ?? index + 1}`}
+                aria-label={`Remove media ${item.file?.name || item.name || index + 1}`}
                 className="w-full aspect-square bg-border bg-center bg-cover cursor-pointer relative"
                 key={item.id}
                 style={{

--- a/lib/components/post-box/upload-media-button.test.tsx
+++ b/lib/components/post-box/upload-media-button.test.tsx
@@ -221,7 +221,7 @@ describe('UploadMediaButton', () => {
         expect(mockOnAddAttachment).toHaveBeenCalledTimes(1)
         expect(mockOnAddAttachment).toHaveBeenCalledWith(
           expect.objectContaining({
-            name: 'new-file.jpg'
+            name: ''
           })
         )
       })
@@ -292,7 +292,7 @@ describe('UploadMediaButton', () => {
       })
 
       mockOnAddAttachment.mockImplementation((attachment) => {
-        processingOrder.push(`add-${attachment.name}`)
+        processingOrder.push(`add-${attachment.file?.name ?? attachment.name}`)
       })
 
       render(
@@ -354,7 +354,7 @@ describe('UploadMediaButton', () => {
       expect(mockOnAddAttachment).toHaveBeenCalledTimes(1)
       expect(mockOnAddAttachment).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'file2.jpg'
+          name: ''
         })
       )
 
@@ -396,7 +396,7 @@ describe('UploadMediaButton', () => {
           url: 'blob:test-url',
           width: 0,
           height: 0,
-          name: 'test.jpg',
+          name: '',
           file: expect.any(File)
         })
       })

--- a/lib/components/post-box/upload-media-button.tsx
+++ b/lib/components/post-box/upload-media-button.tsx
@@ -57,7 +57,9 @@ export const UploadMediaButton: FC<Props> = ({
     if (availableSlots <= 0) return
 
     const filteredFiles = selectedFiles.filter((file) => {
-      return !attachments.some((attachment) => attachment.name === file.name)
+      return !attachments.some(
+        (attachment) => (attachment.file?.name ?? attachment.name) === file.name
+      )
     })
 
     if (filteredFiles.length !== selectedFiles.length) {
@@ -91,7 +93,7 @@ export const UploadMediaButton: FC<Props> = ({
               url: previewUrl,
               width: 0,
               height: 0,
-              name: targetFile.name,
+              name: '',
               file
             }
           } catch (error) {

--- a/lib/components/posts/status-reply-box.tsx
+++ b/lib/components/posts/status-reply-box.tsx
@@ -205,7 +205,9 @@ export const StatusReplyBox: FC<Props> = ({
                 isLoading: false
               })
             )
-            throw new Error(`Fail to upload ${attachment.name}`)
+            throw new Error(
+              `Fail to upload ${attachment.file?.name ?? attachment.name ?? 'file'}`
+            )
           }
         })
       )

--- a/lib/services/statuses/mediaIds.test.ts
+++ b/lib/services/statuses/mediaIds.test.ts
@@ -1,4 +1,9 @@
-import { resolveStatusAttachmentMediaIds } from '@/lib/services/statuses/mediaIds'
+import { Database } from '@/lib/database/types'
+import {
+  getAttachmentsFromMediaIds,
+  resolveStatusAttachmentMediaIds
+} from '@/lib/services/statuses/mediaIds'
+import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 
 const statusWithAttachments = (
@@ -56,5 +61,57 @@ describe('resolveStatusAttachmentMediaIds', () => {
     expect(
       resolveStatusAttachmentMediaIds(statusWithAttachments([]), ['12'])
     ).toEqual(['12'])
+  })
+})
+
+describe('getAttachmentsFromMediaIds', () => {
+  it('uses media description when present and does not fall back to fileName when description is empty', async () => {
+    const mockDatabase = {
+      getMediaByIdForAccount: vi.fn().mockImplementation(({ mediaId }) => {
+        if (mediaId === '1') {
+          return Promise.resolve({
+            id: '1',
+            original: {
+              path: 'medias/with-desc.png',
+              mimeType: 'image/png',
+              metaData: { width: 100, height: 100 },
+              fileName: 'with-desc.png'
+            },
+            description: 'Custom alt text'
+          })
+        }
+        return Promise.resolve({
+          id: '2',
+          original: {
+            path: 'medias/without-desc.png',
+            mimeType: 'image/png',
+            metaData: { width: 100, height: 100 },
+            fileName: 'without-desc.png'
+          },
+          description: null
+        })
+      })
+    } as unknown as Database
+
+    const currentActor = {
+      id: 'https://llun.test/users/test1',
+      account: { id: 'account-1' }
+    } as unknown as Actor
+
+    const attachments = await getAttachmentsFromMediaIds(
+      mockDatabase,
+      currentActor,
+      ['1', '2']
+    )
+    expect(attachments).toEqual([
+      expect.objectContaining({
+        id: '1',
+        name: 'Custom alt text'
+      }),
+      expect.objectContaining({
+        id: '2'
+      })
+    ])
+    expect(attachments?.[1].name).toBeUndefined()
   })
 })

--- a/lib/services/statuses/mediaIds.ts
+++ b/lib/services/statuses/mediaIds.ts
@@ -42,9 +42,7 @@ export const getAttachmentsFromMediaIds = async (
       ...(media.thumbnail
         ? { posterUrl: getMediaUrl(media.thumbnail.path) }
         : {}),
-      ...(media.description || media.original.fileName
-        ? { name: media.description || media.original.fileName }
-        : {})
+      ...(media.description ? { name: media.description } : {})
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes the media alt text handling across the client, post composers, and server media resolution so that image file names are no longer used as the default alt text, and user-provided or AI-generated descriptions are preserved.

### Problem
1. When uploading media via `POST /api/v2/media`, the client helper `uploadAttachment` (`lib/client.ts`) discarded `media.description` and hardcoded `name: file.name`.
2. When creating statuses with media IDs via Mastodon API (`POST /api/v1/statuses`) or scheduled status jobs, `getAttachmentsFromMediaIds` (`lib/services/statuses/mediaIds.ts`) fell back to `media.original.fileName` whenever `media.description` was empty or null.
3. In the post composer UI (`UploadMediaButton`), selecting a file initialized the attachment's `name` to `targetFile.name`.

### Changes
- **`lib/services/statuses/mediaIds.ts`**: Removed fallback to `media.original.fileName` in `getAttachmentsFromMediaIds`.
- **`lib/client.ts`**: Propagated `media.description` (or `completion.completed.name`) in `uploadAttachment` instead of forcing `file.name`.
- **`lib/components/post-box/upload-media-button.tsx`**: Initialized attachment `name: ''` and updated duplicate file checking to inspect `attachment.file?.name ?? attachment.name`.
- **`lib/components/post-box/post-box.tsx` & `lib/components/posts/status-reply-box.tsx`**: Updated upload error messages and remove button `aria-label`s to safely fall back to `attachment.file?.name`.
- **Tests**: Added tests in `mediaIds.test.ts` and `client.test.ts`, and updated `app/api/v1/statuses/route.test.ts` and `upload-media-button.test.tsx`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
