### PR TITLE
Bump version to v1.154.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.154.3",
+  "version": "1.154.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.154.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.154.3`
- Base main SHA: `56fcb66805587cefe27de92cc54d505ed630fb14`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
