### PR TITLE
fix: show redirect page for non-local actor follower and following lists

### DIFF
--- a/app/(timeline)/[actor]/FollowList.test.tsx
+++ b/app/(timeline)/[actor]/FollowList.test.tsx
@@ -71,4 +71,10 @@ describe('FollowList', () => {
       })
     ).toBeInTheDocument()
   })
+
+  it('renders empty state message when users array is empty', () => {
+    render(<FollowList users={[]} isLoggedIn />)
+
+    expect(screen.getByText('No accounts found.')).toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/FollowList.tsx
+++ b/app/(timeline)/[actor]/FollowList.tsx
@@ -23,6 +23,14 @@ export const FollowList: FC<Props> = ({
     [blockedActorIds]
   )
 
+  if (users.length === 0) {
+    return (
+      <div className="p-8 text-center text-sm text-muted-foreground">
+        No accounts found.
+      </div>
+    )
+  }
+
   return (
     <div className="divide-y">
       {users.map((user) => {

--- a/app/(timeline)/[actor]/followers/page.test.tsx
+++ b/app/(timeline)/[actor]/followers/page.test.tsx
@@ -2,27 +2,35 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { notFound, redirect } from 'next/navigation'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
 
 import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
-import Page from './page'
+import Page, { generateMetadata } from './page'
 
 const mockDatabase = {
   getFollowers: vi.fn(),
   getActorFromId: vi.fn()
 }
 
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  }),
+  getBaseURL: () => 'https://llun.social'
+}))
+
 vi.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
 }))
 
 vi.mock('next/navigation', () => ({
-  notFound: vi.fn(),
-  redirect: vi.fn()
+  notFound: vi.fn()
 }))
 
 vi.mock('@/lib/services/auth/getSession', () => ({
@@ -53,7 +61,6 @@ const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
 const mockGetActorFromSession = vi.mocked(getActorFromSession)
 const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
 const mockGetProfileData = vi.mocked(getProfileData)
-const mockRedirect = vi.mocked(redirect)
 const mockNotFound = vi.mocked(notFound)
 
 describe('[actor] followers page', () => {
@@ -65,16 +72,57 @@ describe('[actor] followers page', () => {
     mockGetProfileData.mockResolvedValue(null)
   })
 
-  it('redirects logged-out visitors on non-local actor to the main actor profile', async () => {
+  it('renders ActorRedirectCard for non-local actor when logged out', async () => {
     mockGetServerAuthSession.mockResolvedValue(null)
     mockIsLocalFederationDomain.mockResolvedValue(false)
-    mockGetProfileData.mockResolvedValue(null)
 
-    await Page({
+    const element = await Page({
       params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
     })
+    render(element)
 
-    expect(mockRedirect).toHaveBeenCalledWith('/@clairenony@pouet.chapril.org')
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to pouet\.chapril\.org/i
+    })
+    expect(continueLink).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony/followers'
+    )
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  it('renders ActorRedirectCard for non-local actor when logged in', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@Edent@mastodon.social' })
+    })
+    render(element)
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to mastodon\.social/i
+    })
+    expect(continueLink).toHaveAttribute(
+      'href',
+      'https://mastodon.social/@Edent/followers'
+    )
     expect(mockNotFound).not.toHaveBeenCalled()
   })
 
@@ -88,6 +136,92 @@ describe('[actor] followers page', () => {
     })
 
     expect(mockNotFound).toHaveBeenCalled()
-    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('renders FollowList for local actor with followers', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/localuser',
+        preferredUsername: 'localuser'
+      } as never,
+      followersCount: 1,
+      followingCount: 0,
+      statusesCount: 0,
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null }
+    })
+    mockDatabase.getFollowers.mockResolvedValue([
+      {
+        id: 'follow-1',
+        actorId: 'https://llun.social/users/follower1',
+        targetActorId: 'https://llun.social/users/localuser',
+        status: 'Accepted',
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://llun.social/users/follower1',
+      username: 'follower1',
+      domain: 'llun.social',
+      name: 'Follower 1',
+      summary: '',
+      iconUrl: '',
+      headerImageUrl: '',
+      followersUrl: 'https://llun.social/users/follower1/followers',
+      inboxUrl: 'https://llun.social/users/follower1/inbox',
+      sharedInboxUrl: 'https://llun.social/inbox',
+      followingCount: 0,
+      followersCount: 0,
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 0
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@localuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByTestId('follow-list')).toBeInTheDocument()
+    expect(screen.getByText('1 accounts')).toBeInTheDocument()
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  describe('generateMetadata', () => {
+    it('sets canonical link and noindex robots for non-local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(false)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @clairenony@pouet.chapril.org Followers',
+        robots: { index: false, follow: false },
+        alternates: {
+          canonical: 'https://pouet.chapril.org/@clairenony/followers'
+        }
+      })
+    })
+
+    it('sets standard metadata for local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@localuser@llun.social' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @localuser@llun.social Followers'
+      })
+    })
   })
 })

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -1,13 +1,15 @@
 import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
