### PR TITLE
Bump version to v1.153.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.0",
+  "version": "1.153.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.0`
- Base main SHA: `1b688579bc0137d90e607ad594ed51dfbeb1e795`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
