### PR TITLE
Bump version to v1.154.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.154.1",
+  "version": "1.154.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.154.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.154.1`
- Base main SHA: `82ee8417409235fca18e5035aa7fa7ab6ed5f092`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
