### PR TITLE
Bump version to v1.154.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.154.0",
+  "version": "1.154.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.154.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.154.0`
- Base main SHA: `c6baf0955239ed13e0739a8c621c7bb1ad35d798`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
