### PR TITLE
fix: prevent post-vote count clobber and make federated create recovery idempotent

### DIFF
--- a/app/api/v1/accounts/vote/route.test.ts
+++ b/app/api/v1/accounts/vote/route.test.ts
@@ -62,7 +62,7 @@ describe('POST /api/v1/accounts/vote', () => {
     mockSyncRemotePoll.mockImplementation(({ status }) => status)
   })
 
-  it('records votes, sends poll votes, syncs remote poll, and returns updated status', async () => {
+  it('records votes, sends poll votes, and returns the locally-updated status without a post-vote remote sync', async () => {
     const updatedStatus = {
       ...pollStatus,
       choices: [
@@ -74,14 +74,18 @@ describe('POST /api/v1/accounts/vote', () => {
       .mockResolvedValueOnce(pollStatus)
       .mockResolvedValueOnce(updatedStatus)
 
-    const syncedStatus = {
+    // If the route synced from the remote here it would overwrite the local
+    // tallies with a stale count that does not yet include the just-cast vote.
+    // Stub the sync to return exactly that stale shape so a revert of the fix
+    // (which restores the call) makes the response assertion below fail.
+    const staleSyncedStatus = {
       ...pollStatus,
       choices: [
-        { title: 'Red', totalVotes: 10 },
-        { title: 'Blue', totalVotes: 5 }
+        { title: 'Red', totalVotes: 0 },
+        { title: 'Blue', totalVotes: 0 }
       ]
     }
-    mockSyncRemotePoll.mockResolvedValueOnce(syncedStatus)
+    mockSyncRemotePoll.mockResolvedValue(staleSyncedStatus)
 
     const response = await POST(
       new NextRequest('https://local.test/api/v1/accounts/vote', {
@@ -106,11 +110,10 @@ describe('POST /api/v1/accounts/vote', () => {
       status: pollStatus,
       choices: [0]
     })
-    expect(mockSyncRemotePoll).toHaveBeenCalledWith({
-      database: mockDatabase,
-      status: updatedStatus
-    })
-    expect(await response.json()).toEqual({ status: syncedStatus })
+    // Design (a): no immediate post-vote sync — the voter's own vote survives
+    // in the response, and reconciliation is deferred to the next poll GET.
+    expect(mockSyncRemotePoll).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual({ status: updatedStatus })
   })
 
   it('rejects invalid choice indices', async () => {

--- a/app/api/v1/accounts/vote/route.ts
+++ b/app/api/v1/accounts/vote/route.ts
@@ -1,6 +1,5 @@
 import { sendPollVotes } from '@/lib/activities'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { syncRemotePoll } from '@/lib/services/polls/syncRemotePoll'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -99,20 +98,24 @@ export const POST = traceApiRoute(
 
     await sendPollVotes({ currentActor, status, choices })
 
+    // Return the locally-updated status WITHOUT syncing from the remote here.
+    // `recordPollVotes` already incremented this instance's own
+    // `poll_choices.totalVotes`, but the remote origin has almost certainly
+    // not processed the vote we just delivered — so `syncRemotePoll` would
+    // overwrite the local tallies with the origin's stale count and make the
+    // voter watch their own vote vanish from the response. Reconciliation is
+    // deferred to the next independent read: GET /api/v1/polls/:id is the one
+    // path that syncs (timeline serialization never does), and clients issue
+    // that per-poll GET when they re-render a poll, so the origin's
+    // authoritative count is picked up once it reflects the vote.
     const updatedStatus = await database.getStatus({
       statusId,
       withReplies: false
     })
-    const syncedStatus = updatedStatus
-      ? await syncRemotePoll({
-          database,
-          status: updatedStatus
-        })
-      : null
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: { status: syncedStatus ?? updatedStatus }
+      data: { status: updatedStatus }
     })
   })
 )

--- a/app/api/v1/polls/[id]/votes/route.test.ts
+++ b/app/api/v1/polls/[id]/votes/route.test.ts
@@ -41,8 +41,14 @@ vi.mock('@/lib/services/statusAccess', () => ({
   canActorReadStatus: vi.fn().mockResolvedValue(true)
 }))
 
+const mockGetMastodonStatus = vi.fn()
 vi.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
-  getMastodonStatus: vi.fn().mockResolvedValue({ poll: { id: 'poll-1' } })
+  getMastodonStatus: (...params: unknown[]) => mockGetMastodonStatus(...params)
+}))
+
+const mockSyncRemotePoll = vi.fn()
+vi.mock('@/lib/services/polls/syncRemotePoll', () => ({
+  syncRemotePoll: (...params: unknown[]) => mockSyncRemotePoll(...params)
 }))
 
 const createRequest = (body: unknown) =>
@@ -63,6 +69,8 @@ describe('POST /api/v1/polls/[id]/votes', () => {
       choices: [{ title: 'a' }, { title: 'b' }]
     })
     mockDatabase.recordPollVotes.mockResolvedValue(true)
+    mockGetMastodonStatus.mockResolvedValue({ poll: { id: 'poll-1' } })
+    mockSyncRemotePoll.mockImplementation(({ status }) => status)
   })
 
   it.each([
@@ -86,6 +94,50 @@ describe('POST /api/v1/polls/[id]/votes', () => {
       actorId: mockCurrentActor.id,
       choices: expected
     })
+  })
+
+  it('serializes the locally-updated status without a post-vote remote sync', async () => {
+    const votedStatus = {
+      id: POLL_ID,
+      type: 'Poll',
+      pollType: 'multiple',
+      endAt: Date.now() + 60_000,
+      choices: [
+        { title: 'a', totalVotes: 1 },
+        { title: 'b', totalVotes: 0 }
+      ]
+    }
+    mockDatabase.getStatus
+      .mockResolvedValueOnce({
+        id: POLL_ID,
+        type: 'Poll',
+        pollType: 'multiple',
+        endAt: Date.now() + 60_000,
+        choices: [{ title: 'a' }, { title: 'b' }]
+      })
+      .mockResolvedValueOnce(votedStatus)
+
+    // A revert of the fix would pass this stale, vote-less status to
+    // getMastodonStatus instead of the locally-voted one below.
+    mockSyncRemotePoll.mockResolvedValue({
+      ...votedStatus,
+      choices: [
+        { title: 'a', totalVotes: 0 },
+        { title: 'b', totalVotes: 0 }
+      ]
+    })
+
+    const response = await POST(createRequest({ choices: ['0'] }), {
+      params: Promise.resolve({ id: urlToId(POLL_ID) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockSyncRemotePoll).not.toHaveBeenCalled()
+    expect(mockGetMastodonStatus).toHaveBeenCalledWith(
+      mockDatabase,
+      votedStatus,
+      mockCurrentActor.id
+    )
   })
 
   it('still rejects non-numeric choices', async () => {

--- a/app/api/v1/polls/[id]/votes/route.ts
+++ b/app/api/v1/polls/[id]/votes/route.ts
@@ -4,7 +4,6 @@ import { sendPollVotes } from '@/lib/activities'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { resolveStatusIdParam } from '@/lib/services/mastodon/resolveClientId'
-import { syncRemotePoll } from '@/lib/services/polls/syncRemotePoll'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
@@ -179,14 +178,19 @@ export const POST = traceApiRoute(
         })
       }
 
-      const syncedStatus = await syncRemotePoll({
-        database,
-        status: updatedStatus
-      })
-
+      // Serialize the locally-updated status WITHOUT syncing from the remote
+      // here. `recordPollVotes` already incremented this instance's own
+      // `poll_choices.totalVotes`, but the remote origin has almost certainly
+      // not processed the vote we just delivered — so `syncRemotePoll` would
+      // overwrite the local tallies with the origin's stale count and make the
+      // voter watch their own vote vanish from the response. Reconciliation is
+      // deferred to the next independent read: GET /api/v1/polls/:id is the
+      // one path that syncs (timeline serialization never does), and clients
+      // issue that per-poll GET when they re-render a poll, so the origin's
+      // authoritative count is picked up once it reflects the vote.
       const mastodonStatus = await getMastodonStatus(
         database,
-        syncedStatus,
+        updatedStatus,
         currentActor.id
       )
       if (!mastodonStatus?.poll) {

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -30,6 +30,7 @@ import {
   announceOriginalPointer,
   wherePubliclyReadableStatus
 } from '@/lib/database/sql/utils/publiclyReadableStatus'
+import { recoverFromDuplicateInsert } from '@/lib/database/sql/utils/recoverFromDuplicateInsert'
 import {
   StatusHashtagTagRow,
   selectHashtagTagsByStatusIds
@@ -54,6 +55,7 @@ import {
   CreateNoteParams,
   CreatePollAnswerParams,
   CreatePollParams,
+  CreateStatusResult,
   CreateTagParams,
   DeleteStatusParams,
   DeleteStatusTagsByTypeParams,
@@ -533,7 +535,7 @@ export const StatusSQLDatabaseMixin = (
   }
 
   // Public
-  async function createNote({
+  async function createNoteWithResult({
     id,
     url,
     actorId,
@@ -549,7 +551,7 @@ export const StatusSQLDatabaseMixin = (
     applicationWebsite = null,
     createdAt,
     publicId
-  }: CreateNoteParams) {
+  }: CreateNoteParams): Promise<CreateStatusResult> {
     const currentTime = new Date()
     const statusCreatedAt = createdAt ? new Date(createdAt) : currentTime
     const statusPublicId =
@@ -574,76 +576,74 @@ export const StatusSQLDatabaseMixin = (
       createdAt: statusCreatedAt
     }
 
-    try {
-      await database.transaction(async (trx) => {
-        await trx('statuses').insert({
-          id,
-          publicId: statusPublicId,
-          url,
-          urlHash: getStatusUrlHash(url),
-          actorId,
-          type: StatusType.enum.Note,
-          content: statusContent,
-          applicationName,
-          applicationWebsite,
-          reply,
-          replyHash: getStatusReplyHash(reply),
-          createdAt: statusCreatedAt,
-          updatedAt: statusUpdatedAt
-        })
-        await updateStatusCounters({
-          actorId,
-          type: StatusType.enum.Note,
-          reply,
-          content,
-          step: 'increment',
-          trx,
-          currentTime,
-          statusCreatedAt
-        })
-        await Promise.all(
-          to.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'to',
+    const outcome = await recoverFromDuplicateInsert({
+      insert: () =>
+        database.transaction(async (trx) => {
+          await trx('statuses').insert({
+            id,
+            publicId: statusPublicId,
+            url,
+            urlHash: getStatusUrlHash(url),
+            actorId,
+            type: StatusType.enum.Note,
+            content: statusContent,
+            applicationName,
+            applicationWebsite,
+            reply,
+            replyHash: getStatusReplyHash(reply),
+            createdAt: statusCreatedAt,
+            updatedAt: statusUpdatedAt
+          })
+          await updateStatusCounters({
+            actorId,
+            type: StatusType.enum.Note,
+            reply,
+            content,
+            step: 'increment',
+            trx,
+            currentTime,
+            statusCreatedAt
+          })
+          await Promise.all(
+            to.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'to',
 
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
           )
-        )
 
-        await Promise.all(
-          cc.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'cc',
+          await Promise.all(
+            cc.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'cc',
 
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
           )
-        )
-      })
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        const existingStatus = await getStatus({
-          statusId: id,
-          withReplies: false
-        })
-        if (existingStatus) return existingStatus
-      }
-      throw error
+        }),
+      getExisting: () => getStatus({ statusId: id, withReplies: false })
+    })
+    if (outcome.recovered) {
+      // A concurrent delivery of the same note won the unique key; return its
+      // row with isNew=false so the caller skips its side effects.
+      return { status: outcome.existing, isNew: false }
     }
 
     await indexStatusSearchDocument(database, { status: searchStatus })
 
     const actor = await actorDatabase.getActorFromId({ id: actorId })
-    return StatusNote.parse({
+    const status = StatusNote.parse({
       id,
       publicId: statusPublicId,
       url,
@@ -680,6 +680,11 @@ export const StatusSQLDatabaseMixin = (
       createdAt: getCompatibleTime(statusCreatedAt),
       updatedAt: getCompatibleTime(statusUpdatedAt)
     })
+    return { status, isNew: true }
+  }
+
+  async function createNote(params: CreateNoteParams): Promise<Status> {
+    return (await createNoteWithResult(params)).status
   }
 
   async function updateNote({
@@ -952,69 +957,65 @@ export const StatusSQLDatabaseMixin = (
       publicId ?? generatePublicId(statusCreatedAt.getTime())
     const statusUpdatedAt = currentTime
 
-    try {
-      await database.transaction(async (trx) => {
-        await trx('statuses').insert({
-          id,
-          publicId: statusPublicId,
-          url: null,
-          urlHash: null,
-          actorId,
-          type: StatusType.enum.Announce,
-          reply: '',
-          replyHash: null,
-          content: originalStatusId,
-          originalStatusId,
-          createdAt: statusCreatedAt,
-          updatedAt: statusUpdatedAt
-        })
-        await updateStatusCounters({
-          actorId,
-          type: StatusType.enum.Announce,
-          reply: '',
-          content: originalStatusId,
-          step: 'increment',
-          trx,
-          currentTime,
-          statusCreatedAt
-        })
-        await Promise.all(
-          to.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'to',
+    const outcome = await recoverFromDuplicateInsert({
+      insert: () =>
+        database.transaction(async (trx) => {
+          await trx('statuses').insert({
+            id,
+            publicId: statusPublicId,
+            url: null,
+            urlHash: null,
+            actorId,
+            type: StatusType.enum.Announce,
+            reply: '',
+            replyHash: null,
+            content: originalStatusId,
+            originalStatusId,
+            createdAt: statusCreatedAt,
+            updatedAt: statusUpdatedAt
+          })
+          await updateStatusCounters({
+            actorId,
+            type: StatusType.enum.Announce,
+            reply: '',
+            content: originalStatusId,
+            step: 'increment',
+            trx,
+            currentTime,
+            statusCreatedAt
+          })
+          await Promise.all(
+            to.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'to',
 
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
           )
-        )
 
-        await Promise.all(
-          cc.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'cc',
+          await Promise.all(
+            cc.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'cc',
 
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
           )
-        )
-      })
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        const existingStatus = await getStatus({
-          statusId: id,
-          withReplies: false
-        })
-        if (existingStatus) return existingStatus
-      }
-      throw error
+        }),
+      getExisting: () => getStatus({ statusId: id, withReplies: false })
+    })
+    if (outcome.recovered) {
+      return outcome.existing
     }
 
     const [originalStatus, actor] = await Promise.all([
@@ -1041,7 +1042,7 @@ export const StatusSQLDatabaseMixin = (
     })
   }
 
-  async function createPoll({
+  async function createPollWithResult({
     id,
     url,
     actorId,
@@ -1060,7 +1061,7 @@ export const StatusSQLDatabaseMixin = (
     applicationWebsite = null,
     createdAt,
     publicId
-  }: CreatePollParams) {
+  }: CreatePollParams): Promise<CreateStatusResult> {
     const currentTime = new Date()
     const statusCreatedAt = createdAt ? new Date(createdAt) : currentTime
     const statusPublicId =
@@ -1085,90 +1086,88 @@ export const StatusSQLDatabaseMixin = (
       createdAt: statusCreatedAt
     }
 
-    try {
-      await database.transaction(async (trx) => {
-        await trx('statuses').insert({
-          id,
-          publicId: statusPublicId,
-          url,
-          urlHash: getStatusUrlHash(url),
-          actorId,
-          type: StatusType.enum.Poll,
-          content: statusContent,
-          applicationName,
-          applicationWebsite,
-          reply,
-          replyHash: getStatusReplyHash(reply),
-          createdAt: statusCreatedAt,
-          updatedAt: statusUpdatedAt
-        })
-        await updateStatusCounters({
-          actorId,
-          type: StatusType.enum.Poll,
-          reply,
-          content,
-          step: 'increment',
-          trx,
-          currentTime,
-          statusCreatedAt
-        })
-        await Promise.all(
-          choices.map((choice) => {
-            const title = typeof choice === 'string' ? choice : choice.title
-            const totalVotes =
-              typeof choice === 'string' ? 0 : (choice.totalVotes ?? 0)
-            return trx('poll_choices').insert({
-              statusId: id,
-              title,
-              totalVotes,
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+    const outcome = await recoverFromDuplicateInsert({
+      insert: () =>
+        database.transaction(async (trx) => {
+          await trx('statuses').insert({
+            id,
+            publicId: statusPublicId,
+            url,
+            urlHash: getStatusUrlHash(url),
+            actorId,
+            type: StatusType.enum.Poll,
+            content: statusContent,
+            applicationName,
+            applicationWebsite,
+            reply,
+            replyHash: getStatusReplyHash(reply),
+            createdAt: statusCreatedAt,
+            updatedAt: statusUpdatedAt
           })
-        )
-        await Promise.all(
-          to.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'to',
-
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
+          await updateStatusCounters({
+            actorId,
+            type: StatusType.enum.Poll,
+            reply,
+            content,
+            step: 'increment',
+            trx,
+            currentTime,
+            statusCreatedAt
+          })
+          await Promise.all(
+            choices.map((choice) => {
+              const title = typeof choice === 'string' ? choice : choice.title
+              const totalVotes =
+                typeof choice === 'string' ? 0 : (choice.totalVotes ?? 0)
+              return trx('poll_choices').insert({
+                statusId: id,
+                title,
+                totalVotes,
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
             })
           )
-        )
+          await Promise.all(
+            to.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'to',
 
-        await Promise.all(
-          cc.map((actorId) =>
-            trx('recipients').insert({
-              id: crypto.randomUUID(),
-              statusId: id,
-              actorId,
-              type: 'cc',
-
-              createdAt: statusUpdatedAt,
-              updatedAt: statusUpdatedAt
-            })
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
           )
-        )
-      })
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        const existingStatus = await getStatus({
-          statusId: id,
-          withReplies: false
-        })
-        if (existingStatus) return existingStatus
-      }
-      throw error
+
+          await Promise.all(
+            cc.map((actorId) =>
+              trx('recipients').insert({
+                id: crypto.randomUUID(),
+                statusId: id,
+                actorId,
+                type: 'cc',
+
+                createdAt: statusUpdatedAt,
+                updatedAt: statusUpdatedAt
+              })
+            )
+          )
+        }),
+      getExisting: () => getStatus({ statusId: id, withReplies: false })
+    })
+    if (outcome.recovered) {
+      // A concurrent delivery of the same poll won the unique key; return its
+      // row with isNew=false so the caller skips its side effects.
+      return { status: outcome.existing, isNew: false }
     }
 
     await indexStatusSearchDocument(database, { status: searchStatus })
 
     const actor = await actorDatabase.getActorFromId({ id: actorId })
-    return StatusPoll.parse({
+    const status = StatusPoll.parse({
       id,
       publicId: statusPublicId,
       url,
@@ -1208,6 +1207,11 @@ export const StatusSQLDatabaseMixin = (
       createdAt: getCompatibleTime(statusCreatedAt),
       updatedAt: getCompatibleTime(statusUpdatedAt)
     })
+    return { status, isNew: true }
+  }
+
+  async function createPoll(params: CreatePollParams): Promise<Status> {
+    return (await createPollWithResult(params)).status
   }
 
   async function updatePoll({
@@ -3967,11 +3971,13 @@ export const StatusSQLDatabaseMixin = (
 
   return {
     createNote,
+    createNoteWithResult,
     updateNote,
     updateStatusQuoteApprovalPolicy,
     updateNoteVisibility,
     createAnnounce,
     createPoll,
+    createPollWithResult,
     updatePoll,
     getStatus,
     getStatusReplies,

--- a/lib/database/sql/utils/recoverFromDuplicateInsert.ts
+++ b/lib/database/sql/utils/recoverFromDuplicateInsert.ts
@@ -1,0 +1,48 @@
+import { isUniqueConstraintError } from './isUniqueConstraintError'
+
+/**
+ * Outcome of an insert guarded against a concurrent duplicate.
+ *
+ * `recovered: false` — this call performed the insert and owns the row it just
+ * wrote, so the caller should run its post-insert side effects.
+ * `recovered: true` — a concurrent writer won the same unique key; `existing`
+ * is the winner's row, and the caller must NOT re-run non-idempotent side
+ * effects (they belong to the winner).
+ */
+export type DuplicateInsertOutcome<T> =
+  { recovered: false } | { recovered: true; existing: T }
+
+/**
+ * Run an insert that races on a unique key, and recover the winner's row when
+ * a concurrent writer got there first.
+ *
+ * The two federated-delivery jobs that create statuses (`createNoteJob`,
+ * `createPollJob`) each guard with a `getStatus` check before inserting, but
+ * two concurrent deliveries of the same object both pass that check and both
+ * insert — one wins, the other hits the unique constraint. Returning the
+ * winner's row lets the loser no-op instead of failing, and the discriminated
+ * `recovered` flag is what tells the caller it was a no-op so it does not
+ * re-run createTag / createAttachment / increaseHashtagCounter etc. on top of
+ * the winner's.
+ *
+ * A unique-constraint error whose row cannot then be found is re-thrown
+ * unchanged — the original behaviour of the inline catch blocks this replaces.
+ */
+export const recoverFromDuplicateInsert = async <T>({
+  insert,
+  getExisting
+}: {
+  insert: () => Promise<void>
+  getExisting: () => Promise<T | null>
+}): Promise<DuplicateInsertOutcome<T>> => {
+  try {
+    await insert()
+    return { recovered: false }
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const existing = await getExisting()
+      if (existing) return { recovered: true, existing }
+    }
+    throw error
+  }
+}

--- a/lib/jobs/createAnnounceJob.ts
+++ b/lib/jobs/createAnnounceJob.ts
@@ -29,6 +29,11 @@ export const createAnnounceJob: JobHandle = createJobHandle(
       normalizeActivityPubAnnounce(message.data)
     )
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed announce payload',
+        job: CREATE_ANNOUNCE_JOB_NAME,
+        announceId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const status = parseResult.data

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -580,6 +580,66 @@ describe('createNoteJob', () => {
     expect(hashtagTags[0].value).toEqual('https://somewhere.test/tags/testing')
   })
 
+  it('recovers a concurrent duplicate insert without re-running tag or hashtag side effects', async () => {
+    const noteId = `https://${actor1!.domain}/notes/dup-recovery-${Date.now()}`
+    const note = MockMastodonActivityPubNote({
+      id: noteId,
+      content: '<p>Race #dup</p>',
+      tags: [
+        {
+          type: 'Hashtag',
+          href: 'https://somewhere.test/tags/dup',
+          name: '#dup'
+        }
+      ]
+    })
+
+    // Stand in for the delivery that WON the race and committed first: the row
+    // already exists, so createNoteWithResult's insert below will hit the
+    // unique constraint and take the recovery path.
+    await database.createNote({
+      id: noteId,
+      url: noteId,
+      actorId: note.attributedTo,
+      text: '<p>Race #dup</p>',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      createdAt: new Date(note.published).getTime()
+    })
+
+    // Simulate the losing delivery: its own pre-insert getStatus check saw no
+    // row (the winner had not committed when it ran), so it proceeds into
+    // createNoteWithResult and only discovers the duplicate at the INSERT —
+    // i.e. the recovery path returns the winner's row with isNew=false. The
+    // recovery lookup inside createNoteWithResult uses the module's own
+    // getStatus closure, not this spied property, so it still finds the row.
+    const getStatusSpy = vi
+      .spyOn(database, 'getStatus')
+      .mockResolvedValueOnce(null)
+    const createTagSpy = vi.spyOn(database, 'createTag')
+    const increaseHashtagCounterSpy = vi.spyOn(
+      database,
+      'increaseHashtagCounter'
+    )
+
+    try {
+      await createNoteJob(database, {
+        id: 'id-dup-recovery',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note
+      })
+
+      // The winning delivery owns every side effect; the recovered loser must
+      // skip them, or the hashtag counter permanently double-counts.
+      expect(createTagSpy).not.toHaveBeenCalled()
+      expect(increaseHashtagCounterSpy).not.toHaveBeenCalled()
+    } finally {
+      getStatusSpy.mockRestore()
+      createTagSpy.mockRestore()
+      increaseHashtagCounterSpy.mockRestore()
+    }
+  })
+
   it('stores inbound emoji tags so remote custom emoji render locally', async () => {
     const noteId = `https://${actor1!.domain}/notes/emoji-test-${Date.now()}`
     const note = MockMastodonActivityPubNote({

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -46,6 +46,7 @@ import {
 } from '@/lib/utils/activitypub'
 import { isValidFocalPoint } from '@/lib/utils/focalPoint'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { createPollJob } from './createPollJob'
@@ -73,6 +74,11 @@ export const createNoteJob = createJobHandle(
       normalizeActivityPubContent(message.data)
     )
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed note payload',
+        job: CREATE_NOTE_JOB_NAME,
+        statusId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const note = parseResult.data as BaseNote
@@ -112,9 +118,9 @@ export const createNoteJob = createJobHandle(
       database
     })
 
-    const [, status] = await Promise.all([
+    const [, createResult] = await Promise.all([
       recordActorIfNeeded({ actorId, database }),
-      database.createNote({
+      database.createNoteWithResult({
         id: note.id,
         url: typeof note.url === 'string' ? note.url : note.id,
 
@@ -131,6 +137,18 @@ export const createNoteJob = createJobHandle(
         createdAt: publishedAt
       })
     ])
+    const { status, isNew } = createResult
+
+    // A concurrent delivery of the same note won the unique-key insert, so this
+    // call recovered the winner's row rather than creating one. The winner's own
+    // run owns every side effect below — the quote edge, tags, hashtag counters,
+    // attachments, timelines and link preview — so re-running them here would
+    // double-count (an inflated hashtag counter, duplicate tags/timeline rows).
+    // This is the concurrent-race twin of the `if (existingStatus) return` guard
+    // above, which drops a sequential duplicate the same way.
+    if (!isNew) {
+      return
+    }
 
     // Content-detected language, stored separately from the declared
     // `language` above so the Translate gate can fall back to it when a

--- a/lib/jobs/createPollJob.test.ts
+++ b/lib/jobs/createPollJob.test.ts
@@ -425,6 +425,64 @@ describe('createPollJob', () => {
     }
   })
 
+  it('recovers a concurrent duplicate insert without re-running tag or hashtag side effects', async () => {
+    const pollId = `${REMOTE_ACTOR_ID}/questions/dup-recovery-${Date.now()}`
+    const question = MockActivityPubQuestion({
+      id: pollId,
+      oneOf: [createOption('Red'), createOption('Blue')],
+      tags: [
+        {
+          type: 'Hashtag',
+          name: '#dup',
+          href: 'https://example.com/tags/dup'
+        }
+      ]
+    })
+
+    // Stand in for the delivery that WON the race and committed first, so the
+    // createPollWithResult insert inside the job hits the unique constraint and
+    // takes the recovery path (isNew=false).
+    await database.createPoll({
+      id: pollId,
+      url: pollId,
+      actorId: question.attributedTo,
+      text: '<p>What is your favorite color?</p>',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      endAt: Date.now() + 24 * 60 * 60 * 1000,
+      choices: ['Red', 'Blue']
+    })
+
+    // Simulate the losing delivery: its own pre-insert getStatus check saw no
+    // row, so it proceeds into createPollWithResult and only discovers the
+    // duplicate at the INSERT. The recovery lookup inside createPollWithResult
+    // uses the module's own getStatus closure, not this spied property.
+    const getStatusSpy = vi
+      .spyOn(database, 'getStatus')
+      .mockResolvedValueOnce(null)
+    const createTagSpy = vi.spyOn(database, 'createTag')
+    const increaseHashtagCounterSpy = vi.spyOn(
+      database,
+      'increaseHashtagCounter'
+    )
+
+    try {
+      await createPollJob(database, {
+        id: 'id-poll-dup-recovery',
+        name: CREATE_POLL_JOB_NAME,
+        data: question,
+        verifiedSenderActorId: question.attributedTo
+      })
+
+      expect(createTagSpy).not.toHaveBeenCalled()
+      expect(increaseHashtagCounterSpy).not.toHaveBeenCalled()
+    } finally {
+      getStatusSpy.mockRestore()
+      createTagSpy.mockRestore()
+      increaseHashtagCounterSpy.mockRestore()
+    }
+  })
+
   it('handles poll as reply', async () => {
     const replyToId = `${actor1?.id}/statuses/post-1`
     const question = MockActivityPubQuestion({

--- a/lib/jobs/createPollJob.ts
+++ b/lib/jobs/createPollJob.ts
@@ -16,6 +16,7 @@ import {
   normalizeActivityPubContent,
   toRecipientArray
 } from '@/lib/utils/activitypub'
+import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_POLL_JOB_NAME } from './names'
@@ -28,6 +29,11 @@ export const createPollJob = createJobHandle(
       normalizeActivityPubContent(message.data)
     )
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed poll payload',
+        job: CREATE_POLL_JOB_NAME,
+        statusId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const question = parseResult.data
@@ -74,12 +80,12 @@ export const createPollJob = createJobHandle(
       database
     })
 
-    const [, status] = await Promise.all([
+    const [, createResult] = await Promise.all([
       recordActorIfNeeded({
         actorId: question.attributedTo,
         database
       }),
-      database.createPoll({
+      database.createPollWithResult({
         id: question.id,
         url: typeof question.url === 'string' ? question.url : question.id,
 
@@ -102,6 +108,17 @@ export const createPollJob = createJobHandle(
         createdAt: new Date(question.published).getTime()
       })
     ])
+    const { status, isNew } = createResult
+
+    // A concurrent delivery of the same poll won the unique-key insert, so this
+    // call recovered the winner's row rather than creating one. The winner's own
+    // run owns every side effect below — timelines, tags, hashtag counters — so
+    // re-running them here would double-count. This is the concurrent-race twin
+    // of the `if (existingStatus) return` guard above, which drops a sequential
+    // duplicate the same way.
+    if (!isNew) {
+      return
+    }
 
     // Content-detected language, stored separately from the declared
     // `language` above so the Translate gate can fall back to it when a

--- a/lib/jobs/createPollVoteJob.ts
+++ b/lib/jobs/createPollVoteJob.ts
@@ -25,6 +25,11 @@ export const createPollVoteJob = createJobHandle(
 
     const parseResult = Note.safeParse(normalizedData)
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed poll vote payload',
+        job: CREATE_POLL_VOTE_JOB_NAME,
+        statusId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const note = parseResult.data

--- a/lib/jobs/dropMalformedPayloadLogging.test.ts
+++ b/lib/jobs/dropMalformedPayloadLogging.test.ts
@@ -1,0 +1,121 @@
+import { Database } from '@/lib/database/types'
+import { createAnnounceJob } from '@/lib/jobs/createAnnounceJob'
+import { createNoteJob } from '@/lib/jobs/createNoteJob'
+import { createPollJob } from '@/lib/jobs/createPollJob'
+import { createPollVoteJob } from '@/lib/jobs/createPollVoteJob'
+import {
+  CREATE_ANNOUNCE_JOB_NAME,
+  CREATE_NOTE_JOB_NAME,
+  CREATE_POLL_JOB_NAME,
+  CREATE_POLL_VOTE_JOB_NAME,
+  UPDATE_NOTE_JOB_NAME,
+  UPDATE_POLL_JOB_NAME
+} from '@/lib/jobs/names'
+import { updateNoteJob } from '@/lib/jobs/updateNoteJob'
+import { updatePollJob } from '@/lib/jobs/updatePollJob'
+import { JobHandle } from '@/lib/services/queue/type'
+import { logger } from '@/lib/utils/logger'
+
+// vi.mock factories are hoisted, so the mock fn is created INSIDE the factory
+// and read back through the imported binding rather than referenced from an
+// outer const (which would not be initialised when the factory runs).
+vi.mock('@/lib/utils/logger', () => {
+  const mockLogger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => mockLogger)
+  }
+  return {
+    logger: mockLogger,
+    levelToSeverity: {},
+    getLoggerOptions: () => ({})
+  }
+})
+
+// A malformed payload returns before any database access, so the jobs never
+// touch this stub.
+const database = {} as unknown as Database
+const PAYLOAD_ID = 'https://malformed.test/object/1'
+
+const cases: {
+  description: string
+  run: JobHandle
+  job: string
+  message: string
+  idKey: string
+}[] = [
+  {
+    description: 'createNoteJob',
+    run: createNoteJob,
+    job: CREATE_NOTE_JOB_NAME,
+    message: 'Dropping malformed note payload',
+    idKey: 'statusId'
+  },
+  {
+    description: 'createPollJob',
+    run: createPollJob,
+    job: CREATE_POLL_JOB_NAME,
+    message: 'Dropping malformed poll payload',
+    idKey: 'statusId'
+  },
+  {
+    description: 'updateNoteJob',
+    run: updateNoteJob,
+    job: UPDATE_NOTE_JOB_NAME,
+    message: 'Dropping malformed note update payload',
+    idKey: 'statusId'
+  },
+  {
+    description: 'updatePollJob',
+    run: updatePollJob,
+    job: UPDATE_POLL_JOB_NAME,
+    message: 'Dropping malformed poll update payload',
+    idKey: 'statusId'
+  },
+  {
+    description: 'createAnnounceJob',
+    run: createAnnounceJob,
+    job: CREATE_ANNOUNCE_JOB_NAME,
+    message: 'Dropping malformed announce payload',
+    idKey: 'announceId'
+  },
+  {
+    description: 'createPollVoteJob',
+    run: createPollVoteJob,
+    job: CREATE_POLL_VOTE_JOB_NAME,
+    message: 'Dropping malformed poll vote payload',
+    idKey: 'statusId'
+  }
+]
+
+describe('dropping a malformed federated payload logs a warning', () => {
+  beforeEach(() => {
+    // A vi.fn() created inside a vi.mock factory is not reset by
+    // vi.restoreAllMocks(), so clear it explicitly between cases.
+    vi.mocked(logger.warn).mockReset()
+  })
+
+  it.each(cases)(
+    '$description warns with the job name and payload id',
+    async ({ run, job, message, idKey }) => {
+      await run(database, {
+        id: 'malformed',
+        name: job,
+        data: { id: PAYLOAD_ID, invalid: true }
+      })
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message,
+          job,
+          [idKey]: PAYLOAD_ID
+        })
+      )
+    }
+  )
+})

--- a/lib/jobs/updateNoteJob.ts
+++ b/lib/jobs/updateNoteJob.ts
@@ -61,6 +61,11 @@ export const updateNoteJob = createJobHandle(
       normalizeActivityPubContent(message.data)
     )
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed note update payload',
+        job: UPDATE_NOTE_JOB_NAME,
+        statusId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const note = parseResult.data as BaseNote

--- a/lib/jobs/updatePollJob.ts
+++ b/lib/jobs/updatePollJob.ts
@@ -17,6 +17,11 @@ export const updatePollJob = createJobHandle(
       normalizeActivityPubContent(message.data)
     )
     if (!parseResult.success) {
+      logger.warn({
+        message: 'Dropping malformed poll update payload',
+        job: UPDATE_POLL_JOB_NAME,
+        statusId: (message.data as { id?: unknown } | null)?.id
+      })
       return
     }
     const question = parseResult.data

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -600,6 +600,20 @@ export type CreatePollParams = BaseCreateStatusParams & {
   // Mastodon poll[hide_totals]: hide per-option tallies until the poll expires.
   hideTotals?: boolean
 }
+
+/**
+ * Discriminated result of a status create that recovers from a concurrent
+ * duplicate insert. `isNew` is false when a racing delivery of the same object
+ * won the unique key and this call returned the winner's existing row — the
+ * signal `createNoteJob` / `createPollJob` read to skip re-running their
+ * (non-idempotent) tag / attachment / hashtag side effects. The plain
+ * `createNote` / `createPoll` methods keep returning just the `Status`; only
+ * the `*WithResult` variants surface `isNew`.
+ */
+export type CreateStatusResult = {
+  status: Status
+  isNew: boolean
+}
 export type UpdatePollParams = Pick<CreatePollParams, 'text' | 'summary'> &
   BaseStatusParams & {
     choices: { title: string; totalVotes: number }[]
@@ -891,8 +905,13 @@ export type RecordPollVotesParams = {
 
 export interface StatusDatabase {
   createNote(params: CreateNoteParams): Promise<Status>
+  // Same insert as createNote, but reports whether the row was newly created
+  // (isNew) or recovered from a concurrent duplicate. See CreateStatusResult.
+  createNoteWithResult(params: CreateNoteParams): Promise<CreateStatusResult>
   createAnnounce(params: CreateAnnounceParams): Promise<Status | null>
   createPoll(params: CreatePollParams): Promise<Status>
+  // Same insert as createPoll, but reports whether the row was newly created.
+  createPollWithResult(params: CreatePollParams): Promise<CreateStatusResult>
   updateNote(params: UpdateNoteParams): Promise<Status | null>
   // Rewrites the status's quote-approval policy in the content blob without
   // recording an edit (no status_history append, no edited_at bump).


### PR DESCRIPTION
Stacked on #1710 (**base: `pr/02-remote-hardening`**). Review only this PR's own commit; it retargets to `main` once #1710 merges.

### 1. Post-vote sync clobbered the voter's own vote
After recording a local vote and delivering it, both vote routes immediately called `syncRemotePoll`, which overwrites `poll_choices.totalVotes` with the origin's count — which does **not** yet include the just-cast vote — so the voter watched their own vote vanish. Chose design (a): drop the immediate post-vote sync and let the next independent read reconcile. Verified `GET /api/v1/polls/:id` syncs on its own and `syncRemotePoll` is called from only these routes, so no count is lost. `syncRemotePoll.ts` itself is untouched.

### 2. Non-idempotent side effects on the duplicate-recovery race
PR #1690's unique-constraint recovery in `createNote`/`createPoll`/`createAnnounce` returns the winner's row, but callers couldn't tell it was a no-op, so `createNoteJob`/`createPollJob` re-ran `createTag` / `createAttachment` / `increaseHashtagCounter` on exactly the concurrent-delivery race the recovery targets. Added additive `createNoteWithResult`/`createPollWithResult` returning `{ status, isNew }` (an **additive wrapper** — changing the base return type would have rippled into 179 call sites across 42 files; the two jobs that need `isNew` call the wrappers and skip side effects when `isNew` is false). The 3 copy-pasted recovery catch blocks now share `recoverFromDuplicateInsert`.

### 3. Malformed federated payloads dropped silently
The `safeParse` early-returns added by PR #1674 to the queue job handlers dropped malformed payloads with zero trace. Added a `logger.warn` naming the job and payload id at all 6 sites (`createNoteJob`, `createPollJob`, `updateNoteJob`, `updatePollJob`, `createAnnounceJob`, `createPollVoteJob`). (The #1694 `targetStatus` fallback is already covered by #1704's tests.)

Every fix has a prove-by-revert regression test; the idempotency test asserts the tag/hashtag side effects run once, not twice, on the real recovery path. Full gate green in the integrated stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
