### PR TITLE
minor: list remote accounts' followers and following over the Mastodon API

### DIFF
--- a/app/api/v1/accounts/[id]/followCollectionHandler.ts
+++ b/app/api/v1/accounts/[id]/followCollectionHandler.ts
@@ -1,0 +1,280 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import {
+  RemoteFollowField,
+  getRemoteFollowCollectionPage
+} from '@/lib/services/mastodon/remoteFollowCollection'
+import { resolveActorIdParam } from '@/lib/services/mastodon/resolveClientId'
+import { Actor } from '@/lib/types/domain/actor'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
+import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
+import { ERROR_400, apiCorsError, apiResponse } from '@/lib/utils/response'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+
+// Shared handler for GET /api/v1/accounts/:id/following and /followers.
+// https://docs.joinmastodon.org/methods/accounts/#following
+// https://docs.joinmastodon.org/methods/accounts/#followers
+//
+// Public with optional auth. Paginated with Mastodon id cursors + Link
+// headers, mirroring the accounts/:id/statuses route.
+//
+// A LOCAL actor's list is the `follows` table, and the cursor is the follow-row
+// id (the column getFollowing/getFollowers paginate on), not the account id.
+//
+// A REMOTE actor's list is read live from the collection its own server
+// publishes — see `lib/services/mastodon/remoteFollowCollection.ts` — because
+// the `follows` table only holds relationships this instance took part in,
+// which for a remote actor is one local follower and nothing followed. On that
+// path the cursor is the remote page URL: `max_id` carries the page's `next`,
+// `min_id` its `prev`, so an unmodified Mastodon client paginates by sending
+// the Link header's value straight back. A cursor that parses as a URL is
+// accepted only for a page of THAT actor's collection (the service applies
+// the same `isCollectionPageUrl` check `remote-statuses` applies to its
+// `page_url`), and is a 400 otherwise. A cursor that is not a URL is a follow-row id from the local
+// path and is answered from local rows.
+//
+// The remote read is only made for a signed-in viewer. The route is public,
+// and each page can cost a signed fetch per unknown actor on it, so an
+// anonymous caller gets the local rows exactly as before — the same line
+// `search` and `accounts/lookup` draw around `resolve=true`. Every failure on
+// the remote path (blocked domain, unreachable server, hidden collection)
+// also falls back to the local rows, so today's behaviour is the floor.
+
+export const FOLLOW_COLLECTION_CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET
+]
+
+const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
+
+const FollowCollectionQueryParams = z.object({
+  max_id: z.string().optional(),
+  since_id: z.string().optional(),
+  min_id: z.string().optional(),
+  limit: clampedLimit(80, 40)
+})
+
+interface HandleParams {
+  req: NextRequest
+  database: Database
+  currentActor: Actor | null
+  encodedAccountId: string | undefined
+  field: RemoteFollowField
+}
+
+const isUrlCursor = (cursor: string | undefined): cursor is string => {
+  if (!cursor) return false
+  try {
+    const url = new URL(cursor)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+const getLocalFollows = async (
+  database: Database,
+  field: RemoteFollowField,
+  actorId: string,
+  cursors: {
+    limit: number
+    maxId?: string
+    minId?: string
+    sinceId?: string
+  }
+) => {
+  const follows =
+    field === 'following'
+      ? await database.getFollowing({ actorId, ...cursors })
+      : await database.getFollowers({ targetActorId: actorId, ...cursors })
+  return follows.map((follow) => ({
+    id: follow.id,
+    accountId: field === 'following' ? follow.targetActorId : follow.actorId
+  }))
+}
+
+export const handleFollowCollectionRequest = async ({
+  req,
+  database,
+  currentActor,
+  encodedAccountId,
+  field
+}: HandleParams) => {
+  if (!encodedAccountId) return apiCorsError(req, CORS_HEADERS, 400)
+
+  const id = await resolveActorIdParam(database, encodedAccountId)
+  const actor = await database.getActorFromId({ id })
+  if (!actor) return apiCorsError(req, CORS_HEADERS, 404)
+
+  const url = new URL(req.url)
+  const parsed = FollowCollectionQueryParams.safeParse(
+    Object.fromEntries(url.searchParams.entries())
+  )
+  if (!parsed.success) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_400,
+      responseStatusCode: 400
+    })
+  }
+  const { limit, max_id: maxId, min_id: minId, since_id: sinceId } = parsed.data
+
+  // Percent-encoded: the router hands the id over already decoded, and the
+  // resolver accepts a raw http(s) URI as an id form, so the raw value would
+  // emit a Link URL that does not route back here.
+  const path = `/api/v1/accounts/${encodeURIComponent(encodedAccountId)}/${field}`
+  const host = headerHost(req.headers)
+
+  const isLocalActor = Boolean(actor.privateKey)
+  const pageUrl = isUrlCursor(maxId)
+    ? maxId
+    : isUrlCursor(minId)
+      ? minId
+      : undefined
+
+  if (!isLocalActor && currentActor) {
+    const remote = await serveRemoteCollection({
+      req,
+      database,
+      actorId: actor.id,
+      field,
+      pageUrl,
+      limit,
+      host,
+      path
+    })
+    if (remote) return remote
+  }
+
+  // A remote page URL is meaningless against the follow-row ids the local path
+  // paginates on: it is either a client re-sending a Link cursor to a
+  // now-anonymous session, or one for a collection this instance could not
+  // read this time. Serve the first local page rather than compare a URL
+  // against row ids.
+  const localCursors = {
+    limit,
+    maxId: isUrlCursor(maxId) ? undefined : maxId,
+    minId: isUrlCursor(minId) ? undefined : minId,
+    sinceId: isUrlCursor(sinceId) ? undefined : sinceId
+  }
+  const orderedFollows = await getLocalFollows(
+    database,
+    field,
+    actor.id,
+    localCursors
+  )
+
+  // Batch-hydrate the accounts in a single query, then re-order to match
+  // orderedFollows (getMastodonActorsFromIds does not guarantee order).
+  const accountsById = new Map(
+    (
+      await database.getMastodonActorsFromIds({
+        ids: orderedFollows.map((follow) => follow.accountId)
+      })
+    ).map((account) => [account.url, account])
+  )
+  const accounts = orderedFollows
+    .map((follow) => accountsById.get(follow.accountId))
+    .filter((account): account is NonNullable<typeof account> =>
+      Boolean(account)
+    )
+
+  const additionalHeaders = buildPaginationLinkHeader({
+    host,
+    path,
+    limit,
+    nextMaxId:
+      orderedFollows.length > 0
+        ? orderedFollows[orderedFollows.length - 1].id
+        : null,
+    prevMinId: orderedFollows.length > 0 ? orderedFollows[0].id : null
+  })
+
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: accounts,
+    additionalHeaders
+  })
+}
+
+// The remote branch. Answers null wherever the local rows should be served
+// instead; the one non-null failure is a URL cursor that does not belong to
+// this actor's collection, which is a client error rather than a fallback.
+const serveRemoteCollection = async ({
+  req,
+  database,
+  actorId,
+  field,
+  pageUrl,
+  limit,
+  host,
+  path
+}: {
+  req: NextRequest
+  database: Database
+  actorId: string
+  field: RemoteFollowField
+  pageUrl: string | undefined
+  limit: number
+  host: string | null | undefined
+  path: string
+}): Promise<Response | null> => {
+  try {
+    // Server-to-server fetches are signed by the headless instance actor,
+    // never the viewer's actor; a missing signer degrades to an unsigned
+    // fetch. Domain policy applies to every live-fetch surface, and is checked
+    // here per request rather than inside the cached read so a newly blocked
+    // domain is refused at once.
+    const [canFederate, signingActor] = await Promise.all([
+      canFederateWithDomain(database, actorId),
+      getFederationSigningActorSafe(database, `for remote account ${field}`)
+    ])
+    if (!canFederate) return null
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId,
+      field,
+      signingActor,
+      pageUrl
+    })
+    if (result.status === 'unavailable') return null
+    if (result.status === 'invalid-page') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: result.page.accounts,
+      additionalHeaders: buildPaginationLinkHeader({
+        host,
+        path,
+        limit,
+        nextMaxId: result.page.nextPageUrl,
+        prevMinId: result.page.prevPageUrl
+      })
+    })
+  } catch (error) {
+    logger.warn({
+      message: `Failed to read remote actor ${field} collection; serving local rows`,
+      actorId,
+      err: toLoggableError(error)
+    })
+    return null
+  }
+}

--- a/app/api/v1/accounts/[id]/followCollectionHandler.ts
+++ b/app/api/v1/accounts/[id]/followCollectionHandler.ts
@@ -34,11 +34,14 @@ import { toLoggableError } from '@/lib/utils/toLoggableError'
 // which for a remote actor is one local follower and nothing followed. On that
 // path the cursor is the remote page URL: `max_id` carries the page's `next`,
 // `min_id` its `prev`, so an unmodified Mastodon client paginates by sending
-// the Link header's value straight back. A cursor that parses as a URL is
-// accepted only for a page of THAT actor's collection (the service applies
-// the same `isCollectionPageUrl` check `remote-statuses` applies to its
-// `page_url`), and is a 400 otherwise. A cursor that is not a URL is a follow-row id from the local
-// path and is answered from local rows.
+// the Link header's value straight back. When the remote is consulted, a
+// cursor that parses as a URL is accepted only for a page of THAT actor's
+// collection (the service applies the same `isCollectionPageUrl` check
+// `remote-statuses` applies to its `page_url`) and is a 400 otherwise. On the
+// local path — a local actor, or any of the fallbacks below — a URL cursor is
+// ignored and the first local page served, because it names nothing among the
+// follow-row ids that path paginates on; a cursor that is not a URL is such a
+// row id.
 //
 // The remote read is only made for a signed-in viewer. The route is public,
 // and each page can cost a signed fetch per unknown actor on it, so an
@@ -47,12 +50,7 @@ import { toLoggableError } from '@/lib/utils/toLoggableError'
 // the remote path (blocked domain, unreachable server, hidden collection)
 // also falls back to the local rows, so today's behaviour is the floor.
 