-import { notFound, redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
+import { ActorRedirectCard } from '@/app/(timeline)/[actor]/ActorRedirectCard'
 import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
 import { getFollowListBlockedActorIds } from '@/app/(timeline)/[actor]/getFollowListBlockedActorIds'
 import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { Button } from '@/lib/components/ui/button'
+import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
@@ -23,12 +25,33 @@ export const generateMetadata = async ({
   params
 }: Props): Promise<Metadata> => {
   const { actor } = await params
+  const decodedActorHandle = decodeURIComponent(actor)
+  const parts = decodedActorHandle.split('@').slice(1)
+  if (parts.length === 2) {
+    const [username, domain] = parts
+    const database = getDatabase()
+    if (database) {
+      const isLocal = await isLocalFederationDomain(database, domain)
+      if (!isLocal) {
+        const targetUrl = `https://${domain}/@${username}/followers`
+        return {
+          title: `Activities.next: ${decodedActorHandle} Followers`,
+          robots: { index: false, follow: false },
+          alternates: {
+            canonical: targetUrl
+          }
+        }
+      }
+    }
+  }
+
   return {
-    title: `Activities.next: ${decodeURIComponent(actor)} Followers`
+    title: `Activities.next: ${decodedActorHandle} Followers`
   }
 }
 
 const Page: FC<Props> = async ({ params }) => {
+  const { host } = getConfig()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
 
@@ -43,6 +66,20 @@ const Page: FC<Props> = async ({ params }) => {
   }
   const [actorUsername, actorDomain] = parts
 
+  const isLocal = await isLocalFederationDomain(database, actorDomain)
+  if (!isLocal) {
+    const bareHost = host.includes('://') ? new URL(host).host : host
+    const targetUrl = `https://${actorDomain}/@${actorUsername}/followers`
+    return (
+      <ActorRedirectCard
+        host={bareHost}
+        targetUrl={targetUrl}
+        domain={actorDomain}
+        username={actorUsername}
+      />
+    )
+  }
+
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
@@ -50,10 +87,6 @@ const Page: FC<Props> = async ({ params }) => {
     { currentActor }
   )
   if (!actorProfile) {
-    const isLocal = await isLocalFederationDomain(database, actorDomain)
-    if (!isLoggedIn && !isLocal) {
-      return redirect(`/@${actorUsername}@${actorDomain}`)
-    }
     return notFound()
   }
 

--- a/app/(timeline)/[actor]/following/page.test.tsx
+++ b/app/(timeline)/[actor]/following/page.test.tsx
@@ -2,27 +2,35 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { notFound, redirect } from 'next/navigation'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
 
 import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
-import Page from './page'
+import Page, { generateMetadata } from './page'
 
 const mockDatabase = {
   getFollowing: vi.fn(),
   getActorFromId: vi.fn()
 }
 
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  }),
+  getBaseURL: () => 'https://llun.social'
+}))
+
 vi.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
 }))
 
 vi.mock('next/navigation', () => ({
-  notFound: vi.fn(),
-  redirect: vi.fn()
+  notFound: vi.fn()
 }))
 
 vi.mock('@/lib/services/auth/getSession', () => ({
@@ -53,7 +61,6 @@ const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
 const mockGetActorFromSession = vi.mocked(getActorFromSession)
 const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
 const mockGetProfileData = vi.mocked(getProfileData)
-const mockRedirect = vi.mocked(redirect)
 const mockNotFound = vi.mocked(notFound)
 
 describe('[actor] following page', () => {
@@ -65,16 +72,57 @@ describe('[actor] following page', () => {
     mockGetProfileData.mockResolvedValue(null)
   })
 
-  it('redirects logged-out visitors on non-local actor to the main actor profile', async () => {
+  it('renders ActorRedirectCard for non-local actor when logged out', async () => {
     mockGetServerAuthSession.mockResolvedValue(null)
     mockIsLocalFederationDomain.mockResolvedValue(false)
-    mockGetProfileData.mockResolvedValue(null)
 
-    await Page({
+    const element = await Page({
       params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
     })
+    render(element)
 
-    expect(mockRedirect).toHaveBeenCalledWith('/@clairenony@pouet.chapril.org')
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to pouet\.chapril\.org/i
+    })
+    expect(continueLink).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony/following'
+    )
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  it('renders ActorRedirectCard for non-local actor when logged in', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@Edent@mastodon.social' })
+    })
+    render(element)
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'You are leaving llun.social'
+      })
+    ).toBeInTheDocument()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to mastodon\.social/i
+    })
+    expect(continueLink).toHaveAttribute(
+      'href',
+      'https://mastodon.social/@Edent/following'
+    )
     expect(mockNotFound).not.toHaveBeenCalled()
   })
 
@@ -88,6 +136,92 @@ describe('[actor] following page', () => {
     })
 
     expect(mockNotFound).toHaveBeenCalled()
