### PR TITLE
Bump version to v1.153.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.2",
+  "version": "1.153.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.2`
- Base main SHA: `73471d3793584f26725e4547d8f55211cae974cd`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
