### PR TITLE
fix(polls): sync and preserve remote poll vote counts and percentages

### DIFF
--- a/app/api/v1/accounts/vote/route.test.ts
+++ b/app/api/v1/accounts/vote/route.test.ts
@@ -1,0 +1,150 @@
+import { NextRequest } from 'next/server'
+
+import { StatusType } from '@/lib/types/domain/status'
+
+import { POST } from './route'
+
+const mockSendPollVotes = vi.fn()
+const mockSyncRemotePoll = vi.fn()
+const mockDatabase = {
+  getStatus: vi.fn(),
+  recordPollVotes: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me'
+}
+
+vi.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<object>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<object> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+vi.mock('@/lib/activities', () => ({
+  sendPollVotes: (...params: unknown[]) => mockSendPollVotes(...params)
+}))
+
+vi.mock('@/lib/services/polls/syncRemotePoll', () => ({
+  syncRemotePoll: (...params: unknown[]) => mockSyncRemotePoll(...params)
+}))
+
+const pollStatusId = 'https://remote.test/users/alice/statuses/poll-1'
+const pollStatus = {
+  id: pollStatusId,
+  type: StatusType.enum.Poll,
+  endAt: Date.now() + 60_000,
+  pollType: 'oneOf',
+  choices: [
+    { title: 'Red', totalVotes: 0 },
+    { title: 'Blue', totalVotes: 0 }
+  ]
+}
+
+describe('POST /api/v1/accounts/vote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getStatus.mockResolvedValue(pollStatus)
+    mockDatabase.recordPollVotes.mockResolvedValue(true)
+    mockSyncRemotePoll.mockImplementation(({ status }) => status)
+  })
+
+  it('records votes, sends poll votes, syncs remote poll, and returns updated status', async () => {
+    const updatedStatus = {
+      ...pollStatus,
+      choices: [
+        { title: 'Red', totalVotes: 1 },
+        { title: 'Blue', totalVotes: 0 }
+      ]
+    }
+    mockDatabase.getStatus
+      .mockResolvedValueOnce(pollStatus)
+      .mockResolvedValueOnce(updatedStatus)
+
+    const syncedStatus = {
+      ...pollStatus,
+      choices: [
+        { title: 'Red', totalVotes: 10 },
+        { title: 'Blue', totalVotes: 5 }
+      ]
+    }
+    mockSyncRemotePoll.mockResolvedValueOnce(syncedStatus)
+
+    const response = await POST(
+      new NextRequest('https://local.test/api/v1/accounts/vote', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          statusId: pollStatusId,
+          choices: [0]
+        })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.recordPollVotes).toHaveBeenCalledWith({
+      statusId: pollStatusId,
+      actorId: mockCurrentActor.id,
+      choices: [0]
+    })
+    expect(mockSendPollVotes).toHaveBeenCalledWith({
+      currentActor: mockCurrentActor,
+      status: pollStatus,
+      choices: [0]
+    })
+    expect(mockSyncRemotePoll).toHaveBeenCalledWith({
+      database: mockDatabase,
+      status: updatedStatus
+    })
+    expect(await response.json()).toEqual({ status: syncedStatus })
+  })
+
+  it('rejects invalid choice indices', async () => {
+    const response = await POST(
+      new NextRequest('https://local.test/api/v1/accounts/vote', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          statusId: pollStatusId,
+          choices: [5]
+        })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.recordPollVotes).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 if poll status is not found', async () => {
+    mockDatabase.getStatus.mockResolvedValueOnce(null)
+
+    const response = await POST(
+      new NextRequest('https://local.test/api/v1/accounts/vote', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          statusId: pollStatusId,
+          choices: [0]
+        })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/accounts/vote/route.ts
+++ b/app/api/v1/accounts/vote/route.ts
@@ -1,5 +1,6 @@
 import { sendPollVotes } from '@/lib/activities'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { syncRemotePoll } from '@/lib/services/polls/syncRemotePoll'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -102,10 +103,16 @@ export const POST = traceApiRoute(
       statusId,
       withReplies: false
     })
