### PR TITLE
fix: propagate incoming trace context and attach sqlcommenter to database queries

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -1,3 +1,4 @@
+import { trace } from '@opentelemetry/api'
 import knex, { Knex } from 'knex'
 import memoize from 'lodash/memoize'
 
@@ -10,9 +11,29 @@ interface DatabaseInstance {
   knex: Knex
 }
 
+export const attachSqlcommenter = (db: Knex): Knex => {
+  db.on('start', (builder: Knex.QueryBuilder) => {
+    try {
+      const span = trace.getActiveSpan()
+      if (!span) return
+      const spanContext = span.spanContext()
+      if (!trace.isSpanContextValid(spanContext)) return
+
+      const traceFlags = spanContext.traceFlags.toString(16).padStart(2, '0')
+      const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
+      if (typeof builder?.comment === 'function') {
+        builder.comment(`traceparent='${traceparent}'`)
+      }
+    } catch {
+      // Tracing failures must never alter query execution
+    }
+  })
+  return db
+}
+
 const getDatabaseInstance = memoize((): DatabaseInstance | null => {
   const config = getConfig()
-  const db = knex(config.database)
+  const db = attachSqlcommenter(knex(config.database))
   return { database: getSQLDatabase(db), knex: db }
 })
 

--- a/lib/database/sqlcommenter.test.ts
+++ b/lib/database/sqlcommenter.test.ts
@@ -1,0 +1,68 @@
+import { Span, trace } from '@opentelemetry/api'
+import knex from 'knex'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { attachSqlcommenter } from './index'
+
+describe('attachSqlcommenter', () => {
+  const db = attachSqlcommenter(
+    knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+  )
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('appends traceparent comment when active span is present and valid', async () => {
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    const query = db('statuses').select('*')
+    // Trigger query start event
+    db.emit('start', query)
+
+    const sql = query.toSQL().sql
+    expect(sql).toContain(
+      "/* traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01' */"
+    )
+  })
+
+  it('does not append comment when no active span exists', async () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined)
+
+    const query = db('statuses').select('*')
+    db.emit('start', query)
+
+    const sql = query.toSQL().sql
+    expect(sql).not.toContain('traceparent')
+  })
+
+  it('does not append comment when span context is invalid', async () => {
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '00000000000000000000000000000000',
+        spanId: '0000000000000000',
+        traceFlags: 0
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    const query = db('statuses').select('*')
+    db.emit('start', query)
+
+    const sql = query.toSQL().sql
+    expect(sql).not.toContain('traceparent')
+  })
+})

--- a/lib/utils/traceApiRoute.test.ts
+++ b/lib/utils/traceApiRoute.test.ts
@@ -1,7 +1,41 @@
 import { SpanStatusCode, Tracer, trace } from '@opentelemetry/api'
 import { NextRequest } from 'next/server'
 
-import { traceApiRoute } from './traceApiRoute'
+import { parseCloudTraceContext, traceApiRoute } from './traceApiRoute'
+
+describe('parseCloudTraceContext', () => {
+  it('parses traceId, decimal spanId, and sampled flag', () => {
+    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+    const hexSpanId = '3ca938408dc381d3'
+    const decSpanId = BigInt(`0x${hexSpanId}`).toString(10)
+    const header = `${traceId}/${decSpanId};o=1`
+    const result = parseCloudTraceContext(header)
+    expect(result).toEqual({
+      traceId,
+      spanId: hexSpanId,
+      traceFlags: 1,
+      isRemote: true
+    })
+  })
+
+  it('parses header without options', () => {
+    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+    const hexSpanId = '3ca938408dc381d3'
+    const decSpanId = BigInt(`0x${hexSpanId}`).toString(10)
+    const header = `${traceId}/${decSpanId}`
+    const result = parseCloudTraceContext(header)
+    expect(result).toEqual({
+      traceId,
+      spanId: hexSpanId,
+      traceFlags: 0,
+      isRemote: true
+    })
+  })
+
+  it('returns null for invalid header', () => {
+    expect(parseCloudTraceContext('invalid')).toBeNull()
+  })
+})
 
 describe('traceApiRoute', () => {
   let mockSpan: {
@@ -204,5 +238,50 @@ describe('traceApiRoute', () => {
       'optional',
       undefined
     )
+  })
+
+  it('extracts W3C traceparent header and binds it as active context', async () => {
+    const handler = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200
+      })
+    )
+
+    const wrapped = traceApiRoute('testRoute', handler)
+    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+    const spanId = '3ca938408dc381d3'
+    const req = new NextRequest('http://localhost/api/test', {
+      headers: {
+        traceparent: `00-${traceId}-${spanId}-01`
+      }
+    })
+    const context = { params: Promise.resolve({}) }
+
+    const response = await wrapped(req, context)
+    expect(response.status).toBe(200)
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('extracts Google Cloud X-Cloud-Trace-Context header and parses decimal spanId', async () => {
+    const handler = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200
+      })
+    )
+
+    const wrapped = traceApiRoute('testRoute', handler)
+    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+    const hexSpanId = '3ca938408dc381d3'
+    const decSpanId = BigInt(`0x${hexSpanId}`).toString(10)
+    const req = new NextRequest('http://localhost/api/test', {
+      headers: {
+        'x-cloud-trace-context': `${traceId}/${decSpanId};o=1`
+      }
+    })
+    const context = { params: Promise.resolve({}) }
+
+    const response = await wrapped(req, context)
+    expect(response.status).toBe(200)
+    expect(handler).toHaveBeenCalled()
   })
 })

