### PR TITLE
Bump version to v1.152.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.151.4",
+  "version": "1.152.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.152.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.151.4`
- Base main SHA: `96fb018bd724bddadd0191d651155bdcf84b8577`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
