### PR TITLE
fix: handle boosted and relayed polls in announce jobs

### DIFF
--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -12,6 +12,7 @@ import { FollowRequest } from '@/lib/activities/followAction'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { LikeStatus } from '@/lib/activities/likeAction'
+import { BaseNote } from '@/lib/activities/note'
 import { NOTE_ACTIVITY_CONTEXT } from '@/lib/activities/noteContext'
 import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
 import {
@@ -120,7 +121,7 @@ interface GetNoteParams {
 export const getNote = async ({
   statusId,
   signingActor
-}: GetNoteParams): Promise<Note | null> =>
+}: GetNoteParams): Promise<BaseNote | null> =>
   withSpan('activity', 'getNote', { statusId }, async (span) => {
     try {
       const { statusCode, body } = await request({

--- a/lib/jobs/createAnnounceJob.test.ts
+++ b/lib/jobs/createAnnounceJob.test.ts
@@ -10,7 +10,13 @@ import { seedDatabase } from '@/lib/stub/database'
 import { stubNoteId } from '@/lib/stub/note'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
-import { Status, StatusAnnounce, StatusNote } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusAnnounce,
+  StatusNote,
+  StatusPoll,
+  StatusType
+} from '@/lib/types/domain/status'
 
 enableFetchMocks()
 
@@ -193,5 +199,71 @@ describe('Announce action', () => {
       domain: 'somewhere.test',
       createdAt: expect.toBeNumber()
     })
+  })
+
+  it('loads announce Question status (poll) and saves it locally as a poll', async () => {
+    const statusId = stubNoteId()
+    const announceStatusId = 'https://somewhere.test/statuses/announce-poll'
+    const pollCreator = 'https://somewhere.test/actors/pollcreator'
+    fetchMock.mockOnceIf(
+      announceStatusId,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: announceStatusId,
+        type: 'Question',
+        attributedTo: pollCreator,
+        content: '<p>What is your favorite color?</p>',
+        published: '2026-08-30T04:27:44Z',
+        to: ['https://www.w3.org/ns/activitystreams#Public'],
+        cc: [],
+        oneOf: [
+          {
+            type: 'Note',
+            name: 'Red',
+            replies: { type: 'Collection', totalItems: 10 }
+          },
+          {
+            type: 'Note',
+            name: 'Blue',
+            replies: { type: 'Collection', totalItems: 20 }
+          }
+        ]
+      })
+    )
+
+    await createAnnounceJob(database, {
+      id: 'id-poll-announce',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: MockAnnounceStatus({
+        actorId: ACTOR1_ID,
+        statusId,
+        announceStatusId
+      })
+    })
+
+    const status = (await database.getStatus({
+      statusId: `${statusId}/activity`
+    })) as StatusAnnounce
+    expect(status).toBeDefined()
+    const boostedStatus = (await database.getStatus({
+      statusId: announceStatusId
+    })) as StatusPoll
+    expect(boostedStatus).toBeDefined()
+    expect(boostedStatus.type).toEqual(StatusType.enum.Poll)
+    expect(boostedStatus.choices).toEqual([
+      expect.objectContaining({ title: 'Red' }),
+      expect.objectContaining({ title: 'Blue' })
+    ])
+    expect(status.originalStatus).toEqual(boostedStatus)
+  })
+
+  it('gracefully ignores malformed announce payloads without error', async () => {
+    await expect(
+      createAnnounceJob(database, {
+        id: 'id-malformed',
+        name: CREATE_ANNOUNCE_JOB_NAME,
+        data: { invalid: true } as unknown as AnnounceStatus
+      })
+    ).resolves.toBeUndefined()
   })
 })

