### PR TITLE
fix: handle boosted polls and use safeParse in queue jobs

### DIFF
--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -1595,6 +1595,14 @@ describe('createNoteJob', () => {
           data: questionPayload as unknown as Note
         })
       ).resolves.toBeUndefined()
+
+      await expect(
+        createNoteJob(database, {
+          id: 'malformed-job',
+          name: CREATE_NOTE_JOB_NAME,
+          data: { invalid: 'payload' }
+        })
+      ).resolves.toBeUndefined()
     })
   })
 })

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -101,9 +101,9 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
       if (!signingActor) return
       const note = await getNote({ statusId: objectId, signingActor })
       if (!note) return
-      // createNoteJob enforces the note author's federation policy and persists
+      // createNoteJob or createPollJob enforces the author's federation policy and persists
       // the status; called without verifiedSenderActorId so the relay's
-      // signature does not have to match the note's author.
+      // signature does not have to match the author.
       if (note.type === ENTITY_TYPE_QUESTION) {
         await createPollJob(database, {
           id: note.id,
@@ -119,7 +119,7 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
       }
       // Look the stored status up by the note's canonical id — a remote server
       // may canonicalize the requested object id (trailing slash, protocol,
-      // redirect), and createNoteJob persists it under note.id.
+      // redirect), and createNoteJob/createPollJob persists it under note.id.
       status = await database.getStatus({
         statusId: note.id,
         withReplies: false

--- a/lib/jobs/processForwardedActivityJob.ts
+++ b/lib/jobs/processForwardedActivityJob.ts
@@ -183,7 +183,7 @@ export const processForwardedActivityJob = createJobHandle(
       // verifiedSenderActorId: authenticity came from the origin fetch, so the
       // forwarder's signature does not have to match the note's author —
       // exactly how createRelayAnnounceJob calls createNoteJob. createNoteJob
-      // still enforces the author's own federation policy itself.
+      // and createPollJob still enforce the author's own federation policy itself.
       const stored = await database.getStatus({
         statusId: note.id,
         withReplies: false

--- a/lib/jobs/updateNoteJob.ts
+++ b/lib/jobs/updateNoteJob.ts
@@ -19,6 +19,7 @@ import { getQueue } from '@/lib/services/queue'
 import { syncQuoteEdgeFromUpdate } from '@/lib/services/quotes/persistInboundQuoteEdge'
 import {
   ArticleContent,
+  ENTITY_TYPE_QUESTION,
   ImageContent,
   Note,
   PageContent,
@@ -35,8 +36,10 @@ import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { createNoteJob } from './createNoteJob'
+import { createPollJob } from './createPollJob'
 import {
   CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME,
   FORWARD_ACTIVITY_JOB_NAME,
   UPDATE_NOTE_JOB_NAME
 } from './names'
@@ -138,13 +141,22 @@ export const updateNoteJob = createJobHandle(
       database,
       note,
       actorId: existingStatus.actorId,
-      storeNote: (fetchedQuotedNote, bound) =>
-        createNoteJob(database, {
+      storeNote: (fetchedQuotedNote, bound) => {
+        if (fetchedQuotedNote.type === ENTITY_TYPE_QUESTION) {
+          return createPollJob(database, {
+            id: fetchedQuotedNote.id,
+            name: CREATE_POLL_JOB_NAME,
+            data: fetchedQuotedNote,
+            ...bound
+          })
+        }
+        return createNoteJob(database, {
           id: fetchedQuotedNote.id,
           name: CREATE_NOTE_JOB_NAME,
           data: fetchedQuotedNote,
           ...bound
         })
+      }
     })
 
     // Re-detect the content language alongside the edit; the previous


### PR DESCRIPTION
## Summary

Fixes QStash queue processing 400 error when handling incoming ActivityPub `Announce` activities that boost a remote poll (`Question` object).

### Root Cause
When an incoming `Announce` activity boosted an unstored status, `createAnnounceJob` fetched the remote object via `getNote(...)` and unconditionally passed it to `createNoteJob`.
Because `createNoteJob` validates payloads using `BaseNoteSchema` (which excludes `Question`), `BaseNoteSchema.parse` threw an unhandled `ZodError` (`invalid_union`), failing the `/api/v1/queue/qstash` queue handler with HTTP 400.

### Changes
- In `createAnnounceJob.ts`, `createRelayAnnounceJob.ts`, and `processForwardedActivityJob.ts`, check `boostedStatus.type === ENTITY_TYPE_QUESTION` and route to `createPollJob` / `updatePollJob` instead of note handlers.
- In `createNoteJob.ts`, `updateNoteJob.ts`, `updatePollJob.ts`, and `createAnnounceJob.ts`, use `safeParse` instead of `.parse()` on incoming payloads to prevent unhandled `ZodError` exceptions crashing queue workers.
- In `createNoteJob.ts` and `updateNoteJob.ts`, route quoted `Question` objects to `createPollJob` during quote resolution/synchronization.
- Updated `getNote` return type in `lib/activities/index.ts` to `Promise<BaseNote | null>` (which encompasses all ActivityStreams status types including `Question`).
- Added unit tests in `createAnnounceJob.test.ts` and `createNoteJob.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
