### PR TITLE
Bump version to v1.152.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.152.0",
+  "version": "1.152.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.152.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.152.0`
- Base main SHA: `6b5eb70406c74a61f43a6e1f0b4577f256c1c1d0`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
