### PR TITLE
feat: add loading states for user profiles, statuses, and follow lists

### DIFF
--- a/app/(timeline)/[actor]/[status]/loading.test.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { StatusLoading } from './loading'
+
+describe('[status] loading', () => {
+  it('renders loading post skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading post')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports StatusLoading named component', () => {
+    render(<StatusLoading />)
+
+    expect(screen.getByLabelText('Loading post')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/[status]/loading.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react'
+
+export const StatusLoading: FC = () => {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading post"
+      className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
+    >
+      <div className="flex items-center gap-3 border-b bg-background/90 px-5 py-3">
+        <div className="h-8 w-8 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-1">
+          <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+
+      <div className="p-5">
+        <div className="flex items-center gap-3">
+          <div className="size-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="space-y-1.5">
+            <div className="h-4 w-36 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+          <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+        </div>
+
+        <div className="mt-6 flex gap-8 border-t pt-4">
+          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default StatusLoading

--- a/app/(timeline)/[actor]/followers/loading.test.tsx
+++ b/app/(timeline)/[actor]/followers/loading.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { FollowersLoading } from './loading'
+
+describe('[actor]/followers loading', () => {
+  it('renders loading followers skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading followers')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports FollowersLoading named component', () => {
+    render(<FollowersLoading />)
+
+    expect(screen.getByLabelText('Loading followers')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/followers/loading.tsx
+++ b/app/(timeline)/[actor]/followers/loading.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react'
+
+export const FollowersLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading followers" className="space-y-6">
+      <div className="flex items-start gap-3">
+        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-1">
+          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+
+      <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+        {[0, 1, 2, 3].map((index) => (
+          <div key={index} className="flex items-center gap-3 px-5 py-4">
+            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default FollowersLoading

--- a/app/(timeline)/[actor]/following/loading.test.tsx
+++ b/app/(timeline)/[actor]/following/loading.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { FollowingLoading } from './loading'
+
+describe('[actor]/following loading', () => {
+  it('renders loading following skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading following')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports FollowingLoading named component', () => {
+    render(<FollowingLoading />)
+
+    expect(screen.getByLabelText('Loading following')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/following/loading.tsx
+++ b/app/(timeline)/[actor]/following/loading.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react'
+
+export const FollowingLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading following" className="space-y-6">
+      <div className="flex items-start gap-3">
+        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-1">
+          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+
+      <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+        {[0, 1, 2, 3].map((index) => (
+          <div key={index} className="flex items-center gap-3 px-5 py-4">
+            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default FollowingLoading

--- a/app/(timeline)/[actor]/loading.test.tsx
+++ b/app/(timeline)/[actor]/loading.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { ProfileLoading } from './loading'
+
+describe('[actor] loading', () => {
+  it('renders loading profile skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading profile')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports ProfileLoading named component', () => {
+    render(<ProfileLoading />)
+
+    expect(screen.getByLabelText('Loading profile')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -1,0 +1,67 @@
+import { FC } from 'react'
+
+export const ProfileLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading profile" className="space-y-6">
+      <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+        <div className="relative h-36 animate-pulse bg-muted md:h-52" />
+
+        <div className="relative px-6 pb-6">
+          <div className="relative -mt-10 h-20 w-20 animate-pulse rounded-full border-4 border-background bg-muted" />
+
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <div className="h-7 w-48 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
+            </div>
+            <div className="h-9 w-28 animate-pulse rounded-md bg-muted" />
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-6">
+            <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+      </section>
+
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
+          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
+          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
+        </div>
+
+        <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+          {[0, 1, 2].map((index) => (
+            <div key={index} className="flex gap-3 p-4">
+              <div className="size-10 shrink-0 animate-pulse rounded-full bg-muted" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex items-center gap-2">
+                  <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                  <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+                </div>
+                <div className="space-y-1.5">
+                  <div className="h-4 w-full animate-pulse rounded bg-muted" />
+                  <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
+                </div>
+                <div className="flex gap-6 pt-2">
+                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
+                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
+                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProfileLoading


### PR DESCRIPTION
## Summary

Adds Next.js App Router loading boundaries (`loading.tsx`) for user profiles, status conversation details, and following/followers lists under `app/(timeline)/[actor]`.

When a logged-in user navigates to an external/remote actor profile (or status), Next.js App Router previously suspended navigation on the current page while server components performed ActivityPub network fetches across the federation, making the app appear unresponsive. Adding dedicated `loading.tsx` fallbacks ensures immediate transition with skeleton UI while data is fetched.

- Added profile loading skeleton in `app/(timeline)/[actor]/loading.tsx`
- Added status loading skeleton in `app/(timeline)/[actor]/[status]/loading.tsx`
- Added followers loading skeleton in `app/(timeline)/[actor]/followers/loading.tsx`
- Added following loading skeleton in `app/(timeline)/[actor]/following/loading.tsx`
- Added co-located unit tests for all loading components

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)