### PR TITLE
feat(otel): add gcp trace context propagator and tune batch span processor

### DIFF
--- a/instrumentation.node.test.ts
+++ b/instrumentation.node.test.ts
@@ -1,7 +1,10 @@
+import { CloudPropagator } from '@google-cloud/opentelemetry-cloud-trace-propagator'
 import { OTLPTraceExporter as GrpcOLTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc'
 import { OTLPTraceExporter as HttpOLTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPTraceExporter as ProtoOLTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { gcpDetector } from '@opentelemetry/resource-detector-gcp'
 import { NodeSDK } from '@opentelemetry/sdk-node'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -29,10 +32,16 @@ vi.mock('google-auth-library', () => {
     })
   }
 })
+vi.mock('@google-cloud/opentelemetry-cloud-trace-propagator', () => ({
+  CloudPropagator: vi.fn()
+}))
 vi.mock('@opentelemetry/exporter-trace-otlp-grpc')
 vi.mock('@opentelemetry/exporter-trace-otlp-http')
 vi.mock('@opentelemetry/exporter-trace-otlp-proto')
 vi.mock('@opentelemetry/sdk-node')
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+  BatchSpanProcessor: vi.fn()
+}))
 vi.mock('./lib/config', () => ({
   getConfig: vi.fn()
 }))
@@ -191,8 +200,14 @@ describe('instrumentation.node', () => {
       expect(NodeSDK).not.toHaveBeenCalled()
     })
 
-    it('starts NodeSDK when openTelemetry is configured', async () => {
+    it('starts NodeSDK with BatchSpanProcessor and CloudPropagator when protocol is google', async () => {
       const mockStart = vi.fn()
+      const mockSpanProcessor = { id: 'mock-span-processor' }
+      vi.mocked(BatchSpanProcessor).mockImplementation(function (
+        this: unknown
+      ) {
+        return mockSpanProcessor as unknown as BatchSpanProcessor
+      } as unknown as typeof BatchSpanProcessor)
       vi.mocked(NodeSDK).mockImplementation(function (this: unknown) {
         return {
           start: mockStart
@@ -207,7 +222,57 @@ describe('instrumentation.node', () => {
 
       await registerNodeInstrumentation()
 
+      expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object), {
+        scheduledDelayMillis: 500,
+        maxExportBatchSize: 64
+      })
+      expect(CloudPropagator).toHaveBeenCalledTimes(1)
       expect(NodeSDK).toHaveBeenCalledTimes(1)
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceDetectors: [gcpDetector],
+          spanProcessors: [mockSpanProcessor],
+          textMapPropagator: expect.any(Object)
+        })
+      )
+      expect(mockStart).toHaveBeenCalledTimes(1)
+    })
+
+    it('starts NodeSDK with BatchSpanProcessor but without CloudPropagator when protocol is not google', async () => {
+      const mockStart = vi.fn()
+      const mockSpanProcessor = { id: 'mock-span-processor' }
+      vi.mocked(BatchSpanProcessor).mockImplementation(function (
+        this: unknown
+      ) {
+        return mockSpanProcessor as unknown as BatchSpanProcessor
+      } as unknown as typeof BatchSpanProcessor)
+      vi.mocked(NodeSDK).mockImplementation(function (this: unknown) {
+        return {
+          start: mockStart
+        } as unknown as NodeSDK
+      } as unknown as typeof NodeSDK)
+
+      vi.mocked(getConfig).mockReturnValue({
+        openTelemetry: {
+          protocol: 'grpc',
+          endpoint: 'localhost:4317'
+        }
+      } as Config)
+
+      await registerNodeInstrumentation()
+
+      expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object), {
+        scheduledDelayMillis: 500,
+        maxExportBatchSize: 64
+      })
+      expect(CloudPropagator).not.toHaveBeenCalled()
+      expect(NodeSDK).toHaveBeenCalledTimes(1)
+      const sdkConfig = vi.mocked(NodeSDK).mock.calls[0][0] as {
+        resourceDetectors?: unknown[]
+        spanProcessors?: unknown[]
+      }
+      expect(sdkConfig.resourceDetectors).toBeUndefined()
+      expect(sdkConfig.spanProcessors).toEqual([mockSpanProcessor])
       expect(mockStart).toHaveBeenCalledTimes(1)
     })
   })