--- a/lib/jobs/createAnnounceJob.ts
+++ b/lib/jobs/createAnnounceJob.ts
@@ -5,14 +5,16 @@ import {
 import { getNote } from '@/lib/activities'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { createNoteJob } from '@/lib/jobs/createNoteJob'
+import { createPollJob } from '@/lib/jobs/createPollJob'
 import {
   CREATE_ANNOUNCE_JOB_NAME,
-  CREATE_NOTE_JOB_NAME
+  CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME
 } from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
 import { addStatusToTimelines } from '@/lib/services/timelines'
-import { Announce } from '@/lib/types/activitypub'
+import { Announce, ENTITY_TYPE_QUESTION } from '@/lib/types/activitypub'
 import {
   normalizeActivityPubAnnounce,
   toRecipientArray
@@ -21,7 +23,13 @@ import {
 export const createAnnounceJob: JobHandle = createJobHandle(
   CREATE_ANNOUNCE_JOB_NAME,
   async (database, message) => {
-    const status = Announce.parse(normalizeActivityPubAnnounce(message.data))
+    const parseResult = Announce.safeParse(
+      normalizeActivityPubAnnounce(message.data)
+    )
+    if (!parseResult.success) {
+      return
+    }
+    const status = parseResult.data
 
     let object: string
     if (typeof status.object === 'string') {
@@ -47,11 +55,19 @@ export const createAnnounceJob: JobHandle = createJobHandle(
       if (!boostedStatus) {
         return
       }
-      await createNoteJob(database, {
-        id: boostedStatus.id,
-        name: CREATE_NOTE_JOB_NAME,
-        data: boostedStatus
-      })
+      if (boostedStatus.type === ENTITY_TYPE_QUESTION) {
+        await createPollJob(database, {
+          id: boostedStatus.id,
+          name: CREATE_POLL_JOB_NAME,
+          data: boostedStatus
+        })
+      } else {
+        await createNoteJob(database, {
+          id: boostedStatus.id,
+          name: CREATE_NOTE_JOB_NAME,
+          data: boostedStatus
+        })
+      }
     }
     const existingAnnounce = await database.getStatus({
       statusId: status.id,

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -1568,5 +1568,33 @@ describe('createNoteJob', () => {
       )
       expect(forwardCalls).toHaveLength(0)
     })
+
+    it('gracefully returns without throwing when given a Question or non-note payload', async () => {
+      const questionPayload = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://somewhere.test/questions/1',
+        type: 'Question',
+        attributedTo: FRIEND_ACTOR_ID,
+        content: '<p>Poll?</p>',
+        published: '2026-08-30T04:27:44Z',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        oneOf: [
+          {
+            type: 'Note',
+            name: 'Option 1',
+            replies: { type: 'Collection', totalItems: 0 }
+          }
+        ]
+      }
+
+      await expect(
+        createNoteJob(database, {
+          id: 'question-in-note-job',
+          name: CREATE_NOTE_JOB_NAME,
+          data: questionPayload as unknown as Note
+        })
+      ).resolves.toBeUndefined()
+    })
   })
 })

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -31,6 +31,7 @@ import {
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import {
   ArticleContent,
+  ENTITY_TYPE_QUESTION,
   ImageContent,
   Note,
   PageContent,
@@ -47,7 +48,12 @@ import { isValidFocalPoint } from '@/lib/utils/focalPoint'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { createJobHandle } from './createJobHandle'
-import { CREATE_NOTE_JOB_NAME, FORWARD_ACTIVITY_JOB_NAME } from './names'
+import { createPollJob } from './createPollJob'
+import {
+  CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME,
+  FORWARD_ACTIVITY_JOB_NAME
+} from './names'
 import { actorMatchesVerifiedSender } from './verifiedSender'
 
 export const createNoteJob = createJobHandle(
@@ -63,9 +69,13 @@ export const createNoteJob = createJobHandle(
       ArticleContent,
       VideoContent
     ])
-    const note = BaseNoteSchema.parse(
+    const parseResult = BaseNoteSchema.safeParse(
       normalizeActivityPubContent(message.data)
-    ) as BaseNote
+    )
+    if (!parseResult.success) {
+      return
+    }
+    const note = parseResult.data as BaseNote
     if (!actorMatchesVerifiedSender(note.attributedTo, message)) {
       return
     }
@@ -152,13 +162,22 @@ export const createNoteJob = createJobHandle(
             database,
             note,
             quotedStatusId,
-            storeNote: (fetchedQuotedNote, bound) =>
-              createNoteJob(database, {
+            storeNote: (fetchedQuotedNote, bound) => {
+              if (fetchedQuotedNote.type === ENTITY_TYPE_QUESTION) {
+                return createPollJob(database, {
+                  id: fetchedQuotedNote.id,
+                  name: CREATE_POLL_JOB_NAME,
+                  data: fetchedQuotedNote,
+                  ...bound
+                })
+              }
+              return createNoteJob(database, {
                 id: fetchedQuotedNote.id,
                 name: CREATE_NOTE_JOB_NAME,
                 data: fetchedQuotedNote,
                 ...bound
               })
+            }
           })
       // Derive and write the edge. An edge may already exist here (e.g. we
       // accepted this actor's QuoteRequest before the Create Note arrived); the

--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -6,6 +6,7 @@ import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { Timeline } from '@/lib/services/timelines/types'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
 
 enableFetchMocks()
 
@@ -165,5 +166,48 @@ describe('createRelayAnnounceJob', () => {
     })
     const matches = federated.filter((status) => status.id === note)
     expect(matches).toHaveLength(1)
+  })
+
+  it('fetches a relayed Question from origin and stores it as a poll', async () => {
+    const remotePoll = 'https://somewhere.test/statuses/relayed-poll'
+    const pollCreator = 'https://somewhere.test/actors/pollcreator2'
+    fetchMock.mockOnceIf(
+      remotePoll,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: remotePoll,
+        type: 'Question',
+        attributedTo: pollCreator,
+        content: '<p>Relayed question</p>',
+        published: '2026-08-30T00:00:00Z',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        oneOf: [
+          {
+            type: 'Note',
+            name: 'Yes',
+            replies: { type: 'Collection', totalItems: 5 }
+          },
+          {
+            type: 'Note',
+            name: 'No',
+            replies: { type: 'Collection', totalItems: 3 }
+          }
+        ]
+      })
+    )
+
+    await createRelayAnnounceJob(database, {
+      id: 'job-relayed-poll',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(remotePoll, `${RELAY_ACTOR}/announce/poll`)
+    })
+
+    const stored = (await database.getStatus({
+      statusId: remotePoll
+    })) as StatusPoll
+    expect(stored).toBeDefined()
+    expect(stored.type).toEqual(StatusType.enum.Poll)
+    expect(stored.choices).toHaveLength(2)
   })
 })

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -4,9 +4,15 @@ import { getNote } from '@/lib/activities'
 import { getConfig } from '@/lib/config'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { createNoteJob } from '@/lib/jobs/createNoteJob'