+    const syncedStatus = updatedStatus
+      ? await syncRemotePoll({
+          database,
+          status: updatedStatus
+        })
+      : null
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: { status: updatedStatus }
+      data: { status: syncedStatus ?? updatedStatus }
     })
   })
 )

--- a/app/api/v1/polls/[id]/route.test.ts
+++ b/app/api/v1/polls/[id]/route.test.ts
@@ -10,6 +10,7 @@ import { POST } from './votes/route'
 const mockGetMastodonStatus = vi.fn()
 const mockSendPollVotes = vi.fn()
 const mockCanActorReadStatus = vi.fn()
+const mockSyncRemotePoll = vi.fn()
 const mockDatabase = {
   getStatus: vi.fn(),
   getStatusIdByPublicId: vi.fn(),
@@ -91,6 +92,10 @@ vi.mock('@/lib/activities', () => ({
   sendPollVotes: (...params: unknown[]) => mockSendPollVotes(...params)
 }))
 
+vi.mock('@/lib/services/polls/syncRemotePoll', () => ({
+  syncRemotePoll: (...params: unknown[]) => mockSyncRemotePoll(...params)
+}))
+
 const pollStatusId = 'https://remote.test/users/alice/statuses/poll-1'
 const encodedPollId = urlToId(pollStatusId)
 const pollStatus = {
@@ -120,6 +125,7 @@ describe('Mastodon poll routes', () => {
     mockDatabase.recordPollVotes.mockResolvedValue(true)
     mockGetMastodonStatus.mockResolvedValue({ poll: mastodonPoll })
     mockCanActorReadStatus.mockResolvedValue(true)
+    mockSyncRemotePoll.mockImplementation(({ status }) => status)
   })
 
   it('returns a Mastodon poll entity', async () => {
@@ -436,5 +442,32 @@ describe('Mastodon poll routes', () => {
 
     expect(response.status).toBe(404)
     expect(mockGetMastodonStatus).not.toHaveBeenCalled()
+  })
+
+  it('syncs remote poll when fetching poll details via GET', async () => {
+    const syncedPollStatus = {
+      ...pollStatus,
+      choices: [
+        { title: 'Red', totalVotes: 5 },
+        { title: 'Blue', totalVotes: 10 }
+      ]
+    }
+    mockSyncRemotePoll.mockResolvedValueOnce(syncedPollStatus)
+
+    const response = await GET(
+      new NextRequest(`https://local.test/api/v1/polls/${encodedPollId}`),
+      { params: Promise.resolve({ id: encodedPollId }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSyncRemotePoll).toHaveBeenCalledWith({
+      database: mockDatabase,
+      status: pollStatus
+    })
+    expect(mockGetMastodonStatus).toHaveBeenCalledWith(
+      mockDatabase,
+      syncedPollStatus,
+      mockCurrentActor.id
+    )
   })
 })

--- a/app/api/v1/polls/[id]/route.ts
+++ b/app/api/v1/polls/[id]/route.ts
@@ -1,6 +1,7 @@
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { resolveStatusIdParam } from '@/lib/services/mastodon/resolveClientId'
+import { syncRemotePoll } from '@/lib/services/polls/syncRemotePoll'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
@@ -59,9 +60,14 @@ export const GET = traceApiRoute(
         })
       }
 
+      const syncedStatus = await syncRemotePoll({
+        database,
+        status
+      })
+
       const mastodonStatus = await getMastodonStatus(
         database,
-        status,
+        syncedStatus,
         currentActor?.id
       )
       if (!mastodonStatus?.poll) {

--- a/app/api/v1/polls/[id]/votes/route.ts
+++ b/app/api/v1/polls/[id]/votes/route.ts
@@ -4,6 +4,7 @@ import { sendPollVotes } from '@/lib/activities'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { resolveStatusIdParam } from '@/lib/services/mastodon/resolveClientId'
+import { syncRemotePoll } from '@/lib/services/polls/syncRemotePoll'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
@@ -178,9 +179,14 @@ export const POST = traceApiRoute(
         })
       }
 
+      const syncedStatus = await syncRemotePoll({
+        database,
+        status: updatedStatus
+      })
+
       const mastodonStatus = await getMastodonStatus(
         database,
-        updatedStatus,
+        syncedStatus,
         currentActor.id
       )
       if (!mastodonStatus?.poll) {

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -157,4 +157,50 @@ describe('Poll', () => {
     expect(screen.getByText('Poll closed')).toBeInTheDocument()
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('updates choices and percentages immediately upon successful vote', async () => {
+    const updatedChoices = [
+      {
+        statusId: pollStatus.id,
+        title: 'First',
+        totalVotes: 1,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      },
+      {
+        statusId: pollStatus.id,
+        title: 'Second',
+        totalVotes: 0,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      }
+    ]
+    mockVotePoll.mockResolvedValueOnce({
+      status: {
+        ...pollStatus,
+        choices: updatedChoices,
+        ownVotes: [0]
+      }
+    })
+
+    render(
+      <Poll
+        status={pollStatus}
+        currentTime={currentTime}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    const firstChoice = screen.getByLabelText('First')
+    fireEvent.click(firstChoice)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Vote' }))
+    })
+
+    // Once voted, it renders results
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(screen.getByText('0%')).toBeInTheDocument()
+    expect(screen.getByText(/1 vote/)).toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -31,11 +31,23 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
       ? status.ownVotes
       : []
   )
+  const [choices, setChoices] = useState(
+    status.type === StatusType.enum.Poll && status.choices ? status.choices : []
+  )
   const [voteError, setVoteError] = useState<string | null>(null)
 
   useEffect(() => {
     setNow(currentTime)
   }, [currentTime])
+
+  useEffect(() => {
+    if (status.type === StatusType.enum.Poll && status.choices) {
+      setChoices(status.choices)
+    }
+    if (status.type === StatusType.enum.Poll && status.ownVotes) {
+      setVotedChoices(status.ownVotes)
+    }
+  }, [status])
 
   useEffect(() => {
     if (pollEndAt === undefined) return
@@ -54,16 +66,15 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
   }, [pollEndAt, status.id])
 
   if (status.type !== StatusType.enum.Poll) return null
-  if (!status.choices) return null
+  if (choices.length === 0) return null
 
   const isPollClosed = now >= status.endAt
-  const choices = status.choices
   const translatedOptions =
     translation?.showingTranslation && translation.translation?.poll
       ? translation.translation.poll.options
       : null
   const titleFor = (index: number) =>
-    translatedOptions?.[index]?.title ?? choices[index].title
+    translatedOptions?.[index]?.title ?? choices[index]?.title ?? ''
   const voteCount = choices.reduce((sum, choice) => sum + choice.totalVotes, 0)
   const totalVotes = voteCount || 1
 
@@ -76,9 +87,23 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
     setIsVoting(true)
     setVoteError(null)
     try {
-      await votePoll({ statusId: status.id, choices: selectedChoices })
+      const result = await votePoll({
+        statusId: status.id,
+        choices: selectedChoices
+      })
       setVotedChoices(selectedChoices)
       setSelectedChoices([])
+      if (result?.status?.choices) {
+        setChoices(result.status.choices)
+      } else {
+        setChoices((prev) =>
+          prev.map((choice, i) =>
+            selectedChoices.includes(i)
+              ? { ...choice, totalVotes: choice.totalVotes + 1 }
+              : choice
+          )
+        )
+      }
     } catch {
       setVoteError('Failed to submit vote. Please try again.')
     } finally {

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1105,15 +1105,18 @@ export const StatusSQLDatabaseMixin = (
           statusCreatedAt
         })
         await Promise.all(
-          choices.map((choice) =>
-            trx('poll_choices').insert({
+          choices.map((choice) => {
+            const title = typeof choice === 'string' ? choice : choice.title
+            const totalVotes =
+              typeof choice === 'string' ? 0 : (choice.totalVotes ?? 0)
+            return trx('poll_choices').insert({
               statusId: id,
-              title: choice,
-
+              title,
+              totalVotes,
               createdAt: statusUpdatedAt,
               updatedAt: statusUpdatedAt
             })
-          )
+          })
         )
         await Promise.all(
           to.map((actorId) =>

--- a/lib/jobs/createPollJob.test.ts
+++ b/lib/jobs/createPollJob.test.ts
@@ -518,4 +518,61 @@ describe('createPollJob', () => {
     }
     expect(status.choices).toHaveLength(2)
   })
+
+  it('preserves existing vote counts from Question options on initial ingestion', async () => {
+    const questionWithVotes = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `https://somewhere.test/actors/pollcreator/questions/with-votes-${Date.now()}`,
+      type: 'Question',
+      attributedTo: REMOTE_ACTOR_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [`${REMOTE_ACTOR_ID}/followers`],
+      content: '<p>How frequently do you chat with LLM?</p>',
+      published: getISOTimeUTC(Date.now()),
+      endTime: getISOTimeUTC(Date.now() + 24 * 60 * 60 * 1000),
+      url: `https://somewhere.test/actors/pollcreator/questions/with-votes-${Date.now()}`,
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'not at all',
+          replies: { type: 'Collection', totalItems: 12 }
+        },
+        {
+          type: 'Note',
+          name: 'a few times per month',
+          replies: { type: 'Collection', totalItems: 34 }
+        },
+        {
+          type: 'Note',
+          name: 'multiple times per week',
+          replies: { type: 'Collection', totalItems: 56 }
+        },
+        {
+          type: 'Note',
+          name: 'over 1 hour per day',
+          replies: { type: 'Collection', totalItems: 78 }
+        }
+      ]
+    }
+
+    await createPollJob(database, {
+      id: 'id-poll-with-votes',
+      name: CREATE_POLL_JOB_NAME,
+      data: questionWithVotes
+    })
+
+    const status = await database.getStatus({
+      statusId: questionWithVotes.id
+    })
+    expect(status).toBeDefined()
+    expect(status?.type).toEqual(StatusType.enum.Poll)
+    if (status?.type !== StatusType.enum.Poll) {
+      fail('Status type must be Poll')
+    }
+    expect(status.choices).toHaveLength(4)
+    expect(status.choices[0].totalVotes).toEqual(12)
+    expect(status.choices[1].totalVotes).toEqual(34)
+    expect(status.choices[2].totalVotes).toEqual(56)
+    expect(status.choices[3].totalVotes).toEqual(78)
+  })
 })

--- a/lib/jobs/createPollJob.ts
+++ b/lib/jobs/createPollJob.ts
@@ -59,8 +59,14 @@ export const createPollJob = createJobHandle(
         ? 'anyOf'
         : 'oneOf'
     const choices =
-      question.oneOf?.map((item) => item.name) ??
-      question.anyOf?.map((item) => item.name) ??
+      question.oneOf?.map((item) => ({
+        title: item.name,
+        totalVotes: item.replies?.totalItems ?? 0
+      })) ??
+      question.anyOf?.map((item) => ({
+        title: item.name,
+        totalVotes: item.replies?.totalItems ?? 0
+      })) ??
       []
 
     await assertActorCanFederate({

--- a/lib/jobs/updatePollJob.test.ts
+++ b/lib/jobs/updatePollJob.test.ts
@@ -213,4 +213,36 @@ describe('updatePollJob', () => {
     const status = await database.getStatus({ statusId: pollId })
     expect(status).toBeNull()
   })
+
+  it('updates multiple-choice (anyOf) poll vote counts', async () => {
+    const pollId = `${REMOTE_ACTOR_ID}/questions/multiple-${Date.now()}`
+    const originalPoll = MockActivityPubQuestion(pollId, {
+      anyOf: [createOption('Option 1', 0), createOption('Option 2', 0)]
+    })
+
+    await createPollJob(database, {
+      id: 'id-anyof-create',
+      name: CREATE_POLL_JOB_NAME,
+      data: originalPoll
+    })
+
+    const updatedPoll = MockActivityPubQuestion(pollId, {
+      anyOf: [createOption('Option 1', 15), createOption('Option 2', 20)]
+    })
+
+    await updatePollJob(database, {
+      id: 'id-anyof-update',
+      name: UPDATE_POLL_JOB_NAME,
+      data: updatedPoll
+    })
+
+    const status = await database.getStatus({ statusId: pollId })
+    expect(status).toBeDefined()
+    if (status?.type !== StatusType.enum.Poll) {
+      fail('Status type must be Poll')
+    }
+    expect(status.choices).toHaveLength(2)
+    expect(status.choices[0].totalVotes).toEqual(15)
+    expect(status.choices[1].totalVotes).toEqual(20)
+  })
 })

--- a/lib/jobs/updatePollJob.ts
+++ b/lib/jobs/updatePollJob.ts
@@ -38,7 +38,12 @@ export const updatePollJob = createJobHandle(
         question.oneOf?.map((answer) => ({
           title: answer.name,
           totalVotes: answer.replies?.totalItems ?? 0
-        })) ?? []
+        })) ??
+        question.anyOf?.map((answer) => ({
+          title: answer.name,
+          totalVotes: answer.replies?.totalItems ?? 0
+        })) ??
+        []
     })
   }
 )

