### PR TITLE
fix: make profile and actor loading skeletons visibly shimmer

### DIFF
--- a/app/(timeline)/[actor]/[status]/loading.test.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.test.tsx
@@ -21,12 +21,18 @@ describe('[status] loading', () => {
     expect(screen.getByLabelText('Loading post')).toBeInTheDocument()
   })
 
-  it('renders placeholders with the shimmer skeleton utility', () => {
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    // jsdom paints no CSS so classes are the observable; every leaf <div> in
+    // this skeleton is a placeholder (containers always hold further divs),
+    // and a bare `length > 0` missed both a partial strip and a future
+    // unstyled row; the `.skeleton` definition itself is guarded by
+    // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-
-    // jsdom paints no CSS, so the class is the observable — see
-    // app/globals.skeleton.test.ts for the definition guard.
-    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    const leaves = Array.from(container.querySelectorAll('div')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
 })

--- a/app/(timeline)/[actor]/[status]/loading.test.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.test.tsx
@@ -20,4 +20,13 @@ describe('[status] loading', () => {
 
     expect(screen.getByLabelText('Loading post')).toBeInTheDocument()
   })
+
+  it('renders placeholders with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+
+    // jsdom paints no CSS, so the class is the observable — see
+    // app/globals.skeleton.test.ts for the definition guard.
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
 })

--- a/app/(timeline)/[actor]/[status]/loading.tsx
+++ b/app/(timeline)/[actor]/[status]/loading.tsx
@@ -8,32 +8,32 @@ export const StatusLoading: FC = () => {
       className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm"
     >
       <div className="flex items-center gap-3 border-b bg-background/90 px-5 py-3">
-        <div className="h-8 w-8 animate-pulse rounded-md bg-muted" />
+        <div className="skeleton h-8 w-8 rounded-md" />
         <div className="space-y-1">
-          <div className="h-4 w-16 animate-pulse rounded bg-muted" />
-          <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-4 w-16 rounded" />
+          <div className="skeleton h-3 w-32 rounded" />
         </div>
       </div>
 
       <div className="p-5">
         <div className="flex items-center gap-3">
-          <div className="size-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="skeleton size-12 shrink-0 rounded-full" />
           <div className="space-y-1.5">
-            <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="skeleton h-4 w-36 rounded" />
+            <div className="skeleton h-3 w-24 rounded" />
           </div>
         </div>
 
         <div className="mt-4 space-y-2">
-          <div className="h-4 w-full animate-pulse rounded bg-muted" />
-          <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
-          <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-4 w-full rounded" />
+          <div className="skeleton h-4 w-5/6 rounded" />
+          <div className="skeleton h-4 w-2/3 rounded" />
         </div>
 
         <div className="mt-6 flex gap-8 border-t pt-4">
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-5 w-12 rounded" />
+          <div className="skeleton h-5 w-12 rounded" />
+          <div className="skeleton h-5 w-12 rounded" />
         </div>
       </div>
     </div>

--- a/app/(timeline)/[actor]/followers/loading.test.tsx
+++ b/app/(timeline)/[actor]/followers/loading.test.tsx
@@ -21,12 +21,18 @@ describe('[actor]/followers loading', () => {
     expect(screen.getByLabelText('Loading followers')).toBeInTheDocument()
   })
 
-  it('renders placeholders with the shimmer skeleton utility', () => {
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    // jsdom paints no CSS so classes are the observable; every leaf <div> in
+    // this skeleton is a placeholder (containers always hold further divs),
+    // and a bare `length > 0` missed both a partial strip and a future
+    // unstyled row; the `.skeleton` definition itself is guarded by
+    // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-
-    // jsdom paints no CSS, so the class is the observable — see
-    // app/globals.skeleton.test.ts for the definition guard.
-    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    const leaves = Array.from(container.querySelectorAll('div')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
 })

--- a/app/(timeline)/[actor]/followers/loading.test.tsx
+++ b/app/(timeline)/[actor]/followers/loading.test.tsx
@@ -20,4 +20,13 @@ describe('[actor]/followers loading', () => {
 
     expect(screen.getByLabelText('Loading followers')).toBeInTheDocument()
   })
+
+  it('renders placeholders with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+
+    // jsdom paints no CSS, so the class is the observable — see
+    // app/globals.skeleton.test.ts for the definition guard.
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
 })

--- a/app/(timeline)/[actor]/followers/loading.tsx
+++ b/app/(timeline)/[actor]/followers/loading.tsx
@@ -4,23 +4,23 @@ export const FollowersLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading followers" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
+        <div className="skeleton h-9 w-9 shrink-0 rounded-md" />
         <div className="space-y-1">
-          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
-          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-7 w-32 rounded-md" />
+          <div className="skeleton h-4 w-24 rounded" />
         </div>
       </div>
 
       <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         {[0, 1, 2, 3].map((index) => (
           <div key={index} className="flex items-center gap-3 px-5 py-4">
-            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="skeleton h-12 w-12 shrink-0 rounded-full" />
             <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+              <div className="skeleton h-4 w-36 rounded" />
+              <div className="skeleton h-3 w-28 rounded" />
+              <div className="skeleton h-3 w-48 rounded" />
             </div>
-            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
+            <div className="skeleton h-8 w-20 shrink-0 rounded-md" />
           </div>
         ))}
       </div>

--- a/app/(timeline)/[actor]/following/loading.test.tsx
+++ b/app/(timeline)/[actor]/following/loading.test.tsx
@@ -20,4 +20,13 @@ describe('[actor]/following loading', () => {
 
     expect(screen.getByLabelText('Loading following')).toBeInTheDocument()
   })
+
+  it('renders placeholders with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+
+    // jsdom paints no CSS, so the class is the observable — see
+    // app/globals.skeleton.test.ts for the definition guard.
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
 })