--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -1,3 +1,4 @@
+import { CloudPropagator as CloudTraceContextPropagator } from '@google-cloud/opentelemetry-cloud-trace-propagator'
 import {
   CompositePropagator,
   W3CBaggagePropagator,
@@ -12,6 +13,7 @@ import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { GoogleAuth } from 'google-auth-library'
 
 import { type Config, getConfig } from './lib/config'
@@ -82,6 +84,10 @@ export const registerNodeInstrumentation = async () => {
   if (!exporter) return
 
   const isGoogle = config.openTelemetry?.protocol === 'google'
+  const spanProcessor = new BatchSpanProcessor(exporter, {
+    scheduledDelayMillis: 500,
+    maxExportBatchSize: 64
+  })
 
   sdk = new NodeSDK({
     resource: resourceFromAttributes({
@@ -89,9 +95,13 @@ export const registerNodeInstrumentation = async () => {
       environment: process.env.NODE_ENV
     }),
     ...(isGoogle ? { resourceDetectors: [gcpDetector] } : {}),
-    traceExporter: exporter,
+    spanProcessors: [spanProcessor],
     textMapPropagator: new CompositePropagator({
-      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()]
+      propagators: [
+        new W3CTraceContextPropagator(),
+        new W3CBaggagePropagator(),
+        ...(isGoogle ? [new CloudTraceContextPropagator()] : [])
+      ]
     }),
     instrumentations: [
       new KnexInstrumentation(),

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@better-auth/utils": "0.5.0",
     "@better-fetch/fetch": "1.3.1",
     "@date-fns/utc": "^2.1.1",
+    "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.22.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.221.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google-cloud/opentelemetry-cloud-trace-propagator@npm:^0.22.0":
+  version: 0.22.0
+  resolution: "@google-cloud/opentelemetry-cloud-trace-propagator@npm:0.22.0"
+  dependencies:
+    hex2dec: "npm:^1.0.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+    "@opentelemetry/core": ^2.0.0
+  checksum: 10c0/d16a538e03c05baa6d413a8beced0e67ee07377aa4ac6a0473090d28724ad220310fdd5fd90b3d3f2ce6c2403d408916216333beffff6abdacddd57621c9c1c2
+  languageName: node
+  linkType: hard
+
 "@grpc/grpc-js@npm:^1.14.3":
   version: 1.14.4
   resolution: "@grpc/grpc-js@npm:1.14.4"
@@ -4280,6 +4292,7 @@ __metadata:
     "@better-auth/utils": "npm:0.5.0"
     "@better-fetch/fetch": "npm:1.3.1"
     "@date-fns/utc": "npm:^2.1.1"
+    "@google-cloud/opentelemetry-cloud-trace-propagator": "npm:^0.22.0"
     "@next/env": "npm:^16.3.3"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/core": "npm:^2.10.0"
@@ -5859,6 +5872,13 @@ __metadata:
   version: 5.0.0
   resolution: "help-me@npm:5.0.0"
   checksum: 10c0/054c0e2e9ae2231c85ab5e04f75109b9d068ffcc54e58fb22079822a5ace8ff3d02c66fd45379c902ad5ab825e5d2e1451fcc2f7eab1eb49e7d488133ba4cacb
+  languageName: node
+  linkType: hard
+
+"hex2dec@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "hex2dec@npm:1.1.2"
+  checksum: 10c0/ff2de92d4c6b87c16abc78ca9f5f2d1401c6dbe6cf7af7401a75d61f61fa7d9e40ff51a72d00e316a94856e21ac6e009f0cb20b1281ab46f63104b5d6e554609
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Finalizes the OpenTelemetry setup on top of the `oltp` branch so that distributed traces connect seamlessly across Google Cloud Run, QStash, and Google Cloud SQL:
- Installs and imports `@google-cloud/opentelemetry-cloud-trace-propagator` (`CloudTraceContextPropagator`).
- Adds `CloudTraceContextPropagator` to `CompositePropagator` in `NodeSDK` when `protocol === 'google'` to extract `X-Cloud-Trace-Context` globally.
- Tunes `BatchSpanProcessor` export interval with `scheduledDelayMillis: 500` and `maxExportBatchSize: 64` to prevent spans from being dropped during Cloud Run CPU throttling / scale-to-zero.
- Adds comprehensive unit test coverage in `instrumentation.node.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)