### PR TITLE
fix: append the sqlcommenter trace tag as a statement suffix

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -11,6 +11,25 @@ interface DatabaseInstance {
   knex: Knex
 }
 
+// sqlcommenter (https://google.github.io/sqlcommenter/spec/) — and Cloud SQL
+// Insights specifically, which is why this exists — parses the trace tag out
+// of a TRAILING SQL comment. knex's own `builder.comment()` cannot produce
+// that: its query compiler's `components` order always places `comments`
+// before `columns`/`join`/`where`, so `.comment()` compiles as a LEADING
+// comment (`/* … */ select …`) no matter when it is called. Insights would
+// therefore never see the tag, and the query <-> trace correlation this
+// feature exists for would silently never work.
+//
+// Rather than fight the compiler's fixed component order, wrap this one
+// builder's `toSQL()` so the tag is appended to the already-compiled SQL
+// string instead. Mutating the returned `Sql` object's `.sql` field (rather
+// than re-running the compiler with a different comment placement) also keeps
+// `Sql#toNative()` in sync for free: its `toNative()` closure reads `.sql` off
+// that same object at call time, so it picks up the appended suffix too.
+// Appending happens on the object `toSQL()` hands back, before binding
+// positions are rewritten for the target dialect (e.g. `?` -> `$1` for
+// PostgreSQL) — the trace tag never contains a `?`, so it cannot shift any
+// binding position.
 export const attachSqlcommenter = (db: Knex): Knex => {
   db.on('start', (builder: Knex.QueryBuilder) => {
     try {
@@ -21,8 +40,29 @@ export const attachSqlcommenter = (db: Knex): Knex => {
 
       const traceFlags = spanContext.traceFlags.toString(16).padStart(2, '0')
       const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
-      if (typeof builder?.comment === 'function') {
-        builder.comment(`traceparent='${traceparent}'`)
+      const commentSuffix = ` /* traceparent='${traceparent}' */`
+
+      if (typeof builder?.toSQL !== 'function') return
+      // knex fires `start` once per EXECUTION, not once per builder, and a
+      // builder can be executed more than once (awaiting the same instance
+      // twice re-runs `client.runner(this).run()`). Without this guard the
+      // second `start` would capture the already-patched `toSQL` as its
+      // "original" and stack a second identical suffix. Mark the instance so a
+      // re-fired `start` is a no-op.
+      const patchable = builder as Knex.QueryBuilder & {
+        __sqlcommenterPatched?: boolean
+      }
+      if (patchable.__sqlcommenterPatched) return
+      patchable.__sqlcommenterPatched = true
+      const originalToSQL = builder.toSQL.bind(builder)
+      builder.toSQL = () => {
+        const compiled = originalToSQL()
+        try {
+          compiled.sql = `${compiled.sql}${commentSuffix}`
+        } catch {
+          // Tracing failures must never alter query execution
+        }
+        return compiled
       }
     } catch {
       // Tracing failures must never alter query execution

--- a/lib/database/sqlcommenter.test.ts
+++ b/lib/database/sqlcommenter.test.ts
@@ -38,6 +38,84 @@ describe('attachSqlcommenter', () => {
     )
   })
 
+  it('appends the traceparent comment only once when the same builder is executed twice', async () => {
+    // knex fires `start` once per execution, and a builder can be executed
+    // more than once. Without an idempotency guard the second `start` captures
+    // the already-patched toSQL and stacks a second identical suffix.
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    const query = db('statuses').select('*')
+    db.emit('start', query)
+    db.emit('start', query)
+
+    const occurrences = query.toSQL().sql.match(/\/\* traceparent=/g) ?? []
+    expect(occurrences).toHaveLength(1)
+  })
+
+  it('appends the traceparent comment as a SUFFIX, never a leading comment', async () => {
+    // Cloud SQL Insights (and the sqlcommenter spec generally) parses the
+    // trace tag out of a comment trailing the statement. knex's own
+    // `builder.comment()` always compiles as a LEADING comment, so this test
+    // pins the placement explicitly rather than merely asserting the tag is
+    // present somewhere in the string (see `toContain` above, which passes
+    // whether the tag is a prefix or a suffix and would not have caught the
+    // original bug).
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    const query = db('statuses').select('*')
+    db.emit('start', query)
+
+    const sql = query.toSQL().sql
+
+    // The compiled statement must not START with the comment (that is what
+    // knex's `builder.comment()` produces) and must END with it instead.
+    expect(sql).not.toMatch(/^\s*\/\*/)
+    expect(sql).toMatch(
+      /\/\* traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01' \*\/\s*$/
+    )
+    expect(sql.indexOf('/*')).toBeGreaterThan(sql.indexOf('select'))
+  })
+
+  it('appends the traceparent comment onto toNative() output too', async () => {
+    // `Sql#toNative()` is a separate closure over the same compiled object;
+    // some dialects read `.sql` through it rather than the plain `.sql`
+    // field, so the suffix must be visible there as well.
+    const mockSpan = {
+      spanContext: () => ({
+        traceId: '02dad5002ab305f1fd75ae8bd0d46e94',
+        spanId: '3ca938408dc381d3',
+        traceFlags: 1
+      })
+    } as unknown as Span
+
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan)
+
+    const query = db('statuses').select('*')
+    db.emit('start', query)
+
+    const compiled = query.toSQL()
+    const native = compiled.toNative()
+    expect(native.sql).toMatch(
+      /\/\* traceparent='00-02dad5002ab305f1fd75ae8bd0d46e94-3ca938408dc381d3-01' \*\/\s*$/
+    )
+  })
+
   it('does not append comment when no active span exists', async () => {
     vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined)
 

--- a/lib/utils/traceApiRoute.test.ts
+++ b/lib/utils/traceApiRoute.test.ts
@@ -1,7 +1,49 @@
-import { SpanStatusCode, Tracer, trace } from '@opentelemetry/api'
+import {
+  SpanContext,
+  SpanStatusCode,
+  TextMapPropagator,
+  Tracer,
+  propagation,
+  trace
+} from '@opentelemetry/api'
 import { NextRequest } from 'next/server'
 
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
+
 import { parseCloudTraceContext, traceApiRoute } from './traceApiRoute'
+
+// A minimal, spec-shaped W3C `traceparent` propagator used ONLY to exercise
+// `extractTraceContext`'s call to `propagation.extract()` in tests below.
+// Without *some* propagator registered, `propagation.extract()` is a no-op
+// by default (`NoopTextMapPropagator`), so a `traceparent` header would never
+// actually bind to context — production relies on an OTel SDK registering
+// the real `W3CTraceContextPropagator` (from `@opentelemetry/core`, which is
+// not a declared dependency of this repo). Tests build minimal fakes against
+// the `@opentelemetry/api` interfaces instead, the same way
+// `lib/testing/recordingTracer.ts` builds a fake tracer/context manager.
+const w3cTraceparentPropagator: TextMapPropagator = {
+  inject: () => {
+    // Not exercised by these tests — traceApiRoute only extracts.
+  },
+  fields: () => ['traceparent'],
+  extract: (activeCtx, carrier, getter) => {
+    const header = getter.get(carrier, 'traceparent')
+    if (typeof header !== 'string') return activeCtx
+    const match = header.match(
+      /^[0-9a-f]{2}-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i
+    )
+    if (!match) return activeCtx
+    const [, traceId, spanId, flagsHex] = match
+    const spanContext: SpanContext = {
+      traceId,
+      spanId,
+      traceFlags: parseInt(flagsHex, 16),
+      isRemote: true
+    }
+    if (!trace.isSpanContextValid(spanContext)) return activeCtx
+    return trace.setSpanContext(activeCtx, spanContext)
+  }
+}
 
 describe('parseCloudTraceContext', () => {
   it('parses traceId, decimal spanId, and sampled flag', () => {
@@ -240,48 +282,100 @@ describe('traceApiRoute', () => {
     )
   })
 
-  it('extracts W3C traceparent header and binds it as active context', async () => {
-    const handler = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ success: true }), {
-        status: 200
-      })
-    )
+  // The "extracts …" test above (and this block's two tests, before they
+  // were strengthened) only asserted a 200 response and that the handler
+  // ran — which would pass even if the extracted trace context (W3C
+  // `traceparent` or `X-Cloud-Trace-Context`) were parsed and then silently
+  // discarded rather than bound as the active context. The block below
+  // instead captures the ACTIVE SPAN CONTEXT observed from *inside* the handler and
+  // asserts it descends from the injected header, which is the only way to
+  // prove `context.with(parentContext, …)` actually threaded the extracted
+  // context through to the wrapped handler.
+  //
+  // This needs a REAL context manager and tracer, not the `mockSpan` stub
+  // used by every other test in this file: that stub's `startActiveSpan`
+  // never calls `context.with()`, so `trace.getActiveSpan()` inside the
+  // handler would read whatever the environment's context manager reports —
+  // which, with no context manager registered (the default), is always
+  // `undefined` regardless of whether propagation actually worked. Swap in
+  // `setupRecordingTracer()` (a real in-memory context manager + tracer,
+  // built only against `@opentelemetry/api`) for this block instead.
+  describe('active span context propagation', () => {
+    let harness: ReturnType<typeof setupRecordingTracer>
 
-    const wrapped = traceApiRoute('testRoute', handler)
-    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
-    const spanId = '3ca938408dc381d3'
-    const req = new NextRequest('http://localhost/api/test', {
-      headers: {
-        traceparent: `00-${traceId}-${spanId}-01`
-      }
+    beforeEach(() => {
+      // Undo the outer `beforeEach`'s `trace.getTracer` stub first — it
+      // shadows the real `trace.getTracer`, which `setupRecordingTracer()`
+      // needs untouched so it can register its own global tracer provider.
+      vi.restoreAllMocks()
+      harness = setupRecordingTracer()
+      propagation.setGlobalPropagator(w3cTraceparentPropagator)
     })
-    const context = { params: Promise.resolve({}) }
 
-    const response = await wrapped(req, context)
-    expect(response.status).toBe(200)
-    expect(handler).toHaveBeenCalled()
-  })
-
-  it('extracts Google Cloud X-Cloud-Trace-Context header and parses decimal spanId', async () => {
-    const handler = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ success: true }), {
-        status: 200
-      })
-    )
-
-    const wrapped = traceApiRoute('testRoute', handler)
-    const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
-    const hexSpanId = '3ca938408dc381d3'
-    const decSpanId = BigInt(`0x${hexSpanId}`).toString(10)
-    const req = new NextRequest('http://localhost/api/test', {
-      headers: {
-        'x-cloud-trace-context': `${traceId}/${decSpanId};o=1`
-      }
+    afterEach(() => {
+      propagation.disable()
+      harness.cleanup()
     })
-    const context = { params: Promise.resolve({}) }
 
-    const response = await wrapped(req, context)
-    expect(response.status).toBe(200)
-    expect(handler).toHaveBeenCalled()
+    it('extracts W3C traceparent header and binds it as the active span context inside the handler', async () => {
+      let capturedSpanContext: SpanContext | undefined
+      const handler = vi.fn().mockImplementation(async () => {
+        capturedSpanContext = trace.getActiveSpan()?.spanContext()
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200
+        })
+      })
+
+      const wrapped = traceApiRoute('testRoute', handler)
+      const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+      const spanId = '3ca938408dc381d3'
+      const req = new NextRequest('http://localhost/api/test', {
+        headers: {
+          traceparent: `00-${traceId}-${spanId}-01`
+        }
+      })
+      const context = { params: Promise.resolve({}) }
+
+      const response = await wrapped(req, context)
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+
+      // The span active INSIDE the handler must descend from the extracted
+      // remote span: same trace id, and parented on the injected span id.
+      expect(capturedSpanContext?.traceId).toBe(traceId)
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].parentSpanId).toBe(spanId)
+      expect(harness.recordedSpans[0].name).toBe('api.testRoute')
+    })
+
+    it('extracts Google Cloud X-Cloud-Trace-Context header and binds it as the active span context inside the handler', async () => {
+      let capturedSpanContext: SpanContext | undefined
+      const handler = vi.fn().mockImplementation(async () => {
+        capturedSpanContext = trace.getActiveSpan()?.spanContext()
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200
+        })
+      })
+
+      const wrapped = traceApiRoute('testRoute', handler)
+      const traceId = '02dad5002ab305f1fd75ae8bd0d46e94'
+      const hexSpanId = '3ca938408dc381d3'
+      const decSpanId = BigInt(`0x${hexSpanId}`).toString(10)
+      const req = new NextRequest('http://localhost/api/test', {
+        headers: {
+          'x-cloud-trace-context': `${traceId}/${decSpanId};o=1`
+        }
+      })
+      const context = { params: Promise.resolve({}) }
+
+      const response = await wrapped(req, context)
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+
+      expect(capturedSpanContext?.traceId).toBe(traceId)
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].parentSpanId).toBe(hexSpanId)
+      expect(harness.recordedSpans[0].name).toBe('api.testRoute')
+    })
   })
 })