-export const FOLLOW_COLLECTION_CORS_HEADERS = [
-  HttpMethod.enum.OPTIONS,
-  HttpMethod.enum.GET
-]
-
-const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
+export const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 const FollowCollectionQueryParams = z.object({
   max_id: z.string().optional(),

--- a/app/api/v1/accounts/[id]/followCollectionHandler.ts
+++ b/app/api/v1/accounts/[id]/followCollectionHandler.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode, trace } from '@opentelemetry/api'
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
@@ -268,6 +269,13 @@ const serveRemoteCollection = async ({
       })
     })
   } catch (error) {
+    const span = trace.getActiveSpan()
+    if (span) {
+      span.recordException(
+        error instanceof Error ? error : new Error(String(error))
+      )
+      span.setStatus({ code: SpanStatusCode.ERROR })
+    }
     logger.warn({
       message: `Failed to read remote actor ${field} collection; serving local rows`,
       actorId,

--- a/app/api/v1/accounts/[id]/followers/route.test.ts
+++ b/app/api/v1/accounts/[id]/followers/route.test.ts
@@ -6,7 +6,7 @@ import { getFederationSigningActorSafe } from '@/lib/services/federation/getFede
 import { getRemoteFollowCollectionPage } from '@/lib/services/mastodon/remoteFollowCollection'
 import { seedDatabase } from '@/lib/stub/database'
 import { actorPublicId } from '@/lib/stub/publicIds'
-import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { urlToId } from '@/lib/utils/urlToId'
@@ -301,11 +301,11 @@ describe('GET /api/v1/accounts/:id/followers for a remote actor', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json()
-    const localFollows = await database.getFollowers({
-      targetActorId: EXTERNAL_ACTOR1,
-      limit: 40
-    })
-    expect(data.length).toBe(localFollows.length)
+    // The seed's local follower row for EXTERNAL_ACTOR1 (actor1), not the
+    // mocked remote page (actor2).
+    expect(data.map((account: { uri: string }) => account.uri)).toEqual([
+      ACTOR1_ID
+    ])
   })
 
   it('serves the local rows for a blocked domain without fetching it', async () => {

--- a/app/api/v1/accounts/[id]/followers/route.test.ts
+++ b/app/api/v1/accounts/[id]/followers/route.test.ts
@@ -1,9 +1,14 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { getRemoteFollowCollectionPage } from '@/lib/services/mastodon/remoteFollowCollection'
 import { seedDatabase } from '@/lib/stub/database'
 import { actorPublicId } from '@/lib/stub/publicIds'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { GET } from './route'
@@ -26,6 +31,16 @@ vi.mock('next/headers', () => ({
 }))
 
 vi.mock('better-auth/oauth2', () => ({ verifyBearerToken: vi.fn() }))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: vi.fn()
+}))
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActorSafe: vi.fn()
+}))
+vi.mock('@/lib/services/mastodon/remoteFollowCollection', () => ({
+  getRemoteFollowCollectionPage: vi.fn()
+}))
 
 vi.mock('@/lib/config', () => ({
   getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
@@ -141,5 +156,185 @@ describe('GET /api/v1/accounts/:id/followers', () => {
       params: Promise.resolve({ id: urlToId(unknown) })
     })
     expect(response.status).toBe(404)
+  })
+})
+
+describe('GET /api/v1/accounts/:id/followers for a remote actor', () => {
+  const database = getTestSQLDatabase()
+  const signingActor = { id: 'https://llun.test/users/__instance__' }
+  const nextPageUrl = `${EXTERNAL_ACTOR1}/followers?page=2`
+  const prevPageUrl = `${EXTERNAL_ACTOR1}/followers?page=1`
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(getRemoteFollowCollectionPage).mockReset()
+    vi.mocked(canFederateWithDomain).mockReset()
+    vi.mocked(getFederationSigningActorSafe).mockReset()
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    vi.mocked(canFederateWithDomain).mockResolvedValue(true)
+    vi.mocked(getFederationSigningActorSafe).mockResolvedValue(
+      signingActor as never
+    )
+    vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+      status: 'ok',
+      page: {
+        accounts: await database.getMastodonActorsFromIds({
+          ids: [ACTOR2_ID]
+        }),
+        nextPageUrl,
+        prevPageUrl,
+        totalItems: 42
+      }
+    })
+  })
+
+  it('serves the remote collection page for a signed-in viewer', async () => {
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((account: { uri: string }) => account.uri)).toEqual([
+      ACTOR2_ID
+    ])
+    // Signed by the headless instance actor, never the viewer.
+    expect(getRemoteFollowCollectionPage).toHaveBeenCalledWith({
+      database,
+      actorId: EXTERNAL_ACTOR1,
+      field: 'followers',
+      signingActor,
+      pageUrl: undefined
+    })
+    // The remote page URLs ride in the Mastodon cursors, so an unmodified
+    // client paginates by sending them straight back.
+    const link = response.headers.get('Link')
+    expect(link).toContain(`max_id=${encodeURIComponent(nextPageUrl)}`)
+    expect(link).toContain('rel="next"')
+    expect(link).toContain(`min_id=${encodeURIComponent(prevPageUrl)}`)
+    expect(link).toContain('rel="prev"')
+  })
+
+  it.each([
+    { cursor: 'max_id', pageUrl: nextPageUrl },
+    { cursor: 'min_id', pageUrl: prevPageUrl }
+  ])(
+    'forwards a $cursor cursor naming a page of the collection',
+    async ({ cursor, pageUrl }) => {
+      const response = await GET(
+        createRequest(
+          EXTERNAL_ACTOR1,
+          `?${cursor}=${encodeURIComponent(pageUrl)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(getRemoteFollowCollectionPage).toHaveBeenCalledWith(
+        expect.objectContaining({ pageUrl })
+      )
+    }
+  )
+
+  it('answers 400 when the service refuses the cursor as a page of another collection', async () => {
+    vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+      status: 'invalid-page'
+    })
+
+    const response = await GET(
+      createRequest(
+        EXTERNAL_ACTOR1,
+        `?max_id=${encodeURIComponent(`${EXTERNAL_ACTOR1}/following?page=2`)}`
+      ),
+      { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  it('serves the local rows to an anonymous caller without any remote fetch', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(getRemoteFollowCollectionPage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'the remote publishes no page (hidden collection)',
+      arrange: () =>
+        vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+          status: 'unavailable'
+        })
+    },
+    {
+      description: 'the remote read throws',
+      arrange: () =>
+        vi
+          .mocked(getRemoteFollowCollectionPage)
+          .mockRejectedValue(new Error('unreachable'))
+    }
+  ])('falls back to the local rows when $description', async ({ arrange }) => {
+    arrange()
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    const localFollows = await database.getFollowers({
+      targetActorId: EXTERNAL_ACTOR1,
+      limit: 40
+    })
+    expect(data.length).toBe(localFollows.length)
+  })
+
+  it('serves the local rows for a blocked domain without fetching it', async () => {
+    vi.mocked(canFederateWithDomain).mockResolvedValue(false)
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(getRemoteFollowCollectionPage).not.toHaveBeenCalled()
+  })
+
+  it('ignores a remote page cursor on the local fallback path', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const getLocal = vi.spyOn(database, 'getFollowers')
+
+    const response = await GET(
+      createRequest(
+        EXTERNAL_ACTOR1,
+        `?max_id=${encodeURIComponent(nextPageUrl)}`
+      ),
+      { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(getLocal).toHaveBeenCalledWith(
+      expect.objectContaining({ maxId: undefined })
+    )
+    getLocal.mockRestore()
   })
 })

--- a/app/api/v1/accounts/[id]/followers/route.ts
+++ b/app/api/v1/accounts/[id]/followers/route.ts
@@ -1,5 +1,5 @@
 import {
-  FOLLOW_COLLECTION_CORS_HEADERS,
+  CORS_HEADERS,
   handleFollowCollectionRequest
 } from '@/app/api/v1/accounts/[id]/followCollectionHandler'
 import {
@@ -9,8 +9,6 @@ import {
 import { Scope } from '@/lib/types/database/operations'
 import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-
-const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 

--- a/app/api/v1/accounts/[id]/followers/route.ts
+++ b/app/api/v1/accounts/[id]/followers/route.ts
@@ -1,24 +1,16 @@
-import { z } from 'zod'
-
+import {
+  FOLLOW_COLLECTION_CORS_HEADERS,
+  handleFollowCollectionRequest
+} from '@/app/api/v1/accounts/[id]/followCollectionHandler'
 import {
   OptionalOAuthGuard,
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
-import { headerHost } from '@/lib/services/guards/headerHost'
-import { resolveActorIdParam } from '@/lib/services/mastodon/resolveClientId'
 import { Scope } from '@/lib/types/database/operations'
-import { clampedLimit } from '@/lib/utils/clampedLimit'
-import { HttpMethod } from '@/lib/utils/http-headers'
-import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
-import {
-  ERROR_400,
-  apiCorsError,
-  apiResponse,
-  defaultOptions
-} from '@/lib/utils/response'
+import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
-const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -26,95 +18,20 @@ interface Params {
   id: string
 }
 
-const FollowersQueryParams = z.object({
-  max_id: z.string().optional(),
-  since_id: z.string().optional(),
-  min_id: z.string().optional(),
-  limit: clampedLimit(80, 40)
-})
-
-// GET /api/v1/accounts/:id/followers — accounts which follow the given account.
-// https://docs.joinmastodon.org/methods/accounts/#followers
-//
-// Public with optional auth. Paginated with Mastodon id cursors + Link headers,
-// mirroring the accounts/:id/statuses route. The cursor is the underlying
-// follow-row id (the column getFollowers paginates on), not the account id.
+// GET /api/v1/accounts/:id/followers — see followCollectionHandler.ts for the
+// local-vs-remote actor split and the cursor shapes.
 export const GET = traceApiRoute(
   'getAccountFollowers',
   OptionalOAuthGuard<Params>(
     [Scope.enum.read, Scope.enum['read:follows']],
     async (req, context) => {
-      const { database, params } = context
-      const encodedAccountId = (await params).id
-      if (!encodedAccountId) return apiCorsError(req, CORS_HEADERS, 400)
-
-      const id = await resolveActorIdParam(database, encodedAccountId)
-      const actor = await database.getActorFromId({ id })
-      if (!actor) return apiCorsError(req, CORS_HEADERS, 404)
-
-      const url = new URL(req.url)
-      const parsed = FollowersQueryParams.safeParse(
-        Object.fromEntries(url.searchParams.entries())
-      )
-      if (!parsed.success) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
-        })
-      }
-      const {
-        limit,
-        max_id: maxId,
-        min_id: minId,
-        since_id: sinceId
-      } = parsed.data
-
-      // getFollowers applies the correct ordering per cursor and always returns
-      // newest-first; the cursor is the follow-row id.
-      const orderedFollows = await database.getFollowers({
-        targetActorId: id,
-        limit,
-        maxId,
-        minId,
-        sinceId
-      })
-
-      // Batch-hydrate the follower accounts in a single query, then re-order to
-      // match orderedFollows (getMastodonActorsFromIds does not guarantee order).
-      const accountsById = new Map(
-        (
-          await database.getMastodonActorsFromIds({
-            ids: orderedFollows.map((follow) => follow.actorId)
-          })
-        ).map((account) => [account.url, account])
-      )
-      const accounts = orderedFollows
-        .map((follow) => accountsById.get(follow.actorId))
-        .filter((account): account is NonNullable<typeof account> =>
-          Boolean(account)
-        )
-
-      const additionalHeaders = buildPaginationLinkHeader({
-        host: headerHost(req.headers),
-        // Percent-encoded: the router hands the id over already decoded, and
-        // the resolver accepts a raw http(s) URI as an id form, so the raw
-        // value would emit a Link URL that does not route back here.
-        path: `/api/v1/accounts/${encodeURIComponent(encodedAccountId)}/followers`,
-        limit,
-        nextMaxId:
-          orderedFollows.length > 0
-            ? orderedFollows[orderedFollows.length - 1].id
-            : null,
-        prevMinId: orderedFollows.length > 0 ? orderedFollows[0].id : null
-      })
-
-      return apiResponse({
+      const { database, currentActor, params } = context
+      return handleFollowCollectionRequest({
         req,
-        allowedMethods: CORS_HEADERS,
-        data: accounts,
-        additionalHeaders
+        database,
+        currentActor,
+        encodedAccountId: (await params).id,
+        field: 'followers'
       })
     },
     { errorResponse: corsErrorResponse(CORS_HEADERS), matchMode: 'any' }

--- a/app/api/v1/accounts/[id]/following/route.test.ts
+++ b/app/api/v1/accounts/[id]/following/route.test.ts
@@ -1,8 +1,14 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { getRemoteFollowCollectionPage } from '@/lib/services/mastodon/remoteFollowCollection'
 import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { GET } from './route'
@@ -25,6 +31,16 @@ vi.mock('next/headers', () => ({
 }))
 
 vi.mock('better-auth/oauth2', () => ({ verifyBearerToken: vi.fn() }))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: vi.fn()
+}))
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActorSafe: vi.fn()
+}))
+vi.mock('@/lib/services/mastodon/remoteFollowCollection', () => ({
+  getRemoteFollowCollectionPage: vi.fn()
+}))
 
 vi.mock('@/lib/config', () => ({
   getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
@@ -112,4 +128,184 @@ describe('GET /api/v1/accounts/:id/following', () => {
       )
     }
   )
+})
+
+describe('GET /api/v1/accounts/:id/following for a remote actor', () => {
+  const database = getTestSQLDatabase()
+  const signingActor = { id: 'https://llun.test/users/__instance__' }
+  const nextPageUrl = `${EXTERNAL_ACTOR1}/following?page=2`
+  const prevPageUrl = `${EXTERNAL_ACTOR1}/following?page=1`
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(getRemoteFollowCollectionPage).mockReset()
+    vi.mocked(canFederateWithDomain).mockReset()
+    vi.mocked(getFederationSigningActorSafe).mockReset()
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    vi.mocked(canFederateWithDomain).mockResolvedValue(true)
+    vi.mocked(getFederationSigningActorSafe).mockResolvedValue(
+      signingActor as never
+    )
+    vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+      status: 'ok',
+      page: {
+        accounts: await database.getMastodonActorsFromIds({
+          ids: [ACTOR2_ID]
+        }),
+        nextPageUrl,
+        prevPageUrl,
+        totalItems: 42
+      }
+    })
+  })
+
+  it('serves the remote collection page for a signed-in viewer', async () => {
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((account: { uri: string }) => account.uri)).toEqual([
+      ACTOR2_ID
+    ])
+    // Signed by the headless instance actor, never the viewer.
+    expect(getRemoteFollowCollectionPage).toHaveBeenCalledWith({
+      database,
+      actorId: EXTERNAL_ACTOR1,
+      field: 'following',
+      signingActor,
+      pageUrl: undefined
+    })
+    // The remote page URLs ride in the Mastodon cursors, so an unmodified
+    // client paginates by sending them straight back.
+    const link = response.headers.get('Link')
+    expect(link).toContain(`max_id=${encodeURIComponent(nextPageUrl)}`)
+    expect(link).toContain('rel="next"')
+    expect(link).toContain(`min_id=${encodeURIComponent(prevPageUrl)}`)
+    expect(link).toContain('rel="prev"')
+  })
+
+  it.each([
+    { cursor: 'max_id', pageUrl: nextPageUrl },
+    { cursor: 'min_id', pageUrl: prevPageUrl }
+  ])(
+    'forwards a $cursor cursor naming a page of the collection',
+    async ({ cursor, pageUrl }) => {
+      const response = await GET(
+        createRequest(
+          EXTERNAL_ACTOR1,
+          `?${cursor}=${encodeURIComponent(pageUrl)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+      )
+
+      expect(response.status).toBe(200)
+      expect(getRemoteFollowCollectionPage).toHaveBeenCalledWith(
+        expect.objectContaining({ pageUrl })
+      )
+    }
+  )
+
+  it('answers 400 when the service refuses the cursor as a page of another collection', async () => {
+    vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+      status: 'invalid-page'
+    })
+
+    const response = await GET(
+      createRequest(
+        EXTERNAL_ACTOR1,
+        `?max_id=${encodeURIComponent(`${EXTERNAL_ACTOR1}/followers?page=2`)}`
+      ),
+      { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  it('serves the local rows to an anonymous caller without any remote fetch', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(getRemoteFollowCollectionPage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'the remote publishes no page (hidden collection)',
+      arrange: () =>
+        vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
+          status: 'unavailable'
+        })
+    },
+    {
+      description: 'the remote read throws',
+      arrange: () =>
+        vi
+          .mocked(getRemoteFollowCollectionPage)
+          .mockRejectedValue(new Error('unreachable'))
+    }
+  ])('falls back to the local rows when $description', async ({ arrange }) => {
+    arrange()
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    const localFollows = await database.getFollowing({
+      actorId: EXTERNAL_ACTOR1,
+      limit: 40
+    })
+    expect(data.length).toBe(localFollows.length)
+  })
+
+  it('serves the local rows for a blocked domain without fetching it', async () => {
+    vi.mocked(canFederateWithDomain).mockResolvedValue(false)
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(getRemoteFollowCollectionPage).not.toHaveBeenCalled()
+  })
+
+  it('ignores a remote page cursor on the local fallback path', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const getLocal = vi.spyOn(database, 'getFollowing')
+
+    const response = await GET(
+      createRequest(
+        EXTERNAL_ACTOR1,
+        `?max_id=${encodeURIComponent(nextPageUrl)}`
+      ),
+      { params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(getLocal).toHaveBeenCalledWith(
+      expect.objectContaining({ maxId: undefined })
+    )
+    getLocal.mockRestore()
+  })
 })