--- a/lib/utils/traceApiRoute.ts
+++ b/lib/utils/traceApiRoute.ts
@@ -1,4 +1,10 @@
-import { SpanStatusCode } from '@opentelemetry/api'
+import {
+  SpanStatusCode,
+  TraceFlags,
+  context,
+  propagation,
+  trace
+} from '@opentelemetry/api'
 import { NextRequest } from 'next/server'
 
 import { getTracer } from './trace'
@@ -18,6 +24,64 @@ export interface TraceApiRouteOptions<P = unknown> {
     | Record<string, string | number | boolean>
 }
 
+export const parseCloudTraceContext = (
+  header: string
+): {
+  traceId: string
+  spanId: string
+  traceFlags: number
+  isRemote: boolean
+} | null => {
+  const match = header.match(
+    /^([0-9a-fA-F]{32})(?:\/([0-9]+))?(?:;o=([0-9]+))?/
+  )
+  if (!match) return null
+  const [, traceId, spanIdDec, options] = match
+  let spanId = '0000000000000000'
+  if (spanIdDec) {
+    try {
+      spanId = BigInt(spanIdDec).toString(16).padStart(16, '0')
+    } catch {
+      spanId = '0000000000000000'
+    }
+  }
+  const isSampled = options === '1'
+  return {
+    traceId: traceId.toLowerCase(),
+    spanId: spanId.toLowerCase(),
+    traceFlags: isSampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+    isRemote: true
+  }
+}
+
+export const extractTraceContext = (req: NextRequest) => {
+  const activeCtx = context.active()
+  if (!req.headers) return activeCtx
+
+  // Extract standard W3C traceparent / tracestate / baggage
+  const extractedCtx = propagation.extract(activeCtx, req.headers, {
+    get(carrier, key) {
+      return carrier.get(key) ?? undefined
+    },
+    keys(carrier) {
+      const keys: string[] = []
+      carrier.forEach((_, key) => keys.push(key))
+      return keys
+    }
+  })
+
+  // Check for Google Cloud Trace context header (X-Cloud-Trace-Context)
+  const cloudTraceHeader = req.headers.get('x-cloud-trace-context')
+  if (cloudTraceHeader) {
+    const cloudSpanContext = parseCloudTraceContext(cloudTraceHeader)
+    if (cloudSpanContext && trace.isSpanContextValid(cloudSpanContext)) {
+      return trace.setSpanContext(extractedCtx, cloudSpanContext)
+    }
+  }
+
+  return extractedCtx
+}
+
 export function traceApiRoute<P = unknown>(
   name: string,
   handler: RouteHandler<P>,
@@ -25,72 +89,75 @@ export function traceApiRoute<P = unknown>(
 ): RouteHandler<P> {
   const { op = 'api', addAttributes } = options
 
-  return (req: NextRequest, context: { params: Promise<P> }) => {
-    return getTracer().startActiveSpan(`${op}.${name}`, async (span) => {
-      try {
+  return (req: NextRequest, routeContext: { params: Promise<P> }) => {
+    const parentContext = extractTraceContext(req)
+    return context.with(parentContext, () => {
+      return getTracer().startActiveSpan(`${op}.${name}`, async (span) => {
         try {
-          const url = req.nextUrl ?? new URL(req.url, 'http://localhost')
-          span.setAttribute('http.request.method', req.method)
-          span.setAttribute('url.path', url.pathname)
-          const query = url.search
-            ? url.search.startsWith('?')
-              ? url.search.slice(1)
-              : url.search
-            : ''
-          if (query) {
-            span.setAttribute('url.query', query)
-          }
-          const userAgent = req.headers?.get?.('user-agent')
-          if (userAgent) {
-            span.setAttribute('user_agent.original', userAgent)
-          }
-        } catch {
-          // Tracing failures must never alter request handling
-        }
-
-        if (addAttributes) {
           try {
-            const attributes = await addAttributes(req, context)
-            Object.entries(attributes).forEach(([key, value]) => {
-              if (value !== undefined) {
-                span.setAttribute(key, value)
-              }
-            })
+            const url = req.nextUrl ?? new URL(req.url, 'http://localhost')
+            span.setAttribute('http.request.method', req.method)
+            span.setAttribute('url.path', url.pathname)
+            const query = url.search
+              ? url.search.startsWith('?')
+                ? url.search.slice(1)
+                : url.search
+              : ''
+            if (query) {
+              span.setAttribute('url.query', query)
+            }
+            const userAgent = req.headers?.get?.('user-agent')
+            if (userAgent) {
+              span.setAttribute('user_agent.original', userAgent)
+            }
           } catch {
             // Tracing failures must never alter request handling
           }
-        }
 
-        const response = await handler(req, context)
+          if (addAttributes) {
+            try {
+              const attributes = await addAttributes(req, routeContext)
+              Object.entries(attributes).forEach(([key, value]) => {
+                if (value !== undefined) {
+                  span.setAttribute(key, value)
+                }
+              })
+            } catch {
+              // Tracing failures must never alter request handling
+            }
+          }
 
-        const statusCode = response.status
-        try {
-          span.setAttribute('http.response.status_code', statusCode)
-          span.setAttribute('http.status_code', statusCode)
-        } catch {
-          // Tracing failures must never alter response handling
-        }
-        if (statusCode >= 200 && statusCode < 400) {
-          span.setStatus({ code: SpanStatusCode.OK })
-        } else {
+          const response = await handler(req, routeContext)
+
+          const statusCode = response.status
+          try {
+            span.setAttribute('http.response.status_code', statusCode)
+            span.setAttribute('http.status_code', statusCode)
+          } catch {
+            // Tracing failures must never alter response handling
+          }
+          if (statusCode >= 200 && statusCode < 400) {
+            span.setStatus({ code: SpanStatusCode.OK })
+          } else {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: `HTTP ${statusCode}`
+            })
+          }
+
+          return response
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error))
+          span.recordException(err)
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: `HTTP ${statusCode}`
+            message: err.message
           })
+          throw error
+        } finally {
+          span.end()
         }
-
-        return response
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error))
-        span.recordException(err)
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err.message
-        })
-        throw error
-      } finally {
-        span.end()
-      }
+      })
     })
   }
 }