-import { CREATE_NOTE_JOB_NAME, RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
+import { createPollJob } from '@/lib/jobs/createPollJob'
+import {
+  CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME,
+  RELAY_ANNOUNCE_JOB_NAME
+} from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
+import { ENTITY_TYPE_QUESTION } from '@/lib/types/activitypub'
 import { Status } from '@/lib/types/domain/status'
 import {
   ACTIVITY_STREAM_PUBLIC,
@@ -98,11 +104,19 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
       // createNoteJob enforces the note author's federation policy and persists
       // the status; called without verifiedSenderActorId so the relay's
       // signature does not have to match the note's author.
-      await createNoteJob(database, {
-        id: note.id,
-        name: CREATE_NOTE_JOB_NAME,
-        data: note
-      })
+      if (note.type === ENTITY_TYPE_QUESTION) {
+        await createPollJob(database, {
+          id: note.id,
+          name: CREATE_POLL_JOB_NAME,
+          data: note
+        })
+      } else {
+        await createNoteJob(database, {
+          id: note.id,
+          name: CREATE_NOTE_JOB_NAME,
+          data: note
+        })
+      }
       // Look the stored status up by the note's canonical id — a remote server
       // may canonicalize the requested object id (trailing slash, protocol,
       // redirect), and createNoteJob persists it under note.id.

--- a/lib/jobs/processForwardedActivityJob.test.ts
+++ b/lib/jobs/processForwardedActivityJob.test.ts
@@ -5,6 +5,7 @@ import { PROCESS_FORWARDED_ACTIVITY_JOB_NAME } from '@/lib/jobs/names'
 import { processForwardedActivityJob } from '@/lib/jobs/processForwardedActivityJob'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
 
 enableFetchMocks()
 
@@ -294,5 +295,96 @@ describe('processForwardedActivityJob', () => {
       (call) => typeof call?.[0] === 'string' && call[0] === localNote
     )
     expect(calls).toHaveLength(0)
+  })
+
+  it('stores a forwarded Create of a Question by re-fetching from origin', async () => {
+    const questionDoc = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: NOTE_ID,
+      type: 'Question',
+      attributedTo: AUTHOR,
+      content: '<p>What is your choice?</p>',
+      published: '2026-08-28T00:00:00Z',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      url: NOTE_ID,
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'Option A',
+          replies: { type: 'Collection', totalItems: 1 }
+        },
+        {
+          type: 'Note',
+          name: 'Option B',
+          replies: { type: 'Collection', totalItems: 2 }
+        }
+      ]
+    }
+    fetchMock.mockResponseOnce(JSON.stringify(questionDoc))
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Create', { id: NOTE_ID, type: 'Question' }))
+    )
+
+    const status = (await database.getStatus({
+      statusId: NOTE_ID
+    })) as StatusPoll
+    expect(status).toBeDefined()
+    expect(status.type).toEqual(StatusType.enum.Poll)
+    expect(status.actorId).toEqual(AUTHOR)
+    expect(status.choices).toHaveLength(2)
+  })
+
+  it('updates an existing poll on a forwarded Update of a Question', async () => {
+    // First, store the poll
+    const initialQuestion = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: NOTE_ID,
+      type: 'Question',
+      attributedTo: AUTHOR,
+      content: '<p>Vote on this!</p>',
+      published: '2026-08-28T00:00:00Z',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      url: NOTE_ID,
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'Option 1',
+          replies: { type: 'Collection', totalItems: 0 }
+        }
+      ]
+    }
+    fetchMock.mockResponseOnce(JSON.stringify(initialQuestion))
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Create', { id: NOTE_ID, type: 'Question' }))
+    )
+
+    // Now update with new vote count
+    const updatedQuestion = {
+      ...initialQuestion,
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'Option 1',
+          replies: { type: 'Collection', totalItems: 10 }
+        }
+      ]
+    }
+    fetchMock.mockResponseOnce(JSON.stringify(updatedQuestion))
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Update', { id: NOTE_ID, type: 'Question' }))
+    )
+
+    const status = (await database.getStatus({
+      statusId: NOTE_ID
+    })) as StatusPoll
+    expect(status).toBeDefined()
+    expect(status.type).toEqual(StatusType.enum.Poll)
+    expect(status.choices[0].totalVotes).toEqual(10)
   })
 })

