### PR TITLE
feat(ui): add light stripe shimmer loading states across slow-loading pages

### DIFF
--- a/app/(timeline)/[actor]/[status]/loading.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
 
+import { PostSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
 export const StatusLoading: FC = () => {
   return (
     <div
@@ -7,34 +9,41 @@ export const StatusLoading: FC = () => {
       aria-label="Loading post"
       className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
     >
-      <div className="flex items-center gap-3 border-b bg-background/90 px-5 py-3">
-        <div className="h-8 w-8 animate-pulse rounded-md bg-muted" />
-        <div className="space-y-1">
-          <div className="h-4 w-16 animate-pulse rounded bg-muted" />
-          <div className="h-3 w-32 animate-pulse rounded bg-muted" />
-        </div>
+      {/* Header bar */}
+      <div className="flex items-center gap-4 border-b p-4" aria-hidden="true">
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <Skeleton className="h-6 w-24" />
       </div>
 
-      <div className="p-5">
+      {/* Focused post detail */}
+      <div className="space-y-4 border-b p-6" aria-hidden="true">
         <div className="flex items-center gap-3">
-          <div className="size-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <Skeleton className="h-12 w-12 rounded-full" />
           <div className="space-y-1.5">
-            <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3.5 w-24" />
           </div>
         </div>
 
-        <div className="mt-4 space-y-2">
-          <div className="h-4 w-full animate-pulse rounded bg-muted" />
-          <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
-          <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+        <div className="space-y-2 pt-2">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-4/5" />
+          <Skeleton className="h-5 w-3/5" />
         </div>
 
-        <div className="mt-6 flex gap-8 border-t pt-4">
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+        <Skeleton className="h-4 w-32 pt-2" />
+
+        <div className="flex gap-6 border-t pt-4">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-16" />
         </div>
+      </div>
+
+      {/* Replies list */}
+      <div className="divide-y" aria-hidden="true">
+        <PostSkeleton framed={false} />
+        <PostSkeleton framed={false} />
       </div>
     </div>
   )

--- a/app/(timeline)/[actor]/followers/loading.test.tsx
+++ b/app/(timeline)/[actor]/followers/loading.test.tsx
@@ -3,16 +3,20 @@
  */
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 
 import Loading, { FollowersLoading } from './loading'
 
 describe('[actor]/followers loading', () => {
-  it('renders loading followers skeleton with accessibility attributes', () => {
-    render(<Loading />)
+  it('renders loading followers skeleton with accessibility attributes and shimmer', () => {
+    const { container } = render(<Loading />)
 
     const loadingRegion = screen.getByLabelText('Loading followers')
     expect(loadingRegion).toBeInTheDocument()
     expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(15)
   })
 
   it('exports FollowersLoading named component', () => {

--- a/app/(timeline)/[actor]/followers/loading.tsx
+++ b/app/(timeline)/[actor]/followers/loading.tsx
@@ -1,28 +1,27 @@
 import { FC } from 'react'
 
+import { Skeleton, UserRowSkeleton } from '@/lib/components/ui/skeleton'
+
 export const FollowersLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading followers" className="space-y-6">
-      <div className="flex items-start gap-3">
-        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
-        <div className="space-y-1">
-          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
-          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+      <div className="flex items-start gap-3" aria-hidden="true">
+        <Skeleton className="h-9 w-9 shrink-0 rounded-md" />
+        <div className="space-y-1.5">
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-4 w-24" />
         </div>
       </div>
 
-      <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        {[0, 1, 2, 3].map((index) => (
-          <div key={index} className="flex items-center gap-3 px-5 py-4">
-            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
-            </div>
-            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
-          </div>
-        ))}
+      <div
+        className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
+        aria-hidden="true"
+      >
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
       </div>
     </div>
   )

--- a/app/(timeline)/[actor]/following/loading.test.tsx
+++ b/app/(timeline)/[actor]/following/loading.test.tsx
@@ -3,16 +3,20 @@
  */
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 
 import Loading, { FollowingLoading } from './loading'
 
 describe('[actor]/following loading', () => {
-  it('renders loading following skeleton with accessibility attributes', () => {
-    render(<Loading />)
+  it('renders loading following skeleton with accessibility attributes and shimmer', () => {
+    const { container } = render(<Loading />)
 
     const loadingRegion = screen.getByLabelText('Loading following')
     expect(loadingRegion).toBeInTheDocument()
     expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(15)
   })
 
   it('exports FollowingLoading named component', () => {

--- a/app/(timeline)/[actor]/following/loading.tsx
+++ b/app/(timeline)/[actor]/following/loading.tsx
@@ -1,28 +1,27 @@
 import { FC } from 'react'
 
+import { Skeleton, UserRowSkeleton } from '@/lib/components/ui/skeleton'
+
 export const FollowingLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading following" className="space-y-6">
-      <div className="flex items-start gap-3">
-        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
-        <div className="space-y-1">
-          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
-          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+      <div className="flex items-start gap-3" aria-hidden="true">
+        <Skeleton className="h-9 w-9 shrink-0 rounded-md" />
+        <div className="space-y-1.5">
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-4 w-24" />
         </div>
       </div>
 
-      <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        {[0, 1, 2, 3].map((index) => (
-          <div key={index} className="flex items-center gap-3 px-5 py-4">
-            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
-            </div>
-            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
-          </div>
-        ))}
+      <div
+        className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
+        aria-hidden="true"
+      >
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
       </div>
     </div>
   )

--- a/app/(timeline)/[actor]/loading.test.tsx
+++ b/app/(timeline)/[actor]/loading.test.tsx
@@ -3,16 +3,20 @@
  */
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 
 import Loading, { ProfileLoading } from './loading'
 
 describe('[actor] loading', () => {
-  it('renders loading profile skeleton with accessibility attributes', () => {
-    render(<Loading />)
+  it('renders loading profile skeleton with accessibility attributes and shimmer', () => {
+    const { container } = render(<Loading />)
 
     const loadingRegion = screen.getByLabelText('Loading profile')
     expect(loadingRegion).toBeInTheDocument()
     expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThan(10)
   })
 
   it('exports ProfileLoading named component', () => {

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -1,63 +1,32 @@
 import { FC } from 'react'
 
+import {
+  PostSkeleton,
+  ProfileHeaderSkeleton,
+  Skeleton
+} from '@/lib/components/ui/skeleton'
+
 export const ProfileLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading profile" className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <div className="relative h-36 animate-pulse bg-muted md:h-52" />
-
-        <div className="relative px-6 pb-6">
-          <div className="relative -mt-10 h-20 w-20 animate-pulse rounded-full border-4 border-background bg-muted" />
-
-          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-2">
-              <div className="h-7 w-48 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
-            </div>
-            <div className="h-9 w-28 animate-pulse rounded-md bg-muted" />
-          </div>
-
-          <div className="mt-4 space-y-2">
-            <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
-          </div>
-
-          <div className="mt-5 flex flex-wrap gap-6">
-            <div className="h-4 w-16 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
-          </div>
-        </div>
-      </section>
+      <ProfileHeaderSkeleton />
 
       <div className="space-y-4">
-        <div className="flex gap-2">
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
+        {/* Timeline tab strip placeholder */}
+        <div
+          className="flex gap-2 border-b border-border/60 pb-3"
+          aria-hidden="true"
+        >
+          <Skeleton className="h-9 w-20 rounded-md" />
+          <Skeleton className="h-9 w-20 rounded-md" />
+          <Skeleton className="h-9 w-20 rounded-md" />
         </div>
 
-        <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-          {[0, 1, 2].map((index) => (
-            <div key={index} className="flex gap-3 p-4">
-              <div className="size-10 shrink-0 animate-pulse rounded-full bg-muted" />
-              <div className="min-w-0 flex-1 space-y-2">
-                <div className="flex items-center gap-2">
-                  <div className="h-4 w-32 animate-pulse rounded bg-muted" />
-                  <div className="h-3 w-20 animate-pulse rounded bg-muted" />
-                </div>
-                <div className="space-y-1.5">
-                  <div className="h-4 w-full animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
-                </div>
-                <div className="flex gap-6 pt-2">
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
-                </div>
-              </div>
-            </div>
-          ))}
+        {/* Statuses list */}
+        <div className="space-y-4" aria-hidden="true">
+          <PostSkeleton framed={true} />
+          <PostSkeleton framed={true} hasMedia />
+          <PostSkeleton framed={true} />
         </div>
       </div>
     </div>

--- a/app/(timeline)/admin/loading.tsx
+++ b/app/(timeline)/admin/loading.tsx
@@ -1,0 +1,45 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton hasAction={true} />
+
+      {/* Main stat cards grid */}
+      <div
+        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
+        aria-hidden="true"
+      >
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-2xl border bg-background/80 p-5 shadow-sm space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-8 w-8 rounded-lg" />
+            </div>
+            <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-12 w-full rounded-md" />
+          </div>
+        ))}
+      </div>
+
+      {/* Breakdown chart cards */}
+      <div className="grid gap-6 md:grid-cols-2" aria-hidden="true">
+        <div className="rounded-2xl border bg-background/80 p-6 shadow-sm space-y-4">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+        </div>
+        <div className="rounded-2xl border bg-background/80 p-6 shadow-sm space-y-4">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/bookmarks/loading.tsx
+++ b/app/(timeline)/bookmarks/loading.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, PostSkeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton hasDescription={false} />
+      <div className="space-y-4">
+        <PostSkeleton framed={true} />
+        <PostSkeleton framed={true} hasMedia />
+        <PostSkeleton framed={true} />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/explore/ExplorePageClient.tsx
+++ b/app/(timeline)/explore/ExplorePageClient.tsx
@@ -14,6 +14,7 @@ import { Posts } from '@/lib/components/posts/posts'
 import { TrendLinkCard } from '@/lib/components/trends/trend-link-card'
 import { TrendTagRow } from '@/lib/components/trends/trend-tag-row'
 import { Button } from '@/lib/components/ui/button'
+import { Skeleton } from '@/lib/components/ui/skeleton'
 import { Tabs, TabsList, TabsTrigger } from '@/lib/components/ui/tabs'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -47,10 +48,10 @@ const SkeletonRows = ({ count = 4 }: { count?: number }) => (
     {Array.from({ length: count }).map((_, index) => (
       <div key={index} className="flex items-center justify-between gap-4 py-2">
         <div className="w-full space-y-2">
-          <div className="h-3.5 w-32 rounded bg-muted" />
-          <div className="h-3 w-48 rounded bg-muted/60" />
+          <Skeleton className="h-3.5 w-32" />
+          <Skeleton className="h-3 w-48" />
         </div>
-        <div className="h-6 w-14 rounded bg-muted/60" />
+        <Skeleton className="h-6 w-14 rounded-md" />
       </div>
     ))}
   </div>

--- a/app/(timeline)/explore/loading.test.tsx
+++ b/app/(timeline)/explore/loading.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import Loading from './loading'
+
+describe('Explore loading page', () => {
+  it('renders explore loading skeleton', () => {
+    const { container } = render(<Loading />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/app/(timeline)/explore/loading.tsx
+++ b/app/(timeline)/explore/loading.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-4">
+      <PageHeaderSkeleton />
+
+      {/* Tabs */}
+      <div
+        className="grid grid-cols-3 gap-1 rounded-lg bg-muted/60 p-1"
+        aria-hidden="true"
+      >
+        <Skeleton className="h-8 rounded-md" />
+        <Skeleton className="h-8 rounded-md" />
+        <Skeleton className="h-8 rounded-md" />
+      </div>
+
+      {/* Content card */}
+      <div
+        className="rounded-2xl border bg-card/80 p-4 shadow-sm space-y-3"
+        aria-hidden="true"
+      >
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between gap-4 border-b border-border/60 py-3 last:border-b-0"
+          >
+            <div className="w-full space-y-2">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3.5 w-48" />
+            </div>
+            <Skeleton className="h-6 w-14 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/favorites/loading.tsx
+++ b/app/(timeline)/favorites/loading.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, PostSkeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton hasDescription={false} />
+      <div className="space-y-4">
+        <PostSkeleton framed={true} />
+        <PostSkeleton framed={true} hasMedia />
+        <PostSkeleton framed={true} />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/fitness/heatmap/loading.tsx
+++ b/app/(timeline)/fitness/heatmap/loading.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton />
+
+      <div
+        className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm space-y-4 p-4"
+        aria-hidden="true"
+      >
+        {/* Region pills bar */}
+        <div className="flex gap-2 pb-2 border-b border-border/60">
+          <Skeleton className="h-8 w-24 rounded-full" />
+          <Skeleton className="h-8 w-20 rounded-full" />
+          <Skeleton className="h-8 w-28 rounded-full" />
+        </div>
+
+        {/* Map canvas container */}
+        <Skeleton className="h-[480px] w-full rounded-xl" />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/fitness/loading.test.tsx
+++ b/app/(timeline)/fitness/loading.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import Loading from './loading'
+
+describe('Fitness loading page', () => {
+  it('renders fitness overview loading skeleton', () => {
+    const { container } = render(<Loading />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/app/(timeline)/fitness/loading.tsx
+++ b/app/(timeline)/fitness/loading.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton />
+
+      {/* Stats summary & Heatmap Card */}
+      <div
+        className="rounded-2xl border bg-background/80 p-6 shadow-sm space-y-6"
+        aria-hidden="true"
+      >
+        {/* Metric tiles */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="space-y-1.5 rounded-xl bg-muted/40 p-4">
+              <Skeleton className="h-3.5 w-16" />
+              <Skeleton className="h-6 w-24" />
+            </div>
+          ))}
+        </div>
+
+        {/* Heatmap graph placeholder */}
+        <div className="space-y-2 pt-2">
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <Skeleton className="h-36 w-full rounded-xl" />
+        </div>
+      </div>
+
+      {/* Recent activities section */}
+      <div className="space-y-4" aria-hidden="true">
+        <Skeleton className="h-6 w-36" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-2xl border bg-background/80 p-5 shadow-sm space-y-3"
+            >
+              <div className="flex justify-between items-start">
+                <div className="space-y-1.5">
+                  <Skeleton className="h-5 w-44" />
+                  <Skeleton className="h-3.5 w-28" />
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+              <div className="flex gap-6 pt-1">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/lists/loading.tsx
+++ b/app/(timeline)/lists/loading.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton hasAction={true} />
+
+      {/* Lists section */}
+      <div className="space-y-3" aria-hidden="true">
+        <Skeleton className="h-6 w-24" />
+        <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm divide-y divide-border/60">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="flex items-center justify-between p-4">
+              <div className="space-y-1.5 flex-1 min-w-0">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-3.5 w-24" />
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="flex -space-x-2">
+                  <Skeleton className="h-7 w-7 rounded-full border-2 border-background" />
+                  <Skeleton className="h-7 w-7 rounded-full border-2 border-background" />
+                  <Skeleton className="h-7 w-7 rounded-full border-2 border-background" />
+                </div>
+                <Skeleton className="h-5 w-5 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Collections section */}
+      <div className="space-y-3" aria-hidden="true">
+        <Skeleton className="h-6 w-32" />
+        <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm divide-y divide-border/60">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="flex items-center justify-between p-4">
+              <div className="space-y-1.5 flex-1 min-w-0">
+                <Skeleton className="h-5 w-36" />
+                <Skeleton className="h-3.5 w-48" />
+              </div>
+              <Skeleton className="h-5 w-5 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/loading.tsx
+++ b/app/(timeline)/loading.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+
+import { ComposerSkeleton, PostSkeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <ComposerSkeleton />
+      <div className="space-y-4">
+        <PostSkeleton framed={true} />
+        <PostSkeleton framed={true} hasMedia />
+        <PostSkeleton framed={true} />
+        <PostSkeleton framed={true} />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/messages/loading.tsx
+++ b/app/(timeline)/messages/loading.tsx
@@ -1,0 +1,67 @@
+import { FC } from 'react'
+
+import { PageHeaderSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-4">
+      <PageHeaderSkeleton hasAction={true} />
+
+      <div
+        className="grid min-h-[500px] overflow-hidden rounded-2xl border bg-background/80 shadow-sm md:grid-cols-[320px_1fr]"
+        aria-hidden="true"
+      >
+        {/* Left pane: conversation list */}
+        <div className="border-r border-border/60 p-3 space-y-3">
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div
+                key={index}
+                className="flex items-center gap-3 rounded-lg p-2.5"
+              >
+                <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-1.5 min-w-0">
+                  <div className="flex justify-between items-center">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-10" />
+                  </div>
+                  <Skeleton className="h-3.5 w-36" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right pane: message thread placeholder */}
+        <div className="hidden md:flex flex-col justify-between p-4">
+          <div className="flex items-center gap-3 border-b border-border/60 pb-3">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+
+          <div className="space-y-3 py-6">
+            <div className="flex gap-2 max-w-[70%]">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+              <Skeleton className="h-12 w-48 rounded-2xl rounded-tl-sm" />
+            </div>
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-44 rounded-2xl rounded-tr-sm" />
+            </div>
+            <div className="flex gap-2 max-w-[70%]">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+              <Skeleton className="h-16 w-60 rounded-2xl rounded-tl-sm" />
+            </div>
+          </div>
+
+          <div className="flex gap-2 pt-2 border-t border-border/60">
+            <Skeleton className="h-10 flex-1 rounded-lg" />
+            <Skeleton className="h-10 w-10 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/notifications/loading.test.tsx
+++ b/app/(timeline)/notifications/loading.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import Loading from './loading'
+
+describe('Notifications loading page', () => {
+  it('renders notifications loading skeleton', () => {
+    const { container } = render(<Loading />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/app/(timeline)/notifications/loading.tsx
+++ b/app/(timeline)/notifications/loading.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+
+import {
+  NotificationRowSkeleton,
+  PageHeaderSkeleton,
+  Skeleton
+} from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      {/* Subnav filter tabs placeholder */}
+      <div
+        className="flex gap-2 border-b border-border/60 pb-3"
+        aria-hidden="true"
+      >
+        <Skeleton className="h-9 w-16 rounded-md" />
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
+
+      <PageHeaderSkeleton hasAction={true} />
+
+      <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+        <NotificationRowSkeleton />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -21,6 +21,7 @@ import { TrendingNowBlock } from '@/lib/components/trends/trending-now-block'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
+import { UserRowSkeleton } from '@/lib/components/ui/skeleton'
 import { Tabs, TabsList, TabsTrigger } from '@/lib/components/ui/tabs'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -555,11 +556,12 @@ export const SearchPageClient = ({
             <p>Try again in a moment.</p>
           </div>
         ) : isLoading ? (
-          <div
-            className="p-8 text-center text-muted-foreground"
-            aria-live="polite"
-          >
-            <p className="text-sm font-medium">Searching...</p>
+          <div aria-live="polite">
+            <span className="sr-only">Searching...</span>
+            <UserRowSkeleton />
+            <UserRowSkeleton />
+            <UserRowSkeleton />
+            <UserRowSkeleton />
           </div>
         ) : !submittedQuery.trim() ? (
           <div className="p-8 text-center text-muted-foreground">

--- a/app/(timeline)/search/loading.tsx
+++ b/app/(timeline)/search/loading.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react'
+
+import {
+  PageHeaderSkeleton,
+  Skeleton,
+  UserRowSkeleton
+} from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton />
+
+      {/* Search form */}
+      <div className="flex gap-2" aria-hidden="true">
+        <Skeleton className="h-11 flex-1 rounded-md" />
+        <Skeleton className="h-11 w-24 rounded-md" />
+      </div>
+
+      {/* Tabs */}
+      <div
+        className="grid grid-cols-4 gap-1 rounded-lg bg-muted/60 p-1"
+        aria-hidden="true"
+      >
+        <Skeleton className="h-8 rounded-md" />
+        <Skeleton className="h-8 rounded-md" />
+        <Skeleton className="h-8 rounded-md" />
+        <Skeleton className="h-8 rounded-md" />
+      </div>
+
+      {/* Results placeholder */}
+      <div
+        className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
+        aria-hidden="true"
+      >
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+        <UserRowSkeleton />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/(timeline)/search/page.tsx
+++ b/app/(timeline)/search/page.tsx
@@ -2,6 +2,11 @@ import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 
+import {
+  PageHeaderSkeleton,
+  Skeleton,
+  UserRowSkeleton
+} from '@/lib/components/ui/skeleton'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -14,6 +19,33 @@ export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Activities.next: Search'
 }
+
+const SearchFallback = () => (
+  <div className="space-y-6">
+    <PageHeaderSkeleton />
+    <div className="flex gap-2" aria-hidden="true">
+      <Skeleton className="h-11 flex-1 rounded-md" />
+      <Skeleton className="h-11 w-24 rounded-md" />
+    </div>
+    <div
+      className="grid grid-cols-4 gap-1 rounded-lg bg-muted/60 p-1"
+      aria-hidden="true"
+    >
+      <Skeleton className="h-8 rounded-md" />
+      <Skeleton className="h-8 rounded-md" />
+      <Skeleton className="h-8 rounded-md" />
+      <Skeleton className="h-8 rounded-md" />
+    </div>
+    <div
+      className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
+      aria-hidden="true"
+    >
+      <UserRowSkeleton />
+      <UserRowSkeleton />
+      <UserRowSkeleton />
+    </div>
+  </div>
+)
 
 const Page = async () => {
   const { host, mediaStorage } = getConfig()
@@ -31,13 +63,7 @@ const Page = async () => {
   const settings = await database.getActorSettings({ actorId: actor.id })
 
   return (
-    <Suspense
-      fallback={
-        <div className="p-8 text-center text-muted-foreground">
-          <p className="text-sm font-medium">Loading search...</p>
-        </div>
-      }
-    >
+    <Suspense fallback={<SearchFallback />}>
       <SearchPageClient
         host={host}
         currentActor={getActorProfile(actor)}

--- a/app/(timeline)/tags/[tag]/loading.tsx
+++ b/app/(timeline)/tags/[tag]/loading.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+
+import { PostSkeleton, Skeleton } from '@/lib/components/ui/skeleton'
+
+const Loading: FC = () => {
+  return (
+    <div className="space-y-6">
+      <div
+        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        aria-hidden="true"
+      >
+        <div className="space-y-1.5">
+          <Skeleton className="h-8 w-36" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+
+      <div className="space-y-4">
+        <PostSkeleton framed={true} />
+        <PostSkeleton framed={true} hasMedia />
+        <PostSkeleton framed={true} />
+      </div>
+    </div>
+  )
+}
+
+export default Loading

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,6 +253,19 @@
   .no-scrollbar::-webkit-scrollbar {
     display: none;
   }
+
+  .animate-shimmer {
+    animation: shimmer 1.8s infinite linear;
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 /* Markdown content styles for PostBox preview and Status display */

--- a/lib/components/ui/skeleton.test.tsx
+++ b/lib/components/ui/skeleton.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ComposerSkeleton,
+  NotificationRowSkeleton,
+  PageHeaderSkeleton,
+  PostSkeleton,
+  ProfileHeaderSkeleton,
+  Skeleton,
+  UserRowSkeleton
+} from './skeleton'
+
+describe('Skeleton UI components', () => {
+  it('renders base Skeleton with shimmer classes and data-slot', () => {
+    const { container } = render(<Skeleton className="h-4 w-20" />)
+    const el = container.querySelector('[data-slot="skeleton"]')
+    expect(el).toBeInTheDocument()
+    expect(el).toHaveClass('h-4')
+    expect(el).toHaveClass('w-20')
+    expect(el).toHaveClass('bg-muted')
+    expect(el).toHaveClass('after:animate-shimmer')
+  })
+
+  it('renders PageHeaderSkeleton with title and description', () => {
+    const { container } = render(<PageHeaderSkeleton hasAction />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders PostSkeleton with framed and unframed variants', () => {
+    const { container: framedContainer } = render(
+      <PostSkeleton framed={true} hasMedia />
+    )
+    expect(framedContainer.querySelector('.rounded-2xl')).toBeInTheDocument()
+
+    const { container: unframedContainer } = render(
+      <PostSkeleton framed={false} />
+    )
+    expect(
+      unframedContainer.querySelector('.rounded-2xl')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders ComposerSkeleton', () => {
+    const { container } = render(<ComposerSkeleton />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThan(4)
+  })
+
+  it('renders UserRowSkeleton', () => {
+    const { container } = render(<UserRowSkeleton />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('renders ProfileHeaderSkeleton', () => {
+    const { container } = render(<ProfileHeaderSkeleton />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThan(6)
+  })
+
+  it('renders NotificationRowSkeleton', () => {
+    const { container } = render(<NotificationRowSkeleton />)
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/lib/components/ui/skeleton.tsx
+++ b/lib/components/ui/skeleton.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn(
+        'relative overflow-hidden rounded-md bg-muted',
+        'after:absolute after:inset-0 after:-translate-x-full',
+        'after:animate-shimmer',
+        'after:bg-gradient-to-r after:from-transparent after:via-white/60 dark:after:via-white/10 after:to-transparent',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PageHeaderSkeleton({
+  hasDescription = true,
+  hasAction = false,
+  className
+}: {
+  hasDescription?: boolean
+  hasAction?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <div className="space-y-1.5">
+        <Skeleton className="h-8 w-44" />
+        {hasDescription && <Skeleton className="h-4 w-72" />}
+      </div>
+      {hasAction && <Skeleton className="h-9 w-28 rounded-md" />}
+    </div>
+  )
+}
+
+function PostSkeleton({
+  framed = true,
+  hasMedia = false,
+  className
+}: {
+  framed?: boolean
+  hasMedia?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        framed
+          ? 'overflow-hidden rounded-2xl border bg-background/80 p-4 shadow-sm'
+          : 'border-b border-border/60 p-4 last:border-b-0',
+        'space-y-3',
+        className
+      )}
+      aria-hidden="true"
+    >
+      {/* Author row */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+        <div className="flex-1 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-3.5 w-20" />
+          </div>
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+
+      {/* Post body */}
+      <div className="space-y-2 pt-1">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+
+      {/* Optional media placeholder */}
+      {hasMedia && <Skeleton className="h-48 w-full rounded-xl" />}
+
+      {/* Action buttons */}
+      <div className="flex items-center justify-between pt-2">
+        <div className="flex items-center gap-6">
+          <Skeleton className="h-5 w-8 rounded" />
+          <Skeleton className="h-5 w-8 rounded" />
+          <Skeleton className="h-5 w-8 rounded" />
+          <Skeleton className="h-5 w-8 rounded" />
+        </div>
+        <Skeleton className="h-5 w-5 rounded" />
+      </div>
+    </div>
+  )
+}
+
+function ComposerSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-2xl border bg-background/80 p-4 shadow-sm space-y-3',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <div className="flex gap-3">
+        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+        <Skeleton className="h-20 flex-1 rounded-xl" />
+      </div>
+      <div className="flex items-center justify-between pt-1">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+        <Skeleton className="h-9 w-20 rounded-md" />
+      </div>
+    </div>
+  )
+}
+
+function UserRowSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex items-start justify-between gap-3 p-4 border-b border-border/60 last:border-b-0',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        <Skeleton className="h-11 w-11 shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3.5 w-24" />
+          </div>
+          <Skeleton className="h-3.5 w-3/4 max-w-sm" />
+        </div>
+      </div>
+      <Skeleton className="h-8 w-20 shrink-0 rounded-md" />
+    </div>
+  )
+}
+
+function ProfileHeaderSkeleton({ className }: { className?: string }) {
+  return (
+    <section
+      className={cn(
+        'overflow-hidden rounded-2xl border bg-background/80 shadow-sm',
+        className
+      )}
+      aria-hidden="true"
+    >
+      {/* Banner */}
+      <Skeleton className="h-40 w-full rounded-none sm:h-48" />
+
+      <div className="relative px-6 pb-6">
+        {/* Avatar */}
+        <Skeleton className="relative -mt-10 h-20 w-20 rounded-full border-4 border-background" />
+
+        {/* Name and actions */}
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1.5">
+            <Skeleton className="h-7 w-44" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+
+        {/* Bio */}
+        <div className="mt-4 space-y-2">
+          <Skeleton className="h-4 w-full max-w-lg" />
+          <Skeleton className="h-4 w-4/5 max-w-md" />
+        </div>
+
+        {/* Counts row */}
+        <div className="mt-5 flex flex-wrap gap-6">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+
+        {/* Featured tags */}
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Skeleton className="h-6 w-20 rounded-full" />
+          <Skeleton className="h-6 w-16 rounded-full" />
+          <Skeleton className="h-6 w-24 rounded-full" />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function NotificationRowSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-4 border-b border-border/60 last:border-b-0',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+      <div className="flex-1 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-3 w-12" />
+        </div>
+        <Skeleton className="h-3.5 w-4/5 max-w-md" />
+      </div>
+    </div>
+  )
+}
+
+export {
+  Skeleton,
+  PageHeaderSkeleton,
+  PostSkeleton,
+  ComposerSkeleton,
+  UserRowSkeleton,
+  ProfileHeaderSkeleton,
+  NotificationRowSkeleton
+}


### PR DESCRIPTION
## Summary
Adds smooth shimmer loading animations and comprehensive route loading states (`loading.tsx` and Suspense fallbacks) across the application, featuring a light stripe sweeping gradient animation across muted skeleton placeholders in both light and dark themes.

Key additions:
- Keyframe `@keyframes shimmer` and `.animate-shimmer` utility class in `app/globals.css`.
- Reusable skeleton primitives and composite components in `lib/components/ui/skeleton.tsx` (`Skeleton`, `PageHeaderSkeleton`, `PostSkeleton`, `ComposerSkeleton`, `UserRowSkeleton`, `ProfileHeaderSkeleton`, `NotificationRowSkeleton`).
- Route loading screens for explicitly requested and slow-loading pages:
  - Profile (`[actor]/loading.tsx`)
  - Following (`[actor]/following/loading.tsx`)
  - Followers (`[actor]/followers/loading.tsx`)
  - Main Timeline (`(timeline)/loading.tsx`)
  - Status Detail (`[actor]/[status]/loading.tsx`)
  - Notifications (`notifications/loading.tsx`)
  - Explore (`explore/loading.tsx` + tab skeletons in `ExplorePageClient.tsx`)
  - Bookmarks (`bookmarks/loading.tsx`)
  - Favorites (`favorites/loading.tsx`)
  - Tags (`tags/[tag]/loading.tsx`)
  - Messages (`messages/loading.tsx`)
  - Fitness Overview (`fitness/loading.tsx`)
  - Fitness Heatmap (`fitness/heatmap/loading.tsx`)
  - Lists (`lists/loading.tsx`)
  - Admin Overview (`admin/loading.tsx`)
  - Search (`search/loading.tsx`, `search/page.tsx` fallback, and in-flight skeletons in `SearchPageClient.tsx`)
- Unit test suite for skeleton components and loading route pages.

## Screenshots
UI verification performed with Playwright snapshots across light and dark modes.

## Checklist
- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)