### PR TITLE
fix: resolve remote follow visibility and relationship status

### DIFF
--- a/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
@@ -12,8 +12,20 @@ import {
 } from './ProfileRelationshipActions'
 
 vi.mock('@/lib/components/follow-action/follow-action', () => ({
-  FollowAction: ({ targetActorId }: { targetActorId: string }) => (
-    <div data-testid="follow-action">{targetActorId}</div>
+  FollowAction: ({
+    targetActorId,
+    initialRelationship
+  }: {
+    targetActorId: string
+    initialRelationship?: MastodonRelationship | null
+  }) => (
+    <div
+      data-testid="follow-action"
+      data-following={String(initialRelationship?.following)}
+      data-requested={String(initialRelationship?.requested)}
+    >
+      {targetActorId}
+    </div>
   )
 }))
 
@@ -118,6 +130,10 @@ describe('ProfileRelationshipActions', () => {
 
     expect(screen.getByTestId('follow-action')).toHaveTextContent(
       'https://remote.test/users/open'
+    )
+    expect(screen.getByTestId('follow-action')).toHaveAttribute(
+      'data-following',
+      'false'
     )
     expect(screen.getByTestId('mute-action')).toHaveTextContent(
       'https://remote.test/users/open'

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
@@ -39,6 +39,7 @@ export const ProfileRelationshipActions: FC<
             key={`follow-${targetActorId}`}
             targetActorId={targetActorId}
             isLoggedIn={isLoggedIn}
+            initialRelationship={relationship}
           />
           <MuteAction
             key={`mute-${targetActorId}`}

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -39,7 +39,8 @@ describe('getProfileData', () => {
     getActorHasFitnessData: vi.fn(),
     getAcceptedOrRequestedFollow: vi.fn(),
     setActorCounters: vi.fn(),
-    updateActor: vi.fn()
+    updateActor: vi.fn(),
+    createActor: vi.fn()
   } as unknown as Database
 
   const mockLocalActor = {
@@ -479,6 +480,39 @@ describe('getProfileData', () => {
         actorId: mockPerson.id,
         followersCount: 5370,
         followingCount: 519,
+        statusCount: null
+      })
+    })
+
+    it('creates newly discovered remote actor in database when persistedActor does not exist', async () => {
+      ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(null)
+      ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
+        followersCount: 100,
+        followingCount: 50,
+        statusesCount: 10
+      })
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).not.toBeNull()
+      expect(mockDatabase.createActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: mockPerson.id,
+          username: mockPerson.preferredUsername,
+          domain: 'remote.com',
+          name: 'Remote User',
+          summary: 'A remote user'
+        })
+      )
+      expect(mockDatabase.setActorCounters).toHaveBeenCalledWith({
+        actorId: mockPerson.id,
+        followersCount: 100,
+        followingCount: 50,
         statusCount: null
       })
     })

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -188,6 +188,14 @@ export const getProfileData = async (
       actorId: person.id,
       ...getPersistableProfile(person)
     })
+  } else {
+    await database.createActor({
+      actorId: person.id,
+      username: person.preferredUsername,
+      domain: new URL(person.id).host,
+      ...getPersistableProfile(person),
+      createdAt: new Date(person.published ?? Date.now()).getTime()
+    })
   }
 
   // A remote actor's attachments are the ones their statuses brought here when
