### PR TITLE
fix: handle unique constraint collision in status creation

### DIFF
--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -3325,6 +3325,31 @@ describe('StatusDatabase', () => {
           }
         ])
       })
+
+      it('returns existing status without throwing unique constraint error when status id already exists', async () => {
+        const statusId = `${extraActorId}/statuses/duplicate-note-test`
+        const created = await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: extraActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'First insertion'
+        })
+        const duplicate = await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: extraActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Second insertion with same id'
+        })
+
+        expect(duplicate).toBeDefined()
+        expect(duplicate.id).toBe(statusId)
+        expect((duplicate as StatusNote).text).toBe('First insertion')
+        expect(duplicate.publicId).toBe(created.publicId)
+      })
     })
 
     describe('createPoll', () => {
@@ -3386,6 +3411,35 @@ describe('StatusDatabase', () => {
           statusId: pollId
         })) as StatusPoll
         expect(fetched.hideTotals).toBe(true)
+      })
+
+      it('returns existing poll without throwing unique constraint error when status id already exists', async () => {
+        const pollId = `${emptyActorId}/statuses/duplicate-poll-test`
+        const created = await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'First poll insertion',
+          choices: ['Option 1', 'Option 2'],
+          endAt: Date.now() + 60_000
+        })
+        const duplicate = await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Second poll insertion with same id',
+          choices: ['Option A', 'Option B'],
+          endAt: Date.now() + 60_000
+        })
+
+        expect(duplicate).toBeDefined()
+        expect(duplicate.id).toBe(pollId)
+        expect((duplicate as StatusPoll).text).toBe('First poll insertion')
+        expect(duplicate.publicId).toBe(created.publicId)
       })
     })
 
@@ -4395,6 +4449,37 @@ describe('StatusDatabase', () => {
 
         const originalStatus = announceStatus.originalStatus
         expect(originalStatus.id).toEqual(note.id)
+      })
+
+      it('returns existing announce without throwing unique constraint error when status id already exists', async () => {
+        const originalStatusId = `${TEST_ID_ORIGINAL}/statuses/duplicate-announce-target`
+        await database.createNote({
+          id: originalStatusId,
+          url: originalStatusId,
+          actorId: TEST_ID_ORIGINAL,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Post to announce'
+        })
+        const announceId = `${TEST_ID_BOOSTER}/statuses/duplicate-announce-test`
+        const created = await database.createAnnounce({
+          id: announceId,
+          actorId: TEST_ID_BOOSTER,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId
+        })
+        const duplicate = await database.createAnnounce({
+          id: announceId,
+          actorId: TEST_ID_BOOSTER,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId
+        })
+
+        expect(duplicate).toBeDefined()
+        expect(duplicate.id).toBe(announceId)
+        expect(duplicate.publicId).toBe(created.publicId)
       })
     })
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -574,60 +574,71 @@ export const StatusSQLDatabaseMixin = (
       createdAt: statusCreatedAt
     }
 
-    await database.transaction(async (trx) => {
-      await trx('statuses').insert({
-        id,
-        publicId: statusPublicId,
-        url,
-        urlHash: getStatusUrlHash(url),
-        actorId,
-        type: StatusType.enum.Note,
-        content: statusContent,
-        applicationName,
-        applicationWebsite,
-        reply,
-        replyHash: getStatusReplyHash(reply),
-        createdAt: statusCreatedAt,
-        updatedAt: statusUpdatedAt
-      })
-      await updateStatusCounters({
-        actorId,
-        type: StatusType.enum.Note,
-        reply,
-        content,
-        step: 'increment',
-        trx,
-        currentTime,
-        statusCreatedAt
-      })
-      await Promise.all(
-        to.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'to',
+    try {
+      await database.transaction(async (trx) => {
+        await trx('statuses').insert({
+          id,
+          publicId: statusPublicId,
+          url,
+          urlHash: getStatusUrlHash(url),
+          actorId,
+          type: StatusType.enum.Note,
+          content: statusContent,
+          applicationName,
+          applicationWebsite,
+          reply,
+          replyHash: getStatusReplyHash(reply),
+          createdAt: statusCreatedAt,
+          updatedAt: statusUpdatedAt
+        })
+        await updateStatusCounters({
+          actorId,
+          type: StatusType.enum.Note,
+          reply,
+          content,
+          step: 'increment',
+          trx,
+          currentTime,
+          statusCreatedAt
+        })
+        await Promise.all(
+          to.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'to',
 
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
         )
-      )
 
-      await Promise.all(
-        cc.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'cc',
+        await Promise.all(
+          cc.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'cc',
 
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
         )
-      )
-    })
+      })
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        const existingStatus = await getStatus({
+          statusId: id,
+          withReplies: false
+        })
+        if (existingStatus) return existingStatus
+      }
+      throw error
+    }
 
     await indexStatusSearchDocument(database, { status: searchStatus })
 