--- a/lib/jobs/processForwardedActivityJob.ts
+++ b/lib/jobs/processForwardedActivityJob.ts
@@ -6,19 +6,23 @@ import { compactActivityPub } from '@/lib/activities/jsonld'
 import { getConfig } from '@/lib/config'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
-import { Tombstone } from '@/lib/types/activitypub'
+import { ENTITY_TYPE_QUESTION, Tombstone } from '@/lib/types/activitypub'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { request } from '@/lib/utils/request'
 import { withSpan } from '@/lib/utils/trace'
 
 import { createJobHandle } from './createJobHandle'
 import { createNoteJob } from './createNoteJob'
+import { createPollJob } from './createPollJob'
 import {
   CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME,
   PROCESS_FORWARDED_ACTIVITY_JOB_NAME,
-  UPDATE_NOTE_JOB_NAME
+  UPDATE_NOTE_JOB_NAME,
+  UPDATE_POLL_JOB_NAME
 } from './names'
 import { updateNoteJob } from './updateNoteJob'
+import { updatePollJob } from './updatePollJob'
 
 // A FORWARDED activity (AP §7.1.2 inbox forwarding): delivered by a server
 // whose HTTP signature verified as some OTHER actor than the activity's
@@ -185,19 +189,35 @@ export const processForwardedActivityJob = createJobHandle(
         withReplies: false
       })
       if (activity.type === 'Update' && stored) {
-        await updateNoteJob(database, {
-          id: note.id,
-          name: UPDATE_NOTE_JOB_NAME,
-          data: note
-        })
+        if (note.type === ENTITY_TYPE_QUESTION) {
+          await updatePollJob(database, {
+            id: note.id,
+            name: UPDATE_POLL_JOB_NAME,
+            data: note
+          })
+        } else {
+          await updateNoteJob(database, {
+            id: note.id,
+            name: UPDATE_NOTE_JOB_NAME,
+            data: note
+          })
+        }
         span.setAttribute('outcome', 'update_applied')
         return
       }
-      await createNoteJob(database, {
-        id: note.id,
-        name: CREATE_NOTE_JOB_NAME,
-        data: note
-      })
+      if (note.type === ENTITY_TYPE_QUESTION) {
+        await createPollJob(database, {
+          id: note.id,
+          name: CREATE_POLL_JOB_NAME,
+          data: note
+        })
+      } else {
+        await createNoteJob(database, {
+          id: note.id,
+          name: CREATE_NOTE_JOB_NAME,
+          data: note
+        })
+      }
       span.setAttribute('outcome', 'create_stored')
     })
   }

