### PR TITLE
Bump version to v1.153.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.6",
+  "version": "1.153.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.153.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.153.6`
- Base main SHA: `9add2d27ba873afffb3d54d66839ab85700e47f1`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
