### PR TITLE
fix(otel): resolve auth header normalization and auto-detect gcp.project_id

### DIFF
--- a/instrumentation.node.test.ts
+++ b/instrumentation.node.test.ts
@@ -144,6 +144,29 @@ describe('instrumentation.node', () => {
       })
     })
 
+    it('handles plain object return from authClient.getRequestHeaders for google protocol', async () => {
+      mockGetRequestHeaders.mockResolvedValueOnce({
+        authorization: 'Bearer plain-token'
+      })
+
+      const config = {
+        openTelemetry: {
+          protocol: 'google'
+        }
+      } as Config
+
+      getTraceExporter(config)
+
+      const callArgs = vi.mocked(ProtoOLTPTraceExporter).mock.calls[0][0] as {
+        url: string
+        headers: () => Promise<Record<string, string>>
+      }
+      const headers = await callArgs.headers()
+      expect(headers).toEqual({
+        authorization: 'Bearer plain-token'
+      })
+    })
+
     it('uses custom endpoint and merges custom headers for google protocol when provided', async () => {
       const config = {
         openTelemetry: {

--- a/instrumentation.node.test.ts
+++ b/instrumentation.node.test.ts
@@ -25,11 +25,14 @@ const mockGetClient = vi.fn().mockResolvedValue({
   getRequestHeaders: mockGetRequestHeaders
 })
 
+const mockGetProjectId = vi.fn().mockResolvedValue('mock-gcp-project')
+
 vi.mock('google-auth-library', () => {
   return {
     GoogleAuth: vi.fn().mockImplementation(function (this: unknown) {
       return {
-        getClient: mockGetClient
+        getClient: mockGetClient,
+        getProjectId: mockGetProjectId
       }
     })
   }

--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -54,8 +54,9 @@ export const getTraceExporter = (config: Config) => {
       return new HttpOLTPTraceExporter(options)
     case 'google': {
       let authClient: Awaited<ReturnType<GoogleAuth['getClient']>> | null = null
+      const url = endpoint ?? 'https://telemetry.googleapis.com/v1/traces'
       return new ProtoOLTPTraceExporter({
-        url: endpoint ?? 'https://telemetry.googleapis.com/v1/traces',
+        url,
         headers: async () => {
           if (!authClient) {
             const auth = new GoogleAuth({
@@ -63,9 +64,22 @@ export const getTraceExporter = (config: Config) => {
             })
             authClient = await auth.getClient()
           }
-          const rawHeaders = await authClient.getRequestHeaders()
+          const rawHeaders = await authClient.getRequestHeaders(url)
+          const authHeaders =
+            rawHeaders instanceof Headers
+              ? Object.fromEntries(rawHeaders.entries())
+              : typeof (rawHeaders as { entries?: unknown })?.entries ===
+                  'function'
+                ? Object.fromEntries(
+                    (
+                      rawHeaders as {
+                        entries: () => Iterable<[string, string]>
+                      }
+                    ).entries()
+                  )
+                : ((rawHeaders ?? {}) as Record<string, string>)
           return {
-            ...Object.fromEntries(rawHeaders.entries()),
+            ...authHeaders,
             ...(parsedHeaders ?? {})
           }
         }

--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -102,11 +102,20 @@ export const registerNodeInstrumentation = async () => {
   const isGoogle = config.openTelemetry?.protocol === 'google'
   const spanProcessor = new SimpleSpanProcessor(exporter)
 
+  let projectId: string | null = null
+  if (isGoogle) {
+    const auth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/cloud-platform'
+    })
+    projectId = await auth.getProjectId().catch(() => null)
+  }
+
   sdk = new NodeSDK({
     sampler: new AlwaysOnSampler(),
     resource: resourceFromAttributes({
       'service.name': TRACE_APPLICATION_SCOPE,
-      environment: process.env.NODE_ENV
+      environment: process.env.NODE_ENV,
+      ...(projectId ? { 'gcp.project_id': projectId } : {})
     }),
     ...(isGoogle ? { resourceDetectors: [gcpDetector] } : {}),
     spanProcessors: [spanProcessor],

--- a/lib/utils/traceApiRoute.ts
+++ b/lib/utils/traceApiRoute.ts
@@ -70,12 +70,15 @@ export const extractTraceContext = (req: NextRequest) => {
     }
   })
 
-  // Check for Google Cloud Trace context header (X-Cloud-Trace-Context)
-  const cloudTraceHeader = req.headers.get('x-cloud-trace-context')
-  if (cloudTraceHeader) {
-    const cloudSpanContext = parseCloudTraceContext(cloudTraceHeader)
-    if (cloudSpanContext && trace.isSpanContextValid(cloudSpanContext)) {
-      return trace.setSpanContext(extractedCtx, cloudSpanContext)
+  // Check for Google Cloud Trace context header (X-Cloud-Trace-Context) as fallback
+  const existingSpanContext = trace.getSpanContext(extractedCtx)
+  if (!existingSpanContext || !trace.isSpanContextValid(existingSpanContext)) {
+    const cloudTraceHeader = req.headers.get('x-cloud-trace-context')
+    if (cloudTraceHeader) {
+      const cloudSpanContext = parseCloudTraceContext(cloudTraceHeader)
+      if (cloudSpanContext && trace.isSpanContextValid(cloudSpanContext)) {
+        return trace.setSpanContext(extractedCtx, cloudSpanContext)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

When PR #1696 was deployed, traces were still missing due to two remaining blockers in the OTLP exporter setup:

1. **`rawHeaders.entries is not a function` in `headers()` callback**:
   - `google-auth-library` returns a plain JavaScript object (e.g. `{ authorization: 'Bearer ...' }`) in Cloud Run when using ADC.
   - Calling `rawHeaders.entries()` resulted in an unhandled `TypeError` inside the HTTP export transport, silently crashing all trace export requests.
   - Now safely normalizes `rawHeaders` whether it is a plain object or a `Headers` instance, and explicitly passes `url` to `authClient.getRequestHeaders(url)`.

2. **Missing `gcp.project_id` Resource Attribute**:
   - Google Telemetry API requires `gcp.project_id` on the Resource attributes to route incoming spans to the correct GCP project.
   - `registerNodeInstrumentation` now automatically resolves the Google Cloud Project ID via `auth.getProjectId()` and attaches `'gcp.project_id'` to the OpenTelemetry `Resource` without requiring manual `OTEL_RESOURCE_ATTRIBUTES` configuration.

3. **Fallback Trace Context Handling in `traceApiRoute`**:
   - Only falls back to parsing `x-cloud-trace-context` if no valid W3C `traceparent` context was extracted.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)