@@ -936,59 +947,70 @@ export const StatusSQLDatabaseMixin = (
       publicId ?? generatePublicId(statusCreatedAt.getTime())
     const statusUpdatedAt = currentTime
 
-    await database.transaction(async (trx) => {
-      await trx('statuses').insert({
-        id,
-        publicId: statusPublicId,
-        url: null,
-        urlHash: null,
-        actorId,
-        type: StatusType.enum.Announce,
-        reply: '',
-        replyHash: null,
-        content: originalStatusId,
-        originalStatusId,
-        createdAt: statusCreatedAt,
-        updatedAt: statusUpdatedAt
-      })
-      await updateStatusCounters({
-        actorId,
-        type: StatusType.enum.Announce,
-        reply: '',
-        content: originalStatusId,
-        step: 'increment',
-        trx,
-        currentTime,
-        statusCreatedAt
-      })
-      await Promise.all(
-        to.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'to',
+    try {
+      await database.transaction(async (trx) => {
+        await trx('statuses').insert({
+          id,
+          publicId: statusPublicId,
+          url: null,
+          urlHash: null,
+          actorId,
+          type: StatusType.enum.Announce,
+          reply: '',
+          replyHash: null,
+          content: originalStatusId,
+          originalStatusId,
+          createdAt: statusCreatedAt,
+          updatedAt: statusUpdatedAt
+        })
+        await updateStatusCounters({
+          actorId,
+          type: StatusType.enum.Announce,
+          reply: '',
+          content: originalStatusId,
+          step: 'increment',
+          trx,
+          currentTime,
+          statusCreatedAt
+        })
+        await Promise.all(
+          to.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'to',
 
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
         )
-      )
 
-      await Promise.all(
-        cc.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'cc',
+        await Promise.all(
+          cc.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'cc',
 
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
         )
-      )
-    })
+      })
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        const existingStatus = await getStatus({
+          statusId: id,
+          withReplies: false
+        })
+        if (existingStatus) return existingStatus
+      }
+      throw error
+    }
 
     const [originalStatus, actor] = await Promise.all([
       getStatus({ statusId: originalStatusId }),
@@ -1055,71 +1077,82 @@ export const StatusSQLDatabaseMixin = (
       createdAt: statusCreatedAt
     }
 
-    await database.transaction(async (trx) => {
-      await trx('statuses').insert({
-        id,
-        publicId: statusPublicId,
-        url,
-        urlHash: getStatusUrlHash(url),
-        actorId,
-        type: StatusType.enum.Poll,
-        content: statusContent,
-        applicationName,
-        applicationWebsite,
-        reply,
-        replyHash: getStatusReplyHash(reply),
-        createdAt: statusCreatedAt,
-        updatedAt: statusUpdatedAt
+    try {
+      await database.transaction(async (trx) => {
+        await trx('statuses').insert({
+          id,
+          publicId: statusPublicId,
+          url,
+          urlHash: getStatusUrlHash(url),
+          actorId,
+          type: StatusType.enum.Poll,
+          content: statusContent,
+          applicationName,
+          applicationWebsite,
+          reply,
+          replyHash: getStatusReplyHash(reply),
+          createdAt: statusCreatedAt,
+          updatedAt: statusUpdatedAt
+        })
+        await updateStatusCounters({
+          actorId,
+          type: StatusType.enum.Poll,
+          reply,
+          content,
+          step: 'increment',
+          trx,
+          currentTime,
+          statusCreatedAt
+        })
+        await Promise.all(
+          choices.map((choice) =>
+            trx('poll_choices').insert({
+              statusId: id,
+              title: choice,
+
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
+        )
+        await Promise.all(
+          to.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'to',
+
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
+        )
+
+        await Promise.all(
+          cc.map((actorId) =>
+            trx('recipients').insert({
+              id: crypto.randomUUID(),
+              statusId: id,
+              actorId,
+              type: 'cc',
+
+              createdAt: statusUpdatedAt,
+              updatedAt: statusUpdatedAt
+            })
+          )
+        )
       })
-      await updateStatusCounters({
-        actorId,
-        type: StatusType.enum.Poll,
-        reply,
-        content,
-        step: 'increment',
-        trx,
-        currentTime,
-        statusCreatedAt
-      })
-      await Promise.all(
-        choices.map((choice) =>
-          trx('poll_choices').insert({
-            statusId: id,
-            title: choice,
-
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
-        )
-      )
-      await Promise.all(
-        to.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'to',
-
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
-        )
-      )
-
-      await Promise.all(
-        cc.map((actorId) =>
-          trx('recipients').insert({
-            id: crypto.randomUUID(),
-            statusId: id,
-            actorId,
-            type: 'cc',
-
-            createdAt: statusUpdatedAt,
-            updatedAt: statusUpdatedAt
-          })
-        )
-      )
-    })
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        const existingStatus = await getStatus({
+          statusId: id,
+          withReplies: false
+        })
+        if (existingStatus) return existingStatus
+      }
+      throw error
+    }
 
     await indexStatusSearchDocument(database, { status: searchStatus })
 


### PR DESCRIPTION
## Summary
When concurrent ActivityPub workers or inbound federation requests process duplicate or shared status IDs simultaneously, inserting into the `statuses` table could raise a unique constraint collision (`statuses_pkey`, error code 23505 in PostgreSQL / `SQLITE_CONSTRAINT_UNIQUE` in SQLite).

This change wraps the status creation transactions in `createNote`, `createAnnounce`, and `createPoll` with a try/catch block that rescues `isUniqueConstraintError(error)` and returns the existing status record (`getStatus({ statusId: id, withReplies: false })`) rather than throwing an unhandled database error.

## Changes
- `lib/database/sql/status.ts`: Catch `isUniqueConstraintError` in `createNote`, `createAnnounce`, and `createPoll` and return the existing status.
- `lib/database/sql/status.test.ts`: Add test cases verifying that duplicate status IDs return the existing status without throwing unique constraint errors.

## Test Results
- `yarn test lib/database/sql/status.test.ts` passed (172 tests).
- Prettier, Oxlint, TypeScript typecheck, Next.js build, and the full test suite passed in sequence:
  - `yarn run prettier --write .`
  - `yarn lint` (0 errors)
  - `yarn typecheck`
  - `yarn build`
  - `yarn test` (920 test files, 12,379 tests passed)