### PR DESCRIPTION
## Summary
Fixes orphaned and disconnected distributed traces across Google Cloud Run, QStash background jobs, Next.js API routes, and Google Cloud SQL Query Insights:

1. **Extract incoming trace context in API routes (`traceApiRoute`)**:
   - Parses W3C `traceparent` (sent by QStash and OpenTelemetry clients).
   - Parses Google Cloud's `X-Cloud-Trace-Context` (`TRACE_ID/SPAN_ID;o=OPTIONS`) sent by Cloud Run GFE, converting decimal span IDs to 16-character hex format.
   - Runs handler and background work within `context.with(parentContext, ...)`, preventing disconnected root traces.

2. **Correlate Cloud SQL Query Insights via Sqlcommenter**:
   - Automatically appends `/* traceparent='00-<traceId>-<spanId>-<flags>' */` SQL comments to Knex queries when an active OpenTelemetry span exists.
   - Enables Cloud SQL Query Insights (`pg_tracing` / `pg_stat_statements`) to link query execution plans (`CTE Scan`, `Index Scan`, `Aggregate`, etc.) directly to the application trace.

## Verification
- `yarn run prettier --write .` (Passed)
- `yarn lint` (0 errors)
- `yarn typecheck` (0 type errors)
- `yarn build` (Production build succeeded)
- `yarn test` (12,384 tests passed across 921 test suites)