### PR TITLE
fix: disable viewport prefetch on user profile and navigation links

### DIFF
--- a/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
+++ b/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
@@ -72,7 +72,9 @@ export const AuthorizeInteractionCard: FC<AuthorizeInteractionCardProps> = ({
         {isSelf ? null : <FollowAction targetActorId={actor.id} isLoggedIn />}
         {profileUrl ? (
           <Button variant="outline" asChild>
-            <Link href={profileUrl}>View profile</Link>
+            <Link href={profileUrl} prefetch={false}>
+              View profile
+            </Link>
           </Button>
         ) : null}
       </CardFooter>

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -116,6 +116,7 @@ const Page: FC<Props> = async ({ params }) => {
         <Button variant="ghost" size="icon" asChild>
           <Link
             href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+            prefetch={false}
           >
             <ArrowLeft className="h-5 w-5" />
             <span className="sr-only">Back to profile</span>

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -116,6 +116,7 @@ const Page: FC<Props> = async ({ params }) => {
         <Button variant="ghost" size="icon" asChild>
           <Link
             href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+            prefetch={false}
           >
             <ArrowLeft className="h-5 w-5" />
             <span className="sr-only">Back to profile</span>

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -224,6 +224,7 @@ const Page: FC<Props> = async ({ params }) => {
             </div>
             <Link
               href={`/@${person.preferredUsername}@${actorDomain}/following`}
+              prefetch={false}
               className="hover:underline"
             >
               <span className="font-semibold">{followingCount}</span>{' '}
@@ -231,6 +232,7 @@ const Page: FC<Props> = async ({ params }) => {
             </Link>
             <Link
               href={`/@${person.preferredUsername}@${actorDomain}/followers`}
+              prefetch={false}
               className="hover:underline"
             >
               <span className="font-semibold">{followersCount}</span>{' '}

--- a/lib/components/actor-switcher/ActorSwitcher.test.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.test.tsx
@@ -3,8 +3,26 @@
  */
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
 import { ActorSwitcher } from './ActorSwitcher'
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    prefetch,
+    ...rest
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string
+    prefetch?: boolean | 'auto' | null
+    children: ReactNode
+  }) => (
+    <a href={href} data-prefetch={String(prefetch)} {...rest}>
+      {children}
+    </a>
+  )
+}))
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
@@ -33,11 +51,12 @@ const profileHref = '/@alice@activities.local'
 
 describe('ActorSwitcher', () => {
   describe('with a single actor', () => {
-    it('renders the whole row as a link to the profile', () => {
+    it('renders the whole row as a link to the profile without prefetch', () => {
       render(<ActorSwitcher currentActor={alice} actors={[alice]} />)
 
       const link = screen.getByRole('link')
       expect(link).toHaveAttribute('href', profileHref)
+      expect(link).toHaveAttribute('data-prefetch', 'false')
       expect(link).toHaveTextContent('Alice')
       expect(link).toHaveTextContent('@alice@activities.local')
     })
@@ -60,13 +79,14 @@ describe('ActorSwitcher', () => {
   })
 
   describe('with multiple actors', () => {
-    it('links only the avatar icon to the profile', () => {
+    it('links only the avatar icon to the profile without prefetch', () => {
       render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
 
       const iconLink = screen.getByRole('link', {
         name: "View Alice's profile"
       })
       expect(iconLink).toHaveAttribute('href', profileHref)
+      expect(iconLink).toHaveAttribute('data-prefetch', 'false')
     })
 
     it('renders the name/handle/arrow as the dropdown trigger, not a link', () => {

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -120,6 +120,7 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
     return (
       <Link
         href={profileHref}
+        prefetch={false}
         className="flex items-center gap-3 rounded-lg p-2 cursor-pointer hover:bg-muted transition-colors w-full overflow-hidden"
       >
         {avatar}
@@ -138,6 +139,7 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
         <div className="flex items-center gap-3 rounded-lg p-2 hover:bg-muted transition-colors w-full">
           <Link
             href={profileHref}
+            prefetch={false}
             aria-label={`View ${displayName}'s profile`}
             className="shrink-0 rounded-full cursor-pointer"
           >

--- a/lib/components/layout/mobile-nav.tsx
+++ b/lib/components/layout/mobile-nav.tsx
@@ -107,6 +107,7 @@ export function MobileNav({
       <DropdownMenuItem key={item.key} asChild>
         <Link
           href={item.href}
+          prefetch={false}
           aria-current={isActive ? 'page' : undefined}
           className={cn(
             'flex items-center gap-2',
@@ -130,6 +131,7 @@ export function MobileNav({
             <li key={item.key} className="min-w-0">
               <Link
                 href={item.href}
+                prefetch={false}
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'relative flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 px-2 py-2 text-xs font-medium transition-colors',

--- a/lib/components/layout/sidebar.test.tsx
+++ b/lib/components/layout/sidebar.test.tsx
@@ -9,10 +9,31 @@ import {
   waitFor,
   within
 } from '@testing-library/react'
-import { ReactElement } from 'react'
+import {
+  type AnchorHTMLAttributes,
+  type ReactElement,
+  type ReactNode
+} from 'react'
 
 import { NavPreferencesProvider } from '@/lib/components/layout/nav-preferences-context'
 import { Sidebar } from '@/lib/components/layout/sidebar'
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    prefetch,
+    ...rest
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string
+    prefetch?: boolean | 'auto' | null
+    children: ReactNode
+  }) => (
+    <a href={href} data-prefetch={String(prefetch)} {...rest}>
+      {children}
+    </a>
+  )
+}))
 
 const mockPathname = vi.fn(() => '/lists')
 vi.mock('next/navigation', () => ({
@@ -95,6 +116,30 @@ describe('Sidebar', () => {
         name: /collapse lists|expand lists/i
       })
     ).not.toBeInTheDocument()
+  })
+
+  it('renders user profile link with prefetch disabled', () => {
+    mockPathname.mockReturnValue('/')
+    renderSidebar(
+      <Sidebar
+        lists={[]}
+        user={{
+          handle: '@alice@activities.local',
+          username: 'alice',
+          name: 'Alice'
+        }}
+      />
+    )
+
+    const profileLinks = screen
+      .getAllByRole('link')
+      .filter(
+        (link) => link.getAttribute('href') === '/@alice@activities.local'
+      )
+    expect(profileLinks.length).toBeGreaterThan(0)
+    for (const link of profileLinks) {
+      expect(link).toHaveAttribute('data-prefetch', 'false')
+    }
   })
 
   describe('customization', () => {

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -468,6 +468,7 @@ export function Sidebar({
             <div className="border-t p-4">
               <Link
                 href={`/${user.handle}`}
+                prefetch={false}
                 className="flex items-center gap-3 rounded-lg p-2 cursor-pointer hover:bg-muted transition-colors"
               >
                 <Avatar className="h-10 w-10">
@@ -625,7 +626,11 @@ export function Sidebar({
           <div className="border-t p-3">
             <Tooltip>
               <TooltipTrigger asChild>
-                <Link href={`/${user.handle}`} className="cursor-pointer block">
+                <Link
+                  href={`/${user.handle}`}
+                  prefetch={false}
+                  className="cursor-pointer block"
+                >
                   <Avatar className="h-10 w-10">
                     {user.avatarUrl && <AvatarImage src={user.avatarUrl} />}
                     <AvatarFallback className="bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300">


### PR DESCRIPTION
## Summary

When visiting an actor's profile page (such as a remote profile like `/@dansup@pixelfed.social`) while logged in, Next.js App Router continuously sent `_rsc` background prefetch requests (`next-router-prefetch: 1`) for the current user's profile path (e.g. `/@null@llun.dev`) in an infinite loop.

### Cause
1. `Sidebar` (both desktop and tablet rail), `ActorSwitcher`, and `MobileNav` rendered the logged-in user's profile `<Link>` without `prefetch={false}`.
2. Because `Sidebar` is fixed in the viewport, Next.js automatically registered an IntersectionObserver and prefetched the profile route.
3. Dynamic actor routes (`/[actor]`) use session cookies and dynamic headers, meaning Next.js App Router client router cache gives them a 0-second stale time (`staleTimes.dynamic: 0`).
4. On profile pages (especially remote profiles), asynchronous operations like `FollowAction` fetching follow status from `/api/v1/accounts/relationships` or `ActorTimelines` updating status state caused re-renders. Every re-render caused Next.js to re-evaluate visible `<Link>` elements, seeing the 0s-stale profile prefetch and firing it repeatedly.

### Fix
- Added `prefetch={false}` to desktop and tablet rail profile links in `Sidebar`.
- Added `prefetch={false}` to single-actor and multi-actor avatar profile links in `ActorSwitcher`.
- Added `prefetch={false}` to menu and direct navigation links in `MobileNav`.
- Added `prefetch={false}` to Following/Followers links in profile `page.tsx`, `followers/page.tsx`, `following/page.tsx`, and `AuthorizeInteractionCard.tsx`.
- Added unit tests in `ActorSwitcher.test.tsx` and `sidebar.test.tsx` asserting `prefetch={false}`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
