### PR TITLE
fix(database): attach traceparent sqlcomment on executed queries for Cloud SQL

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -12,22 +12,37 @@ interface DatabaseInstance {
 }
 
 export const attachSqlcommenter = (db: Knex): Knex => {
-  db.on('start', (builder: Knex.QueryBuilder) => {
-    try {
-      const span = trace.getActiveSpan()
-      if (!span) return
-      const spanContext = span.spanContext()
-      if (!trace.isSpanContextValid(spanContext)) return
+  const origQuery = db.client?.query
+  if (typeof origQuery === 'function') {
+    db.client.query = function (
+      connection: unknown,
+      obj: { sql: string; [key: string]: unknown } | string
+    ) {
+      try {
+        const span = trace.getActiveSpan()
+        if (span) {
+          const spanContext = span.spanContext()
+          if (trace.isSpanContextValid(spanContext)) {
+            const traceFlags = spanContext.traceFlags
+              .toString(16)
+              .padStart(2, '0')
+            const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
+            const comment = `/*traceparent='${traceparent}'*/`
 
-      const traceFlags = spanContext.traceFlags.toString(16).padStart(2, '0')
-      const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
-      if (typeof builder?.comment === 'function') {
-        builder.comment(`traceparent='${traceparent}'`)
+            if (typeof obj === 'string') {
+              obj = `${obj} ${comment}`
+            } else if (obj && typeof obj.sql === 'string') {
+              obj.sql = `${obj.sql} ${comment}`
+            }
+          }
+        }
+      } catch {
+        // Tracing failures must never alter query execution
       }
-    } catch {
-      // Tracing failures must never alter query execution
+
+      return origQuery.call(this, connection, obj)
     }
-  })
+  }
   return db
 }
 

--- a/lib/database/sqlcommenter.test.ts
+++ b/lib/database/sqlcommenter.test.ts
@@ -13,8 +13,19 @@ describe('attachSqlcommenter', () => {
     })
   )
 
+  let executedSql: string[] = []
+  const origDriverQuery = db.client._query
+  db.client._query = function (
+    conn: unknown,
+    obj: { sql: string; [key: string]: unknown }
+  ) {
+    executedSql.push(obj.sql)
+    return origDriverQuery.apply(this, [conn, obj])
+  }
+
   afterEach(() => {
     vi.restoreAllMocks()
+    executedSql = []
   })
 
   it('appends traceparent comment when active span is present and valid', async () => {
@@ -28,24 +39,19 @@ describe('attachSqlcommenter', () => {
 
     vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
 
-    const query = db('statuses').select('*')
-    // Trigger query start event
-    db.emit('start', query)
+    await db.raw('SELECT 1')
 
-    const sql = query.toSQL().sql
-    expect(sql).toContain(
-      "/* traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01' */"
+    expect(executedSql[0]).toContain(
+      "/*traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01'*/"
     )
   })
 
   it('does not append comment when no active span exists', async () => {
     vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined)
 
-    const query = db('statuses').select('*')
-    db.emit('start', query)
+    await db.raw('SELECT 1')
 
-    const sql = query.toSQL().sql
-    expect(sql).not.toContain('traceparent')
+    expect(executedSql[0]).not.toContain('traceparent')
   })
 
   it('does not append comment when span context is invalid', async () => {
@@ -59,10 +65,8 @@ describe('attachSqlcommenter', () => {
 
     vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
 
-    const query = db('statuses').select('*')
-    db.emit('start', query)
+    await db.raw('SELECT 1')
 
-    const sql = query.toSQL().sql
-    expect(sql).not.toContain('traceparent')
+    expect(executedSql[0]).not.toContain('traceparent')
   })
 })


### PR DESCRIPTION
## Summary

This PR fixes distributed trace propagation from `activities.next` to **Google Cloud SQL (Query Insights)**:

### Root Cause
- Google Cloud SQL Query Insights parses SQL comments formatted as `/*traceparent='00-TRACE_ID-SPAN_ID-01'*/` appended to SQL statements to link the database query execution to the active trace span in Google Cloud Trace.
- Previously, `attachSqlcommenter` in `lib/database/index.ts` was listening to Knex's `db.on('start', (builder) => ...)` and attempting to call `builder.comment(...)`.
- In Knex, `builder.comment(...)` does not exist on the start event object (and for `db.raw(...)` it is a `Raw` object without `.comment()`). Because of this, no SQL comments were ever attached to queries sent to Cloud SQL, leaving Cloud SQL Query Insights spans unlinked (with their own independent trace IDs).

### Solution
- Updated `attachSqlcommenter` to wrap `db.client.query(connection, obj)`:
  - Extracts the active span context (`traceId`, `spanId`, `traceFlags`).
  - Appends `/*traceparent='00-${traceId}-${spanId}-${traceFlags}'*/` directly to `obj.sql`.
  - Seamlessly supports `db('table')`, `db.raw(...)`, transactions (`trx`), and all query types sent to PostgreSQL / Cloud SQL.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)