### PR TITLE
fix(otel): remove KnexInstrumentation to resolve Cloud SQL Query span collision

### DIFF
--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -7,7 +7,6 @@ import { OTLPTraceExporter as GrpcOLTPTraceExporter } from '@opentelemetry/expor
 import { OTLPTraceExporter as HttpOLTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPTraceExporter as ProtoOLTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
-import { KnexInstrumentation } from '@opentelemetry/instrumentation-knex'
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp'
 import { resourceFromAttributes } from '@opentelemetry/resources'
@@ -123,7 +122,6 @@ export const registerNodeInstrumentation = async () => {
       propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()]
     }),
     instrumentations: [
-      new KnexInstrumentation(),
       new HttpInstrumentation({
         ignoreIncomingRequestHook: (req) => {
           const url = req.url ?? ''

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -11,36 +11,52 @@ interface DatabaseInstance {
   knex: Knex
 }
 
-export const attachSqlcommenter = (db: Knex): Knex => {
-  const origQuery = db.client?.query
-  if (typeof origQuery === 'function') {
-    db.client.query = function (
-      connection: unknown,
-      obj: { sql: string; [key: string]: unknown } | string
-    ) {
-      try {
-        const span = trace.getActiveSpan()
-        if (span) {
-          const spanContext = span.spanContext()
-          if (trace.isSpanContextValid(spanContext)) {
-            const traceFlags = spanContext.traceFlags
-              .toString(16)
-              .padStart(2, '0')
-            const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
-            const comment = `/*traceparent='${traceparent}'*/`
+interface WrappedClient {
+  query: (
+    connection: unknown,
+    obj: { sql: string; [key: string]: unknown } | string
+  ) => unknown
+  __sqlcommenterWrapped__?: boolean
+}
 
-            if (typeof obj === 'string') {
-              obj = `${obj} ${comment}`
-            } else if (obj && typeof obj.sql === 'string') {
-              obj.sql = `${obj.sql} ${comment}`
+export const attachSqlcommenter = (db: Knex): Knex => {
+  const Client = (db.client?.constructor ??
+    (knex as unknown as { Client: { prototype: WrappedClient } }).Client) as {
+    prototype: WrappedClient
+  }
+  const target = Client?.prototype ?? (db.client as unknown as WrappedClient)
+  if (target && !target.__sqlcommenterWrapped__) {
+    const origQuery = target.query
+    if (typeof origQuery === 'function') {
+      target.query = function (
+        connection: unknown,
+        obj: { sql: string; [key: string]: unknown } | string
+      ) {
+        try {
+          const span = trace.getActiveSpan()
+          if (span) {
+            const spanContext = span.spanContext()
+            if (trace.isSpanContextValid(spanContext)) {
+              const traceFlags = spanContext.traceFlags
+                .toString(16)
+                .padStart(2, '0')
+              const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
+              const comment = `/*traceparent='${traceparent}'*/`
+
+              if (typeof obj === 'string') {
+                obj = `${obj} ${comment}`
+              } else if (obj && typeof obj.sql === 'string') {
+                obj.sql = `${obj.sql} ${comment}`
+              }
             }
           }
+        } catch {
+          // Tracing failures must never alter query execution
         }
-      } catch {
-        // Tracing failures must never alter query execution
-      }
 
-      return origQuery.call(this, connection, obj)
+        return origQuery.call(this, connection, obj)
+      }
+      target.__sqlcommenterWrapped__ = true
     }
   }
   return db


### PR DESCRIPTION
### Summary

When `KnexInstrumentation` from `@opentelemetry/instrumentation-knex` is enabled, it creates a client-side database span (`select.actors`) with its own `spanId` for every query and sets it as the active span context.

When `attachSqlcommenter` subsequently read the active span context to generate `/*traceparent='00-traceId-spanId-01'*/`, it passed that client span's ID to Cloud SQL. Google Cloud SQL Query Insights uses the `parent_id` from the comment as the `spanId` of its `Cloud SQL Query` span. Because both the application's Knex span and Cloud SQL's span shared the identical `spanId`, Cloud Trace encountered a span ID collision where Cloud SQL's span showed up as a root span without parentage.

### Changes
1. Removed `KnexInstrumentation` so the application's true request / service span (e.g. `api.getInstance`) remains active when SQL queries are prepared.
2. Cloud SQL Query Insights now receives the application's request span ID in `traceparent`, attaching the database query execution plans directly as children under the application span in Google Cloud Trace.
3. Enhanced `attachSqlcommenter` to ensure client prototype-level wrapping.

### Verification
- Prettier, Oxlint, TypeScript typecheck, Next.js build, and Vitest suite (12,453 tests) pass.