--- a/lib/services/polls/syncRemotePoll.test.ts
+++ b/lib/services/polls/syncRemotePoll.test.ts
@@ -1,0 +1,286 @@
+import { getNote } from '@/lib/activities'
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status, StatusPoll, StatusType } from '@/lib/types/domain/status'
+
+import {
+  resetSyncRemotePollStateForTesting,
+  syncRemotePoll
+} from './syncRemotePoll'
+
+vi.mock('@/lib/activities', () => ({
+  getNote: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: vi
+    .fn()
+    .mockResolvedValue({ id: 'https://local.test/actor' })
+}))
+
+const mockDatabase = {
+  updatePoll: vi.fn()
+} as unknown as Database
+
+const remotePollStatus: StatusPoll = {
+  id: 'https://remote.test/polls/1',
+  url: 'https://remote.test/polls/1',
+  actorId: 'https://remote.test/actors/user',
+  actor: null,
+  isLocalActor: false,
+  type: StatusType.enum.Poll,
+  text: '<p>Favorite color?</p>',
+  summary: '',
+  language: 'en',
+  detectedLanguage: null,
+  to: ['https://www.w3.org/ns/activitystreams#Public'],
+  cc: [],
+  edits: [],
+  reply: '',
+  replies: [],
+  attachments: [],
+  tags: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  isActorBookmarked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  choices: [
+    {
+      statusId: 'https://remote.test/polls/1',
+      title: 'Red',
+      totalVotes: 0,
+      createdAt: 1000,
+      updatedAt: 1000
+    },
+    {
+      statusId: 'https://remote.test/polls/1',
+      title: 'Blue',
+      totalVotes: 0,
+      createdAt: 1000,
+      updatedAt: 1000
+    }
+  ],
+  endAt: 200000,
+  pollType: 'oneOf',
+  hideTotals: false,
+  votersCount: 0,
+  voted: false,
+  ownVotes: [],
+  createdAt: 1000,
+  updatedAt: 1000
+}
+
+describe('syncRemotePoll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSyncRemotePollStateForTesting()
+  })
+
+  it('skips non-poll statuses', async () => {
+    const nonPoll = {
+      ...remotePollStatus,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    const result = await syncRemotePoll({
+      database: mockDatabase,
+      status: nonPoll
+    })
+    expect(result).toBe(nonPoll)
+    expect(getNote).not.toHaveBeenCalled()
+  })
+
+  it('skips local poll statuses', async () => {
+    const localPoll = { ...remotePollStatus, isLocalActor: true }
+    const result = await syncRemotePoll({
+      database: mockDatabase,
+      status: localPoll
+    })
+    expect(result).toBe(localPoll)
+    expect(getNote).not.toHaveBeenCalled()
+  })
+
+  it('fetches remote Question and updates choices and vote counts', async () => {
+    const remoteQuestion = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: remotePollStatus.id,
+      type: 'Question',
+      attributedTo: remotePollStatus.actorId,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      content: '<p>Favorite color?</p>',
+      published: '2026-08-31T00:00:00Z',
+      endTime: '2026-09-05T00:00:00Z',
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'Red',
+          replies: { type: 'Collection', totalItems: 42 }
+        },
+        {
+          type: 'Note',
+          name: 'Blue',
+          replies: { type: 'Collection', totalItems: 58 }
+        }
+      ]
+    }
+    ;(getNote as jest.Mock).mockResolvedValue(remoteQuestion)
+
+    const updatedStatus = {
+      ...remotePollStatus,
+      choices: [
+        { ...remotePollStatus.choices[0], totalVotes: 42 },
+        { ...remotePollStatus.choices[1], totalVotes: 58 }
+      ]
+    }
+    ;(mockDatabase.updatePoll as jest.Mock).mockResolvedValue(updatedStatus)
+
+    const result = await syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus
+    })
+
+    expect(getNote).toHaveBeenCalledWith({
+      statusId: remotePollStatus.id,
+      signingActor: { id: 'https://local.test/actor' }
+    })
+    expect(mockDatabase.updatePoll).toHaveBeenCalledWith({
+      statusId: remotePollStatus.id,
+      summary: '',
+      text: '<p>Favorite color?</p>',
+      choices: [
+        { title: 'Red', totalVotes: 42 },
+        { title: 'Blue', totalVotes: 58 }
+      ],
+      endAt: new Date('2026-09-05T00:00:00Z').getTime()
+    })
+    expect(result).toEqual(updatedStatus)
+  })
+
+  it('handles multiple-choice anyOf polls correctly', async () => {
+    const remoteQuestion = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: remotePollStatus.id,
+      type: 'Question',
+      attributedTo: remotePollStatus.actorId,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      content: '<p>Select features</p>',
+      published: '2026-08-31T00:00:00Z',
+      endTime: '2026-09-05T00:00:00Z',
+      anyOf: [
+        {
+          type: 'Note',
+          name: 'Feature A',
+          replies: { type: 'Collection', totalItems: 10 }
+        },
+        {
+          type: 'Note',
+          name: 'Feature B',
+          replies: { type: 'Collection', totalItems: 20 }
+        }
+      ]
+    }
+    ;(getNote as jest.Mock).mockResolvedValue(remoteQuestion)
+
+    const updatedStatus = {
+      ...remotePollStatus,
+      pollType: 'anyOf',
+      choices: [
+        { ...remotePollStatus.choices[0], title: 'Feature A', totalVotes: 10 },
+        { ...remotePollStatus.choices[1], title: 'Feature B', totalVotes: 20 }
+      ]
+    }
+    ;(mockDatabase.updatePoll as jest.Mock).mockResolvedValue(updatedStatus)
+
+    const result = await syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus
+    })
+
+    expect(mockDatabase.updatePoll).toHaveBeenCalledWith({
+      statusId: remotePollStatus.id,
+      summary: '',
+      text: '<p>Select features</p>',
+      choices: [
+        { title: 'Feature A', totalVotes: 10 },
+        { title: 'Feature B', totalVotes: 20 }
+      ],
+      endAt: new Date('2026-09-05T00:00:00Z').getTime()
+    })
+    expect(result).toEqual(updatedStatus)
+  })
+
+  it('deduplicates concurrent sync requests for the same poll', async () => {
+    let resolveRemoteFetch!: (value: unknown) => void
+    const remoteFetchPromise = new Promise((resolve) => {
+      resolveRemoteFetch = resolve
+    })
+    ;(getNote as jest.Mock).mockImplementation(() => remoteFetchPromise)
+
+    const sync1 = syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus,
+      signingActor: { id: 'https://local.test/actor' } as unknown as Actor
+    })
+    const sync2 = syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus,
+      signingActor: { id: 'https://local.test/actor' } as unknown as Actor
+    })
+
+    expect(getNote).toHaveBeenCalledTimes(1)
+
+    const remoteQuestion = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: remotePollStatus.id,
+      type: 'Question',
+      attributedTo: remotePollStatus.actorId,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      content: '<p>Favorite color?</p>',
+      published: '2026-08-31T00:00:00Z',
+      oneOf: [
+        {
+          type: 'Note',
+          name: 'Red',
+          replies: { type: 'Collection', totalItems: 1 }
+        },
+        {
+          type: 'Note',
+          name: 'Blue',
+          replies: { type: 'Collection', totalItems: 2 }
+        }
+      ]
+    }
+    ;(mockDatabase.updatePoll as jest.Mock).mockResolvedValue({
+      ...remotePollStatus,
+      choices: [
+        { ...remotePollStatus.choices[0], totalVotes: 1 },
+        { ...remotePollStatus.choices[1], totalVotes: 2 }
+      ]
+    })
+
+    resolveRemoteFetch(remoteQuestion)
+    const [res1, res2] = await Promise.all([sync1, sync2])
+    expect(res1).toEqual(res2)
+  })
+
+  it('falls back to existing status on remote fetch failure and cools down', async () => {
+    ;(getNote as jest.Mock).mockRejectedValueOnce(new Error('Network failure'))
+
+    const res1 = await syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus
+    })
+    expect(res1).toBe(remotePollStatus)
+
+    // Second call inside cooldown should not invoke getNote again
+    const res2 = await syncRemotePoll({
+      database: mockDatabase,
+      status: remotePollStatus
+    })
+    expect(res2).toBe(remotePollStatus)
+    expect(getNote).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/services/polls/syncRemotePoll.ts
+++ b/lib/services/polls/syncRemotePoll.ts
@@ -1,0 +1,135 @@
+import { getNote } from '@/lib/activities'
+import { getContent, getSummary } from '@/lib/activities/note'
+import { Database } from '@/lib/database/types'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { ENTITY_TYPE_QUESTION, Question } from '@/lib/types/activitypub'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status, StatusPoll, StatusType } from '@/lib/types/domain/status'
+import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
+import { logger } from '@/lib/utils/logger'
+import { withSpan } from '@/lib/utils/trace'
+
+const FAILURE_COOLDOWN_MS = 60 * 1000
+const REFRESH_WAIT_BUDGET_MS = 5_000
+
+const inflightPollSyncs = new Map<string, Promise<StatusPoll | null>>()
+const failedPollSyncsAt = new Map<string, number>()
+
+export const resetSyncRemotePollStateForTesting = () => {
+  inflightPollSyncs.clear()
+  failedPollSyncsAt.clear()
+}
+
+const raceWithBudget = <T>(promise: Promise<T>, budgetMs: number) => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const budget = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), budgetMs)
+  })
+  return Promise.race([promise, budget]).finally(() => clearTimeout(timer))
+}
+
+const performPollSync = async ({
+  database,
+  status,
+  signingActor
+}: {
+  database: Database
+  status: StatusPoll
+  signingActor?: Actor
+}): Promise<StatusPoll | null> => {
+  try {
+    const signer =
+      signingActor ??
+      (await getFederationSigningActor(database).catch(() => undefined))
+
+    const remoteData = await getNote({
+      statusId: status.id,
+      signingActor: signer
+    })
+    if (!remoteData) {
+      failedPollSyncsAt.set(status.id, Date.now())
+      return null
+    }
+
+    const parseResult = Question.safeParse(
+      normalizeActivityPubContent(remoteData)
+    )
+    if (
+      !parseResult.success ||
+      parseResult.data.type !== ENTITY_TYPE_QUESTION
+    ) {
+      failedPollSyncsAt.set(status.id, Date.now())
+      return null
+    }
+
+    const question = parseResult.data
+    const choices =
+      question.oneOf?.map((answer) => ({
+        title: answer.name,
+        totalVotes: answer.replies?.totalItems ?? 0
+      })) ??
+      question.anyOf?.map((answer) => ({
+        title: answer.name,
+        totalVotes: answer.replies?.totalItems ?? 0
+      })) ??
+      []
+
+    const text = getContent(question)
+    const summary = getSummary(question)
+    const endAt = question.endTime
+      ? new Date(question.endTime).getTime()
+      : undefined
+
+    const updated = await database.updatePoll({
+      statusId: question.id,
+      summary,
+      text,
+      choices,
+      ...(endAt !== undefined ? { endAt } : {})
+    })
+
+    failedPollSyncsAt.delete(status.id)
+    return (updated as StatusPoll) ?? status
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to sync remote poll',
+      statusId: status.id,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    failedPollSyncsAt.set(status.id, Date.now())
+    return null
+  }
+}
+
+export const syncRemotePoll = async ({
+  database,
+  status,
+  signingActor
+}: {
+  database: Database
+  status: Status
+  signingActor?: Actor
+}): Promise<Status> =>
+  withSpan('service', 'syncRemotePoll', { statusId: status.id }, async () => {
+    if (status.type !== StatusType.enum.Poll || status.isLocalActor) {
+      return status
+    }
+
+    const failedAt = failedPollSyncsAt.get(status.id)
+    if (failedAt && Date.now() - failedAt < FAILURE_COOLDOWN_MS) {
+      return status
+    }
+
+    let inflight = inflightPollSyncs.get(status.id)
+    if (!inflight) {
+      inflight = performPollSync({ database, status, signingActor }).finally(
+        () => {
+          inflightPollSyncs.delete(status.id)
+        }
+      )
+      inflightPollSyncs.set(status.id, inflight)
+    }
+
+    const synced = await raceWithBudget(inflight, REFRESH_WAIT_BUDGET_MS)
+    return synced ?? status
+  })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -594,7 +594,7 @@ export type CreateAnnounceParams = Pick<
 }
 
 export type CreatePollParams = BaseCreateStatusParams & {
-  choices: string[]
+  choices: (string | { title: string; totalVotes?: number })[]
   endAt: number
   pollType?: 'oneOf' | 'anyOf'
   // Mastodon poll[hide_totals]: hide per-option tallies until the poll expires.


### PR DESCRIPTION
## Summary
Fixes an issue where remote Mastodon polls showed 0% on every choice and 0 votes in the summary even after voting or ingesting poll activities from remote instances.

## Root Causes & Solutions
1. **Initial Ingestion Discarded Option Tallies**:
   - `lib/jobs/createPollJob.ts` previously only extracted `item.name` and dropped `item.replies?.totalItems`.
   - `lib/database/sql/status.ts` `createPoll` inserted choices without setting `totalVotes`.
   - **Fix**: Updated `CreatePollParams` to support `{ title, totalVotes }` options, updated `createPoll` to persist choice vote counts, and mapped `item.replies?.totalItems ?? 0` in `createPollJob` for both `oneOf` and `anyOf`.

2. **Multiple-choice Polls Ignored on Update**:
   - `lib/jobs/updatePollJob.ts` only handled `question.oneOf`, resetting choices to `[]` on multiple-choice (`question.anyOf`) polls.
   - **Fix**: Added support for `question.anyOf` in `updatePollJob`.

3. **Missing On-Demand Remote Synchronization**:
   - Querying `GET /api/v1/polls/:id` or submitting votes via `POST /api/v1/polls/:id/votes` and `POST /api/v1/accounts/vote` never fetched fresh vote tallies from the origin instance.
   - **Fix**: Implemented `syncRemotePoll` (`lib/services/polls/syncRemotePoll.ts`) with in-flight deduplication, budget race (5s timeout), and failure cooldown (1 minute) to refresh remote Question data on demand.

4. **Frontend Choices State Synchronization**:
   - `lib/components/posts/poll.tsx` did not update choices upon voting.
   - **Fix**: Added `choices` component state, synced with props on change, and updated choices immediately upon voting so percentage bars recalculate without needing a page refresh.

## Verification
- `yarn run prettier --write .` (Passed)
- `yarn lint` (Passed - 0 errors)
- `yarn typecheck` (Passed - 0 errors)
- `yarn build` (Passed - 0 errors)
- `yarn test` (Passed - 922 test files, 12,389 tests passed)