### PR TITLE
fix: harden remote actor persistence and relationship/NodeInfo fan-out

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -3,6 +3,7 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
@@ -18,6 +19,7 @@ vi.mock('@/lib/activities/getActorCollectionCounts')
 vi.mock('@/lib/activities/getActorPerson')
 vi.mock('@/lib/activities/getActorPosts')
 vi.mock('@/lib/activities/getWebfingerSelf')
+vi.mock('@/lib/services/federation/domainPolicy')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/utils/getPersonFromActor')
 vi.mock('@/lib/utils/logger', () => ({
@@ -39,6 +41,7 @@ describe('getProfileData', () => {
     getActorHasFitnessData: vi.fn(),
     getAcceptedOrRequestedFollow: vi.fn(),
     setActorCounters: vi.fn(),
+    getActorFromId: vi.fn(),
     updateActor: vi.fn(),
     createActor: vi.fn()
   } as unknown as Database
@@ -98,6 +101,16 @@ describe('getProfileData', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // `canFederateWithDomain` comes from an auto-mocked module (a vi.mock-factory
+    // fn), so it is not reset by restoreAllMocks — set its default explicitly.
+    // Default to allowed so the existing remote-branch tests are unaffected.
+    ;(canFederateWithDomain as jest.Mock).mockResolvedValue(true)
+    // The remote branch now decides update-vs-create by looking up person.id.
+    // Default to an existing row (update path); tests exercising creation
+    // override this to null.
+    ;(mockDatabase.getActorFromId as jest.Mock).mockResolvedValue({
+      id: 'https://remote.com/users/remoteuser'
+    })
     ;(mockDatabase.getActorStatuses as jest.Mock).mockResolvedValue(
       mockStatuses
     )
@@ -486,6 +499,8 @@ describe('getProfileData', () => {
 
     it('creates newly discovered remote actor in database when persistedActor does not exist', async () => {
       ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(null)
+      // No row under person.id yet — the create branch.
+      ;(mockDatabase.getActorFromId as jest.Mock).mockResolvedValue(null)
       ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
         followersCount: 100,
         followingCount: 50,
@@ -629,6 +644,139 @@ describe('getProfileData', () => {
       expect('signingActor' in personCall).toBe(false)
       const postsCall = (getActorPosts as jest.Mock).mock.calls[0][0]
       expect('signingActor' in postsCall).toBe(false)
+    })
+
+    // Fix A: the update-vs-create decision is keyed on the id actually written
+    // (person.id), not on the handle persistedActor was resolved from, and the
+    // insert survives a concurrent loser + a federation gate fronts the fetch.
+    describe('remote actor persistence hardening', () => {
+      // A split-domain deployment: the handle is @llun@llun.dev but the actor
+      // id lives on social.llun.dev, so getActorFromUsername (keyed on the
+      // handle domain) misses while getActorFromId (keyed on person.id) hits.
+      const splitDomainPerson: Actor = {
+        ...mockPerson,
+        id: 'https://social.llun.dev/users/llun',
+        preferredUsername: 'llun'
+      }
+
+      it('updates the existing row keyed on person.id, not the handle, on a split-domain host', async () => {
+        // Handle lookup misses (its domain differs from the stored id's host).
+        ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(
+          null
+        )
+        ;(getWebfingerSelf as jest.Mock).mockResolvedValue(splitDomainPerson.id)
+        ;(getActorPerson as jest.Mock).mockResolvedValue(splitDomainPerson)
+        // A row already exists under person.id.
+        ;(mockDatabase.getActorFromId as jest.Mock).mockResolvedValue({
+          id: splitDomainPerson.id
+        })
+
+        const result = await getProfileData(
+          mockDatabase,
+          '@llun@llun.dev',
+          true,
+          { currentActor: null }
+        )
+
+        expect(result).not.toBeNull()
+        expect(mockDatabase.getActorFromId).toHaveBeenCalledWith({
+          id: splitDomainPerson.id
+        })
+        expect(mockDatabase.updateActor).toHaveBeenCalledWith(
+          expect.objectContaining({ actorId: splitDomainPerson.id })
+        )
+        expect(mockDatabase.createActor).not.toHaveBeenCalled()
+      })
+
+      it('recovers by updating when a concurrent insert already claimed the id', async () => {
+        ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(
+          null
+        )
+        // No row when we look, so we take the create branch...
+        ;(mockDatabase.getActorFromId as jest.Mock).mockResolvedValue(null)
+        // ...but a concurrent render wins the insert first.
+        ;(mockDatabase.createActor as jest.Mock).mockRejectedValue(
+          Object.assign(new Error('UNIQUE constraint failed: actors.id'), {
+            code: 'SQLITE_CONSTRAINT_UNIQUE'
+          })
+        )
+
+        const result = await getProfileData(
+          mockDatabase,
+          '@remoteuser@remote.com',
+          true,
+          { currentActor: null }
+        )
+
+        expect(result).not.toBeNull()
+        expect(mockDatabase.createActor).toHaveBeenCalled()
+        expect(mockDatabase.updateActor).toHaveBeenCalledWith(
+          expect.objectContaining({ actorId: mockPerson.id })
+        )
+      })
+
+      it('rethrows a non-unique insert error', async () => {
+        ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(
+          null
+        )
+        ;(mockDatabase.getActorFromId as jest.Mock).mockResolvedValue(null)
+        ;(mockDatabase.createActor as jest.Mock).mockRejectedValue(
+          new Error('connection reset')
+        )
+
+        await expect(
+          getProfileData(mockDatabase, '@remoteuser@remote.com', true, {
+            currentActor: null
+          })
+        ).rejects.toThrow('connection reset')
+      })
+
+      it('does not fetch or persist an actor from a non-federatable domain', async () => {
+        ;(canFederateWithDomain as jest.Mock).mockResolvedValue(false)
+
+        const result = await getProfileData(
+          mockDatabase,
+          '@remoteuser@remote.com',
+          true,
+          { currentActor: null }
+        )
+
+        expect(result).toBeNull()
+        expect(getActorPerson).not.toHaveBeenCalled()
+        expect(mockDatabase.createActor).not.toHaveBeenCalled()
+        expect(mockDatabase.updateActor).not.toHaveBeenCalled()
+      })
+
+      // The WebFinger id can be federatable while the server's own canonical
+      // person.id lands on a host that is not — the id actually written. The
+      // second gate must refuse that after the fetch, before any persist.
+      it('refuses to persist when person.id resolves to a non-federatable host', async () => {
+        ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(
+          null
+        )
+        ;(getWebfingerSelf as jest.Mock).mockResolvedValue(
+          'https://llun.dev/users/llun'
+        )
+        ;(getActorPerson as jest.Mock).mockResolvedValue(splitDomainPerson)
+        ;(canFederateWithDomain as jest.Mock).mockImplementation(
+          async (_database: unknown, value: string) =>
+            !value.includes('social.llun.dev')
+        )
+
+        const result = await getProfileData(
+          mockDatabase,
+          '@llun@llun.dev',
+          true,
+          { currentActor: null }
+        )
+
+        expect(result).toBeNull()
+        // The first gate passed, so the fetch happened...
+        expect(getActorPerson).toHaveBeenCalled()
+        // ...but the person.id gate refused the write.
+        expect(mockDatabase.createActor).not.toHaveBeenCalled()
+        expect(mockDatabase.updateActor).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -3,7 +3,9 @@ import { getActorCollectionCounts } from '@/lib/activities/getActorCollectionCou
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import {
   canActorReadStatus,
@@ -15,6 +17,7 @@ import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 type ProfileData = {
   person: Actor
@@ -176,26 +179,61 @@ export const getProfileData = async (
   ])
   if (!actorId) return null
 
+  // Don't fetch or persist actors from domains this instance won't federate
+  // with. Without this gate a hot profile render would search-index and store
+  // an actor from a blocked or (in allowlist mode) non-allowlisted domain. The
+  // WebFinger-resolved id decides federation policy, and it is re-checked
+  // against `person.id` below because that id — the server's own choice of
+  // canonical id — can name a different host.
+  if (!(await canFederateWithDomain(database, actorId))) return null
+
   const signingParams = signingActor ? { signingActor } : {}
   const person = await getActorPerson({ actorId, ...signingParams })
   if (!person) return null
 
-  if (persistedActor) {
+  // The id actually written is `person.id`, not the WebFinger id, so the
+  // federation gate is applied again to the id we persist and index — a
+  // split-domain deployment answers WebFinger for `@llun@llun.dev` with a
+  // Person whose id lives on `social.llun.dev`, so the two hosts differ.
+  if (!(await canFederateWithDomain(database, person.id))) return null
+
+  // Look up the row by the id we are about to write (`person.id`), NOT by the
+  // handle `persistedActor` was resolved from. On a split-domain deployment the
+  // handle (`llun@llun.dev`) and the stored id's host (`social.llun.dev`)
+  // differ, so `getActorFromUsername` misses forever while the row already
+  // exists under `person.id`. Keying the update/create decision on the handle
+  // therefore re-entered the create branch on every render and re-inserted the
+  // same id — a permanent 500 on the `actors_id_unique` constraint.
+  const storedActor = await database.getActorFromId({ id: person.id })
+  const persistableProfile = getPersistableProfile(person)
+  if (storedActor) {
     // Same field set recordActorIfNeeded persists, so the web profile page
     // and the Mastodon API refresh paths write consistent snapshots (including
     // metadata fields and the locked state).
     await database.updateActor({
       actorId: person.id,
-      ...getPersistableProfile(person)
+      ...persistableProfile
     })
   } else {
-    await database.createActor({
-      actorId: person.id,
-      username: person.preferredUsername,
-      domain: new URL(person.id).host,
-      ...getPersistableProfile(person),
-      createdAt: new Date(person.published ?? Date.now()).getTime()
-    })
+    // A concurrent render can insert the same id between the read above and
+    // this insert. Rather than serialize the whole render, treat the unique
+    // violation as "someone else won the race" and fall back to the update the
+    // winner's row now needs — any other error is real and rethrown.
+    try {
+      await database.createActor({
+        actorId: person.id,
+        username: person.preferredUsername,
+        domain: new URL(person.id).host,
+        ...persistableProfile,
+        createdAt: new Date(person.published ?? Date.now()).getTime()
+      })
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) throw error
+      await database.updateActor({
+        actorId: person.id,
+        ...persistableProfile
+      })
+    }
   }
 
   // A remote actor's attachments are the ones their statuses brought here when
@@ -248,7 +286,7 @@ export const getProfileData = async (
     logger.warn({
       message: 'Failed to persist remote actor collection counts',
       actorId: person.id,
-      error: error instanceof Error ? error.message : String(error)
+      err: toLoggableError(error)
     })
   }
 

--- a/app/(timeline)/[actor]/profileFollowLookup.test.ts
+++ b/app/(timeline)/[actor]/profileFollowLookup.test.ts
@@ -83,6 +83,11 @@ describe('profile follow lookup', () => {
     getActorFollowingCount: vi.fn(),
     getActorFollowersCount: vi.fn(),
     getActorHasFitnessData: vi.fn(),
+    // canFederateWithDomain (federation gate added on the remote persist path)
+    getDomainBlockForDomain: vi.fn().mockResolvedValue(null),
+    getDomainAllowForDomain: vi.fn().mockResolvedValue(null),
+    // getProfileData persist branch resolves by the written id (person.id)
+    getActorFromId: vi.fn().mockResolvedValue(null),
     // getRelationship
     isCurrentActorFollowing: vi.fn(),
     isBlocking: vi.fn(),

--- a/app/api/v1/accounts/relationships/route.test.ts
+++ b/app/api/v1/accounts/relationships/route.test.ts
@@ -1,14 +1,31 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { getRelationship } from '@/lib/services/accounts/relationship'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { generatePublicId } from '@/lib/utils/publicId'
 import { urlToId } from '@/lib/utils/urlToId'
 
-import { GET } from './route'
+import { GET, MAX_BATCH_RELATIONSHIPS } from './route'
+
+// Partial mock so getRelationship's default is the REAL implementation
+// (`vi.fn(actual.getRelationship)`) — every test below runs real behaviour —
+// while the "one failing id drops" test can queue a single rejection with
+// `mockRejectedValueOnce`, after which calls fall back to the real impl. Read
+// through the STATIC import above, not vi.importMock: the factory awaits
+// importOriginal, so vi.importMock would hand back the original module instead
+// of this mock (per AGENTS.md, Testing Guidelines).
+vi.mock('@/lib/services/accounts/relationship', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/services/accounts/relationship')
+    >()
+  return { ...actual, getRelationship: vi.fn(actual.getRelationship) }
+})
 
 const mockGetServerSession = vi.fn()
 vi.mock('@/lib/services/auth/getSession', () => ({
@@ -141,5 +158,71 @@ describe('GET /api/v1/accounts/relationships', () => {
       params: Promise.resolve({})
     })
     expect(response.status).toBe(401)
+  })
+
+  // An id that resolves to something that is not an actor URI is dropped by the
+  // isResolvedActorUri filter on the resolver OUTPUT, rather than reaching
+  // getRelationship with a non-id. A publicId-shaped value with no row resolves
+  // to the bare uuid, which is not a URI.
+  it('drops an id that resolves to a non-actor URI', async () => {
+    const response = await GET(createRequest(`id[]=${generatePublicId()}`), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+  })
+
+  // Characterization test pinning the LIVE falsy guard: idToUrl returns '' for a
+  // bad apurl_ value, and the `!targetActorId` guard drops it. This is not dead
+  // code — removing that guard would let '' reach getRelationship.
+  it('drops a bad apurl_ id via the empty-string falsy guard', async () => {
+    const response = await GET(createRequest('id[]=apurl_not-valid-base64!!'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+  })
+
+  it('deduplicates repeated ids', async () => {
+    const id = urlToId(ACTOR2_ID)
+    const response = await GET(createRequest(`id[]=${id}&id[]=${id}`), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toHaveLength(1)
+  })
+
+  it('caps the batch at MAX_BATCH_RELATIONSHIPS distinct ids', async () => {
+    const query = Array.from(
+      { length: MAX_BATCH_RELATIONSHIPS + 5 },
+      (_unused, index) =>
+        `id[]=${encodeURIComponent(`https://remote.test/users/u${index}`)}`
+    ).join('&')
+
+    const response = await GET(createRequest(query), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toHaveLength(MAX_BATCH_RELATIONSHIPS)
+  })
+
+  // Awaiting getRelationship inside the try is what makes the catch reachable;
+  // one failing id is dropped rather than rejecting the whole Promise.all.
+  it('drops a single failing id instead of failing the request', async () => {
+    vi.mocked(getRelationship).mockRejectedValueOnce(new Error('boom'))
+
+    const query = `id[]=${urlToId(ACTOR2_ID)}&id[]=${urlToId(ACTOR3_ID)}`
+    const response = await GET(createRequest(query), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toHaveLength(1)
+    expect(data[0].id).toBe(await emittedActorId(ACTOR3_ID))
   })
 })

--- a/app/api/v1/accounts/relationships/route.ts
+++ b/app/api/v1/accounts/relationships/route.ts
@@ -3,14 +3,24 @@ import {
   OAuthGuardAnyScope,
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
-import { resolveActorIdParams } from '@/lib/services/mastodon/resolveClientId'
+import {
+  isResolvedActorUri,
+  resolveActorIdParams
+} from '@/lib/services/mastodon/resolveClientId'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+// Upper bound on how many accounts a single relationships request may ask
+// about. Mastodon does not document a cap; dedupe + truncate the way
+// `GET /api/v1/accounts` does rather than letting a header-sized id list drive
+// the per-request work. Exported so the route test can exercise truncation.
+export const MAX_BATCH_RELATIONSHIPS = 100
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -28,11 +38,16 @@ export const GET = traceApiRoute(
       const { database, currentActor } = context
 
       const url = new URL(req.url)
-      // Preserve request order and accept both `id[]` and bare `id`.
-      const accountIds = [
-        ...url.searchParams.getAll('id[]'),
-        ...url.searchParams.getAll('id')
-      ].filter(Boolean)
+      // Deduplicate and bound the requested ids, then preserve request order.
+      // Accept both `id[]` and bare `id`.
+      const accountIds = Array.from(
+        new Set(
+          [
+            ...url.searchParams.getAll('id[]'),
+            ...url.searchParams.getAll('id')
+          ].filter(Boolean)
+        )
+      ).slice(0, MAX_BATCH_RELATIONSHIPS)
 
       if (!accountIds.length) {
         return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
@@ -47,17 +62,29 @@ export const GET = traceApiRoute(
         accountIds.map(async (encodedAccountId, index) => {
           try {
             const targetActorId = resolvedIds[index]
-            if (!targetActorId) return null
-            return getRelationship({
+            // Keep the falsy guard AND filter to actual URIs: `idToUrl` returns
+            // '' for a bad `apurl_` (so the falsy guard is live), and returns an
+            // unknown publicId or an unparseable value unchanged — neither is an
+            // actor URI, and `getRelationship` would then key a lookup on a
+            // non-id. The filter runs on the resolver OUTPUT only; it prunes no
+            // input form the resolver accepts.
+            if (!targetActorId || !isResolvedActorUri(targetActorId))
+              return null
+            // Awaited inside the try so a rejection is caught HERE and drops
+            // this one id. Returning the un-awaited promise adopted it after
+            // the try exited, leaving the catch dead — one failing id then
+            // rejected the whole `Promise.all` and failed the request.
+            return await getRelationship({
               database,
               currentActor,
               targetActorId
             })
           } catch (error) {
-            logger.error(
-              { error, accountId: encodedAccountId },
-              `Error processing relationship for ID ${encodedAccountId}`
-            )
+            logger.error({
+              message: 'Error processing relationship for account id',
+              accountId: encodedAccountId,
+              err: toLoggableError(error)
+            })
             return null
           }
         })

--- a/lib/activities/getActorPostsFromAtomFeed.test.ts
+++ b/lib/activities/getActorPostsFromAtomFeed.test.ts
@@ -3,10 +3,15 @@ import { enableFetchMocks } from 'jest-fetch-mock'
 import { getNote } from '@/lib/activities'
 import { MockMastodonActivityPubNote } from '@/lib/stub/note'
 import { MockActivityPubPerson } from '@/lib/stub/person'
+import { createDeferred } from '@/lib/testing/deferred'
 import { Actor } from '@/lib/types/activitypub'
 import { Note } from '@/lib/types/activitypub/objects'
 
-import { getActorPostsFromAtomFeed } from './getActorPostsFromAtomFeed'
+import {
+  ATOM_FEED_FETCH_CONCURRENCY,
+  MAX_ATOM_FEED_ENTRIES,
+  getActorPostsFromAtomFeed
+} from './getActorPostsFromAtomFeed'
 
 enableFetchMocks()
 
@@ -19,7 +24,10 @@ describe('getActorPostsFromAtomFeed', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks()
-    vi.clearAllMocks()
+    // getNote is a vi.mock-factory fn — restoreAllMocks/clearAllMocks do not
+    // reset its implementation. Reset it explicitly so no test inherits a
+    // neighbour's implementation.
+    vi.mocked(getNote).mockReset()
   })
 
   it('returns empty array when actor URL is malformed', async () => {
@@ -210,5 +218,114 @@ describe('getActorPostsFromAtomFeed', () => {
 
     expect(statuses).toHaveLength(1)
     expect(statuses[0].id).toBe(post1Url)
+  })
+
+  const actorId = 'https://pixelfed.example/users/testuser'
+
+  const buildAtomFeed = (entryUrls: string[]) =>
+    `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <id>${actorId}.atom</id>
+      ${entryUrls
+        .map(
+          (url) =>
+            `<entry><id>${url}</id><link rel="alternate" href="${url}" /></entry>`
+        )
+        .join('')}
+    </feed>`
+
+  const serveFeed = (entryUrls: string[]) => {
+    const atomXml = buildAtomFeed(entryUrls)
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}.atom`) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/atom+xml' },
+          body: atomXml
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+  }
+
+  it('fetches at most MAX_ATOM_FEED_ENTRIES entries from a large feed', async () => {
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+    const entryUrls = Array.from(
+      { length: MAX_ATOM_FEED_ENTRIES + 10 },
+      (_unused, index) => `https://pixelfed.example/p/testuser/${5000 + index}`
+    )
+    serveFeed(entryUrls)
+
+    getNoteMock.mockImplementation(
+      async ({ statusId }: { statusId: string }) =>
+        MockMastodonActivityPubNote({
+          id: statusId,
+          from: actorId,
+          content: 'content',
+          withContext: true
+        }) as Note
+    )
+
+    const statuses = await getActorPostsFromAtomFeed({ person })
+
+    expect(getNoteMock).toHaveBeenCalledTimes(MAX_ATOM_FEED_ENTRIES)
+    expect(statuses).toHaveLength(MAX_ATOM_FEED_ENTRIES)
+  })
+
+  it('caps fan-out concurrency at ATOM_FEED_FETCH_CONCURRENCY', async () => {
+    const person = MockActivityPubPerson({ id: actorId }) as Actor
+    const total = ATOM_FEED_FETCH_CONCURRENCY * 2 + 3
+    const entryUrls = Array.from(
+      { length: total },
+      (_unused, index) => `https://pixelfed.example/p/testuser/${6000 + index}`
+    )
+    serveFeed(entryUrls)
+
+    let inFlight = 0
+    let peak = 0
+    const pending: Array<() => void> = []
+    getNoteMock.mockImplementation(({ statusId }: { statusId: string }) => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      // A real deferred, not Promise.resolve: the point is to hold the fan-out
+      // open so the in-flight count is observable batch by batch.
+      const deferred = createDeferred<Note | null>()
+      pending.push(() =>
+        deferred.resolve(
+          MockMastodonActivityPubNote({
+            id: statusId,
+            from: actorId,
+            content: 'content',
+            withContext: true
+          }) as Note
+        )
+      )
+      return deferred.promise.finally(() => {
+        inFlight -= 1
+      })
+    })
+
+    const resultPromise = getActorPostsFromAtomFeed({ person })
+
+    // Macrotask flush drains microtasks so the next chunk's getNote calls land.
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Wait for the first chunk to fire, then assert it saturated at — not past —
+    // the concurrency ceiling.
+    while (pending.length === 0) await flush()
+    expect(peak).toBeLessThanOrEqual(ATOM_FEED_FETCH_CONCURRENCY)
+    expect(inFlight).toBe(ATOM_FEED_FETCH_CONCURRENCY)
+
+    // Resolve the fan-out one chunk at a time; the next chunk only starts once
+    // the current one fully settles.
+    while (pending.length > 0) {
+      const wave = pending.splice(0)
+      wave.forEach((resolve) => resolve())
+      await flush()
+    }
+
+    const statuses = await resultPromise
+    expect(peak).toBeLessThanOrEqual(ATOM_FEED_FETCH_CONCURRENCY)
+    expect(statuses).toHaveLength(total)
   })
 })

--- a/lib/activities/getActorPostsFromAtomFeed.ts
+++ b/lib/activities/getActorPostsFromAtomFeed.ts
@@ -8,8 +8,18 @@ import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Status, fromNote } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
+import { mapWithConcurrency } from '@/lib/utils/mapWithConcurrency'
 import { request } from '@/lib/utils/request'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
+
+// The remote server chooses how many entries its feed carries, and every entry
+// is a separate signed GET back to that server, reachable from a logged-in
+// profile render. Bound both the count and the concurrency so a hostile or
+// simply large feed cannot fan out into an unbounded burst of outbound
+// requests. 40 mirrors Mastodon's own maximum page size.
+export const MAX_ATOM_FEED_ENTRIES = 40
+export const ATOM_FEED_FETCH_CONCURRENCY = 8
 
 interface AtomFeedLink {
   '@_href'?: string
@@ -31,9 +41,6 @@ interface AtomFeedRoot {
   }
 }
 
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : String(error)
-
 const getStatusFromNote = (note: Note): Status | null => {
   try {
     const status = fromNote(note)
@@ -41,7 +48,10 @@ const getStatusFromNote = (note: Note): Status | null => {
       detectLanguageFromHtml(status.text)?.language ?? null
     return status
   } catch (error) {
-    logger.error(`[getActorPostsFromAtomFeed] ${getErrorMessage(error)}`)
+    logger.error({
+      message: 'Failed to build status from Atom feed note',
+      err: toLoggableError(error)
+    })
     return null
   }
 }
@@ -134,16 +144,24 @@ export const getActorPostsFromAtomFeed = async ({
             continue
           }
 
+          // The remote server chooses the entry count, so cap it before the
+          // fan-out; each surviving entry is a signed GET back to that server.
           const entryUrls = entryList
             .map(extractEntryUrl)
             .filter((url): url is string => Boolean(url))
+            .slice(0, MAX_ATOM_FEED_ENTRIES)
 
           if (entryUrls.length === 0) {
             continue
           }
 
-          const statuses = await Promise.all(
-            entryUrls.map(async (entryUrl) => {
+          // Bounded concurrency rather than `Promise.all` over the whole list:
+          // an uncapped fan-out on a remote-chosen entry count is an unbounded
+          // burst of outbound signed fetches.
+          const statuses = await mapWithConcurrency(
+            entryUrls,
+            ATOM_FEED_FETCH_CONCURRENCY,
+            async (entryUrl) => {
               try {
                 const note = await getNote({
                   statusId: entryUrl,
@@ -165,11 +183,11 @@ export const getActorPostsFromAtomFeed = async ({
                 logger.warn({
                   message: 'Failed to fetch note for Atom feed entry',
                   entryUrl,
-                  error: getErrorMessage(error)
+                  err: toLoggableError(error)
                 })
                 return null
               }
-            })
+            }
           )
 
           const validStatuses = statuses.filter(
@@ -182,7 +200,7 @@ export const getActorPostsFromAtomFeed = async ({
           logger.warn({
             message: 'Failed to fetch or parse candidate Atom feed',
             atomUrl,
-            error: getErrorMessage(error)
+            err: toLoggableError(error)
           })
         }
       }

--- a/lib/services/collections/addMembers.ts
+++ b/lib/services/collections/addMembers.ts
@@ -2,7 +2,10 @@ import { randomUUID } from 'crypto'
 
 import { Database } from '@/lib/database/types'
 import { INGEST_COLLECTION_MEMBER_JOB_NAME } from '@/lib/jobs/names'
-import { resolveActorIdParams } from '@/lib/services/mastodon/resolveClientId'
+import {
+  isResolvedActorUri,
+  resolveActorIdParams
+} from '@/lib/services/mastodon/resolveClientId'
 import { notifyAddedToCollection } from '@/lib/services/notifications/collectionNotifications'
 import { getQueue } from '@/lib/services/queue'
 import { logger } from '@/lib/utils/logger'
@@ -12,18 +15,9 @@ import { logger } from '@/lib/utils/logger'
 export const MAX_COLLECTION_ACCOUNT_IDS = 100
 
 // Membership rows store an actor's AP URI, so every resolved id has to be one.
-// `resolveActorIdParams` returns an unknown publicId UNCHANGED (its documented
-// "matches nothing" contract), and `idToUrl` is permissive enough to emit an
-// unparseable string, so the resolved list can contain values that are not
-// URIs at all.
-const isActorUri = (value: string): boolean => {
-  try {
-    const { protocol } = new URL(value)
-    return protocol === 'http:' || protocol === 'https:'
-  } catch {
-    return false
-  }
-}
+// The URI predicate lives in `resolveClientId` as `isResolvedActorUri`, beside
+// the resolvers whose permissive output it filters (the relationships route is
+// the other caller).
 
 // Add members to an owned collection with the standard side effects: notify
 // the newly-added local members (added_to_collection) and enqueue remote-member
@@ -64,7 +58,7 @@ export const addMembersToCollection = async ({
   // One batched publicId lookup for the whole list, not one per id.
   const targetActorIds = (
     await resolveActorIdParams(database, accountIds)
-  ).filter(isActorUri)
+  ).filter(isResolvedActorUri)
   if (targetActorIds.length === 0) return
 
   const addedActorIds = await database.addCollectionMembers({

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -4,11 +4,23 @@ import { MockActivityPubPerson } from '@/lib/stub/person'
 import { Actor } from '@/lib/types/activitypub'
 
 import {
+  FAILURE_TTL_MS,
+  MAX_CACHED_DOMAINS,
+  SUCCESS_TTL_MS,
   clearServerSoftwareCache,
   getServerSoftware,
+  getServerSoftwareCacheSizeForTests,
   isPixelfedActor,
   isPixelfedDomain
 } from './serverSoftware'
+
+const requestedUrls = () =>
+  fetchMock.mock.calls.map((call) => {
+    const [input] = call
+    if (typeof input === 'string') return input
+    if (input instanceof URL) return input.toString()
+    return (input as Request).url
+  })
 
 enableFetchMocks()
 
@@ -114,5 +126,152 @@ describe('serverSoftware', () => {
   it('returns false for malformed person ID', async () => {
     const person = { id: 'invalid-url' } as Actor
     expect(await isPixelfedActor(person)).toBe(false)
+  })
+
+  it('re-probes after a failed lookup expires (FAILURE_TTL_MS)', async () => {
+    vi.useFakeTimers()
+    try {
+      const domain = 'transient.example'
+      fetchMock.mockResponse(async () => ({ status: 404, body: 'Not Found' }))
+
+      expect(await getServerSoftware(domain)).toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      // A failure is a cache HIT until it expires — no second fetch.
+      expect(await getServerSoftware(domain)).toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(FAILURE_TTL_MS + 1)
+      expect(await getServerSoftware(domain)).toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-probes after a successful lookup expires (SUCCESS_TTL_MS)', async () => {
+    vi.useFakeTimers()
+    try {
+      const domain = 'pixelfed.example'
+      let wellKnownFetches = 0
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+          wellKnownFetches += 1
+          return {
+            status: 200,
+            body: JSON.stringify({
+              links: [
+                {
+                  rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                  href: `https://${domain}/api/nodeinfo/2.0.json`
+                }
+              ]
+            })
+          }
+        }
+        if (req.url === `https://${domain}/api/nodeinfo/2.0.json`) {
+          return {
+            status: 200,
+            body: JSON.stringify({ software: { name: 'Pixelfed' } })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      expect(await getServerSoftware(domain)).toBe('pixelfed')
+      expect(wellKnownFetches).toBe(1)
+
+      // Cached within the success window.
+      expect(await getServerSoftware(domain)).toBe('pixelfed')
+      expect(wellKnownFetches).toBe(1)
+
+      vi.advanceTimersByTime(SUCCESS_TTL_MS + 1)
+      expect(await getServerSoftware(domain)).toBe('pixelfed')
+      expect(wellKnownFetches).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('refuses a NodeInfo href on a different host', async () => {
+    const domain = 'victim.example'
+    const evilUrl = 'https://evil.example/nodeinfo/2.0'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: evilUrl
+              }
+            ]
+          })
+        }
+      }
+      // Would report pixelfed IF the cross-host href were ever followed.
+      return {
+        status: 200,
+        body: JSON.stringify({ software: { name: 'pixelfed' } })
+      }
+    })
+
+    expect(await isPixelfedDomain(domain)).toBe(false)
+    expect(requestedUrls()).not.toContain(evilUrl)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a rel-less first link on a different host', async () => {
+    const domain = 'victim2.example'
+    const evilUrl = 'https://evil.example/nodeinfo'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({ links: [{ href: evilUrl }] })
+        }
+      }
+      return {
+        status: 200,
+        body: JSON.stringify({ software: { name: 'pixelfed' } })
+      }
+    })
+
+    expect(await isPixelfedDomain(domain)).toBe(false)
+    expect(requestedUrls()).not.toContain(evilUrl)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('still follows a rel-less first link on the same host (compatibility fallback preserved)', async () => {
+    const domain = 'norel.example'
+    const infoUrl = `https://${domain}/nodeinfo/2.0`
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({ links: [{ href: infoUrl }] })
+        }
+      }
+      if (req.url === infoUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({ software: { name: 'Pixelfed' } })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await getServerSoftware(domain)).toBe('pixelfed')
+  })
+
+  it('evicts the oldest entry past MAX_CACHED_DOMAINS', async () => {
+    fetchMock.mockResponse(async () => ({ status: 404, body: 'Not Found' }))
+
+    for (let index = 0; index < MAX_CACHED_DOMAINS + 10; index += 1) {
+      await getServerSoftware(`d${index}.example`)
+    }
+
+    expect(getServerSoftwareCacheSizeForTests()).toBe(MAX_CACHED_DOMAINS)
   })
 })

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -1,13 +1,70 @@
 import { Actor } from '@/lib/types/activitypub'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
 
-const domainSoftwareCache = new Map<string, string>()
+type CacheEntry = {
+  // '' is the negative-cache value (probe failed / not resolvable), kept
+  // distinct from "not cached" so a failure does not re-probe until it expires.
+  software: string
+  expiresAt: number
+}
+
+// A resolved software name barely changes, so hold it a day; a failure was
+// often transient, so re-probe after a few minutes rather than marking a real
+// instance non-Pixelfed forever. The pre-TTL cache stored the '' failure
+// sentinel as a permanent HIT, which is exactly that bug.
+export const SUCCESS_TTL_MS = 24 * 60 * 60 * 1000
+export const FAILURE_TTL_MS = 5 * 60 * 1000
+
+// The entries expire but nothing sweeps them, and NodeInfo is probed for
+// whichever domains remote actors bring in. Bound the map so a long-lived
+// process cannot accumulate one entry per domain it has ever seen. Mirrors
+// `MAX_CACHED_ACTORS` in `lib/services/statuses/actorPublicStatusesCount.ts`.
+export const MAX_CACHED_DOMAINS = 512
+
+const domainSoftwareCache = new Map<string, CacheEntry>()
+
+// Insertion-order eviction, mirroring `setBoundedEntry` in
+// `actorPublicStatusesCount.ts` and `setBoundedCacheValue` in
+// `lib/utils/host.ts` — both are private to their own domains, so this is a
+// deliberate copy rather than an export widened for one caller.
+const setBoundedEntry = (domain: string, software: string, ttlMs: number) => {
+  if (domainSoftwareCache.has(domain)) {
+    domainSoftwareCache.delete(domain)
+  } else if (domainSoftwareCache.size >= MAX_CACHED_DOMAINS) {
+    const oldestDomain = domainSoftwareCache.keys().next().value
+    if (oldestDomain !== undefined) domainSoftwareCache.delete(oldestDomain)
+  }
+
+  domainSoftwareCache.set(domain, {
+    software,
+    expiresAt: Date.now() + ttlMs
+  })
+}
+
+// A NodeInfo document is served by the instance itself, so its discovery link
+// must point back at the same host. Following a cross-host href would let a
+// hostile `.well-known/nodeinfo` redirect the probe at an arbitrary server. The
+// `typeof href === 'string'` guard was missing on the old rel-less fallback.
+const isSameHostNodeInfoLink = (
+  link: { rel?: string; href?: string },
+  expectedHost: string
+): boolean => {
+  if (typeof link.href !== 'string') return false
+  try {
+    return new URL(link.href).host.toLowerCase() === expectedHost
+  } catch {
+    return false
+  }
+}
 
 export const clearServerSoftwareCache = () => {
   domainSoftwareCache.clear()
 }
+
+export const getServerSoftwareCacheSizeForTests = () => domainSoftwareCache.size
 
 export const getServerSoftware = async (
   domain: string
@@ -17,8 +74,8 @@ export const getServerSoftware = async (
     if (!normalizedDomain) return null
 
     const cached = domainSoftwareCache.get(normalizedDomain)
-    if (cached !== undefined) {
-      return cached || null
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.software || null
     }
 
     try {
@@ -31,7 +88,7 @@ export const getServerSoftware = async (
       })
 
       if (statusCode !== 200 || !body || typeof body !== 'string') {
-        domainSoftwareCache.set(normalizedDomain, '')
+        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
         return null
       }
 
@@ -39,17 +96,21 @@ export const getServerSoftware = async (
         links?: Array<{ rel?: string; href?: string }>
       }
 
+      const links = nodeInfoWellKnown.links ?? []
       const nodeInfoLink =
-        nodeInfoWellKnown.links?.find(
+        links.find(
           (link) =>
-            typeof link.href === 'string' &&
+            isSameHostNodeInfoLink(link, normalizedDomain) &&
             (link.rel?.includes('nodeinfo') ||
               link.rel?.includes('schema.2.0') ||
               link.rel?.includes('schema.2.1'))
-        ) ?? nodeInfoWellKnown.links?.[0]
+        ) ??
+        // Compatibility fallback for a server that omits a recognizable rel:
+        // the first link regardless of rel, but still pinned to this host.
+        links.find((link) => isSameHostNodeInfoLink(link, normalizedDomain))
 
       if (!nodeInfoLink?.href) {
-        domainSoftwareCache.set(normalizedDomain, '')
+        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
         return null
       }
 
@@ -62,7 +123,7 @@ export const getServerSoftware = async (
       })
 
       if (infoStatus !== 200 || !infoBody || typeof infoBody !== 'string') {
-        domainSoftwareCache.set(normalizedDomain, '')
+        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
         return null
       }
 
@@ -71,15 +132,19 @@ export const getServerSoftware = async (
       }
 
       const softwareName = schema.software?.name?.trim().toLowerCase() ?? ''
-      domainSoftwareCache.set(normalizedDomain, softwareName)
+      setBoundedEntry(
+        normalizedDomain,
+        softwareName,
+        softwareName ? SUCCESS_TTL_MS : FAILURE_TTL_MS
+      )
       return softwareName || null
     } catch (error) {
       logger.warn({
         message: 'Failed to resolve server software via NodeInfo',
         domain: normalizedDomain,
-        error: error instanceof Error ? error.message : String(error)
+        err: toLoggableError(error)
       })
-      domainSoftwareCache.set(normalizedDomain, '')
+      setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
       return null
     }
   })

--- a/lib/services/federation/statusDelivery.ts
+++ b/lib/services/federation/statusDelivery.ts
@@ -6,6 +6,7 @@ import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
+import { mapWithConcurrency } from '@/lib/utils/mapWithConcurrency'
 
 import { filterFederatedUrls } from './domainPolicy'
 
@@ -42,21 +43,6 @@ const isSameOriginActorId = (actorId: string, currentActor: Actor) => {
   } catch {
     return false
   }
-}
-
-const mapWithConcurrency = async <T, TResult>(
-  items: T[],
-  concurrency: number,
-  mapper: (item: T) => Promise<TResult>
-): Promise<TResult[]> => {
-  const results: TResult[] = []
-
-  for (let index = 0; index < items.length; index += concurrency) {
-    const chunk = items.slice(index, index + concurrency)
-    results.push(...(await Promise.all(chunk.map(mapper))))
-  }
-
-  return results
 }
 
 const getRemoteActorInboxForMissingActor = async ({

--- a/lib/services/mastodon/resolveClientId.ts
+++ b/lib/services/mastodon/resolveClientId.ts
@@ -85,3 +85,19 @@ export const resolveActorIdParams = (
   resolveIdParams(params, (publicIds) =>
     database.getActorIdsByPublicIds({ publicIds })
   )
+
+// A resolved id is only usable where an actor AP URI is required. The
+// resolvers above return an unknown publicId UNCHANGED (their documented
+// "matches nothing" contract), and `idToUrl` is permissive enough to emit an
+// unparseable string, so a resolved list can hold values that are not URIs at
+// all. Callers that persist a resolved id or feed it to `new URL` filter the
+// OUTPUT of the resolvers through this — it never prunes an input form the
+// resolvers accept.
+export const isResolvedActorUri = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/lib/services/polls/syncRemotePoll.ts
+++ b/lib/services/polls/syncRemotePoll.ts
@@ -10,6 +10,7 @@ import {
   normalizeActivityPubUri
 } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
 
 const FAILURE_COOLDOWN_MS = 60 * 1000
@@ -128,7 +129,7 @@ const performPollSync = async ({
     logger.warn({
       message: 'Failed to sync remote poll',
       statusId: status.id,
-      error: error instanceof Error ? error.message : String(error)
+      err: toLoggableError(error)
     })
     failedPollSyncsAt.set(status.id, Date.now())
     return null

--- a/lib/utils/mapWithConcurrency.ts
+++ b/lib/utils/mapWithConcurrency.ts
@@ -1,0 +1,14 @@
+export const mapWithConcurrency = async <T, TResult>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<TResult>
+): Promise<TResult[]> => {
+  const results: TResult[] = []
+
+  for (let index = 0; index < items.length; index += concurrency) {
+    const chunk = items.slice(index, index + concurrency)
+    results.push(...(await Promise.all(chunk.map(mapper))))
+  }
+
+  return results
+}


### PR DESCRIPTION
Part of a stacked series from a post-merge audit (PRs 2–6). **Base: `main`.**

Hardens the remote-actor persistence and relationship/NodeInfo paths.

### 1. `getProfileData.ts` — permanent 500 on split-domain deployments + missing federation gate
The remote branch looked up `persistedActor` by the **handle** (`username`+`domain`) but wrote keyed on `person.id` (server-chosen). On a standard `LOCAL_DOMAIN ≠ WEB_DOMAIN` deployment (handle `@llun@llun.dev`, actor id `https://social.llun.dev/users/llun`) the handle lookup misses forever, so every load re-entered the insert branch and 500'd on `actors_id_unique` — permanent, not just a race. There was also no `canFederateWithDomain` gate, so any logged-in visit to `/@user@blocked.example` persisted **and search-indexed** that actor (and on allowlist-mode instances, any domain at all).
Fix: gate both `actorId` and the written `person.id` through `canFederateWithDomain`; look up by the id actually written; wrap the insert so a concurrent loser converges via `updateActor` instead of 500ing. Not routed through `recordActorIfNeeded` (it re-fetches the Person doc — wasteful on a hot render).

### 2. `relationships` route — 3 real defects (the audit's "dead guard" claim was **refuted**)
The `if (!targetActorId)` guard is **live** (kept + pinned by a characterization test) — `idToUrl` returns `''` for a bad `apurl_`. The real defects: an unresolvable publicId came back through a fallback as a fabricated all-false relationship with a mangled `"<uuid>:"` id (now dropped via `isResolvedActorUri`); the id list was uncapped and undeduped (now `Set` + `MAX_BATCH_RELATIONSHIPS = 100`, matching the sibling routes); and the `catch` was **dead** because `return getRelationship(...)` adopted the promise after the `try` exited (now `return await`, so one failing id drops instead of failing the whole request).

### 3. `getActorPostsFromAtomFeed` — uncapped remote fan-out
`Promise.all(entryUrls.map(getNote…))` with the entry count chosen by the remote server, one signed GET each, reachable from a logged-in profile render. Now capped at `MAX_ATOM_FEED_ENTRIES = 40` and run through the extracted `mapWithConcurrency` at concurrency 8.

### 4. `serverSoftware.ts` — permanent negative cache + unpinned NodeInfo href
The cache was an unbounded module `Map` with no TTL; the `''` failure sentinel was a permanent cache HIT, so one transient error marked a real Pixelfed instance non-Pixelfed for the process lifetime. Now `{ software, expiresAt }` with 24h success / 5min failure TTLs, bounded at 512 with insertion-order eviction, and the NodeInfo href is host-pinned (defence in depth — `safeRemoteFetch` already blocks the internal-network reach; a pre-fetch pin does not close redirect-driven host changes since `RequestResult` drops the post-redirect url).

**Logging:** every catch this PR touches now uses `err: toLoggableError(error)` per the guidelines.

**Deferred (stated so the trail records it):** audit item 7 (follow-route triple-fetch dedup, FollowList per-row relationship batching) and serverSoftware in-flight request dedup — each is a larger signature-changing change on its own.

Every fix has a prove-by-revert regression test. Full gate green as the integrated stack base (build + 12,562 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
