### PR TITLE
Bump version to v1.151.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.151.1",
+  "version": "1.151.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.151.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.151.1`
- Base main SHA: `4a59270101fc37d20b7695eb7bd05aa3f574d870`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
