### PR TITLE
Bump version to v1.154.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.153.7",
+  "version": "1.154.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.154.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.153.7`
- Base main SHA: `d4518704cd330561601c9eb7ef244e90b285e331`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