--- a/app/api/v1/accounts/[id]/following/route.test.ts
+++ b/app/api/v1/accounts/[id]/following/route.test.ts
@@ -126,6 +126,8 @@ describe('GET /api/v1/accounts/:id/following', () => {
       expect(getFollowingSpy).toHaveBeenCalledWith(
         expect.objectContaining({ limit: expected })
       )
+
+      getFollowingSpy.mockRestore()
     }
   )
 })

--- a/app/api/v1/accounts/[id]/following/route.test.ts
+++ b/app/api/v1/accounts/[id]/following/route.test.ts
@@ -163,8 +163,11 @@ describe('GET /api/v1/accounts/:id/following for a remote actor', () => {
     vi.mocked(getRemoteFollowCollectionPage).mockResolvedValue({
       status: 'ok',
       page: {
+        // ACTOR3, not ACTOR2: the seed has EXTERNAL_ACTOR1 following ACTOR2,
+        // so a body of [ACTOR2] would also be what the LOCAL rows answer and
+        // the assertion could not tell the two branches apart.
         accounts: await database.getMastodonActorsFromIds({
-          ids: [ACTOR2_ID]
+          ids: [ACTOR3_ID]
         }),
         nextPageUrl,
         prevPageUrl,
@@ -181,7 +184,7 @@ describe('GET /api/v1/accounts/:id/following for a remote actor', () => {
     expect(response.status).toBe(200)
     const data = await response.json()
     expect(data.map((account: { uri: string }) => account.uri)).toEqual([
-      ACTOR2_ID
+      ACTOR3_ID
     ])
     // Signed by the headless instance actor, never the viewer.
     expect(getRemoteFollowCollectionPage).toHaveBeenCalledWith({
@@ -272,11 +275,11 @@ describe('GET /api/v1/accounts/:id/following for a remote actor', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json()
-    const localFollows = await database.getFollowing({
-      actorId: EXTERNAL_ACTOR1,
-      limit: 40
-    })
-    expect(data.length).toBe(localFollows.length)
+    // The seed's local following row for EXTERNAL_ACTOR1, not the mocked
+    // remote page.
+    expect(data.map((account: { uri: string }) => account.uri)).toEqual([
+      ACTOR2_ID
+    ])
   })
 
   it('serves the local rows for a blocked domain without fetching it', async () => {

--- a/app/api/v1/accounts/[id]/following/route.ts
+++ b/app/api/v1/accounts/[id]/following/route.ts
@@ -1,24 +1,16 @@
-import { z } from 'zod'
-
+import {
+  FOLLOW_COLLECTION_CORS_HEADERS,
+  handleFollowCollectionRequest
+} from '@/app/api/v1/accounts/[id]/followCollectionHandler'
 import {
   OptionalOAuthGuard,
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
-import { headerHost } from '@/lib/services/guards/headerHost'
-import { resolveActorIdParam } from '@/lib/services/mastodon/resolveClientId'
 import { Scope } from '@/lib/types/database/operations'
-import { clampedLimit } from '@/lib/utils/clampedLimit'
-import { HttpMethod } from '@/lib/utils/http-headers'
-import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
-import {
-  ERROR_400,
-  apiCorsError,
-  apiResponse,
-  defaultOptions
-} from '@/lib/utils/response'
+import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
-const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -26,95 +18,20 @@ interface Params {
   id: string
 }
 
-const FollowingQueryParams = z.object({
-  max_id: z.string().optional(),
-  since_id: z.string().optional(),
-  min_id: z.string().optional(),
-  limit: clampedLimit(80, 40)
-})
-
-// GET /api/v1/accounts/:id/following — accounts the given account follows.
-// https://docs.joinmastodon.org/methods/accounts/#following
-//
-// Public with optional auth. Paginated with Mastodon id cursors + Link headers,
-// mirroring the accounts/:id/statuses route. The cursor is the underlying
-// follow-row id (the column getFollowing paginates on), not the account id.
+// GET /api/v1/accounts/:id/following — see followCollectionHandler.ts for the
+// local-vs-remote actor split and the cursor shapes.
 export const GET = traceApiRoute(
   'getAccountFollowing',
   OptionalOAuthGuard<Params>(
     [Scope.enum.read, Scope.enum['read:follows']],
     async (req, context) => {
-      const { database, params } = context
-      const encodedAccountId = (await params).id
-      if (!encodedAccountId) return apiCorsError(req, CORS_HEADERS, 400)
-
-      const id = await resolveActorIdParam(database, encodedAccountId)
-      const actor = await database.getActorFromId({ id })
-      if (!actor) return apiCorsError(req, CORS_HEADERS, 404)
-
-      const url = new URL(req.url)
-      const parsed = FollowingQueryParams.safeParse(
-        Object.fromEntries(url.searchParams.entries())
-      )
-      if (!parsed.success) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
-        })
-      }
-      const {
-        limit,
-        max_id: maxId,
-        min_id: minId,
-        since_id: sinceId
-      } = parsed.data
-
-      // getFollowing applies the correct ordering per cursor and always returns
-      // newest-first; the cursor is the follow-row id.
-      const orderedFollows = await database.getFollowing({
-        actorId: id,
-        limit,
-        maxId,
-        minId,
-        sinceId
-      })
-
-      // Batch-hydrate the followed accounts in a single query, then re-order to
-      // match orderedFollows (getMastodonActorsFromIds does not guarantee order).
-      const accountsById = new Map(
-        (
-          await database.getMastodonActorsFromIds({
-            ids: orderedFollows.map((follow) => follow.targetActorId)
-          })
-        ).map((account) => [account.url, account])
-      )
-      const accounts = orderedFollows
-        .map((follow) => accountsById.get(follow.targetActorId))
-        .filter((account): account is NonNullable<typeof account> =>
-          Boolean(account)
-        )
-
-      const additionalHeaders = buildPaginationLinkHeader({
-        host: headerHost(req.headers),
-        // Percent-encoded: the router hands the id over already decoded, and
-        // the resolver accepts a raw http(s) URI as an id form, so the raw
-        // value would emit a Link URL that does not route back here.
-        path: `/api/v1/accounts/${encodeURIComponent(encodedAccountId)}/following`,
-        limit,
-        nextMaxId:
-          orderedFollows.length > 0
-            ? orderedFollows[orderedFollows.length - 1].id
-            : null,
-        prevMinId: orderedFollows.length > 0 ? orderedFollows[0].id : null
-      })
-
-      return apiResponse({
+      const { database, currentActor, params } = context
+      return handleFollowCollectionRequest({
         req,
-        allowedMethods: CORS_HEADERS,
-        data: accounts,
-        additionalHeaders
+        database,
+        currentActor,
+        encodedAccountId: (await params).id,
+        field: 'following'
       })
     },
     { errorResponse: corsErrorResponse(CORS_HEADERS), matchMode: 'any' }

--- a/app/api/v1/accounts/[id]/following/route.ts
+++ b/app/api/v1/accounts/[id]/following/route.ts
@@ -1,5 +1,5 @@
 import {
-  FOLLOW_COLLECTION_CORS_HEADERS,
+  CORS_HEADERS,
   handleFollowCollectionRequest
 } from '@/app/api/v1/accounts/[id]/followCollectionHandler'
 import {
@@ -9,8 +9,6 @@ import {
 import { Scope } from '@/lib/types/database/operations'
 import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-
-const CORS_HEADERS = FOLLOW_COLLECTION_CORS_HEADERS
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -404,17 +404,22 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   the federation signing actor, and serialize each listed actor as an Account
   entity. The remote page URLs ride in the Mastodon cursors — the Link header's
   `max_id` carries the page's `next` and `min_id` its `prev` — so an unmodified
-  client paginates by sending them back; a URL cursor is accepted only for a
-  page of that actor's collection and is a `400` otherwise, and `limit` is
-  echoed in the Link header but the page size is the remote server's. Only a
-  signed-in viewer triggers the remote read: an anonymous caller, a blocked
-  domain, an unreachable server, and a hidden collection (Mastodon's "hide your
-  social graph", which publishes a size but no page) all fall back to the
-  locally-known rows, so the old behaviour is the floor. Each page resolves at
-  most 20 actors this instance has never stored (five at a time, each a
-  `recordActorIfNeeded`) and drops the rest of that page's unknowns; a resolved
-  page is cached for 60 seconds per actor, field and page, with concurrent
-  misses sharing one fetch. Activity.next's own ActivityPub `followers` and
+  client paginates by sending them back. When the remote is consulted, a URL
+  cursor is accepted only for a page of that actor's collection and is a
+  `400` otherwise; `limit` is echoed in the Link header but the page size is
+  the remote server's, capped at 80. Only a signed-in viewer triggers the
+  remote read: an anonymous caller, a blocked domain, an unreachable server or
+  actor document, a page in a shape the reader does not handle, and a hidden
+  collection (Mastodon's "hide your social graph", which publishes a size but
+  no page) all fall back to the locally-known rows, so the old behaviour is the
+  floor — and on that fallback a URL cursor is ignored and the first local page
+  served. Each page resolves at most 20 actors this instance has never stored
+  (five at a time, each a `recordActorIfNeeded`) and drops the rest of that
+  page's unknowns; a resolved page is cached for 60 seconds per actor, field
+  and page, with concurrent misses sharing one fetch. The cache bounds repeat
+  opens only, since a page URL is client-chosen; a process-wide cap of four
+  uncached remote reads in flight is what bounds a flood, answering the local
+  rows past it. Activity.next's own ActivityPub `followers` and
   `following` collections still publish only `totalItems`, so another
   Activity.next instance cannot list this instance's users this way yet.
 - **Admin CRUD extras** — custom emoji, domain allow/deny lists (with import),

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -395,6 +395,28 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
 
 - **Remote statuses** — `/api/v1/accounts/:id/remote-statuses` exposes cached
   remote posts for an actor.
+- **Remote follow lists are read live from the remote collections.** Mastodon
+  answers `GET /api/v1/accounts/:id/followers` and `/following` for a remote
+  account from the relationships it already knows about, so a small instance
+  shows one local follower and nothing followed. For a remote actor these two
+  routes instead read the actor's own `followers`/`following` ActivityPub
+  collections (`lib/services/mastodon/remoteFollowCollection.ts`), signed by
+  the federation signing actor, and serialize each listed actor as an Account
+  entity. The remote page URLs ride in the Mastodon cursors — the Link header's
+  `max_id` carries the page's `next` and `min_id` its `prev` — so an unmodified
+  client paginates by sending them back; a URL cursor is accepted only for a
+  page of that actor's collection and is a `400` otherwise, and `limit` is
+  echoed in the Link header but the page size is the remote server's. Only a
+  signed-in viewer triggers the remote read: an anonymous caller, a blocked
+  domain, an unreachable server, and a hidden collection (Mastodon's "hide your
+  social graph", which publishes a size but no page) all fall back to the
+  locally-known rows, so the old behaviour is the floor. Each page resolves at
+  most 20 actors this instance has never stored (five at a time, each a
+  `recordActorIfNeeded`) and drops the rest of that page's unknowns; a resolved
+  page is cached for 60 seconds per actor, field and page, with concurrent
+  misses sharing one fetch. Activity.next's own ActivityPub `followers` and
+  `following` collections still publish only `totalItems`, so another
+  Activity.next instance cannot list this instance's users this way yet.
 - **Admin CRUD extras** — custom emoji, domain allow/deny lists (with import),
   announcements, filters, and rules management under `/api/v1/admin/*` and
   `/api/v2/admin/*`.

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -401,27 +401,28 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   shows one local follower and nothing followed. For a remote actor these two
   routes instead read the actor's own `followers`/`following` ActivityPub
   collections (`lib/services/mastodon/remoteFollowCollection.ts`), signed by
-  the federation signing actor, and serialize each listed actor as an Account
-  entity. The remote page URLs ride in the Mastodon cursors — the Link header's
-  `max_id` carries the page's `next` and `min_id` its `prev` — so an unmodified
-  client paginates by sending them back. When the remote is consulted, a URL
-  cursor is accepted only for a page of that actor's collection and is a
-  `400` otherwise; `limit` is echoed in the Link header but the page size is
-  the remote server's, capped at 80. Only a signed-in viewer triggers the
-  remote read: an anonymous caller, a blocked domain, an unreachable server or
-  actor document, a page in a shape the reader does not handle, and a hidden
-  collection (Mastodon's "hide your social graph", which publishes a size but
-  no page) all fall back to the locally-known rows, so the old behaviour is the
-  floor — and on that fallback a URL cursor is ignored and the first local page
-  served. Each page resolves at most 20 actors this instance has never stored
-  (five at a time, each a `recordActorIfNeeded`) and drops the rest of that
-  page's unknowns; a resolved page is cached for 60 seconds per actor, field
-  and page, with concurrent misses sharing one fetch. The cache bounds repeat
-  opens only, since a page URL is client-chosen; a process-wide cap of four
-  uncached remote reads in flight is what bounds a flood, answering the local
-  rows past it. Activity.next's own ActivityPub `followers` and
-  `following` collections still publish only `totalItems`, so another
-  Activity.next instance cannot list this instance's users this way yet.
+  the federation signing actor when one is available, and serialize each listed
+  actor as an Account entity. The remote page URLs ride in the Mastodon
+  cursors — the Link header's `max_id` carries the page's `next` and `min_id` its
+  `prev` — so an unmodified client paginates by sending them back. When the
+  remote is consulted, a URL cursor is accepted only for a page of that actor's
+  collection and is a `400` otherwise; `limit` is echoed in the Link header but
+  the page size is the remote server's, capped at 80. Only a signed-in viewer
+  triggers the remote read: an anonymous caller, a blocked domain, an unreachable
+  server or actor document, a page in a shape the reader does not handle, and a
+  hidden collection (Mastodon's "hide your social graph", which publishes a size
+  but no page) all fall back to the locally-known rows, so the old behaviour is
+  the floor — and on that fallback a URL cursor is ignored and the first local
+  page served. Each page resolves at most 20 actors this instance has never
+  stored (five at a time, each a `recordActorIfNeeded`) and drops the rest of
+  that page's unknowns; a resolved page is cached for 60 seconds per actor,
+  field and page, with concurrent misses sharing one fetch. The cache bounds
+  repeat opens only, since a page URL is client-chosen; a cap of four uncached
+  remote reads in flight per database instance (one per process today) is what
+  bounds a flood, answering the local rows past it. Activity.next's own
+  ActivityPub `followers` and `following` collections still publish only
+  `totalItems`, so another Activity.next instance cannot list this instance's
+  users this way yet.
 - **Admin CRUD extras** — custom emoji, domain allow/deny lists (with import),
   announcements, filters, and rules management under `/api/v1/admin/*` and
   `/api/v2/admin/*`.

--- a/lib/services/mastodon/remoteFollowCollection.test.ts
+++ b/lib/services/mastodon/remoteFollowCollection.test.ts
@@ -1,4 +1,7 @@
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  BlockedFederationDomainError,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import { getActorCollections } from '@/lib/activities/getActorCollections'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
@@ -8,11 +11,17 @@ import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
 import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { createDeferred } from '@/lib/testing/deferred'
+import { Actor } from '@/lib/types/domain/actor'
+import { logger } from '@/lib/utils/logger'
 
 import {
+  MAX_CACHED_PAGES,
+  MAX_IN_FLIGHT_REMOTE_READS,
+  MAX_PAGE_ITEMS,
   MAX_UNKNOWN_ACTORS_PER_PAGE,
   REMOTE_FOLLOW_PAGE_TTL_MS,
   RemoteFollowCollectionResult,
+  UNKNOWN_ACTOR_CONCURRENCY,
   getRemoteFollowCollectionPage,
   resetRemoteFollowCollectionCacheForTests
 } from './remoteFollowCollection'
@@ -28,7 +37,10 @@ vi.mock('@/lib/activities/getActorPerson', () => ({
   getActorPerson: vi.fn()
 }))
 
-vi.mock('@/lib/actions/utils', () => ({
+// Partial: the real BlockedFederationDomainError class is what the service
+// tests errors against with instanceof.
+vi.mock('@/lib/actions/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/actions/utils')>()),
   recordActorIfNeeded: vi.fn()
 }))
 
@@ -39,7 +51,7 @@ const person = MockActivityPubPerson({ id: REMOTE_ACTOR_ID })
 const signingActor = { id: 'https://llun.test/users/__instance__' } as never
 
 const mockCollectionPage = (
-  orderedItems: unknown[],
+  orderedItems: unknown,
   extra: { next?: string; prev?: string; totalItems?: number } = {}
 ) => {
   vi.mocked(getActorCollections).mockResolvedValue({
@@ -50,7 +62,9 @@ const mockCollectionPage = (
       next: extra.next,
       prev: extra.prev
     },
-    totalItems: extra.totalItems ?? orderedItems.length
+    totalItems:
+      extra.totalItems ??
+      (Array.isArray(orderedItems) ? orderedItems.length : 0)
   })
 }
 
@@ -59,8 +73,26 @@ const accountUris = (result: RemoteFollowCollectionResult) =>
     ? result.page.accounts.map((account) => account.uri)
     : result.status
 
+const unknownActorIds = (count: number) =>
+  Array.from(
+    { length: count },
+    (_, index) => `https://many.test/users/u${index}`
+  )
+
 describe('getRemoteFollowCollectionPage', () => {
   const database = getTestSQLDatabase()
+
+  const insertActor = async (actorId: string) =>
+    database.createActor({
+      actorId,
+      username: 'new',
+      domain: new URL(actorId).host,
+      inboxUrl: `${actorId}/inbox`,
+      sharedInboxUrl: `${actorId}/inbox`,
+      followersUrl: `${actorId}/followers`,
+      publicKey: 'public key',
+      createdAt: Date.now()
+    })
 
   beforeAll(async () => {
     await database.migrate()
@@ -77,7 +109,11 @@ describe('getRemoteFollowCollectionPage', () => {
     vi.mocked(recordActorIfNeeded).mockReset()
     vi.mocked(getActorPerson).mockResolvedValue(person)
     resetRemoteFollowCollectionCacheForTests()
+  })
+
+  afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('returns stored actors as accounts in the order the remote page listed them', async () => {
@@ -120,19 +156,9 @@ describe('getRemoteFollowCollectionPage', () => {
   })
 
   it('records an unknown actor once and places it where the page listed it', async () => {
-    vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
-      const actor = await database.createActor({
-        actorId,
-        username: 'new',
-        domain: new URL(actorId).host,
-        inboxUrl: `${actorId}/inbox`,
-        sharedInboxUrl: `${actorId}/inbox`,
-        followersUrl: `${actorId}/followers`,
-        publicKey: 'public key',
-        createdAt: Date.now()
-      })
-      return actor ?? undefined
-    })
+    vi.mocked(recordActorIfNeeded).mockImplementation(
+      async ({ actorId }) => (await insertActor(actorId)) ?? undefined
+    )
     mockCollectionPage([ACTOR2_ID, NEW_ACTOR_ID, ACTOR3_ID])
 
     const result = await getRemoteFollowCollectionPage({
@@ -152,16 +178,22 @@ describe('getRemoteFollowCollectionPage', () => {
   })
 
   it('drops an actor that cannot be recorded instead of failing the page', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined)
     vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
       if (actorId === 'https://blocked.test/users/x') {
-        throw new Error('Federation with actor domain is blocked')
+        throw new BlockedFederationDomainError(actorId)
+      }
+      if (actorId === 'https://broken.test/users/z') {
+        throw new Error('insert failed')
       }
       return undefined
     })
     mockCollectionPage([
       ACTOR2_ID,
       'https://blocked.test/users/x',
-      'https://gone.test/users/y'
+      'https://gone.test/users/y',
+      'https://broken.test/users/z'
     ])
 
     const result = await getRemoteFollowCollectionPage({
@@ -171,15 +203,36 @@ describe('getRemoteFollowCollectionPage', () => {
     })
 
     expect(accountUris(result)).toEqual([ACTOR2_ID])
+    // A blocked domain is policy, logged at debug; a real failure is a warn.
+    expect(debug).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toMatchObject({
+      actorId: 'https://broken.test/users/z'
+    })
   })
 
-  it('resolves at most MAX_UNKNOWN_ACTORS_PER_PAGE unknown actors per page', async () => {
+  it('keeps an actor whose insert lost a race but whose row now exists', async () => {
+    const racedActorId = 'https://raced.test/users/r'
+    vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
+      // Someone else inserted the row between our read and our insert.
+      await insertActor(actorId)
+      throw new Error('UNIQUE constraint failed: actors.id')
+    })
+    mockCollectionPage([racedActorId, ACTOR2_ID])
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    expect(accountUris(result)).toEqual([racedActorId, ACTOR2_ID])
+  })
+
+  it('resolves at most MAX_UNKNOWN_ACTORS_PER_PAGE unknown actors per page, in page order', async () => {
     vi.mocked(recordActorIfNeeded).mockResolvedValue(undefined)
-    const unknownIds = Array.from(
-      { length: MAX_UNKNOWN_ACTORS_PER_PAGE + 5 },
-      (_, index) => `https://many.test/users/u${index}`
-    )
-    mockCollectionPage(unknownIds)
+    const ids = unknownActorIds(MAX_UNKNOWN_ACTORS_PER_PAGE + 5)
+    mockCollectionPage(ids)
 
     await getRemoteFollowCollectionPage({
       database,
@@ -194,7 +247,58 @@ describe('getRemoteFollowCollectionPage', () => {
     // the page rather than an arbitrary sample of it.
     expect(
       vi.mocked(recordActorIfNeeded).mock.calls.map((call) => call[0].actorId)
-    ).toEqual(unknownIds.slice(0, MAX_UNKNOWN_ACTORS_PER_PAGE))
+    ).toEqual(ids.slice(0, MAX_UNKNOWN_ACTORS_PER_PAGE))
+  })
+
+  it('records unknown actors at most UNKNOWN_ACTOR_CONCURRENCY at a time', async () => {
+    const pending: Array<ReturnType<typeof createDeferred<Actor | undefined>>> =
+      []
+    vi.mocked(recordActorIfNeeded).mockImplementation(() => {
+      const deferred = createDeferred<Actor | undefined>()
+      pending.push(deferred)
+      return deferred.promise
+    })
+    mockCollectionPage(unknownActorIds(MAX_UNKNOWN_ACTORS_PER_PAGE))
+
+    const result = getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    // Let the Person, collection and batch lookup settle so the workers start.
+    await vi.waitFor(() =>
+      expect(pending.length).toBe(UNKNOWN_ACTOR_CONCURRENCY)
+    )
+
+    // Settling one frees exactly one slot.
+    pending[0].resolve(undefined)
+    await vi.waitFor(() =>
+      expect(pending.length).toBe(UNKNOWN_ACTOR_CONCURRENCY + 1)
+    )
+    expect(recordActorIfNeeded).toHaveBeenCalledTimes(
+      UNKNOWN_ACTOR_CONCURRENCY + 1
+    )
+
+    // Let the rest through and finish the page.
+    vi.mocked(recordActorIfNeeded).mockResolvedValue(undefined)
+    for (const deferred of pending) deferred.resolve(undefined)
+    expect((await result).status).toBe('ok')
+  })
+
+  it('serves at most MAX_PAGE_ITEMS actors from one remote page', async () => {
+    const lookup = vi.spyOn(database, 'getMastodonActorsFromIds')
+    vi.mocked(recordActorIfNeeded).mockResolvedValue(undefined)
+    mockCollectionPage(unknownActorIds(MAX_PAGE_ITEMS + 50))
+
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    // One bounded batch lookup: never a whereIn over the whole remote page.
+    expect(lookup).toHaveBeenCalledTimes(1)
+    expect(lookup.mock.calls[0][0].ids).toHaveLength(MAX_PAGE_ITEMS)
   })
 
   it.each([
@@ -299,6 +403,14 @@ describe('getRemoteFollowCollectionPage', () => {
         vi
           .mocked(getActorCollections)
           .mockResolvedValue({ page: null, totalItems: 12 })
+    },
+    {
+      description: 'the page carries no orderedItems array',
+      arrange: () => mockCollectionPage(undefined)
+    },
+    {
+      description: 'the page carries orderedItems that is not an array',
+      arrange: () => mockCollectionPage({ items: [ACTOR2_ID] })
     }
   ])('answers unavailable when $description', async ({ arrange }) => {
     arrange()
@@ -310,6 +422,13 @@ describe('getRemoteFollowCollectionPage', () => {
         field: 'followers'
       })
     ).resolves.toEqual({ status: 'unavailable' })
+    // ...and caches it: an unreadable page is not retried on every open.
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    expect(getActorPerson).toHaveBeenCalledTimes(1)
   })
 
   it('shares one fetch between concurrent callers and serves it for the TTL', async () => {
@@ -367,6 +486,39 @@ describe('getRemoteFollowCollectionPage', () => {
     expect(getActorCollections).toHaveBeenCalledTimes(3)
   })
 
+  it.each([
+    {
+      description: 'query parameters in another order',
+      spelling: `${REMOTE_ACTOR_ID}/followers?page=2&limit=40`,
+      respelling: `${REMOTE_ACTOR_ID}/followers?limit=40&page=2`
+    },
+    {
+      description: 'a fragment',
+      spelling: `${REMOTE_ACTOR_ID}/followers?page=2`,
+      respelling: `${REMOTE_ACTOR_ID}/followers?page=2#top`
+    }
+  ])(
+    'keys the cache on the page, not on its spelling: $description',
+    async ({ spelling, respelling }) => {
+      mockCollectionPage([ACTOR2_ID])
+
+      await getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers',
+        pageUrl: spelling
+      })
+      await getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers',
+        pageUrl: respelling
+      })
+
+      expect(getActorCollections).toHaveBeenCalledTimes(1)
+    }
+  )
+
   it('refetches once the TTL has passed', async () => {
     vi.useFakeTimers()
     mockCollectionPage([ACTOR2_ID])
@@ -386,16 +538,74 @@ describe('getRemoteFollowCollectionPage', () => {
     expect(getActorCollections).toHaveBeenCalledTimes(2)
   })
 
-  it('does not cache a failure', async () => {
-    vi.mocked(getActorCollections).mockRejectedValueOnce(new Error('boom'))
-
-    await expect(
+  it('evicts the oldest entry past MAX_CACHED_PAGES', async () => {
+    mockCollectionPage([ACTOR2_ID])
+    const readPage = (index: number) =>
       getRemoteFollowCollectionPage({
         database,
         actorId: REMOTE_ACTOR_ID,
-        field: 'followers'
+        field: 'followers',
+        pageUrl: `${REMOTE_ACTOR_ID}/followers?page=${index}`
       })
-    ).rejects.toThrow('boom')
+
+    for (let index = 0; index <= MAX_CACHED_PAGES; index += 1) {
+      await readPage(index)
+    }
+    expect(getActorCollections).toHaveBeenCalledTimes(MAX_CACHED_PAGES + 1)
+
+    // Page 1 is still cached; page 0, the oldest, was evicted by the insert
+    // that overflowed the map.
+    await readPage(1)
+    expect(getActorCollections).toHaveBeenCalledTimes(MAX_CACHED_PAGES + 1)
+    await readPage(0)
+    expect(getActorCollections).toHaveBeenCalledTimes(MAX_CACHED_PAGES + 2)
+  })
+
+  it('answers unavailable, uncached, past MAX_IN_FLIGHT_REMOTE_READS uncached reads', async () => {
+    const deferred =
+      createDeferred<Awaited<ReturnType<typeof getActorCollections>>>()
+    vi.mocked(getActorCollections).mockReturnValue(deferred.promise)
+    const readPage = (index: number) =>
+      getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers',
+        pageUrl: `${REMOTE_ACTOR_ID}/followers?page=${index}`
+      })
+
+    const inFlight = Array.from(
+      { length: MAX_IN_FLIGHT_REMOTE_READS },
+      (_, index) => readPage(index)
+    )
+    // One past the cap: refused at once, without touching the network.
+    await expect(readPage(MAX_IN_FLIGHT_REMOTE_READS)).resolves.toEqual({
+      status: 'unavailable'
+    })
+    expect(getActorPerson).toHaveBeenCalledTimes(MAX_IN_FLIGHT_REMOTE_READS)
+    // A cached page is still served while the cap is reached: the very
+    // promise already in flight, not a refusal.
+    expect(readPage(0)).toBe(inFlight[0])
+
+    deferred.resolve({ page: null, totalItems: 0 })
+    await Promise.all(inFlight)
+
+    // The refusal was not cached: with the slots free, the same page is read.
+    await readPage(MAX_IN_FLIGHT_REMOTE_READS)
+    expect(getActorPerson).toHaveBeenCalledTimes(MAX_IN_FLIGHT_REMOTE_READS + 1)
+  })
+
+  it('does not cache a failure and frees its in-flight slot', async () => {
+    vi.mocked(getActorCollections).mockRejectedValue(new Error('boom'))
+
+    for (let index = 0; index <= MAX_IN_FLIGHT_REMOTE_READS; index += 1) {
+      await expect(
+        getRemoteFollowCollectionPage({
+          database,
+          actorId: REMOTE_ACTOR_ID,
+          field: 'followers'
+        })
+      ).rejects.toThrow('boom')
+    }
 
     mockCollectionPage([ACTOR2_ID])
     const result = await getRemoteFollowCollectionPage({
@@ -404,6 +614,9 @@ describe('getRemoteFollowCollectionPage', () => {
       field: 'followers'
     })
     expect(accountUris(result)).toEqual([ACTOR2_ID])
-    expect(getActorCollections).toHaveBeenCalledTimes(2)
+    // Every failed read was a real attempt, and none of them held a slot.
+    expect(getActorCollections).toHaveBeenCalledTimes(
+      MAX_IN_FLIGHT_REMOTE_READS + 2
+    )
   })
 })

--- a/lib/services/mastodon/remoteFollowCollection.test.ts
+++ b/lib/services/mastodon/remoteFollowCollection.test.ts
@@ -1,0 +1,409 @@
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { getActorCollections } from '@/lib/activities/getActorCollections'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
+import { createDeferred } from '@/lib/testing/deferred'
+
+import {
+  MAX_UNKNOWN_ACTORS_PER_PAGE,
+  REMOTE_FOLLOW_PAGE_TTL_MS,
+  RemoteFollowCollectionResult,
+  getRemoteFollowCollectionPage,
+  resetRemoteFollowCollectionCacheForTests
+} from './remoteFollowCollection'
+
+vi.mock('@/lib/activities/getActorCollections', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/lib/activities/getActorCollections')
+  >()),
+  getActorCollections: vi.fn()
+}))
+
+vi.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: vi.fn()
+}))
+
+vi.mock('@/lib/actions/utils', () => ({
+  recordActorIfNeeded: vi.fn()
+}))
+
+const REMOTE_ACTOR_ID = 'https://remote.test/users/verge'
+const NEW_ACTOR_ID = 'https://elsewhere.test/users/new'
+
+const person = MockActivityPubPerson({ id: REMOTE_ACTOR_ID })
+const signingActor = { id: 'https://llun.test/users/__instance__' } as never
+
+const mockCollectionPage = (
+  orderedItems: unknown[],
+  extra: { next?: string; prev?: string; totalItems?: number } = {}
+) => {
+  vi.mocked(getActorCollections).mockResolvedValue({
+    page: {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'OrderedCollectionPage' as const,
+      orderedItems: orderedItems as string[],
+      next: extra.next,
+      prev: extra.prev
+    },
+    totalItems: extra.totalItems ?? orderedItems.length
+  })
+}
+
+const accountUris = (result: RemoteFollowCollectionResult) =>
+  result.status === 'ok'
+    ? result.page.accounts.map((account) => account.uri)
+    : result.status
+
+describe('getRemoteFollowCollectionPage', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.mocked(getActorCollections).mockReset()
+    vi.mocked(getActorPerson).mockReset()
+    vi.mocked(recordActorIfNeeded).mockReset()
+    vi.mocked(getActorPerson).mockResolvedValue(person)
+    resetRemoteFollowCollectionCacheForTests()
+    vi.useRealTimers()
+  })
+
+  it('returns stored actors as accounts in the order the remote page listed them', async () => {
+    mockCollectionPage([ACTOR3_ID, EXTERNAL_ACTOR1, ACTOR2_ID], {
+      next: `${REMOTE_ACTOR_ID}/followers?page=2`,
+      prev: `${REMOTE_ACTOR_ID}/followers?page=1`,
+      totalItems: 42
+    })
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers',
+      signingActor
+    })
+
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') return
+    expect(result.page.accounts.map((account) => account.uri)).toEqual([
+      ACTOR3_ID,
+      EXTERNAL_ACTOR1,
+      ACTOR2_ID
+    ])
+    expect(result.page.nextPageUrl).toBe(`${REMOTE_ACTOR_ID}/followers?page=2`)
+    expect(result.page.prevPageUrl).toBe(`${REMOTE_ACTOR_ID}/followers?page=1`)
+    expect(result.page.totalItems).toBe(42)
+    // Every listed actor was already stored, so nothing is fetched.
+    expect(recordActorIfNeeded).not.toHaveBeenCalled()
+    // The Person and the collection are both fetched with the signer given.
+    expect(getActorPerson).toHaveBeenCalledWith({
+      actorId: REMOTE_ACTOR_ID,
+      signingActor
+    })
+    expect(getActorCollections).toHaveBeenCalledWith({
+      person,
+      field: 'followers',
+      signingActor,
+      pageUrl: undefined
+    })
+  })
+
+  it('records an unknown actor once and places it where the page listed it', async () => {
+    vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
+      const actor = await database.createActor({
+        actorId,
+        username: 'new',
+        domain: new URL(actorId).host,
+        inboxUrl: `${actorId}/inbox`,
+        sharedInboxUrl: `${actorId}/inbox`,
+        followersUrl: `${actorId}/followers`,
+        publicKey: 'public key',
+        createdAt: Date.now()
+      })
+      return actor ?? undefined
+    })
+    mockCollectionPage([ACTOR2_ID, NEW_ACTOR_ID, ACTOR3_ID])
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'following',
+      signingActor
+    })
+
+    expect(accountUris(result)).toEqual([ACTOR2_ID, NEW_ACTOR_ID, ACTOR3_ID])
+    expect(recordActorIfNeeded).toHaveBeenCalledTimes(1)
+    expect(recordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: NEW_ACTOR_ID,
+      database,
+      signingActor
+    })
+  })
+
+  it('drops an actor that cannot be recorded instead of failing the page', async () => {
+    vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
+      if (actorId === 'https://blocked.test/users/x') {
+        throw new Error('Federation with actor domain is blocked')
+      }
+      return undefined
+    })
+    mockCollectionPage([
+      ACTOR2_ID,
+      'https://blocked.test/users/x',
+      'https://gone.test/users/y'
+    ])
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    expect(accountUris(result)).toEqual([ACTOR2_ID])
+  })
+
+  it('resolves at most MAX_UNKNOWN_ACTORS_PER_PAGE unknown actors per page', async () => {
+    vi.mocked(recordActorIfNeeded).mockResolvedValue(undefined)
+    const unknownIds = Array.from(
+      { length: MAX_UNKNOWN_ACTORS_PER_PAGE + 5 },
+      (_, index) => `https://many.test/users/u${index}`
+    )
+    mockCollectionPage(unknownIds)
+
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    expect(recordActorIfNeeded).toHaveBeenCalledTimes(
+      MAX_UNKNOWN_ACTORS_PER_PAGE
+    )
+    // The first N in page order, so a client paging through sees the head of
+    // the page rather than an arbitrary sample of it.
+    expect(
+      vi.mocked(recordActorIfNeeded).mock.calls.map((call) => call[0].actorId)
+    ).toEqual(unknownIds.slice(0, MAX_UNKNOWN_ACTORS_PER_PAGE))
+  })
+
+  it.each([
+    {
+      description: 'an object item carrying an id',
+      items: [{ type: 'Person', id: ACTOR2_ID }],
+      expected: [ACTOR2_ID]
+    },
+    {
+      description: 'a blank node id',
+      items: ['_:b0'],
+      expected: []
+    },
+    {
+      description: 'an object without an id',
+      items: [{ type: 'Person' }],
+      expected: []
+    },
+    {
+      description: 'a duplicate of an earlier item',
+      items: [ACTOR3_ID, ACTOR3_ID],
+      expected: [ACTOR3_ID]
+    }
+  ])('reads $description', async ({ items, expected }) => {
+    vi.mocked(recordActorIfNeeded).mockResolvedValue(undefined)
+    mockCollectionPage(items)
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    expect(accountUris(result)).toEqual(expected)
+    expect(recordActorIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'a page of the same collection',
+      pageUrl: `${REMOTE_ACTOR_ID}/followers?page=2`,
+      expectedStatus: 'ok'
+    },
+    {
+      description: "a page of the actor's other collection",
+      pageUrl: `${REMOTE_ACTOR_ID}/following?page=2`,
+      expectedStatus: 'invalid-page'
+    },
+    {
+      description: 'a page on another host',
+      pageUrl: 'https://evil.test/users/verge/followers?page=2',
+      expectedStatus: 'invalid-page'
+    }
+  ])(
+    'accepts a page URL only for this collection: $description',
+    async ({ pageUrl, expectedStatus }) => {
+      mockCollectionPage([ACTOR2_ID])
+
+      const result = await getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers',
+        pageUrl
+      })
+
+      expect(result.status).toBe(expectedStatus)
+      if (expectedStatus === 'ok') {
+        expect(getActorCollections).toHaveBeenCalledWith(
+          expect.objectContaining({ pageUrl })
+        )
+      } else {
+        expect(getActorCollections).not.toHaveBeenCalled()
+      }
+    }
+  )
+
+  it.each([
+    {
+      description: 'the actor document cannot be fetched',
+      arrange: () => {
+        vi.mocked(getActorPerson).mockResolvedValue(null)
+        mockCollectionPage([ACTOR2_ID])
+      }
+    },
+    {
+      description: 'the actor document names no such collection',
+      arrange: () => {
+        vi.mocked(getActorPerson).mockResolvedValue({
+          ...person,
+          followers: undefined
+        })
+        mockCollectionPage([ACTOR2_ID])
+      }
+    },
+    {
+      description: 'there is no collection at all',
+      arrange: () => vi.mocked(getActorCollections).mockResolvedValue(null)
+    },
+    {
+      description: 'the collection has a size but no page',
+      arrange: () =>
+        vi
+          .mocked(getActorCollections)
+          .mockResolvedValue({ page: null, totalItems: 12 })
+    }
+  ])('answers unavailable when $description', async ({ arrange }) => {
+    arrange()
+
+    await expect(
+      getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers'
+      })
+    ).resolves.toEqual({ status: 'unavailable' })
+  })
+
+  it('shares one fetch between concurrent callers and serves it for the TTL', async () => {
+    const deferred =
+      createDeferred<Awaited<ReturnType<typeof getActorCollections>>>()
+    vi.mocked(getActorCollections).mockReturnValue(deferred.promise)
+
+    const first = getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    const second = getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    // The Person fetch is inside the cached work: one, not two.
+    await Promise.resolve()
+    expect(getActorPerson).toHaveBeenCalledTimes(1)
+
+    deferred.resolve({
+      page: {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'OrderedCollectionPage',
+        orderedItems: [ACTOR2_ID]
+      },
+      totalItems: 1
+    })
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    expect(firstResult).toBe(secondResult)
+    expect(getActorCollections).toHaveBeenCalledTimes(1)
+
+    // Still cached: a third call fetches neither the Person nor the page.
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    expect(getActorPerson).toHaveBeenCalledTimes(1)
+    expect(getActorCollections).toHaveBeenCalledTimes(1)
+
+    // A different page, field, or actor is its own entry.
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers',
+      pageUrl: `${REMOTE_ACTOR_ID}/followers?page=2`
+    })
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'following'
+    })
+    expect(getActorCollections).toHaveBeenCalledTimes(3)
+  })
+
+  it('refetches once the TTL has passed', async () => {
+    vi.useFakeTimers()
+    mockCollectionPage([ACTOR2_ID])
+
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    vi.advanceTimersByTime(REMOTE_FOLLOW_PAGE_TTL_MS + 1)
+    await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+
+    expect(getActorCollections).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache a failure', async () => {
+    vi.mocked(getActorCollections).mockRejectedValueOnce(new Error('boom'))
+
+    await expect(
+      getRemoteFollowCollectionPage({
+        database,
+        actorId: REMOTE_ACTOR_ID,
+        field: 'followers'
+      })
+    ).rejects.toThrow('boom')
+
+    mockCollectionPage([ACTOR2_ID])
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers'
+    })
+    expect(accountUris(result)).toEqual([ACTOR2_ID])
+    expect(getActorCollections).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/services/mastodon/remoteFollowCollection.test.ts
+++ b/lib/services/mastodon/remoteFollowCollection.test.ts
@@ -155,6 +155,26 @@ describe('getRemoteFollowCollectionPage', () => {
     })
   })
 