--- a/app/(timeline)/[actor]/following/loading.test.tsx
+++ b/app/(timeline)/[actor]/following/loading.test.tsx
@@ -21,12 +21,18 @@ describe('[actor]/following loading', () => {
     expect(screen.getByLabelText('Loading following')).toBeInTheDocument()
   })
 
-  it('renders placeholders with the shimmer skeleton utility', () => {
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    // jsdom paints no CSS so classes are the observable; every leaf <div> in
+    // this skeleton is a placeholder (containers always hold further divs),
+    // and a bare `length > 0` missed both a partial strip and a future
+    // unstyled row; the `.skeleton` definition itself is guarded by
+    // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-
-    // jsdom paints no CSS, so the class is the observable — see
-    // app/globals.skeleton.test.ts for the definition guard.
-    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    const leaves = Array.from(container.querySelectorAll('div')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
 })

--- a/app/(timeline)/[actor]/following/loading.tsx
+++ b/app/(timeline)/[actor]/following/loading.tsx
@@ -4,23 +4,23 @@ export const FollowingLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading following" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="h-9 w-9 shrink-0 animate-pulse rounded-md bg-muted" />
+        <div className="skeleton h-9 w-9 shrink-0 rounded-md" />
         <div className="space-y-1">
-          <div className="h-7 w-32 animate-pulse rounded-md bg-muted" />
-          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-7 w-32 rounded-md" />
+          <div className="skeleton h-4 w-24 rounded" />
         </div>
       </div>
 
       <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         {[0, 1, 2, 3].map((index) => (
           <div key={index} className="flex items-center gap-3 px-5 py-4">
-            <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="skeleton h-12 w-12 shrink-0 rounded-full" />
             <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="h-4 w-36 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-28 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+              <div className="skeleton h-4 w-36 rounded" />
+              <div className="skeleton h-3 w-28 rounded" />
+              <div className="skeleton h-3 w-48 rounded" />
             </div>
-            <div className="h-8 w-20 shrink-0 animate-pulse rounded-md bg-muted" />
+            <div className="skeleton h-8 w-20 shrink-0 rounded-md" />
           </div>
         ))}
       </div>

--- a/app/(timeline)/[actor]/loading.test.tsx
+++ b/app/(timeline)/[actor]/loading.test.tsx
@@ -21,14 +21,18 @@ describe('[actor] loading', () => {
     expect(screen.getByLabelText('Loading profile')).toBeInTheDocument()
   })
 
-  it('renders placeholders with the shimmer skeleton utility', () => {
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    // jsdom paints no CSS so classes are the observable; every leaf <div> in
+    // this skeleton is a placeholder (containers always hold further divs),
+    // and a bare `length > 0` missed both a partial strip and a future
+    // unstyled row; the `.skeleton` definition itself is guarded by
+    // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-
-    // jsdom paints no CSS, so the class is the observable: the shimmer lives
-    // on the `skeleton` utility (app/globals.css, guarded by
-    // app/globals.skeleton.test.ts), and the old animate-pulse-on-bg-muted
-    // treatment — near-invisible in light mode — must not come back.
-    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    const leaves = Array.from(container.querySelectorAll('div')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
 })

--- a/app/(timeline)/[actor]/loading.test.tsx
+++ b/app/(timeline)/[actor]/loading.test.tsx
@@ -20,4 +20,15 @@ describe('[actor] loading', () => {
 
     expect(screen.getByLabelText('Loading profile')).toBeInTheDocument()
   })
+
+  it('renders placeholders with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+
+    // jsdom paints no CSS, so the class is the observable: the shimmer lives
+    // on the `skeleton` utility (app/globals.css, guarded by
+    // app/globals.skeleton.test.ts), and the old animate-pulse-on-bg-muted
+    // treatment — near-invisible in light mode — must not come back.
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
 })

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -4,56 +4,56 @@ export const ProfileLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading profile" className="space-y-6">
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <div className="relative h-36 animate-pulse bg-muted md:h-52" />
+        <div className="skeleton relative h-36 md:h-52" />
 
         <div className="relative px-6 pb-6">
-          <div className="relative -mt-10 h-20 w-20 animate-pulse rounded-full border-4 border-background bg-muted" />
+          <div className="skeleton relative -mt-10 h-20 w-20 rounded-full border-4 border-background" />
 
           <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-2">
-              <div className="h-7 w-48 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
+              <div className="skeleton h-7 w-48 rounded-md" />
+              <div className="skeleton h-4 w-32 rounded-md" />
             </div>
-            <div className="h-9 w-28 animate-pulse rounded-md bg-muted" />
+            <div className="skeleton h-9 w-28 rounded-md" />
           </div>
 
           <div className="mt-4 space-y-2">
-            <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+            <div className="skeleton h-4 w-3/4 rounded" />
+            <div className="skeleton h-4 w-1/2 rounded" />
           </div>
 
           <div className="mt-5 flex flex-wrap gap-6">
-            <div className="h-4 w-16 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
-            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+            <div className="skeleton h-4 w-16 rounded" />
+            <div className="skeleton h-4 w-20 rounded" />
+            <div className="skeleton h-4 w-20 rounded" />
           </div>
         </div>
       </section>
 
       <div className="space-y-4">
         <div className="flex gap-2">
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
-          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted" />
+          <div className="skeleton h-9 w-20 rounded-lg" />
+          <div className="skeleton h-9 w-20 rounded-lg" />
+          <div className="skeleton h-9 w-20 rounded-lg" />
         </div>
 
         <div className="divide-y overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
           {[0, 1, 2].map((index) => (
             <div key={index} className="flex gap-3 p-4">
-              <div className="size-10 shrink-0 animate-pulse rounded-full bg-muted" />
+              <div className="skeleton size-10 shrink-0 rounded-full" />
               <div className="min-w-0 flex-1 space-y-2">
                 <div className="flex items-center gap-2">
-                  <div className="h-4 w-32 animate-pulse rounded bg-muted" />
-                  <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+                  <div className="skeleton h-4 w-32 rounded" />
+                  <div className="skeleton h-3 w-20 rounded" />
                 </div>
                 <div className="space-y-1.5">
-                  <div className="h-4 w-full animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
+                  <div className="skeleton h-4 w-full rounded" />
+                  <div className="skeleton h-4 w-4/5 rounded" />
                 </div>
                 <div className="flex gap-6 pt-2">
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
-                  <div className="h-4 w-8 animate-pulse rounded bg-muted" />
+                  <div className="skeleton h-4 w-8 rounded" />
+                  <div className="skeleton h-4 w-8 rounded" />
+                  <div className="skeleton h-4 w-8 rounded" />
                 </div>
               </div>
             </div>

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -4,10 +4,10 @@ export const ProfileLoading: FC = () => {
   return (
     <div aria-busy="true" aria-label="Loading profile" className="space-y-6">
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <div className="skeleton relative h-36 md:h-52" />
+        <div className="skeleton h-36 md:h-52" />
 
         <div className="relative px-6 pb-6">
-          <div className="skeleton relative -mt-10 h-20 w-20 rounded-full border-4 border-background" />
+          <div className="skeleton -mt-10 h-20 w-20 rounded-full border-4 border-background" />
 
           <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-2">

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,9 +178,8 @@
   --control-active: hsl(0 0% 30%);
 
   /* Loading skeleton: on the dark ramp visibility comes from going UP — the
-     base sits above the 9% card and the 17% muted track. The highlight is a
-     faint white wash; anything stronger reads as a flashlight sweep on the
-     dark surface. */
+     base sits above the 9% card. The highlight is a faint white wash;
+     anything stronger reads as a flashlight sweep on the dark surface. */
   --skeleton: hsl(0 0% 20%);
   --skeleton-highlight: hsl(0 0% 100% / 0.09);
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,17 @@
      (--muted) track. */
   --control-active: hsl(0 0% 100%);
 
+  /* Loading skeleton placeholder, plus the band the `skeleton` utility sweeps
+     across it. Deliberately NOT --muted: that is a hover/track surface tuned
+     to sit barely off the card (96.1% on the white background), which is why
+     the old `animate-pulse bg-muted` skeletons were invisible — the pulse's
+     whole animated range stayed within ~2 points of lightness. The base must
+     read as a placeholder at rest, because the static block is the entire
+     treatment under prefers-reduced-motion. Guarded by
+     app/globals.skeleton.test.ts. */
+  --skeleton: hsl(0 0% 90%);
+  --skeleton-highlight: hsl(0 0% 100% / 0.75);
+
   /* Link colors for markdown content */
   --link-color: oklch(0.588 0.158 241.966);
   --link-color-hover: oklch(0.518 0.158 241.966);
@@ -165,6 +176,13 @@
   /* The raised active segment sits ~13% above the --muted track (elevation via
      lightness, not shadow). */
   --control-active: hsl(0 0% 30%);
+
+  /* Loading skeleton: on the dark ramp visibility comes from going UP — the
+     base sits above the 9% card and the 17% muted track. The highlight is a
+     faint white wash; anything stronger reads as a flashlight sweep on the
+     dark surface. */
+  --skeleton: hsl(0 0% 20%);
+  --skeleton-highlight: hsl(0 0% 100% / 0.09);
 
   /* Link colors for markdown content */
   --link-color: oklch(0.746 0.16 232.661);
@@ -252,6 +270,46 @@
 
   .no-scrollbar::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Loading placeholder with a moving shimmer band, replacing the stock
+     `animate-pulse bg-muted` treatment whose opacity fade blended an already
+     near-invisible grey TOWARD the background. The sweep is a pseudo-element
+     transform rather than an animated background-position so it stays
+     compositor-friendly, and `overflow: hidden` clips the band to the block's
+     own border radius. Under prefers-reduced-motion the band is removed
+     entirely, leaving the static tinted block — which is why --skeleton must
+     stay visible at rest (app/globals.skeleton.test.ts). */
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    background-color: var(--skeleton);
+  }
+
+  .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background-image: linear-gradient(
+      90deg,
+      transparent,
+      var(--skeleton-highlight) 50%,
+      transparent
+    );
+    animation: skeleton-shimmer 1.6s ease-in-out infinite;
+  }
+
+  @keyframes skeleton-shimmer {
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton::after {
+      display: none;
+    }
   }
 }
 

--- a/app/globals.skeleton.test.ts
+++ b/app/globals.skeleton.test.ts
@@ -55,6 +55,7 @@ const lightnessAndAlphaOf = (
   }
 }
 
+/** Lightness only, for callers that never need the alpha channel. */
 const lightnessOf = (value: string): number =>
   lightnessAndAlphaOf(value).lightness
 
@@ -93,14 +94,13 @@ describe('skeleton loading utility', () => {
       // green. Lightness-space compositing is exact for these grey (0% sat)
       // tokens, and the parser throws loudly on any other value form.
       const block = blockOf(theme)
-      const base = lightnessAndAlphaOf(tokenOf(block, '--skeleton'))
+      const base = lightnessOf(tokenOf(block, '--skeleton'))
       const highlight = lightnessAndAlphaOf(
         tokenOf(block, '--skeleton-highlight')
       )
       const effective =
-        highlight.alpha * highlight.lightness +
-        (1 - highlight.alpha) * base.lightness
-      expect(Math.abs(effective - base.lightness)).toBeGreaterThanOrEqual(5)
+        highlight.alpha * highlight.lightness + (1 - highlight.alpha) * base
+      expect(Math.abs(effective - base)).toBeGreaterThanOrEqual(5)
     }
   )
 

--- a/app/globals.skeleton.test.ts
+++ b/app/globals.skeleton.test.ts
@@ -13,8 +13,11 @@ import { describe, expect, it } from 'vitest'
  * BOTH themes (a token defined only for light silently loses dark), the base
  * tone must stay visibly distinct from the surfaces it loads over (the bug the
  * utility replaced: `animate-pulse bg-muted` at 96.1% lightness on the white
- * background left the whole animation within ~2 points of lightness), and the
- * shimmer must be stilled under prefers-reduced-motion.
+ * background left the whole animation within ~2 points of lightness), the
+ * composited highlight band must stay visibly distinct from the base in each
+ * theme (a highlight whose blended lightness matches the base renders the
+ * shimmer invisible while every other assertion stays green), and the shimmer
+ * must be stilled under prefers-reduced-motion.
  */
 
 // Strip comments first so token parsing cannot match `--token`-like text
@@ -38,12 +41,22 @@ const tokenOf = (block: string, name: string): string => {
   return match[1].trim()
 }
 
-/** Lightness (0-100) of a space-separated `hsl(H S% L% [/ A])` value. */
-const lightnessOf = (value: string): number => {
-  const match = value.match(/hsl\(\s*[\d.]+\s+[\d.]+%\s+([\d.]+)%/)
+/** Lightness (0-100) and alpha (0-1) of a space-separated `hsl(H S% L% [/ A])` value. */
+const lightnessAndAlphaOf = (
+  value: string
+): { lightness: number; alpha: number } => {
+  const match = value.match(
+    /hsl\(\s*[\d.]+\s+[\d.]+%\s+([\d.]+)%(?:\s*\/\s*([\d.]+))?\s*\)/
+  )
   if (!match) throw new Error(`Not a space-separated hsl() value: ${value}`)
-  return Number(match[1])
+  return {
+    lightness: Number(match[1]),
+    alpha: match[2] === undefined ? 1 : Number(match[2])
+  }
 }
+
+const lightnessOf = (value: string): number =>
+  lightnessAndAlphaOf(value).lightness
 
 describe('skeleton loading utility', () => {
   it('defines the .skeleton class the loading skeletons apply', () => {
@@ -71,6 +84,25 @@ describe('skeleton loading utility', () => {
     const card = lightnessOf(tokenOf(dark, '--card'))
     expect(skeleton).toBeGreaterThanOrEqual(card + 8)
   })
+
+  it.each([':root', '.dark'])(
+    'keeps the %s shimmer band visible against the base',
+    (theme) => {
+      // The highlight IS the shimmer: a band whose composited lightness matches
+      // the base renders the sweep invisible while every other assertion stays
+      // green. Lightness-space compositing is exact for these grey (0% sat)
+      // tokens, and the parser throws loudly on any other value form.
+      const block = blockOf(theme)
+      const base = lightnessAndAlphaOf(tokenOf(block, '--skeleton'))
+      const highlight = lightnessAndAlphaOf(
+        tokenOf(block, '--skeleton-highlight')
+      )
+      const effective =
+        highlight.alpha * highlight.lightness +
+        (1 - highlight.alpha) * base.lightness
+      expect(Math.abs(effective - base.lightness)).toBeGreaterThanOrEqual(5)
+    }
+  )
 
   it('stills the shimmer under prefers-reduced-motion', () => {
     expect(css).toMatch(

--- a/app/globals.skeleton.test.ts
+++ b/app/globals.skeleton.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards for the `skeleton` loading utility in app/globals.css.
+ *
+ * The class is applied by the `(timeline)/[actor]` loading skeletons, but
+ * jsdom renders no CSS, so no component test can notice the definition
+ * disappearing — exactly how `no-scrollbar` was once applied for a long time
+ * while being defined nowhere and silently did nothing. These assertions read
+ * the live stylesheet: the utility must exist, its tokens must be declared in
+ * BOTH themes (a token defined only for light silently loses dark), the base
+ * tone must stay visibly distinct from the surfaces it loads over (the bug the
+ * utility replaced: `animate-pulse bg-muted` at 96.1% lightness on the white
+ * background left the whole animation within ~2 points of lightness), and the
+ * shimmer must be stilled under prefers-reduced-motion.
+ */
+
+// Strip comments first so token parsing cannot match `--token`-like text
+// inside a rationale comment (same treatment as app/globals.contrast.test.ts).
+const css = readFileSync(
+  fileURLToPath(new URL('./globals.css', import.meta.url)),
+  'utf8'
+).replace(/\/\*[\s\S]*?\*\//g, '')
+
+/** Extract the body of the first top-level CSS block for a selector. */
+const blockOf = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  if (!match) throw new Error(`Could not find CSS block for ${selector}`)
+  return match[1]
+}
+
+const tokenOf = (block: string, name: string): string => {
+  const match = block.match(new RegExp(`${name}\\s*:\\s*([^;]+);`))
+  if (!match) throw new Error(`No ${name} declaration in block`)
+  return match[1].trim()
+}
+
+/** Lightness (0-100) of a space-separated `hsl(H S% L% [/ A])` value. */
+const lightnessOf = (value: string): number => {
+  const match = value.match(/hsl\(\s*[\d.]+\s+[\d.]+%\s+([\d.]+)%/)
+  if (!match) throw new Error(`Not a space-separated hsl() value: ${value}`)
+  return Number(match[1])
+}
+
+describe('skeleton loading utility', () => {
+  it('defines the .skeleton class the loading skeletons apply', () => {
+    expect(css).toMatch(/\.skeleton\s*\{/)
+    expect(css).toMatch(/\.skeleton::after\s*\{/)
+    expect(css).toMatch(/@keyframes skeleton-shimmer/)
+  })
+
+  it.each([':root', '.dark'])('declares the skeleton tokens in %s', (theme) => {
+    const block = blockOf(theme)
+    expect(tokenOf(block, '--skeleton')).toBeTruthy()
+    expect(tokenOf(block, '--skeleton-highlight')).toBeTruthy()
+  })
+
+  it('keeps the light skeleton visibly darker than the background', () => {
+    const root = blockOf(':root')
+    const skeleton = lightnessOf(tokenOf(root, '--skeleton'))
+    const background = lightnessOf(tokenOf(root, '--background'))
+    expect(skeleton).toBeLessThanOrEqual(background - 8)
+  })
+
+  it('keeps the dark skeleton visibly lighter than the card', () => {
+    const dark = blockOf('.dark')
+    const skeleton = lightnessOf(tokenOf(dark, '--skeleton'))
+    const card = lightnessOf(tokenOf(dark, '--card'))
+    expect(skeleton).toBeGreaterThanOrEqual(card + 8)
+  })
+
+  it('stills the shimmer under prefers-reduced-motion', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{\s*\.skeleton::after\s*\{[^}]*display:\s*none/
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The `(timeline)/[actor]` loading skeletons — profile, followers, following, and status detail — were effectively invisible in light mode. They used Tailwind's stock `animate-pulse` over `bg-muted`, and the light-theme `--muted` (96.1% lightness) sits ~4 lightness points off the white background; since `animate-pulse` fades the block *toward* the background, the entire animated range stayed within ~2 points of lightness. (An earlier shimmer attempt, `383a73fca`, shipped invisible for this same reason and was reverted twice — the guards below exist so this one can't quietly regress the same way.)

This PR replaces that treatment with a shared `skeleton` utility in `app/globals.css`:

- **New `--skeleton` / `--skeleton-highlight` tokens, declared in both themes.** The base tone is clearly distinct from the surfaces it loads over (90% light, 20% dark). `--muted` is untouched — it is a hover/track surface used all over the app.
- **A shimmer sweep**: a `::after` gradient band translated across each block. The animation is a `transform`, not an animated `background-position`, so it stays compositor-friendly, and `overflow: hidden` clips the band to each block's own border radius.
- **`prefers-reduced-motion: reduce` removes the band entirely**, leaving the static tinted block. Because the base is now visible at rest, reduced-motion users get a real placeholder where the old treatment gave them near-white nothing.
- The four `[actor]` loading files swap `animate-pulse bg-muted` for `skeleton`; every shape and layout class is unchanged.

## Tests

- New `app/globals.skeleton.test.ts` pins the stylesheet itself: the `.skeleton` rule exists (guarding the `no-scrollbar` applied-while-defined-nowhere failure mode), both themes declare the tokens, the base tone stays ≥8 lightness points off its surface in each theme, the composited shimmer band stays ≥5 lightness points off the base in each theme (a highlight blending to the base's own lightness renders the sweep invisible), and the reduced-motion block stills the band.
- Each of the four loading tests asserts **every leaf `<div>` carries `skeleton`** (jsdom paints no CSS, so class presence is the guard) — a bare `length > 0` was shown by mutation to pass with a single styled placeholder — plus that `animate-pulse` is gone.

## Verification

- `yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test` all green locally (932 files / 12,451 tests).
- Verified in a real browser against a seeded local SQLite instance (AGENTS.md recipe): light and dark skeletons are clearly visible with the band sweeping (two frames show it at different positions); computed styles confirm `skeleton-shimmer` animates the `::after` band; under emulated `prefers-reduced-motion: reduce` the band computes to `display: none`. Light / dark / reduced-motion screenshots were captured in the working session (`gh` cannot upload images to PR bodies — they can be dragged in from there).

## Review

The sub-agent review loop ran 3 rounds (5 lenses per full round + adversarial verification of each finding): round 1 produced 4 verified findings (the two test-coverage gaps above, found by mutation; an over-claiming CSS comment, trimmed; two redundant `relative` tokens, dropped), round 2 produced 2 minor consistency findings in the new test code, round 3 was clean. All 6 inline threads are replied-to and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
