### PR TITLE
fix: swap the featured-hashtags loading placeholder onto the shared skeleton utility

### DIFF
--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -72,10 +72,8 @@ describe('FeaturedTagsEditor', () => {
 
     const { container } = render(<FeaturedTagsEditor />)
 
-    // jsdom paints no CSS, so the class is the observable: the shimmer lives
-    // on the `skeleton` utility (app/globals.css, guarded by
-    // app/globals.skeleton.test.ts), and the old animate-pulse-on-bg-muted
-    // treatment — near-invisible in light mode — must not come back.
+    // jsdom paints no CSS, so the class is the observable — see
+    // app/globals.skeleton.test.ts for the definition guard.
     expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
     expect(container.querySelector('.animate-pulse')).toBeNull()
 

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -10,6 +10,7 @@ import {
   getFeaturedTags,
   removeFeaturedTag
 } from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 
 import { FeaturedTagsEditor } from './FeaturedTagsEditor'
@@ -57,6 +58,28 @@ describe('FeaturedTagsEditor', () => {
 
   it('shows the empty state when the account has no featured tags', async () => {
     render(<FeaturedTagsEditor />)
+    expect(
+      await screen.findByText('No featured hashtags yet')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the loading placeholders with the shimmer skeleton utility', async () => {
+    // Hold the tags request pending so the assertion really sees the in-flight
+    // skeleton — an already-resolved mock collapses the pending render and the
+    // settled one into a single flush.
+    const pendingTags = createDeferred<FeaturedTag[]>()
+    mockGetFeaturedTags.mockReturnValue(pendingTags.promise)
+
+    const { container } = render(<FeaturedTagsEditor />)
+
+    // jsdom paints no CSS, so the class is the observable: the shimmer lives
+    // on the `skeleton` utility (app/globals.css, guarded by
+    // app/globals.skeleton.test.ts), and the old animate-pulse-on-bg-muted
+    // treatment — near-invisible in light mode — must not come back.
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+
+    pendingTags.resolve([])
     expect(
       await screen.findByText('No featured hashtags yet')
     ).toBeInTheDocument()

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -83,12 +83,12 @@ const LoadingSkeleton: FC = () => (
         key={index}
         className="flex items-center gap-3 rounded-lg border p-3"
       >
-        <span className="h-9 w-9 shrink-0 animate-pulse rounded-lg bg-muted" />
+        <span className="skeleton h-9 w-9 shrink-0 rounded-lg" />
         <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="h-3.5 w-28 animate-pulse rounded bg-muted" />
-          <div className="h-3 w-44 animate-pulse rounded bg-muted" />
+          <div className="skeleton h-3.5 w-28 rounded" />
+          <div className="skeleton h-3 w-44 rounded" />
         </div>
-        <span className="h-8 w-8 shrink-0 animate-pulse rounded-md bg-muted" />
+        <span className="skeleton h-8 w-8 shrink-0 rounded-md" />
       </div>
     ))}
   </div>


### PR DESCRIPTION
## Summary

#1702 replaced the invisible `animate-pulse bg-muted` loading-placeholder treatment with the shared `skeleton` utility across the four `(timeline)/[actor]` loading files. One placeholder was left behind: the `LoadingSkeleton` inside `app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx`, which still faded a near-invisible `bg-muted` toward the background.

This PR swaps its four placeholder blocks (hash tile, two text lines, remove-button block) onto the `skeleton` utility — `animate-pulse` and `bg-muted` dropped, every sizing and rounding class unchanged — mirroring the `[actor]` loading files. The other `animate-pulse` uses in `lib/components/fitness/RegionHeatmapDetail.tsx` are an indeterminate progress-bar fill and a cancel-icon pulse, not placeholders, and are deliberately untouched; after this change no placeholder skeleton in `app/` or `lib/` uses the old treatment.

**Stacked on #1702** (base is its branch, so the diff here is only this change). When #1702 squash-merges, this PR retargets to `main` and needs a rebase onto it (`git rebase --onto origin/main ef64535da`) before merging.

## Tests

- `FeaturedTagsEditor.test.tsx` gains a test in the shape of `app/(timeline)/[actor]/loading.test.tsx`: it holds the featured-tags request pending with `createDeferred` so the in-flight skeleton is really rendered, then asserts `querySelectorAll('.skeleton').length > 0` and no `.animate-pulse` (jsdom paints no CSS, so class presence is the guard). Written first and watched fail against the old classes.
- All 15 tests in the file pass; full suite: 932 files / 12,450 tests green.

## Verification

- `yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test` all green locally.
- Verified in a real browser against a seeded local SQLite instance (AGENTS.md recipe), holding the `/api/v1/featured_tags` responses so the skeleton stays up: 12 `.skeleton` blocks and zero `.animate-pulse`; computed styles show the base at `rgb(230,230,230)` in light and `rgb(51,51,51)` in dark (the `--skeleton` tokens), `overflow: hidden`, and the `::after` band animating `skeleton-shimmer`. Loaded state renders the normal empty state afterwards. Light/dark skeleton and loaded-state screenshots were captured in the working session (`gh` cannot upload images to PR bodies — they can be dragged in from there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)