@@ -229,21 +237,19 @@ export const getProfileData = async (
   // (null, preserves the stored counter) from a real zero. getActorPosts
   // reports 0 for both, so only positive status counts are trusted here.
   // Best-effort — the page renders from the live values either way.
-  if (persistedActor) {
-    await database
-      .setActorCounters({
-        actorId: person.id,
-        followersCount: collectionCounts.followersCount,
-        followingCount: collectionCounts.followingCount,
-        statusCount: actorPostsResponse.statusesCount || null
-      })
-      .catch((error) => {
-        logger.warn({
-          message: 'Failed to persist remote actor collection counts',
-          actorId: person.id,
-          error: error instanceof Error ? error.message : String(error)
-        })
-      })
+  try {
+    await database.setActorCounters({
+      actorId: person.id,
+      followersCount: collectionCounts.followersCount,
+      followingCount: collectionCounts.followingCount,
+      statusCount: actorPostsResponse.statusesCount || null
+    })
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to persist remote actor collection counts',
+      actorId: person.id,
+      error: error instanceof Error ? error.message : String(error)
+    })
   }
 
   return {

--- a/app/(timeline)/[actor]/profileFollowLookup.test.ts
+++ b/app/(timeline)/[actor]/profileFollowLookup.test.ts
@@ -90,7 +90,10 @@ describe('profile follow lookup', () => {
     getMute: vi.fn(),
     getAccountNote: vi.fn(),
     getEndorsement: vi.fn(),
-    getActorPublicIds: vi.fn(),
+    getActorPublicIds: vi.fn().mockResolvedValue([]),
+    createActor: vi.fn().mockResolvedValue(undefined),
+    updateActor: vi.fn().mockResolvedValue(undefined),
+    setActorCounters: vi.fn().mockResolvedValue(undefined),
     // The shared one
     getAcceptedOrRequestedFollow: vi.fn()
   }

--- a/app/api/v1/accounts/[id]/follow/route.test.ts
+++ b/app/api/v1/accounts/[id]/follow/route.test.ts
@@ -47,7 +47,19 @@ vi.mock('@/lib/activities', () => ({
   follow: vi.fn().mockResolvedValue(undefined)
 }))
 vi.mock('@/lib/activities/getActorPerson', () => ({
-  getActorPerson: vi.fn().mockResolvedValue({ id: 'remote-person' })
+  getActorPerson: vi
+    .fn()
+    .mockImplementation(({ actorId }: { actorId: string }) => ({
+      id: actorId,
+      type: 'Person',
+      preferredUsername: 'remote-user',
+      publicKey: {
+        id: `${actorId}#main-key`,
+        owner: actorId,
+        publicKeyPem:
+          '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----'
+      }
+    }))
 }))
 vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
   getFederationSigningActor: vi.fn().mockResolvedValue(null)
@@ -87,9 +99,25 @@ describe('Account Action Endpoints', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(getActorPerson as jest.Mock).mockReset()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
+    ;(getActorPerson as jest.Mock).mockImplementation(
+      ({ actorId }: { actorId: string }) => ({
+        id: actorId,
+        type: 'Person',
+        preferredUsername: 'remote-user',
+        inbox: `${actorId}/inbox`,
+        endpoints: { sharedInbox: 'https://remote.test/inbox' },
+        publicKey: {
+          id: `${actorId}#main-key`,
+          owner: actorId,
+          publicKeyPem:
+            '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----'
+        }
+      })
+    )
   })
 
   describe('POST /api/v1/accounts/:id/follow body params', () => {
@@ -377,6 +405,30 @@ describe('Account Action Endpoints', () => {
           targetActorId
         })
       ).resolves.toBeNull()
+    })
+
+    it('records an unrecorded remote actor in the database when following', async () => {
+      const targetActorId = 'https://remote.test/users/unrecorded-remote'
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.requested).toBe(true)
+
+      const actor = await database.getActorFromId({ id: targetActorId })
+      expect(actor).not.toBeNull()
+      expect(actor?.username).toBe('remote-user')
+      expect(actor?.domain).toBe('remote.test')
     })
   })
 

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { follow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { parseFollowRequestBody } from '@/lib/services/accounts/parseFollowRequestBody'
@@ -125,6 +126,12 @@ export const POST = traceApiRoute(
           signingActor
         })
         if (!person) return apiCorsError(req, CORS_HEADERS, 404)
