### PR TITLE
fix: attach traceparent sqlcomment to queries inside knex transactions

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -11,6 +11,10 @@ interface DatabaseInstance {
   knex: Knex
 }
 
+// Symbol.for (global registry), not Symbol(): Next.js dev Fast Refresh
+// re-evaluates this module while the cached knex dialect class survives, so a
+// per-module Symbol() would never match on reload and query would be
+// re-wrapped every time, stacking duplicate traceparent comments.
 const SQLCOMMENTER_ATTACHED = Symbol.for('activities.next.sqlcommenter')
 
 export const attachSqlcommenter = (db: Knex): Knex => {

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -11,10 +11,17 @@ interface DatabaseInstance {
   knex: Knex
 }
 
+const SQLCOMMENTER_ATTACHED = Symbol.for('activities.next.sqlcommenter')
+
 export const attachSqlcommenter = (db: Knex): Knex => {
-  const origQuery = db.client?.query
-  if (typeof origQuery === 'function') {
-    db.client.query = function (
+  // Patch the dialect class prototype, not the knex instance: knex builds each
+  // transaction client via Object.create(client.constructor.prototype), so an
+  // instance-level override is invisible to every query inside a transaction.
+  const proto = db.client?.constructor?.prototype
+  const origQuery = proto?.query
+  if (typeof origQuery === 'function' && !proto[SQLCOMMENTER_ATTACHED]) {
+    proto[SQLCOMMENTER_ATTACHED] = true
+    proto.query = function (
       connection: unknown,
       obj: { sql: string; [key: string]: unknown } | string
     ) {

--- a/lib/database/sqlcommenter.test.ts
+++ b/lib/database/sqlcommenter.test.ts
@@ -13,9 +13,13 @@ describe('attachSqlcommenter', () => {
     })
   )
 
+  // Capture on the dialect class prototype, not the knex instance: a
+  // transaction client is built via Object.create(client.constructor.prototype)
+  // and never consults instance-level properties.
   let executedSql: string[] = []
-  const origDriverQuery = db.client._query
-  db.client._query = function (
+  const clientProto = db.client.constructor.prototype
+  const origDriverQuery = clientProto._query
+  clientProto._query = function (
     conn: unknown,
     obj: { sql: string; [key: string]: unknown }
   ) {
@@ -42,6 +46,28 @@ describe('attachSqlcommenter', () => {
     await db.raw('SELECT 1')
 
     expect(executedSql[0]).toContain(
+      "/*traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01'*/"
+    )
+  })
+
+  it('appends traceparent comment to queries inside a transaction', async () => {
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    await db.transaction(async (trx) => {
+      await trx.raw('SELECT 1')
+    })
+
+    const selects = executedSql.filter((sql) => sql.startsWith('SELECT 1'))
+    expect(selects).toHaveLength(1)
+    expect(selects[0]).toContain(
       "/*traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01'*/"
     )
   })

--- a/lib/database/sqlcommenter.test.ts
+++ b/lib/database/sqlcommenter.test.ts
@@ -95,4 +95,35 @@ describe('attachSqlcommenter', () => {
 
     expect(executedSql[0]).not.toContain('traceparent')
   })
+
+  it('does not double-attach the comment when a second knex instance shares the dialect prototype', async () => {
+    // Same client ('better-sqlite3') as `db` above, so this instance's
+    // client.constructor is the identical class object, and the guard on
+    // its shared prototype must stop attachSqlcommenter from wrapping
+    // `query` a second time.
+    const secondDb = attachSqlcommenter(
+      knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: { filename: ':memory:' }
+      })
+    )
+
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    await secondDb.raw('SELECT 2')
+
+    const selects = executedSql.filter((sql) => sql.startsWith('SELECT 2'))
+    expect(selects).toHaveLength(1)
+    const traceparentOccurrences = selects[0].match(/\/\*traceparent=/g) ?? []
+    expect(traceparentOccurrences).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1699. Cloud SQL Query Insights spans were appearing in Cloud Trace as isolated root traces (`parentSpanId: null`) instead of nesting under the application spans that triggered the queries.

Investigation found **two independent causes**:

1. **Instance configuration (primary, fixed operationally):** the Cloud SQL instance had Query Insights enabled but not `recordApplicationTags`, which is what makes Query Insights parse sqlcommenter tags — `traceparent` included. Without it, Query Insights discards the comment and mints its own trace IDs for sampled query plans, which is exactly the observed symptom. This is a [community-confirmed failure mode](https://discuss.google.dev/t/query-insights-query-traces-not-linking-up-with-application-traces/98302), and the setting has now been enabled on the instance (no restart required — the update completed in ~2 minutes with the instance available).

2. **Transactions bypassed the sqlcommenter wrapper (this PR):** `attachSqlcommenter` overrode `query` on the knex client *instance*, but knex builds each transaction client via `Object.create(client.constructor.prototype)` ([knex 3.3.0 `makeTxClient`](https://github.com/knex/knex/blob/master/lib/execution/transaction.js)) and captures `const _query = trxClient.query` from the prototype — the instance-level override is never consulted. Every statement inside every `db.transaction()` (83 call sites in `lib/database/sql` plus the better-auth `knexAdapter` — essentially the whole write path) reached PostgreSQL with no traceparent comment, so its Query Insights samples could never link even with the instance flag enabled.

## Fix

Install the wrapper on the dialect class prototype instead of the instance, guarded by a symbol against double attachment. The transaction client inherits the wrapped `query`, and `makeTxClient`'s own wrapper captures and calls through it. Verified mechanically: the comment is appended before knex's `enrichQueryObject`, contains no `?` or `\` (so `positionBindings` cannot mangle it), and node-postgres sends `queryConfig.text` verbatim.

## Verification of the wider diagnosis

- The app side was already attaching correct comments for non-transactional queries: production revision `activitiesnext-01261-qcr` runs exactly `cb500118d` (#1699), deployed ~1h before the sampled example trace — yet that trace (`819965a52958355770648998f47148c0`) contains only Query Insights spans with no application tags at all, confirming the parsing was disabled instance-side.
- sqlcommenter format checked against the spec: trailing comment, single-quoted value, `00-<32hex>-<16hex>-01` — all correct (hex/dash values need no URL encoding).
- `AlwaysOnSampler` means every locally-started span carries sampled flags (`-01`), including under an unsampled Cloud Run LB parent.
- Docs note: query-string truncation (`queryStringLength=1024`) does **not** drop tags ("You can still add tags to queries that exceed the length limit").

## Test

New regression test: a query inside `db.transaction()` must carry the traceparent comment — fails against the old instance-level wrapper (`SELECT 1` reaches the driver bare), passes with the prototype-level attachment. The existing capture hook also moved to the class prototype, since transaction clients never consult instance properties.

A second test (from review round 1) pins the double-attachment guard: attaching sqlcommenter to a second knex instance sharing the dialect class must not stack the wrapper — with the guard removed, queries carry the traceparent comment twice. The `Symbol.for` (vs `Symbol()`) choice is now documented in code: the global-registry key survives module re-evaluation under Next.js dev Fast Refresh, where a per-module symbol would re-wrap `query` on every reload.

## Test results

- `yarn run prettier --write .` ✅
- `yarn lint` ✅ (pre-existing warnings only)
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅ 932 files / 12,455 tests (re-run in full after each review round)

## Known remaining gaps (out of scope, documented for follow-up)

- 6 of 295 route files don't wrap handlers in `traceApiRoute` (`oauth/token`, `api/auth/[...all]`, `api/oauth/authorize`, `v1/trends`, two fitness-heatmap routes) — queries there rely on the HttpInstrumentation span's context.
- knex streams (`client.stream`) bypass the wrapper — zero production callers today.
- Operator scripts and knex-CLI migrations run uninstrumented by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
