### PR TITLE
Bump version to v1.153.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.3",
+  "version": "1.153.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.3`
- Base main SHA: `383a73fca8c646dfed3c3ae381280a2e39228f7f`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
