### PR TITLE
Bump version to v1.151.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.151.2",
+  "version": "1.151.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.151.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.151.2`
- Base main SHA: `a68441ac486b9d8086b9a8e6d878c9d9c42567ef`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