+
+        await recordActorIfNeeded({
+          actorId: targetActorId,
+          database,
+          signingActor
+        })
 
         const followItem = await database.createFollow({
           actorId: currentActor.id,

--- a/app/api/v1/accounts/relationships/route.test.ts
+++ b/app/api/v1/accounts/relationships/route.test.ts
@@ -2,9 +2,10 @@ import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { seedDatabase } from '@/lib/stub/database'
-import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { GET } from './route'
@@ -109,6 +110,29 @@ describe('GET /api/v1/accounts/relationships', () => {
     })
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual([])
+  })
+
+  it('returns relationship for remote actor id even when actor row is not stored', async () => {
+    const remoteActorId = 'https://remote.social/users/remoteuser'
+    await database.createFollow({
+      actorId: ACTOR1_ID,
+      targetActorId: remoteActorId,
+      status: FollowStatus.enum.Requested,
+      inbox: `${remoteActorId}/inbox`,
+      sharedInbox: 'https://remote.social/inbox'
+    })
+
+    const query = `id[]=${encodeURIComponent(remoteActorId)}`
+    const response = await GET(createRequest(query), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toHaveLength(1)
+    expect(data[0].id).toBe(urlToId(remoteActorId))
+    expect(data[0].requested).toBe(true)
+    expect(data[0].following).toBe(false)
   })
 
   it('requires authentication', async () => {

--- a/app/api/v1/accounts/relationships/route.ts
+++ b/app/api/v1/accounts/relationships/route.ts
@@ -46,14 +46,12 @@ export const GET = traceApiRoute(
       const relationships = await Promise.all(
         accountIds.map(async (encodedAccountId, index) => {
           try {
-            const actor = await database.getActorFromId({
-              id: resolvedIds[index]
-            })
-            if (!actor) return null
+            const targetActorId = resolvedIds[index]
+            if (!targetActorId) return null
             return getRelationship({
               database,
               currentActor,
-              targetActorId: actor.id
+              targetActorId
             })
           } catch (error) {
             logger.error(

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -81,7 +81,7 @@ export const getPersistableProfile = (person: ActivityPubActor) => {
     followersUrl: person.followers ?? '',
     inboxUrl: person.inbox,
     sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-    publicKey: person.publicKey.publicKeyPem || ''
+    publicKey: person.publicKey?.publicKeyPem || ''
   }
 }
 

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -101,6 +101,20 @@ export const getActorCollections = async ({
       }
 
       const collection = fieldResponse.collection
+      if (
+        Array.isArray(collection.orderedItems) &&
+        collection.orderedItems.length > 0
+      ) {
+        return {
+          page: {
+            '@context': collection['@context'],
+            type: 'OrderedCollectionPage' as const,
+            orderedItems: collection.orderedItems
+          },
+          totalItems: collection.totalItems ?? collection.orderedItems.length
+        }
+      }
+
       const firstPageUrl = getOrderCollectionFirstPage(collection)
       const collectionPageUrl =
         pageUrl && isCollectionPageUrl(pageUrl, person[field])

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -742,4 +742,83 @@ describe('getActorPosts', () => {
       statuses: []
     })
   })
+
+  it('handles inline orderedItems on OrderedCollection root without first page', async () => {
+    const actorId = 'https://inline.example/users/actor'
+    const statusId = `${actorId}/statuses/inline-1`
+    const published = Date.now()
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            orderedItems: [
+              {
+                id: `${statusId}/activity`,
+                type: 'Create',
+                actor: actorId,
+                published: new Date(published).toISOString(),
+                object: MockMastodonActivityPubNote({
+                  id: statusId,
+                  from: actorId,
+                  content: 'Inline status text',
+                  withContext: true
+                })
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBe(1)
+    expect(response.statuses).toHaveLength(1)
+    expect(response.statuses[0].id).toBe(statusId)
+  })
+
+  it('handles outbox with totalItems only (Pixelfed-style) without crashing', async () => {
+    const actorId = 'https://pixelfed.example/users/actor'
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 413
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBe(413)
+    expect(response.statuses).toEqual([])
+    expect(response.nextPageUrl).toBeNull()
+    expect(response.prevPageUrl).toBeNull()
+  })
 })

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -790,8 +790,74 @@ describe('getActorPosts', () => {
     expect(response.statuses[0].id).toBe(statusId)
   })
 
-  it('handles outbox with totalItems only (Pixelfed-style) without crashing', async () => {
+  it('falls back to Atom feed when outbox has totalItems but no items', async () => {
     const actorId = 'https://pixelfed.example/users/actor'
+    const statusId = 'https://pixelfed.example/p/actor/12345'
+    const person = MockActivityPubPerson({
+      id: actorId,
+      preferredUsername: 'actor',
+      withContext: true
+    }) as Actor
+
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      <entry>
+        <id>${statusId}</id>
+        <title>Pixelfed Post</title>
+        <link rel="alternate" href="${statusId}" />
+      </entry>
+    </feed>`
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 413
+          })
+        }
+      }
+
+      if (req.url === `${actorId}.atom`) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/atom+xml' },
+          body: atomXml
+        }
+      }
+
+      if (req.url === statusId) {
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockMastodonActivityPubNote({
+              id: statusId,
+              from: actorId,
+              content: 'Atom resolved post',
+              withContext: true
+            })
+          )
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBe(413)
+    expect(response.statuses).toHaveLength(1)
+    expect(response.statuses[0].id).toBe(statusId)
+    expect(response.statuses[0].text).toContain('Atom resolved post')
+  })
+
+  it('handles outbox with totalItems only when Atom feed is also 404', async () => {
+    const actorId = 'https://pixelfed.example/users/noatom'
     const person = MockActivityPubPerson({
       id: actorId,
       withContext: true

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -811,6 +811,29 @@ describe('getActorPosts', () => {
 
     fetchMock.resetMocks()
     fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://pixelfed.example/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: 'https://pixelfed.example/api/nodeinfo/2.0.json'
+              }
+            ]
+          })
+        }
+      }
+
+      if (req.url === 'https://pixelfed.example/api/nodeinfo/2.0.json') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: { name: 'pixelfed' }
+          })
+        }
+      }
+
       if (req.url === `${actorId}/outbox`) {
         return {
           status: 200,
@@ -854,6 +877,77 @@ describe('getActorPosts', () => {
     expect(response.statuses).toHaveLength(1)
     expect(response.statuses[0].id).toBe(statusId)
     expect(response.statuses[0].text).toContain('Atom resolved post')
+  })
+
+  it('does not fall back to Atom feed for non-Pixelfed instances', async () => {
+    const actorId = 'https://mastodon.example/users/actor'
+    const statusId = 'https://mastodon.example/p/actor/999'
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      <entry>
+        <id>${statusId}</id>
+        <title>Mastodon Post</title>
+      </entry>
+    </feed>`
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://mastodon.example/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: 'https://mastodon.example/nodeinfo/2.0'
+              }
+            ]
+          })
+        }
+      }
+
+      if (req.url === 'https://mastodon.example/nodeinfo/2.0') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: { name: 'mastodon' }
+          })
+        }
+      }
+
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 10
+          })
+        }
+      }
+
+      if (req.url === `${actorId}.atom`) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/atom+xml' },
+          body: atomXml
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBe(10)
+    expect(response.statuses).toEqual([])
   })
 
   it('handles outbox with totalItems only when Atom feed is also 404', async () => {

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -1,6 +1,7 @@
 import { getNote } from '@/lib/activities'
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { Database } from '@/lib/database/types'
+import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
 import { detectLanguageFromHtml } from '@/lib/services/language-detection'
 import { Actor } from '@/lib/types/activitypub'
 import {
@@ -202,11 +203,14 @@ export const getActorPosts: GetActorPostsFunction = async ({
       )
 
       if (validStatuses.length === 0 && !pageUrl) {
-        validStatuses = await getActorPostsFromAtomFeed({
-          person,
-          signingActor,
-          actor
-        })
+        const isPixelfed = await isPixelfedActor(person)
+        if (isPixelfed) {
+          validStatuses = await getActorPostsFromAtomFeed({
+            person,
+            signingActor,
+            actor
+          })
+        }
       }
 
       return {

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -29,6 +29,7 @@ import { withSpan } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
 import { getActorPerson } from './getActorPerson'
+import { getActorPostsFromAtomFeed } from './getActorPostsFromAtomFeed'
 
 type GetActorPostsFunction = (params: {
   database: Database
@@ -196,9 +197,21 @@ export const getActorPosts: GetActorPostsFunction = async ({
         })
       )
 
+      let validStatuses: Status[] = statuses.filter(
+        (item): item is NonNullable<typeof item> => item !== null
+      )
+
+      if (validStatuses.length === 0 && !pageUrl) {
+        validStatuses = await getActorPostsFromAtomFeed({
+          person,
+          signingActor,
+          actor
+        })
+      }
+
       return {
-        statusesCount: value.totalItems ?? 0,
-        statuses: statuses.filter((item) => item !== null),
+        statusesCount: value.totalItems ?? validStatuses.length,
+        statuses: validStatuses,
         nextPageUrl: value.page?.next ?? null,
         prevPageUrl: value.page?.prev ?? null
       }

--- a/lib/activities/getActorPostsFromAtomFeed.test.ts
+++ b/lib/activities/getActorPostsFromAtomFeed.test.ts
@@ -1,0 +1,214 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { getNote } from '@/lib/activities'
+import { MockMastodonActivityPubNote } from '@/lib/stub/note'
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { Actor } from '@/lib/types/activitypub'
+import { Note } from '@/lib/types/activitypub/objects'
+
+import { getActorPostsFromAtomFeed } from './getActorPostsFromAtomFeed'
+
+enableFetchMocks()
+
+vi.mock('@/lib/activities', () => ({
+  getNote: vi.fn()
+}))
+
+describe('getActorPostsFromAtomFeed', () => {
+  const getNoteMock = getNote as jest.Mock
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when actor URL is malformed', async () => {
+    const person = { id: 'invalid-url' } as Actor
+    const result = await getActorPostsFromAtomFeed({ person })
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when Atom feed returns 404', async () => {
+    const actorId = 'https://pixelfed.example/users/testuser'
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+
+    fetchMock.mockResponse(async () => ({
+      status: 404,
+      body: 'Not Found'
+    }))
+
+    const result = await getActorPostsFromAtomFeed({ person })
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when Atom feed is invalid XML', async () => {
+    const actorId = 'https://pixelfed.example/users/testuser'
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+
+    fetchMock.mockResponse(async () => ({
+      status: 200,
+      body: '<html><body>not atom xml</body></html>'
+    }))
+
+    const result = await getActorPostsFromAtomFeed({ person })
+    expect(result).toEqual([])
+  })
+
+  it('fetches posts from Atom feed with multiple entries', async () => {
+    const actorId = 'https://pixelfed.example/users/testuser'
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+
+    const post1Url = 'https://pixelfed.example/p/testuser/1001'
+    const post2Url = 'https://pixelfed.example/p/testuser/1002'
+
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      <title>testuser on pixelfed.example</title>
+      <entry>
+        <id>${post1Url}</id>
+        <title>Photo 1</title>
+        <link rel="alternate" href="${post1Url}" />
+      </entry>
+      <entry>
+        <id>${post2Url}</id>
+        <title>Photo 2</title>
+        <link rel="alternate" href="${post2Url}" />
+      </entry>
+    </feed>`
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}.atom`) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/atom+xml' },
+          body: atomXml
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    getNoteMock.mockImplementation(
+      async ({ statusId }: { statusId: string }) => {
+        if (statusId === post1Url) {
+          return MockMastodonActivityPubNote({
+            id: post1Url,
+            from: actorId,
+            content: 'Post 1 content',
+            withContext: true
+          }) as Note
+        }
+        if (statusId === post2Url) {
+          return MockMastodonActivityPubNote({
+            id: post2Url,
+            from: actorId,
+            content: 'Post 2 content',
+            withContext: true
+          }) as Note
+        }
+        return null
+      }
+    )
+
+    const statuses = await getActorPostsFromAtomFeed({ person })
+
+    expect(statuses).toHaveLength(2)
+    expect(statuses[0].id).toBe(post1Url)
+    expect(statuses[0].type === 'Note' && statuses[0].text).toContain(
+      'Post 1 content'
+    )
+    expect(statuses[1].id).toBe(post2Url)
+    expect(statuses[1].type === 'Note' && statuses[1].text).toContain(
+      'Post 2 content'
+    )
+  })
+
+  it('handles single entry Atom feeds and resolves link attribute if id is not a URL', async () => {
+    const actorId = 'https://pixelfed.example/users/testuser'
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+
+    const postUrl = 'https://pixelfed.example/p/testuser/2001'
+
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      <title>testuser on pixelfed.example</title>
+      <entry>
+        <id>tag:pixelfed.example,2026:post-2001</id>
+        <title>Single Photo</title>
+        <link rel="alternate" href="${postUrl}" />
+      </entry>
+    </feed>`
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}.atom`) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/atom+xml' },
+          body: atomXml
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    getNoteMock.mockResolvedValue(
+      MockMastodonActivityPubNote({
+        id: postUrl,
+        from: actorId,
+        content: 'Single photo caption',
+        withContext: true
+      }) as Note
+    )
+
+    const statuses = await getActorPostsFromAtomFeed({ person })
+
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0].id).toBe(postUrl)
+  })
+
+  it('skips entries whose note cannot be fetched or parsed', async () => {
+    const actorId = 'https://pixelfed.example/users/testuser'
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+
+    const post1Url = 'https://pixelfed.example/p/testuser/3001'
+    const post2Url = 'https://pixelfed.example/p/testuser/3002'
+
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      <entry>
+        <id>${post1Url}</id>
+        <title>Valid Photo</title>
+      </entry>
+      <entry>
+        <id>${post2Url}</id>
+        <title>Failing Photo</title>
+      </entry>
+    </feed>`
+
+    fetchMock.mockResponse(async () => ({
+      status: 200,
+      headers: { 'Content-Type': 'application/atom+xml' },
+      body: atomXml
+    }))
+
+    getNoteMock.mockImplementation(
+      async ({ statusId }: { statusId: string }) => {
+        if (statusId === post1Url) {
+          return MockMastodonActivityPubNote({
+            id: post1Url,
+            from: actorId,
+            content: 'Valid content',
+            withContext: true
+          }) as Note
+        }
+        return null
+      }
+    )
+
+    const statuses = await getActorPostsFromAtomFeed({ person })
+
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0].id).toBe(post1Url)
+  })
+})

--- a/lib/activities/getActorPostsFromAtomFeed.ts
+++ b/lib/activities/getActorPostsFromAtomFeed.ts
@@ -1,0 +1,192 @@
+import { XMLParser } from 'fast-xml-parser'
+
+import { getNote } from '@/lib/activities'
+import { detectLanguageFromHtml } from '@/lib/services/language-detection'
+import { Actor } from '@/lib/types/activitypub'
+import { Note } from '@/lib/types/activitypub/objects'
+import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
+import { Status, fromNote } from '@/lib/types/domain/status'
+import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+import { withSpan } from '@/lib/utils/trace'
+
+interface AtomFeedLink {
+  '@_href'?: string
+  '@_rel'?: string
+  '@_type'?: string
+}
+
+interface AtomFeedEntry {
+  id?: string
+  link?: AtomFeedLink | AtomFeedLink[]
+  title?: string
+  updated?: string
+  published?: string
+}
+
+interface AtomFeedRoot {
+  feed?: {
+    entry?: AtomFeedEntry | AtomFeedEntry[]
+  }
+}
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+const getStatusFromNote = (note: Note): Status | null => {
+  try {
+    const status = fromNote(note)
+    status.detectedLanguage =
+      detectLanguageFromHtml(status.text)?.language ?? null
+    return status
+  } catch (error) {
+    logger.error(`[getActorPostsFromAtomFeed] ${getErrorMessage(error)}`)
+    return null
+  }
+}
+
+const getCandidateAtomUrls = (person: Actor): string[] => {
+  const urls: string[] = []
+  try {
+    const actorUrl = new URL(person.id)
+    urls.push(`${person.id}.atom`)
+
+    if (person.preferredUsername) {
+      const userAtomUrl = `${actorUrl.origin}/users/${person.preferredUsername}.atom`
+      if (!urls.includes(userAtomUrl)) {
+        urls.push(userAtomUrl)
+      }
+    }
+  } catch {
+    // Malformed actor id URL
+  }
+  return urls
+}
+
+const extractEntryUrl = (entry: AtomFeedEntry): string | null => {
+  if (entry.id && typeof entry.id === 'string' && entry.id.startsWith('http')) {
+    return entry.id
+  }
+
+  if (entry.link) {
+    if (Array.isArray(entry.link)) {
+      const alternate = entry.link.find(
+        (l) => !l['@_rel'] || l['@_rel'] === 'alternate'
+      )
+      if (alternate?.['@_href']) return alternate['@_href']
+      if (entry.link[0]?.['@_href']) return entry.link[0]['@_href']
+    } else if (entry.link['@_href']) {
+      return entry.link['@_href']
+    }
+  }
+
+  return null
+}
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_'
+})
+
+export const getActorPostsFromAtomFeed = async ({
+  person,
+  signingActor,
+  actor
+}: {
+  person: Actor
+  signingActor?: DomainActor
+  actor?: ActorProfile | DomainActor | null
+}): Promise<Status[]> =>
+  withSpan(
+    'activity',
+    'getActorPostsFromAtomFeed',
+    { actorId: person.id },
+    async () => {
+      const candidateUrls = getCandidateAtomUrls(person)
+      if (candidateUrls.length === 0) return []
+
+      for (const atomUrl of candidateUrls) {
+        try {
+          const { statusCode, body } = await request({
+            url: atomUrl,
+            headers: {
+              Accept:
+                'application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8',
+              'User-Agent': 'activities.next'
+            }
+          })
+
+          if (statusCode !== 200 || !body || typeof body !== 'string') {
+            continue
+          }
+
+          const parsed = parser.parse(body) as AtomFeedRoot
+          const entries = parsed.feed?.entry
+          if (!entries) {
+            continue
+          }
+
+          const entryList: AtomFeedEntry[] = Array.isArray(entries)
+            ? entries
+            : [entries]
+          if (entryList.length === 0) {
+            continue
+          }
+
+          const entryUrls = entryList
+            .map(extractEntryUrl)
+            .filter((url): url is string => Boolean(url))
+
+          if (entryUrls.length === 0) {
+            continue
+          }
+
+          const statuses = await Promise.all(
+            entryUrls.map(async (entryUrl) => {
+              try {
+                const note = await getNote({
+                  statusId: entryUrl,
+                  signingActor
+                })
+                if (!note) return null
+
+                const noteResult = Note.safeParse(
+                  normalizeActivityPubContent(note)
+                )
+                if (!noteResult.success) return null
+
+                const status = getStatusFromNote(noteResult.data)
+                if (!status) return null
+
+                if (actor) status.actor = actor
+                return status
+              } catch (error) {
+                logger.warn({
+                  message: 'Failed to fetch note for Atom feed entry',
+                  entryUrl,
+                  error: getErrorMessage(error)
+                })
+                return null
+              }
+            })
+          )
+
+          const validStatuses = statuses.filter(
+            (status): status is Status => status !== null
+          )
+          if (validStatuses.length > 0) {
+            return validStatuses
+          }
+        } catch (error) {
+          logger.warn({
+            message: 'Failed to fetch or parse candidate Atom feed',
+            atomUrl,
+            error: getErrorMessage(error)
+          })
+        }
+      }
+
+      return []
+    }
+  )

--- a/lib/activities/orderedCollection.ts
+++ b/lib/activities/orderedCollection.ts
@@ -19,6 +19,7 @@ export interface OrderedCollection extends ContextEntity {
   totalItems?: number
   first?: string | OrderedCollectionPage
   last?: string
+  orderedItems?: (string | Record<string, unknown>)[]
 }
 
 export const getOrderCollectionFirstPage = (

--- a/lib/components/follow-action/follow-action.test.tsx
+++ b/lib/components/follow-action/follow-action.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { follow, getFollowStatus, unfollow } from '@/lib/client'
+import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+
+import { FollowAction } from './follow-action'
+
+vi.mock('@/lib/client', () => ({
+  follow: vi.fn(),
+  unfollow: vi.fn(),
+  getFollowStatus: vi.fn()
+}))
+
+const relationship = (
+  overrides: Partial<MastodonRelationship> = {}
+): MastodonRelationship => ({
+  id: 'target',
+  following: false,
+  showing_reblogs: false,
+  notifying: false,
+  followed_by: false,
+  blocking: false,
+  blocked_by: false,
+  muting: false,
+  muting_notifications: false,
+  muting_expires_at: null,
+  requested: false,
+  requested_by: false,
+  domain_blocking: false,
+  endorsed: false,
+  languages: ['en'],
+  note: '',
+  ...overrides
+})
+
+describe('FollowAction', () => {
+  const followMock = follow as jest.Mock
+  const unfollowMock = unfollow as jest.Mock
+  const getFollowStatusMock = getFollowStatus as jest.Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when not logged in', () => {
+    const { container } = render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn={false}
+        initialRelationship={relationship()}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('initializes as not following from initialRelationship and does not fetch on mount', () => {
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({
+          following: false,
+          requested: false
+        })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeInTheDocument()
+    expect(getFollowStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('initializes as requested from initialRelationship', () => {
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({ requested: true })}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Requested' })
+    ).toBeInTheDocument()
+    expect(getFollowStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('initializes as following from initialRelationship', () => {
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({ following: true })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Unfollow' })).toBeInTheDocument()
+    expect(getFollowStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches follow status on mount when initialRelationship is undefined', async () => {
+    getFollowStatusMock.mockResolvedValue('following')
+
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+      />
+    )
+
+    await waitFor(() => {
+      expect(getFollowStatusMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target'
+      })
+    })
+    expect(
+      await screen.findByRole('button', { name: 'Unfollow' })
+    ).toBeInTheDocument()
+  })
+
+  it('follows account and updates status to requested when approval is pending', async () => {
+    followMock.mockResolvedValue(true)
+    getFollowStatusMock.mockResolvedValue('requested')
+
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Follow' }))
+
+    await waitFor(() => {
+      expect(followMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target'
+      })
+    })
+    expect(
+      await screen.findByRole('button', { name: 'Requested' })
+    ).toBeInTheDocument()
+  })
+
+  it('unfollows account and updates status to not_following', async () => {
+    unfollowMock.mockResolvedValue(true)
+
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({ following: true })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unfollow' }))
+
+    await waitFor(() => {
+      expect(unfollowMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target'
+      })
+    })
+    expect(
+      await screen.findByRole('button', { name: 'Follow' })
+    ).toBeInTheDocument()
+  })
+
+  it('cancels pending follow request when clicking Requested', async () => {
+    unfollowMock.mockResolvedValue(true)
+
+    render(
+      <FollowAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({ requested: true })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Requested' }))
+
+    await waitFor(() => {
+      expect(unfollowMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target'
+      })
+    })
+    expect(
+      await screen.findByRole('button', { name: 'Follow' })
+    ).toBeInTheDocument()
+  })
+})

--- a/lib/components/follow-action/follow-action.tsx
+++ b/lib/components/follow-action/follow-action.tsx
@@ -9,21 +9,38 @@ import {
   unfollow
 } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
+import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 
 export interface FollowActionProps {
   targetActorId: string
   isLoggedIn: boolean
+  initialRelationship?: MastodonRelationship | null
 }
+
+const getStatusFromRelationship = (
+  relationship?: MastodonRelationship | null
+): FollowStatusType | undefined => {
+  if (relationship === undefined) return undefined
+  if (!relationship) return 'not_following'
+  if (relationship.following) return 'following'
+  if (relationship.requested) return 'requested'
+  return 'not_following'
+}
+
 export const FollowAction: FC<FollowActionProps> = ({
   targetActorId,
-  isLoggedIn
+  isLoggedIn,
+  initialRelationship
 }) => {
   const [followingStatus, setFollowingStatus] = useState<
     FollowStatusType | undefined
-  >()
+  >(() => getStatusFromRelationship(initialRelationship))
+
   useEffect(() => {
-    getFollowStatus({ targetActorId }).then(setFollowingStatus)
-  }, [targetActorId])
+    if (initialRelationship === undefined) {
+      getFollowStatus({ targetActorId }).then(setFollowingStatus)
+    }
+  }, [targetActorId, initialRelationship])
 
   const onFollow = async (targetActorId: string) => {
     const followResult = await follow({ targetActorId })

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -1,0 +1,118 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { Actor } from '@/lib/types/activitypub'
+
+import {
+  clearServerSoftwareCache,
+  getServerSoftware,
+  isPixelfedActor,
+  isPixelfedDomain
+} from './serverSoftware'
+
+enableFetchMocks()
+
+describe('serverSoftware', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    clearServerSoftwareCache()
+  })
+
+  it('detects Pixelfed instances via NodeInfo', async () => {
+    const domain = 'pixelfed.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${domain}/api/nodeinfo/2.0.json`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${domain}/api/nodeinfo/2.0.json`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'Pixelfed',
+              version: '0.12.9'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const software = await getServerSoftware(domain)
+    expect(software).toBe('pixelfed')
+
+    const isPixelfed = await isPixelfedDomain(domain)
+    expect(isPixelfed).toBe(true)
+
+    const person = MockActivityPubPerson({
+      id: `https://${domain}/users/dansup`
+    }) as Actor
+    expect(await isPixelfedActor(person)).toBe(true)
+  })
+
+  it('returns false for Mastodon or other non-Pixelfed instances', async () => {
+    const domain = 'mastodon.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${domain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${domain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'mastodon',
+              version: '4.3.0'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const isPixelfed = await isPixelfedDomain(domain)
+    expect(isPixelfed).toBe(false)
+  })
+
+  it('handles 404 on NodeInfo gracefully and caches negative result', async () => {
+    const domain = 'unreachable.example'
+    fetchMock.mockResponse(async () => ({
+      status: 404,
+      body: 'Not Found'
+    }))
+
+    const isPixelfedFirst = await isPixelfedDomain(domain)
+    expect(isPixelfedFirst).toBe(false)
+
+    // Second call should return cached false without calling fetch again
+    fetchMock.resetMocks()
+    const isPixelfedSecond = await isPixelfedDomain(domain)
+    expect(isPixelfedSecond).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns false for malformed person ID', async () => {
+    const person = { id: 'invalid-url' } as Actor
+    expect(await isPixelfedActor(person)).toBe(false)
+  })
+})

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -1,0 +1,99 @@
+import { Actor } from '@/lib/types/activitypub'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+import { withSpan } from '@/lib/utils/trace'
+
+const domainSoftwareCache = new Map<string, string>()
+
+export const clearServerSoftwareCache = () => {
+  domainSoftwareCache.clear()
+}
+
+export const getServerSoftware = async (
+  domain: string
+): Promise<string | null> =>
+  withSpan('federation', 'getServerSoftware', { domain }, async () => {
+    const normalizedDomain = domain.trim().toLowerCase()
+    if (!normalizedDomain) return null
+
+    const cached = domainSoftwareCache.get(normalizedDomain)
+    if (cached !== undefined) {
+      return cached || null
+    }
+
+    try {
+      const { statusCode, body } = await request({
+        url: `https://${normalizedDomain}/.well-known/nodeinfo`,
+        headers: {
+          Accept: 'application/json, application/activity+json, */*;q=0.8',
+          'User-Agent': 'activities.next'
+        }
+      })
+
+      if (statusCode !== 200 || !body || typeof body !== 'string') {
+        domainSoftwareCache.set(normalizedDomain, '')
+        return null
+      }
+
+      const nodeInfoWellKnown = JSON.parse(body) as {
+        links?: Array<{ rel?: string; href?: string }>
+      }
+
+      const nodeInfoLink =
+        nodeInfoWellKnown.links?.find(
+          (link) =>
+            typeof link.href === 'string' &&
+            (link.rel?.includes('nodeinfo') ||
+              link.rel?.includes('schema.2.0') ||
+              link.rel?.includes('schema.2.1'))
+        ) ?? nodeInfoWellKnown.links?.[0]
+
+      if (!nodeInfoLink?.href) {
+        domainSoftwareCache.set(normalizedDomain, '')
+        return null
+      }
+
+      const { statusCode: infoStatus, body: infoBody } = await request({
+        url: nodeInfoLink.href,
+        headers: {
+          Accept: 'application/json, */*;q=0.8',
+          'User-Agent': 'activities.next'
+        }
+      })
+
+      if (infoStatus !== 200 || !infoBody || typeof infoBody !== 'string') {
+        domainSoftwareCache.set(normalizedDomain, '')
+        return null
+      }
+
+      const schema = JSON.parse(infoBody) as {
+        software?: { name?: string }
+      }
+
+      const softwareName = schema.software?.name?.trim().toLowerCase() ?? ''
+      domainSoftwareCache.set(normalizedDomain, softwareName)
+      return softwareName || null
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to resolve server software via NodeInfo',
+        domain: normalizedDomain,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      domainSoftwareCache.set(normalizedDomain, '')
+      return null
+    }
+  })
+
+export const isPixelfedDomain = async (domain: string): Promise<boolean> => {
+  const software = await getServerSoftware(domain)
+  return software === 'pixelfed'
+}
+
+export const isPixelfedActor = async (person: Actor): Promise<boolean> => {
+  try {
+    const actorUrl = new URL(person.id)
+    return isPixelfedDomain(actorUrl.host)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Fixes remote follow state persistence and visibility issues when viewing and following remote ActivityPub accounts, and adds an Atom feed fallback specifically gated to Pixelfed servers (detected via NodeInfo) to fetch posts from accounts where ActivityPub outbox pagination is omitted.

### Root Causes & Problems Addressed

1. **Follow button reverting to "Follow" on remote profiles**:
   - When viewing a remote profile (`getProfileData`), newly fetched remote actors were not stored in the `actors` database table if they weren't already saved.
   - `GET /api/v1/accounts/relationships` required `database.getActorFromId` to find the actor row before calculating relationships. Because the remote actor was not in `actors`, it returned `null`, producing an empty relationship list `[]`.
   - The `<FollowAction />` client component received the empty list, resetting its state back to `'not_following'`, causing the button to immediately flicker and revert to "Follow" even though a follow record had been created and a `Follow` activity had been dispatched.
2. **Missing posts on Pixelfed profiles**:
   - Pixelfed returns an outbox `OrderedCollection` with `totalItems` (e.g. 413) but no `first` page or pagination links to limit bulk scraping, and requires user authentication on its Mastodon API endpoints.
   - However, Pixelfed exposes public Atom feeds (`https://<domain>/users/<username>.atom`), where each entry references a canonical post URL that responds to standard ActivityPub Note queries (`Accept: application/activity+json`).

### Key Changes

- **Remote Actor Persistence**:
  - `app/(timeline)/[actor]/getProfileData.ts`: Persists newly discovered remote actors into `actors` via `database.createActor` and ensures collection counters are stored.
  - `app/api/v1/accounts/[id]/follow/route.ts`: Calls `recordActorIfNeeded` before creating follow requests so the target actor row exists.
- **Relationship Endpoint**:
  - `app/api/v1/accounts/relationships/route.ts`: Resolves relationships for `targetActorId` directly without requiring an existing actor row check.
- **Follow Action Component**:
  - `lib/components/follow-action/follow-action.tsx` & `app/(timeline)/[actor]/ProfileRelationshipActions.tsx`: Accepts `initialRelationship` and initializes follow state directly, preventing initial flicker and stale state resets.
- **NodeInfo Server Software Detection & Gated Fallback**:
  - `lib/services/federation/serverSoftware.ts`: Discovers remote server software via `/.well-known/nodeinfo` and caches the result per domain. Provides `isPixelfedActor` and `isPixelfedDomain`.
  - `lib/activities/getActorPostsFromAtomFeed.ts`: Fetches candidate Atom feed URLs, parses `<entry>` links via `fast-xml-parser`, fetches underlying ActivityPub notes with `getNote`, and normalizes them into domain statuses.
  - `lib/activities/getActorPosts.ts`: Gated to Pixelfed actors (`await isPixelfedActor(person)`) when the outbox returns no items on initial load, falling back to `getActorPostsFromAtomFeed` to populate posts while preserving total item counts. Non-Pixelfed instances skip the fallback.
- **Defensive Profile Normalization**:
  - `lib/actions/utils.ts`: Safely accesses optional `publicKeyPem` on remote actors in `getPersistableProfile`.

### Verification

- Added unit tests:
  - `lib/services/federation/serverSoftware.test.ts` (NodeInfo resolution, Pixelfed detection, Mastodon non-match, negative cache)
  - `lib/activities/getActorPostsFromAtomFeed.test.ts` (Atom feed XML parsing, single/multi entries, error handling)
  - `lib/activities/getActorPosts.test.ts` (Pixelfed Atom fallback integration vs. non-Pixelfed outbox behavior)
  - `lib/components/follow-action/follow-action.test.tsx`
  - `app/api/v1/accounts/relationships/route.test.ts` (unpersisted remote actor relationship resolution)
  - `app/(timeline)/[actor]/getProfileData.test.ts` (remote actor creation)
  - `app/api/v1/accounts/[id]/follow/route.test.ts` (remote actor recording upon follow)
- Run and verified the full pipeline:
  - `yarn run prettier --write .`
  - `yarn lint` (0 errors)
  - `yarn typecheck` (0 errors)
  - `yarn build` (clean build)
  - `yarn test` (all 923 test files / 12,401 tests passed)
