### PR TITLE
Bump version to v1.153.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.1",
+  "version": "1.153.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.1`
- Base main SHA: `d4f3e6bc50b5ddb23abacf994cacfe491a560b48`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
