### PR TITLE
Bump version to v1.154.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.154.2",
+  "version": "1.154.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.154.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.154.2`
- Base main SHA: `28916eae3f2fb67ee833527244d23f80de446b64`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