+  it('nulls nextPageUrl and prevPageUrl when the remote page URLs are not on this collection', async () => {
+    mockCollectionPage([ACTOR2_ID], {
+      next: `${REMOTE_ACTOR_ID}/followers_page?page=2`,
+      prev: 'https://other-domain.test/users/verge/followers?page=1',
+      totalItems: 1
+    })
+
+    const result = await getRemoteFollowCollectionPage({
+      database,
+      actorId: REMOTE_ACTOR_ID,
+      field: 'followers',
+      signingActor
+    })
+
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') return
+    expect(result.page.nextPageUrl).toBeNull()
+    expect(result.page.prevPageUrl).toBeNull()
+  })
+
   it('records an unknown actor once and places it where the page listed it', async () => {
     vi.mocked(recordActorIfNeeded).mockImplementation(
       async ({ actorId }) => (await insertActor(actorId)) ?? undefined
@@ -212,6 +232,7 @@ describe('getRemoteFollowCollectionPage', () => {
   })
 
   it('keeps an actor whose insert lost a race but whose row now exists', async () => {
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined)
     const racedActorId = 'https://raced.test/users/r'
     vi.mocked(recordActorIfNeeded).mockImplementation(async ({ actorId }) => {
       // Someone else inserted the row between our read and our insert.
@@ -227,6 +248,14 @@ describe('getRemoteFollowCollectionPage', () => {
     })
 
     expect(accountUris(result)).toEqual([racedActorId, ACTOR2_ID])
+    expect(debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: racedActorId,
+        err: expect.objectContaining({
+          message: 'UNIQUE constraint failed: actors.id'
+        })
+      })
+    )
   })
 
   it('resolves at most MAX_UNKNOWN_ACTORS_PER_PAGE unknown actors per page, in page order', async () => {

--- a/lib/services/mastodon/remoteFollowCollection.ts
+++ b/lib/services/mastodon/remoteFollowCollection.ts
@@ -1,0 +1,305 @@
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  getActorCollections,
+  isCollectionPageUrl
+} from '@/lib/activities/getActorCollections'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import { normalizeActivityPubUri } from '@/lib/utils/activitypub'
+import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+
+// The Mastodon `accounts/:id/followers` and `/following` lists for a REMOTE
+// actor. The `follows` table only knows relationships this instance took part
+// in, so for a remote actor those routes could only ever list the local actors
+// on either side of one — a client opening a remote account's Followers sheet
+// saw one local follower and an empty Following. Mastodon itself behaves that
+// way; this is an enhancement over it, and it reads the list the remote server
+// already publishes on the actor's `followers`/`following` collections.
+//
+// Two costs are bounded here rather than in the routes. A collection page is
+// actor URIs, and turning one into Mastodon Account entities needs stored
+// rows: the known ones come back in one batch query, and each UNKNOWN one is a
+// `recordActorIfNeeded` — a signed Person fetch plus three collection-root
+// fetches for its counters, then an insert. So a page resolves at most
+// `MAX_UNKNOWN_ACTORS_PER_PAGE` unknown actors, `UNKNOWN_ACTOR_CONCURRENCY` at
+// a time, and drops the rest of that page's unknowns rather than stalling the
+// request on them. And a resolved page is held for `REMOTE_FOLLOW_PAGE_TTL_MS`
+// as a PROMISE, so a client re-opening the sheet, or two clients opening it at
+// once, share one round of fetches — the same shape as
+// `getCachedActorPublicStatusesCount` (`lib/services/statuses/`), down to
+// deleting the entry on rejection so a failure is retried rather than served
+// for a minute. The actor's own Person document is fetched INSIDE the cached
+// work, because the collection URL lives on it: fetched outside, a cache hit
+// would still cost one signed remote request per page open.
+
+export type RemoteFollowField = 'followers' | 'following'
+
+export const REMOTE_FOLLOW_PAGE_TTL_MS = 60_000
+export const MAX_UNKNOWN_ACTORS_PER_PAGE = 20
+export const UNKNOWN_ACTOR_CONCURRENCY = 5
+// Bounded because entries expire but nothing sweeps them, and which actors and
+// pages get asked for is chosen by clients.
+export const MAX_CACHED_PAGES = 256
+
+export interface RemoteFollowCollectionPage {
+  // In the order the remote page listed them, minus the ones that could not be
+  // resolved to a stored actor.
+  accounts: MastodonAccount[]
+  nextPageUrl: string | null
+  prevPageUrl: string | null
+  totalItems: number
+}
+
+export type RemoteFollowCollectionResult =
+  | { status: 'ok'; page: RemoteFollowCollectionPage }
+  // The remote publishes no page (a hidden collection, an unreachable actor or
+  // collection): the caller should serve what this instance knows locally.
+  | { status: 'unavailable' }
+  // `pageUrl` is not a page of this actor's collection — a client error, not
+  // something to fall back from.
+  | { status: 'invalid-page' }
+
+interface Params {
+  database: Database
+  actorId: string
+  field: RemoteFollowField
+  signingActor?: Actor
+  // A page of the collection to read instead of its first page.
+  pageUrl?: string
+}
+
+type CacheEntry = {
+  result: Promise<RemoteFollowCollectionResult>
+  expiresAt: number
+}
+
+let cacheByDatabase = new WeakMap<Database, Map<string, CacheEntry>>()
+
+const getCacheEntries = (database: Database) => {
+  const entries = cacheByDatabase.get(database)
+  if (entries) return entries
+
+  const created = new Map<string, CacheEntry>()
+  cacheByDatabase.set(database, created)
+  return created
+}
+
+// Insertion-order eviction, the same shape as the outbox count cache.
+const setBoundedEntry = (
+  entries: Map<string, CacheEntry>,
+  key: string,
+  entry: CacheEntry
+) => {
+  if (entries.has(key)) {
+    entries.delete(key)
+  } else if (entries.size >= MAX_CACHED_PAGES) {
+    const oldestKey = entries.keys().next().value
+    if (oldestKey !== undefined) entries.delete(oldestKey)
+  }
+  entries.set(key, entry)
+}
+
+// A collection page item is an actor id, either bare or as an object carrying
+// one. Anything else — a blank node, an object with no id — is skipped rather
+// than fetched.
+const getItemActorId = (item: unknown): string | null => {
+  if (typeof item === 'string') return normalizeActivityPubUri(item)
+  if (item && typeof item === 'object' && 'id' in item) {
+    const id = (item as { id?: unknown }).id
+    return typeof id === 'string' ? normalizeActivityPubUri(id) : null
+  }
+  return null
+}
+
+const getPageUrl = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
+// Runs `task` over `items` with at most `concurrency` in flight. Failures are
+// the task's own to handle; this never rejects on one.
+const runWithConcurrency = async <T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>
+) => {
+  let nextIndex = 0
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const item = items[nextIndex]
+      nextIndex += 1
+      await task(item)
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  )
+}
+
+// The stored actor ids a batch of Mastodon accounts answers for. `uri` is the
+// actor id the row was looked up by; `url` is the profile URL, which for a
+// local actor is the same string and for a remote one usually is not. Keying
+// on both is what the search route does for the same lookup.
+const indexAccountsByActorId = (accounts: MastodonAccount[]) => {
+  const byActorId = new Map<string, MastodonAccount>()
+  for (const account of accounts) {
+    for (const key of [account.uri, account.url]) {
+      const actorId = normalizeActivityPubUri(key)
+      if (actorId && !byActorId.has(actorId)) byActorId.set(actorId, account)
+    }
+  }
+  return byActorId
+}
+
+const resolvePageAccounts = async ({
+  database,
+  actorIds,
+  signingActor
+}: {
+  database: Database
+  actorIds: string[]
+  signingActor?: Actor
+}): Promise<MastodonAccount[]> => {
+  if (actorIds.length === 0) return []
+
+  const knownAccounts = indexAccountsByActorId(
+    await database.getMastodonActorsFromIds({ ids: actorIds })
+  )
+
+  const unknownActorIds = actorIds
+    .filter((actorId) => !knownAccounts.has(actorId))
+    .slice(0, MAX_UNKNOWN_ACTORS_PER_PAGE)
+
+  const recordedActorIds: string[] = []
+  await runWithConcurrency(
+    unknownActorIds,
+    UNKNOWN_ACTOR_CONCURRENCY,
+    async (actorId) => {
+      try {
+        // Refuses a blocked domain by throwing, and answers undefined when the
+        // actor cannot be fetched; both simply leave the entry out of the page.
+        const actor = await recordActorIfNeeded({
+          actorId,
+          database,
+          signingActor
+        })
+        if (actor) recordedActorIds.push(actor.id)
+      } catch (error) {
+        logger.warn({
+          message: 'Failed to record remote follow collection actor',
+          actorId,
+          err: toLoggableError(error)
+        })
+      }
+    }
+  )
+
+  const recordedAccounts =
+    recordedActorIds.length > 0
+      ? indexAccountsByActorId(
+          await database.getMastodonActorsFromIds({ ids: recordedActorIds })
+        )
+      : new Map<string, MastodonAccount>()
+
+  const seen = new Set<string>()
+  return actorIds.flatMap((actorId) => {
+    const account = knownAccounts.get(actorId) ?? recordedAccounts.get(actorId)
+    if (!account || seen.has(account.uri)) return []
+    seen.add(account.uri)
+    return [account]
+  })
+}
+
+const fetchRemoteFollowCollectionPage = async ({
+  database,
+  actorId,
+  field,
+  signingActor,
+  pageUrl
+}: Params): Promise<RemoteFollowCollectionResult> => {
+  const person = await getActorPerson({ actorId, signingActor })
+  const collectionUrl = person?.[field]
+  if (!person || !collectionUrl) return { status: 'unavailable' }
+
+  // The same check `remote-statuses` applies to its `page_url`: a cursor is
+  // only ever a page of THIS actor's collection, never an arbitrary URL this
+  // instance would then fetch on the client's behalf.
+  if (pageUrl && !isCollectionPageUrl(pageUrl, collectionUrl)) {
+    return { status: 'invalid-page' }
+  }
+
+  const collection = await getActorCollections({
+    person,
+    field,
+    signingActor,
+    pageUrl
+  })
+  // No collection, or a collection the remote publishes a size for but no
+  // page of — Mastodon's "hide your social graph" — is the caller's cue to
+  // fall back to what this instance knows locally.
+  if (!collection?.page) return { status: 'unavailable' }
+
+  const actorIds = Array.from(
+    new Set(
+      collection.page.orderedItems
+        .map(getItemActorId)
+        .filter((id): id is string => Boolean(id))
+    )
+  )
+  const accounts = await resolvePageAccounts({
+    database,
+    actorIds,
+    signingActor
+  })
+
+  return {
+    status: 'ok',
+    page: {
+      accounts,
+      nextPageUrl: getPageUrl(collection.page.next),
+      prevPageUrl: getPageUrl(collection.page.prev),
+      totalItems: collection.totalItems
+    }
+  }
+}
+
+/**
+ * One page of a remote actor's `followers` or `following` collection as
+ * Mastodon Account entities. Answers `unavailable` when the remote publishes
+ * no page (a hidden collection, an unreachable actor) — the caller should then
+ * serve the locally-known relationships — and `invalid-page` when `pageUrl`
+ * is not a page of that actor's collection.
+ *
+ * Cached per (database, actor, field, page) for `REMOTE_FOLLOW_PAGE_TTL_MS`;
+ * concurrent misses share one fetch and a rejection evicts the entry. Domain
+ * policy is deliberately NOT part of the cached work: the caller checks
+ * `canFederateWithDomain` per request, so a newly blocked domain is refused at
+ * once rather than served from a warm entry.
+ */
+export const getRemoteFollowCollectionPage = (
+  params: Params
+): Promise<RemoteFollowCollectionResult> => {
+  const { database, actorId, field, pageUrl } = params
+  const entries = getCacheEntries(database)
+  const key = `${field}|${actorId}|${pageUrl ?? ''}`
+  const entry = entries.get(key)
+  if (entry && entry.expiresAt > Date.now()) return entry.result
+
+  const result = fetchRemoteFollowCollectionPage(params).catch((error) => {
+    if (entries.get(key)?.result === result) entries.delete(key)
+    throw error
+  })
+  setBoundedEntry(entries, key, {
+    result,
+    expiresAt: Date.now() + REMOTE_FOLLOW_PAGE_TTL_MS
+  })
+  return result
+}
+
+export const resetRemoteFollowCollectionCacheForTests = () => {
+  if (!process.env.VITEST) {
+    throw new Error('resetRemoteFollowCollectionCacheForTests is test-only')
+  }
+  cacheByDatabase = new WeakMap()
+}

--- a/lib/services/mastodon/remoteFollowCollection.ts
+++ b/lib/services/mastodon/remoteFollowCollection.ts
@@ -61,9 +61,11 @@ export const REMOTE_FOLLOW_PAGE_TTL_MS = 60_000
 export const MAX_PAGE_ITEMS = 80
 export const MAX_UNKNOWN_ACTORS_PER_PAGE = 20
 export const UNKNOWN_ACTOR_CONCURRENCY = 5
-// Uncached page reads in flight at once, across every actor and viewer this
-// process serves. Sized for a handful of people opening sheets at the same
-// moment, not for a page per request.
+// Uncached page reads in flight at once, per database instance (one per process
+// today). Sized for a handful of people opening sheets at the same moment, not
+// for a page per request. Note: a single read holds its slot through up to 20
+// unknown-actor fetches, so slow remote domains can occupy slots under retries;
+// capped low so memory and socket pressure remain bounded.
 export const MAX_IN_FLIGHT_REMOTE_READS = 4
 // Bounded because entries expire but nothing sweeps them, and which actors and
 // pages get asked for is chosen by clients.
@@ -161,8 +163,12 @@ const getItemActorId = (item: unknown): string | null => {
   return null
 }
 
-const getPageUrl = (value: unknown): string | null =>
-  typeof value === 'string' && value.length > 0 ? value : null
+const getPageUrl = (value: unknown, collectionUrl: string): string | null =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  isCollectionPageUrl(value, collectionUrl)
+    ? value
+    : null
 
 // Runs `task` over `items` with at most `concurrency` in flight. Failures are
 // the task's own to handle; this never rejects on one.
@@ -226,7 +232,15 @@ const recordUnknownActor = async ({
     const existing = await database
       .getActorFromId({ id: actorId })
       .catch(() => null)
-    if (existing) return existing.id
+    if (existing) {
+      logger.debug({
+        message:
+          'Actor record threw but row exists (likely insert race or background refresh error)',
+        actorId,
+        err: toLoggableError(error)
+      })
+      return existing.id
+    }
 
     logger.warn({
       message: 'Failed to record remote follow collection actor',
@@ -337,8 +351,8 @@ const fetchRemoteFollowCollectionPage = async ({
     status: 'ok',
     page: {
       accounts,
-      nextPageUrl: getPageUrl(collection.page.next),
-      prevPageUrl: getPageUrl(collection.page.prev),
+      nextPageUrl: getPageUrl(collection.page.next, collectionUrl),
+      prevPageUrl: getPageUrl(collection.page.prev, collectionUrl),
       totalItems: collection.totalItems
     }
   }

--- a/lib/services/mastodon/remoteFollowCollection.ts
+++ b/lib/services/mastodon/remoteFollowCollection.ts
@@ -1,3 +1,5 @@
+import { SpanStatusCode } from '@opentelemetry/api'
+
 import {
   BlockedFederationDomainError,
   recordActorIfNeeded
@@ -13,6 +15,7 @@ import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { normalizeActivityPubUri } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
+import { withSpan } from '@/lib/utils/trace'
 
 // The Mastodon `accounts/:id/followers` and `/following` lists for a REMOTE
 // actor. The `follows` table only knows relationships this instance took part
@@ -210,46 +213,55 @@ const recordUnknownActor = async ({
   database: Database
   actorId: string
   signingActor?: Actor
-}): Promise<string | null> => {
-  try {
-    // Refuses a blocked domain by throwing, and answers undefined when the
-    // actor cannot be fetched; both simply leave the entry out of the page.
-    const actor = await recordActorIfNeeded({ actorId, database, signingActor })
-    return actor?.id ?? null
-  } catch (error) {
-    if (error instanceof BlockedFederationDomainError) {
-      // Policy working as configured, not a failure.
-      logger.debug({
-        message: 'Skipped blocked-domain actor in remote follow collection',
-        actorId
+}): Promise<string | null> =>
+  withSpan('service', 'recordUnknownActor', { actorId }, async (span) => {
+    try {
+      // Refuses a blocked domain by throwing, and answers undefined when the
+      // actor cannot be fetched; both simply leave the entry out of the page.
+      const actor = await recordActorIfNeeded({
+        actorId,
+        database,
+        signingActor
       })
-      return null
-    }
-    // The same unknown actor can be recorded at the same moment from the
-    // other collection's entry (or any other path that records actors); the
-    // loser's insert fails on the id's unique constraint after the row exists.
-    // Re-read before giving the actor up for the whole TTL.
-    const existing = await database
-      .getActorFromId({ id: actorId })
-      .catch(() => null)
-    if (existing) {
-      logger.debug({
-        message:
-          'Actor record threw but row exists (likely insert race or background refresh error)',
+      return actor?.id ?? null
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      if (error instanceof BlockedFederationDomainError) {
+        // Policy working as configured, not a failure.
+        logger.debug({
+          message: 'Skipped blocked-domain actor in remote follow collection',
+          actorId
+        })
+        return null
+      }
+      // The same unknown actor can be recorded at the same moment from the
+      // other collection's entry (or any other path that records actors); the
+      // loser's insert fails on the id's unique constraint after the row exists.
+      // Re-read before giving the actor up for the whole TTL.
+      const existing = await database
+        .getActorFromId({ id: actorId })
+        .catch(() => null)
+      if (existing) {
+        span.recordException(err)
+        logger.debug({
+          message:
+            'Actor record threw but row exists (likely insert race or background refresh error)',
+          actorId,
+          err: toLoggableError(error)
+        })
+        return existing.id
+      }
+
+      span.recordException(err)
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+      logger.warn({
+        message: 'Failed to record remote follow collection actor',
         actorId,
         err: toLoggableError(error)
       })
-      return existing.id
+      return null
     }
-
-    logger.warn({
-      message: 'Failed to record remote follow collection actor',
-      actorId,
-      err: toLoggableError(error)
-    })
-    return null
-  }
-}
+  })
 
 const resolvePageAccounts = async ({
   database,
@@ -306,57 +318,70 @@ const fetchRemoteFollowCollectionPage = async ({
   field,
   signingActor,
   pageUrl
-}: Params): Promise<RemoteFollowCollectionResult> => {
-  const person = await getActorPerson({ actorId, signingActor })
-  const collectionUrl = person?.[field]
-  if (!person || !collectionUrl) return { status: 'unavailable' }
+}: Params): Promise<RemoteFollowCollectionResult> =>
+  withSpan(
+    'service',
+    'fetchRemoteFollowCollectionPage',
+    { actorId, field, ...(pageUrl ? { pageUrl } : {}) },
+    async (span) => {
+      const person = await getActorPerson({ actorId, signingActor })
+      const collectionUrl = person?.[field]
+      if (!person || !collectionUrl) {
+        span.setAttribute('result', 'unavailable')
+        return { status: 'unavailable' }
+      }
 
-  // The same check `remote-statuses` applies to its `page_url`: a cursor is
-  // only ever a page of THIS actor's collection, never an arbitrary URL this
-  // instance would then fetch on the client's behalf.
-  if (pageUrl && !isCollectionPageUrl(pageUrl, collectionUrl)) {
-    return { status: 'invalid-page' }
-  }
+      // The same check `remote-statuses` applies to its `page_url`: a cursor is
+      // only ever a page of THIS actor's collection, never an arbitrary URL this
+      // instance would then fetch on the client's behalf.
+      if (pageUrl && !isCollectionPageUrl(pageUrl, collectionUrl)) {
+        span.setAttribute('result', 'invalid-page')
+        return { status: 'invalid-page' }
+      }
 
-  const collection = await getActorCollections({
-    person,
-    field,
-    signingActor,
-    pageUrl
-  })
-  // No collection, or a collection the remote publishes a size for but no
-  // page of — Mastodon's "hide your social graph" — is the caller's cue to
-  // fall back to what this instance knows locally. So is a page whose items
-  // are not the `orderedItems` array this reader handles (`items`, or a
-  // non-array): the body is parsed JSON with no schema, and a shape this
-  // cannot read must be a cached `unavailable`, never a thrown TypeError that
-  // evicts the entry and is retried on every open.
-  const orderedItems = collection?.page?.orderedItems
-  if (!collection?.page || !Array.isArray(orderedItems)) {
-    return { status: 'unavailable' }
-  }
+      const collection = await getActorCollections({
+        person,
+        field,
+        signingActor,
+        pageUrl
+      })
+      // No collection, or a collection the remote publishes a size for but no
+      // page of — Mastodon's "hide your social graph" — is the caller's cue to
+      // fall back to what this instance knows locally. So is a page whose items
+      // are not the `orderedItems` array this reader handles (`items`, or a
+      // non-array): the body is parsed JSON with no schema, and a shape this
+      // cannot read must be a cached `unavailable`, never a thrown TypeError that
+      // evicts the entry and is retried on every open.
+      const orderedItems = collection?.page?.orderedItems
+      if (!collection?.page || !Array.isArray(orderedItems)) {
+        span.setAttribute('result', 'unavailable')
+        return { status: 'unavailable' }
+      }
 
-  const actorIds = Array.from(
-    new Set(
-      orderedItems.map(getItemActorId).filter((id): id is string => Boolean(id))
-    )
-  ).slice(0, MAX_PAGE_ITEMS)
-  const accounts = await resolvePageAccounts({
-    database,
-    actorIds,
-    signingActor
-  })
+      const actorIds = Array.from(
+        new Set(
+          orderedItems
+            .map(getItemActorId)
+            .filter((id): id is string => Boolean(id))
+        )
+      ).slice(0, MAX_PAGE_ITEMS)
+      const accounts = await resolvePageAccounts({
+        database,
+        actorIds,
+        signingActor
+      })
 
-  return {
-    status: 'ok',
-    page: {
-      accounts,
-      nextPageUrl: getPageUrl(collection.page.next, collectionUrl),
-      prevPageUrl: getPageUrl(collection.page.prev, collectionUrl),
-      totalItems: collection.totalItems
+      return {
+        status: 'ok',
+        page: {
+          accounts,
+          nextPageUrl: getPageUrl(collection.page.next, collectionUrl),
+          prevPageUrl: getPageUrl(collection.page.prev, collectionUrl),
+          totalItems: collection.totalItems
+        }
+      }
     }
-  }
-}
+  )
 
 /**
  * One page of a remote actor's `followers` or `following` collection as

--- a/lib/services/mastodon/remoteFollowCollection.ts
+++ b/lib/services/mastodon/remoteFollowCollection.ts
@@ -1,4 +1,7 @@
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  BlockedFederationDomainError,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import {
   getActorCollections,
   isCollectionPageUrl
@@ -19,27 +22,49 @@ import { toLoggableError } from '@/lib/utils/toLoggableError'
 // way; this is an enhancement over it, and it reads the list the remote server
 // already publishes on the actor's `followers`/`following` collections.
 //
-// Two costs are bounded here rather than in the routes. A collection page is
-// actor URIs, and turning one into Mastodon Account entities needs stored
-// rows: the known ones come back in one batch query, and each UNKNOWN one is a
-// `recordActorIfNeeded` — a signed Person fetch plus three collection-root
-// fetches for its counters, then an insert. So a page resolves at most
-// `MAX_UNKNOWN_ACTORS_PER_PAGE` unknown actors, `UNKNOWN_ACTOR_CONCURRENCY` at
-// a time, and drops the rest of that page's unknowns rather than stalling the
-// request on them. And a resolved page is held for `REMOTE_FOLLOW_PAGE_TTL_MS`
-// as a PROMISE, so a client re-opening the sheet, or two clients opening it at
-// once, share one round of fetches — the same shape as
-// `getCachedActorPublicStatusesCount` (`lib/services/statuses/`), down to
-// deleting the entry on rejection so a failure is retried rather than served
-// for a minute. The actor's own Person document is fetched INSIDE the cached
-// work, because the collection URL lives on it: fetched outside, a cache hit
-// would still cost one signed remote request per page open.
+// The costs are bounded here rather than in the routes, and by three
+// different mechanisms because they bound three different things.
+//
+// A collection page is actor URIs, and turning one into Mastodon Account
+// entities needs stored rows: the known ones come back in one batch query,
+// and each UNKNOWN one is a `recordActorIfNeeded` — a signed Person fetch plus
+// three collection-root fetches for its counters, then an insert. So a page
+// is cut to `MAX_PAGE_ITEMS` ids first, resolves at most
+// `MAX_UNKNOWN_ACTORS_PER_PAGE` unknown actors among them,
+// `UNKNOWN_ACTOR_CONCURRENCY` at a time, and drops the rest of that page's
+// unknowns rather than stalling the request on them.
+//
+// A resolved page is held for `REMOTE_FOLLOW_PAGE_TTL_MS` as a PROMISE, so a
+// client re-opening the sheet, or two clients opening it at once, share one
+// round of fetches — the same shape as `getCachedActorPublicStatusesCount`
+// (`lib/services/statuses/`), down to deleting the entry on rejection so a
+// failure is retried rather than served for a minute. The actor's own Person
+// document is fetched INSIDE the cached work, because the collection URL lives
+// on it: fetched outside, a cache hit would still cost one signed remote
+// request per page open. The cache bounds REPEAT opens and nothing else: a
+// page URL is client-chosen and `isCollectionPageUrl` checks only the
+// origin and path, so a caller can mint a fresh key per request by varying
+// the query string (the key is normalized, which closes reordering and
+// fragments, not a nonce).
+//
+// Adversarial use is bounded by `MAX_IN_FLIGHT_REMOTE_READS` instead: a read
+// that would exceed it answers `unavailable` at once, uncached, and the route
+// serves the local rows — today's behaviour — so a flood degrades this
+// instance to what it did before rather than fanning out to remote servers.
+// A genuine viewer under that load gets the local list for one request, which
+// is the trade the fallback exists for.
 
 export type RemoteFollowField = 'followers' | 'following'
 
 export const REMOTE_FOLLOW_PAGE_TTL_MS = 60_000
+// The route's own maximum page size; a remote page is never served past it.
+export const MAX_PAGE_ITEMS = 80
 export const MAX_UNKNOWN_ACTORS_PER_PAGE = 20
 export const UNKNOWN_ACTOR_CONCURRENCY = 5
+// Uncached page reads in flight at once, across every actor and viewer this
+// process serves. Sized for a handful of people opening sheets at the same
+// moment, not for a page per request.
+export const MAX_IN_FLIGHT_REMOTE_READS = 4
 // Bounded because entries expire but nothing sweeps them, and which actors and
 // pages get asked for is chosen by clients.
 export const MAX_CACHED_PAGES = 256
@@ -56,7 +81,9 @@ export interface RemoteFollowCollectionPage {
 export type RemoteFollowCollectionResult =
   | { status: 'ok'; page: RemoteFollowCollectionPage }
   // The remote publishes no page (a hidden collection, an unreachable actor or
-  // collection): the caller should serve what this instance knows locally.
+  // collection, a page in a shape this reader does not handle), or this
+  // process is already at its in-flight limit: the caller should serve what
+  // this instance knows locally.
   | { status: 'unavailable' }
   // `pageUrl` is not a page of this actor's collection — a client error, not
   // something to fall back from.
@@ -76,13 +103,18 @@ type CacheEntry = {
   expiresAt: number
 }
 
-let cacheByDatabase = new WeakMap<Database, Map<string, CacheEntry>>()
+type CacheState = {
+  entries: Map<string, CacheEntry>
+  inFlightReads: number
+}
 
-const getCacheEntries = (database: Database) => {
-  const entries = cacheByDatabase.get(database)
-  if (entries) return entries
+let cacheByDatabase = new WeakMap<Database, CacheState>()
 
-  const created = new Map<string, CacheEntry>()
+const getCacheState = (database: Database) => {
+  const state = cacheByDatabase.get(database)
+  if (state) return state
+
+  const created: CacheState = { entries: new Map(), inFlightReads: 0 }
   cacheByDatabase.set(database, created)
   return created
 }
@@ -100,6 +132,21 @@ const setBoundedEntry = (
     if (oldestKey !== undefined) entries.delete(oldestKey)
   }
   entries.set(key, entry)
+}
+
+// The same page spelled with its query in another order, or with a fragment,
+// is the same page. A parse failure keeps the raw value; the fetch decides
+// what it is.
+const normalizePageUrlKey = (pageUrl: string | undefined) => {
+  if (!pageUrl) return ''
+  try {
+    const url = new URL(pageUrl)
+    url.hash = ''
+    url.searchParams.sort()
+    return url.toString()
+  } catch {
+    return pageUrl
+  }
 }
 
 // A collection page item is an actor id, either bare or as an object carrying
@@ -137,19 +184,57 @@ const runWithConcurrency = async <T>(
   )
 }
 
-// The stored actor ids a batch of Mastodon accounts answers for. `uri` is the
-// actor id the row was looked up by; `url` is the profile URL, which for a
-// local actor is the same string and for a remote one usually is not. Keying
-// on both is what the search route does for the same lookup.
+// `uri` is the stored actor id the row was looked up by — the serializer
+// writes `sqlActor.id` there — so it is the key a page's actor ids resolve
+// against.
 const indexAccountsByActorId = (accounts: MastodonAccount[]) => {
   const byActorId = new Map<string, MastodonAccount>()
   for (const account of accounts) {
-    for (const key of [account.uri, account.url]) {
-      const actorId = normalizeActivityPubUri(key)
-      if (actorId && !byActorId.has(actorId)) byActorId.set(actorId, account)
-    }
+    const actorId = normalizeActivityPubUri(account.uri)
+    if (actorId && !byActorId.has(actorId)) byActorId.set(actorId, account)
   }
   return byActorId
+}
+
+const recordUnknownActor = async ({
+  database,
+  actorId,
+  signingActor
+}: {
+  database: Database
+  actorId: string
+  signingActor?: Actor
+}): Promise<string | null> => {
+  try {
+    // Refuses a blocked domain by throwing, and answers undefined when the
+    // actor cannot be fetched; both simply leave the entry out of the page.
+    const actor = await recordActorIfNeeded({ actorId, database, signingActor })
+    return actor?.id ?? null
+  } catch (error) {
+    if (error instanceof BlockedFederationDomainError) {
+      // Policy working as configured, not a failure.
+      logger.debug({
+        message: 'Skipped blocked-domain actor in remote follow collection',
+        actorId
+      })
+      return null
+    }
+    // The same unknown actor can be recorded at the same moment from the
+    // other collection's entry (or any other path that records actors); the
+    // loser's insert fails on the id's unique constraint after the row exists.
+    // Re-read before giving the actor up for the whole TTL.
+    const existing = await database
+      .getActorFromId({ id: actorId })
+      .catch(() => null)
+    if (existing) return existing.id
+
+    logger.warn({
+      message: 'Failed to record remote follow collection actor',
+      actorId,
+      err: toLoggableError(error)
+    })
+    return null
+  }
 }
 
 const resolvePageAccounts = async ({
@@ -176,22 +261,12 @@ const resolvePageAccounts = async ({
     unknownActorIds,
     UNKNOWN_ACTOR_CONCURRENCY,
     async (actorId) => {
-      try {
-        // Refuses a blocked domain by throwing, and answers undefined when the
-        // actor cannot be fetched; both simply leave the entry out of the page.
-        const actor = await recordActorIfNeeded({
-          actorId,
-          database,
-          signingActor
-        })
-        if (actor) recordedActorIds.push(actor.id)
-      } catch (error) {
-        logger.warn({
-          message: 'Failed to record remote follow collection actor',
-          actorId,
-          err: toLoggableError(error)
-        })
-      }
+      const recordedId = await recordUnknownActor({
+        database,
+        actorId,
+        signingActor
+      })
+      if (recordedId) recordedActorIds.push(recordedId)
     }
   )
 
@@ -237,16 +312,21 @@ const fetchRemoteFollowCollectionPage = async ({
   })
   // No collection, or a collection the remote publishes a size for but no
   // page of — Mastodon's "hide your social graph" — is the caller's cue to
-  // fall back to what this instance knows locally.
-  if (!collection?.page) return { status: 'unavailable' }
+  // fall back to what this instance knows locally. So is a page whose items
+  // are not the `orderedItems` array this reader handles (`items`, or a
+  // non-array): the body is parsed JSON with no schema, and a shape this
+  // cannot read must be a cached `unavailable`, never a thrown TypeError that
+  // evicts the entry and is retried on every open.
+  const orderedItems = collection?.page?.orderedItems
+  if (!collection?.page || !Array.isArray(orderedItems)) {
+    return { status: 'unavailable' }
+  }
 
   const actorIds = Array.from(
     new Set(
-      collection.page.orderedItems
-        .map(getItemActorId)
-        .filter((id): id is string => Boolean(id))
+      orderedItems.map(getItemActorId).filter((id): id is string => Boolean(id))
     )
-  )
+  ).slice(0, MAX_PAGE_ITEMS)
   const accounts = await resolvePageAccounts({
     database,
     actorIds,
@@ -267,9 +347,11 @@ const fetchRemoteFollowCollectionPage = async ({
 /**
  * One page of a remote actor's `followers` or `following` collection as
  * Mastodon Account entities. Answers `unavailable` when the remote publishes
- * no page (a hidden collection, an unreachable actor) — the caller should then
- * serve the locally-known relationships — and `invalid-page` when `pageUrl`
- * is not a page of that actor's collection.
+ * no page (a hidden collection, an unreachable actor), when the page is in a
+ * shape this reader does not handle, or when this process already has
+ * `MAX_IN_FLIGHT_REMOTE_READS` uncached reads running — the caller should
+ * then serve the locally-known relationships — and `invalid-page` when
+ * `pageUrl` is not a page of that actor's collection.
  *
  * Cached per (database, actor, field, page) for `REMOTE_FOLLOW_PAGE_TTL_MS`;
  * concurrent misses share one fetch and a rejection evicts the entry. Domain
@@ -281,16 +363,25 @@ export const getRemoteFollowCollectionPage = (
   params: Params
 ): Promise<RemoteFollowCollectionResult> => {
   const { database, actorId, field, pageUrl } = params
-  const entries = getCacheEntries(database)
-  const key = `${field}|${actorId}|${pageUrl ?? ''}`
-  const entry = entries.get(key)
+  const state = getCacheState(database)
+  const key = `${field}|${actorId}|${normalizePageUrlKey(pageUrl)}`
+  const entry = state.entries.get(key)
   if (entry && entry.expiresAt > Date.now()) return entry.result
 
-  const result = fetchRemoteFollowCollectionPage(params).catch((error) => {
-    if (entries.get(key)?.result === result) entries.delete(key)
-    throw error
-  })
-  setBoundedEntry(entries, key, {
+  if (state.inFlightReads >= MAX_IN_FLIGHT_REMOTE_READS) {
+    return Promise.resolve({ status: 'unavailable' })
+  }
+
+  state.inFlightReads += 1
+  const result = fetchRemoteFollowCollectionPage(params)
+    .catch((error) => {
+      if (state.entries.get(key)?.result === result) state.entries.delete(key)
+      throw error
+    })
+    .finally(() => {
+      state.inFlightReads -= 1
+    })
+  setBoundedEntry(state.entries, key, {
     result,
     expiresAt: Date.now() + REMOTE_FOLLOW_PAGE_TTL_MS
   })


### PR DESCRIPTION
## Summary

`GET /api/v1/accounts/:id/followers` and `/following` answered from the `follows` table, which only holds relationships this instance took part in. Opening a remote account (e.g. The Verge) in a Mastodon client therefore showed one local follower under **Followers** and "No People Found" under **Following**. Stock Mastodon behaves the same way; this PR is an enhancement over it.

For a **remote** actor the two routes now read the actor's own `followers` / `following` ActivityPub collections and serialize each listed actor as a Mastodon `Account`:

- **`lib/services/mastodon/remoteFollowCollection.ts`** (new) — fetches the actor's Person document and the collection page (via the existing `getActorCollections`, signed by the federation signing actor) inside a 60 s **promise cache** keyed per actor, field and page, so a re-opened sheet or two concurrent viewers share one round of fetches and a failure is never cached. Stored actors are hydrated in one `getMastodonActorsFromIds` batch; at most **20 unknown actors per page** are resolved through `recordActorIfNeeded` (5 at a time) and the rest of that page's unknowns are dropped rather than stalling the request. A page cursor is validated against the actor's own collection with `isCollectionPageUrl` (the same check `remote-statuses` applies to `page_url`) and refused otherwise.
- **`app/api/v1/accounts/[id]/followCollectionHandler.ts`** (new) — one handler for both routes, which were near-identical copies. Local actors keep the exact previous behaviour. For remote actors the remote page URLs ride in the Mastodon cursors (`max_id` = page `next`, `min_id` = page `prev`), so an unmodified client paginates by sending the `Link` header's value straight back. A URL cursor that is not a page of that actor's collection is a `400`.
- **Fallbacks keep today's behaviour as the floor.** The remote read is only made for a signed-in viewer (the route is public and each page can cost a signed fetch per unknown actor — the same line `search` / `accounts/lookup` draw around `resolve=true`). An anonymous caller, a blocked domain (`canFederateWithDomain`, checked per request rather than inside the cache), an unreachable server, an actor document with no such collection, and a hidden collection (Mastodon's "hide your social graph", which publishes a size but no page) all serve the locally-known rows.
- Docs: new bullet in `docs/mastodon-api-compatibility.md`.

Known limitation, unchanged here: this instance's own ActivityPub `followers`/`following` collections still publish only `totalItems` with no page, so another Activity.next instance cannot list our users' follows this way. That is a separate change.

### Tests

- `lib/services/mastodon/remoteFollowCollection.test.ts` — page order, unknown-actor recording (once, in place), the per-page cap and its ordering, item shapes (object with id, blank node, no id, duplicates), cursor validation (same collection / other collection / other host), every `unavailable` cause, concurrent-miss collapsing including the Person fetch, TTL expiry, and failure non-caching.
- Both `route.test.ts` files — remote branch: served page + `Link` cursors carrying the remote page URLs, `max_id`/`min_id` forwarded as `pageUrl`, `400` on a refused cursor, anonymous → local rows with no remote call, fallback to local rows on `unavailable` and on a throw, blocked domain → no remote call, and a URL cursor ignored on the local fallback path. Existing local-actor tests untouched.

Full gate run locally in order: `yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test` (935 files, 12593 tests) — all green.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR — n/a, no migration
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3nuwhCuUMGhpSPAM3oJBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3nuwhCuUMGhpSPAM3oJBf)_