--- a/lib/jobs/updateNoteJob.ts
+++ b/lib/jobs/updateNoteJob.ts
@@ -54,9 +54,13 @@ export const updateNoteJob = createJobHandle(
       ArticleContent,
       VideoContent
     ])
-    const note = BaseNoteSchema.parse(
+    const parseResult = BaseNoteSchema.safeParse(
       normalizeActivityPubContent(message.data)
-    ) as BaseNote
+    )
+    if (!parseResult.success) {
+      return
+    }
+    const note = parseResult.data as BaseNote
     const existingStatus = await database.getStatus({
       statusId: note.id,
       withReplies: false

--- a/lib/jobs/updatePollJob.ts
+++ b/lib/jobs/updatePollJob.ts
@@ -9,7 +9,13 @@ import { UPDATE_POLL_JOB_NAME } from './names'
 export const updatePollJob = createJobHandle(
   UPDATE_POLL_JOB_NAME,
   async (database, message) => {
-    const question = Question.parse(normalizeActivityPubContent(message.data))
+    const parseResult = Question.safeParse(
+      normalizeActivityPubContent(message.data)
+    )
+    if (!parseResult.success) {
+      return
+    }
+    const question = parseResult.data
     const existingStatus = await database.getStatus({
       statusId: question.id,
       withReplies: false
@@ -31,7 +37,7 @@ export const updatePollJob = createJobHandle(
       choices:
         question.oneOf?.map((answer) => ({
           title: answer.name,
-          totalVotes: answer.replies.totalItems
+          totalVotes: answer.replies?.totalItems ?? 0
         })) ?? []
     })
   }

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -164,10 +164,12 @@ export type Note = z.infer<typeof Note>
 export const QuestionOption = z.object({
   type: z.literal('Note'),
   name: z.string().describe('The text of the poll option'),
-  replies: z.object({
-    type: z.literal('Collection'),
-    totalItems: z.number().describe('The number of votes for this option')
-  })
+  replies: z
+    .object({
+      type: z.literal('Collection'),
+      totalItems: z.number().describe('The number of votes for this option')
+    })
+    .nullish()
 })
 
 export type QuestionOption = z.infer<typeof QuestionOption>


### PR DESCRIPTION
## Summary

Fixes an unhandled `ZodError` exception when processing boosted or relayed polls (`Question` objects) in `CreateAnnounceJob`, `CreateRelayAnnounceJob`, and `ProcessForwardedActivityJob`, which caused `/api/v1/queue/qstash` to return HTTP 400 Bad Request.

### Background & Root Cause
- When an `Announce` activity boosts a remote poll (`type: "Question"`), `createAnnounceJob` fetches the original object from origin via `getNote`.
- Previously, `createAnnounceJob` unconditionally forwarded all fetched statuses to `createNoteJob`.
- Inside `createNoteJob`, `BaseNoteSchema.parse()` threw an uncaught `ZodError` because `Question` is not in `BaseNoteSchema` (polls are handled by `createPollJob`).
- This uncaught error bubbled up to `/api/v1/queue/qstash`, which returned a 400 Bad Request to QStash, causing delivery failures and retry loops.

### Changes
- **Announce & Forwarding Job Dispatch**:
  - In `createAnnounceJob`, check `boostedStatus.type === ENTITY_TYPE_QUESTION` and dispatch to `createPollJob` instead of `createNoteJob`.
  - In `createRelayAnnounceJob`, route relayed `Question` objects to `createPollJob`.
  - In `processForwardedActivityJob`, route forwarded `Question` create/update activities to `createPollJob` / `updatePollJob`.
- **Safe Parsing across Queue Jobs**:
  - Replaced `.parse()` with `.safeParse()` in `createAnnounceJob`, `createNoteJob`, `updateNoteJob`, and `updatePollJob` so malformed payloads are safely ignored without throwing fatal errors.
  - In `createNoteJob`'s `resolveInboundQuotedStatus.storeNote`, route quoted `Question` objects to `createPollJob`.
- **ActivityPub Liberal Validation**:
  - Made `QuestionOption.replies` `.nullish()` in `lib/types/activitypub/objects.ts` to accommodate diverse Fediverse server formats.
  - Updated `getNote` return type to `Promise<BaseNote | null>`.
- **Tests**:
  - Added unit tests in `createAnnounceJob.test.ts`, `createNoteJob.test.ts`, `createRelayAnnounceJob.test.ts`, and `processForwardedActivityJob.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
