### PR TITLE
Bump version to v1.155.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.154.4",
+  "version": "1.155.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.154.4`
- Base main SHA: `2231a5e37d35756d89ef42e3f974277228de0fa1`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
