### PR TITLE
minor: add robots.txt metadata route

### DIFF
--- a/app/robots.test.ts
+++ b/app/robots.test.ts
@@ -1,0 +1,34 @@
+import robots from './robots'
+
+describe('robots metadata route', () => {
+  it('returns valid robots.txt rules allowing public pages and disallowing private/API routes', () => {
+    const config = robots()
+
+    expect(config.rules).toBeDefined()
+    expect(config.rules).toEqual({
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/account',
+        '/admin',
+        '/api/',
+        '/auth/',
+        '/authorize_interaction',
+        '/bookmarks',
+        '/collections/new',
+        '/collections/*/edit',
+        '/favorites',
+        '/fitness',
+        '/health',
+        '/inbox',
+        '/lists',
+        '/messages',
+        '/notifications',
+        '/oauth/',
+        '/search',
+        '/settings',
+        '/users/'
+      ]
+    })
+  })
+})

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/account',
+        '/admin',
+        '/api/',
+        '/auth/',
+        '/authorize_interaction',
+        '/bookmarks',
+        '/collections/new',
+        '/collections/*/edit',
+        '/favorites',
+        '/fitness',
+        '/health',
+        '/inbox',
+        '/lists',
+        '/messages',
+        '/notifications',
+        '/oauth/',
+        '/search',
+        '/settings',
+        '/users/'
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `/robots.txt` generation via Next.js App Router metadata route handler (`app/robots.ts`) to define indexing policies for search engine crawlers and bots.

### Indexing Policy Overview

- **Allowed (`allow: '/'`)**:
  - Root landing page (`/`)
  - Federation & discovery endpoints (`/.well-known/*`, `/nodeinfo/*`)
  - Public actor profiles (`/@username`, `/[actor]`) and permalink posts (`/@username/[status]`, `/[actor]/[status]`)
  - Public followers and following lists (`/[actor]/followers`, `/[actor]/following`)
  - Public actor fitness activities & heatmaps (`/[actor]/fitness`, `/[actor]/fitness/heatmap`)
  - Public explore & discovery (`/explore`, `/tags/[tag]`, `/collections/[id]`)
  - Shared route heatmaps (`/embed/heatmap/[token]`, `/u/heatmaps/[token]`)

- **Disallowed (`disallow: [...]`)**:
  - Account management & security (`/account`)
  - Administration (`/admin`)
  - Authentication flows (`/auth/`)
  - OAuth & remote interaction dialogs (`/oauth/`, `/authorize_interaction`)
  - Private user timelines and feeds (`/bookmarks`, `/favorites`, `/messages`, `/notifications`, `/lists`, `/collections/new`, `/collections/*/edit`)
  - Personal fitness dashboard (`/fitness`)
  - Search query pages (`/search`)
  - Internal APIs and machine endpoints (`/api/`, `/users/`, `/inbox`, `/health`)

### Verification

All quality gates passed according to the project's Definition of Done:
- `yarn prettier` (formatting clean)
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (prerendered `○ /robots.txt`)
- `yarn test` (920 test files, 12,351 tests passed)