--- a/lib/utils/traceApiRoute.ts
+++ b/lib/utils/traceApiRoute.ts
@@ -54,6 +54,47 @@ export const parseCloudTraceContext = (
   }
 }
 
+// DELIBERATE TRUST DECISION — remote trace context is honored unverified,
+// on EVERY route this wraps, public and authenticated alike (the vast
+// majority of this app's `app/api/**` routes, plus the ActivityPub inbox and
+// other unauthenticated federation surfaces). Any caller can set a
+// `traceparent` or `X-Cloud-Trace-Context` header naming an arbitrary trace
+// id and a "sampled" flag, and both are bound as this request's parent
+// context below with no authentication or signature check.
+//
+// The accepted risk: a caller can make this app's spans for that request
+// correlate under a trace id of the caller's choosing, and can HINT that the
+// trace should be sampled. Whether that hint is actually honored is decided
+// by whichever OTel SDK/collector an operator attaches externally (this repo
+// depends only on `@opentelemetry/api` — see the `OTEL_EXPORTER_*` table in
+// `docs/environment-variables.md` — and registers no SDK, sampler, or
+// exporter of its own), but the OTel SDK ecosystem's long-standing default is
+// a `ParentBased` sampler, which DOES honor an incoming sampled flag. So on a
+// default setup, a high-volume anonymous caller could inflate sampled span
+// volume against a cost-bearing trace backend (e.g. Google Cloud Trace,
+// which this app has first-class support for via `OTEL_EXPORTER_OTLP_PROTOCOL
+// =google`).
+//
+// This is honored anyway, deliberately, rather than stripped for
+// "unauthenticated" routes, for two reasons. First, honoring the incoming
+// context is the entire point of W3C Trace Context propagation: it is what
+// lets legitimate infrastructure in front of this app (a reverse proxy, a
+// load balancer, or — on Cloud Run specifically — the platform's own
+// front end) correlate a request across hops; refusing it outright would
+// break that correlation for every deployment that propagates traces
+// correctly, to defend against one that does not. Second, `traceApiRoute`
+// wraps handlers uniformly with no signal, at this layer, for whether a
+// given route will end up requiring authentication — that check runs
+// *inside* the handler, after this context has already been extracted — so
+// a "public vs authenticated" split here would need a broader design change
+// (e.g. an explicit flag threaded through every one of this app's route
+// wrappers) than this fix's scope justifies, and an incomplete or guessed
+// split (e.g. inferred from the route path) would be worse than the status
+// quo. An operator who needs to bound this risk on a cost-bearing backend
+// should do so at the sampler layer they control — e.g. a `ParentBased`
+// sampler configured with `remoteParentSampled: alwaysOff` — since that is
+// where the actual export/ingestion (and billing) decision is made, not
+// here.
 export const extractTraceContext = (req: NextRequest) => {
   const activeCtx = context.active()
   if (!req.headers) return activeCtx


### PR DESCRIPTION
Stacked on #1711 (**base: `pr/03-poll-race-idempotency`**). Retargets to `main` as the stack lands.

### The sqlcommenter tag was emitted as a leading comment
knex's `.comment()` always compiles as a **leading** comment (`/* traceparent=... */ select …`) — its `components` order is fixed. But sqlcommenter / Google Cloud SQL Insights parse a **trailing** comment, so the query→trace correlation this feature exists for never worked as shipped.
Fix: on knex's `'start'` event, monkey-patch that query builder instance's own `toSQL()` to append `` ` /* traceparent='...' */` `` onto the compiled `Sql.sql` (and it flows through `toNative()` for free). Runs before dialect bind-position rewriting, so it's safe on PostgreSQL and SQLite; the tag never contains `?`. As a side effect this also extends tagging to INSERT/UPDATE/DELETE, which `.comment()` never reached (only `select`'s compiler read the comments).

### Strengthened the propagation tests
The two `traceApiRoute` propagation tests only asserted a 200 / handler-ran — vacuous, because with the default noop context manager `getActiveSpan()` is always undefined regardless of whether propagation worked. They now install a real in-memory context manager (`setupRecordingTracer`) and assert the **active span context captured from inside the handler** descends from the injected `traceparent`.

### Remote sampling flags — deliberate decision (documented)
Kept W3C propagation as-is (option B) and documented the accepted risk at the extraction site: `traceApiRoute` wraps ~289 routes uniformly including public ones, with no signal at extraction time for whether a route requires auth, so a correct public/authenticated split needs a broader design change; a partial guess is worse. The comment names where an operator actually mitigates (their sampler config, e.g. `ParentBased` with `remoteParentSampled: alwaysOff`).

Prove-by-revert tests: suffix-placement and the strengthened propagation assertions each fail when their fix is reverted. Full gate green in the integrated stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