-    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('renders FollowList for local actor with following', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/localuser',
+        preferredUsername: 'localuser'
+      } as never,
+      followersCount: 0,
+      followingCount: 1,
+      statusesCount: 0,
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null }
+    })
+    mockDatabase.getFollowing.mockResolvedValue([
+      {
+        id: 'follow-1',
+        actorId: 'https://llun.social/users/localuser',
+        targetActorId: 'https://llun.social/users/targetuser',
+        status: 'Accepted',
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://llun.social/users/targetuser',
+      username: 'targetuser',
+      domain: 'llun.social',
+      name: 'Target User',
+      summary: '',
+      iconUrl: '',
+      headerImageUrl: '',
+      followersUrl: 'https://llun.social/users/targetuser/followers',
+      inboxUrl: 'https://llun.social/users/targetuser/inbox',
+      sharedInboxUrl: 'https://llun.social/inbox',
+      followingCount: 0,
+      followersCount: 0,
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 0
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@localuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByTestId('follow-list')).toBeInTheDocument()
+    expect(screen.getByText('1 accounts')).toBeInTheDocument()
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  describe('generateMetadata', () => {
+    it('sets canonical link and noindex robots for non-local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(false)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @clairenony@pouet.chapril.org Following',
+        robots: { index: false, follow: false },
+        alternates: {
+          canonical: 'https://pouet.chapril.org/@clairenony/following'
+        }
+      })
+    })
+
+    it('sets standard metadata for local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ actor: '@localuser@llun.social' })
+      })
+
+      expect(metadata).toEqual({
+        title: 'Activities.next: @localuser@llun.social Following'
+      })
+    })
   })
 })

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -1,13 +1,15 @@
 import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
-import { notFound, redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
+import { ActorRedirectCard } from '@/app/(timeline)/[actor]/ActorRedirectCard'
 import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
 import { getFollowListBlockedActorIds } from '@/app/(timeline)/[actor]/getFollowListBlockedActorIds'
 import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
 import { Button } from '@/lib/components/ui/button'
+import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
@@ -23,12 +25,33 @@ export const generateMetadata = async ({
   params
 }: Props): Promise<Metadata> => {
   const { actor } = await params
+  const decodedActorHandle = decodeURIComponent(actor)
+  const parts = decodedActorHandle.split('@').slice(1)
+  if (parts.length === 2) {
+    const [username, domain] = parts
+    const database = getDatabase()
+    if (database) {
+      const isLocal = await isLocalFederationDomain(database, domain)
+      if (!isLocal) {
+        const targetUrl = `https://${domain}/@${username}/following`
+        return {
+          title: `Activities.next: ${decodedActorHandle} Following`,
+          robots: { index: false, follow: false },
+          alternates: {
+            canonical: targetUrl
+          }
+        }
+      }
+    }
+  }
+
   return {
-    title: `Activities.next: ${decodeURIComponent(actor)} Following`
+    title: `Activities.next: ${decodedActorHandle} Following`
   }
 }
 
 const Page: FC<Props> = async ({ params }) => {
+  const { host } = getConfig()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
 
@@ -43,6 +66,20 @@ const Page: FC<Props> = async ({ params }) => {
   }
   const [actorUsername, actorDomain] = parts
 
+  const isLocal = await isLocalFederationDomain(database, actorDomain)
+  if (!isLocal) {
+    const bareHost = host.includes('://') ? new URL(host).host : host
+    const targetUrl = `https://${actorDomain}/@${actorUsername}/following`
+    return (
+      <ActorRedirectCard
+        host={bareHost}
+        targetUrl={targetUrl}
+        domain={actorDomain}
+        username={actorUsername}
+      />
+    )
+  }
+
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
@@ -50,10 +87,6 @@ const Page: FC<Props> = async ({ params }) => {
     { currentActor }
   )
   if (!actorProfile) {
-    const isLocal = await isLocalFederationDomain(database, actorDomain)
-    if (!isLoggedIn && !isLocal) {
-      return redirect(`/@${actorUsername}@${actorDomain}`)
-    }
     return notFound()
   }
 


### PR DESCRIPTION
## Summary

Addresses the issue where visiting a non-local actor's followers or following page (e.g. `/@Edent@mastodon.social/followers`) shows the remote count with an empty list.

### Why this occurred:
- The local database only stores follow relations for local users; it does not replicate the full follow graph for external actors across the Fediverse.
- Remote ActivityPub collections (such as Mastodon's) provide `totalItems` count, but omit `orderedItems` or `first` pagination for remote servers to prevent mass-scraping.
- The web routes for followers and following queried `database.getFollowers` and `database.getFollowing` directly, resulting in an empty list.

### Solution:
- Update `/followers` and `/following` pages to render `ActorRedirectCard` for non-local actors (matching the existing behavior for external profiles), linking visitors to their home instance's follower/following pages (e.g. `https://mastodon.social/@Edent/followers` and `https://mastodon.social/@Edent/following`).
- Add canonical URLs and `noindex` robots meta for non-local actor follower/following pages.
- Add `"No accounts found."` empty state fallback in `FollowList`.

## Verification
- `yarn run prettier --write .`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test` (919 test files, 12,359 tests passed)