### PR TITLE
Bump version to v1.153.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.4",
+  "version": "1.153.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.4`
- Base main SHA: `5aaa2d42f82407ce4190dadc0306a884b0c5eeb5`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
