### PR TITLE
Bump version to v1.151.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.151.3",
+  "version": "1.151.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.151.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.151.3`
- Base main SHA: `67ee44ae57fb9d69b3d95d841194a905c67ddf6d`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
