### PR TITLE
Bump version to v1.153.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.5",
+  "version": "1.153.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.5`
- Base main SHA: `e69424ea91108ab2b63d8fdf17e20d19eaa263c5`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
