### PR TITLE
Bump version to v1.153.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.152.2",
+  "version": "1.153.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.152.2`
- Base main SHA: `895a206bc9c3a4c8dce7d75810444f55f69805cb`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
