### PR TITLE
feat: disallow /tags and subpaths in robots.txt

### DIFF
--- a/app/robots.test.ts
+++ b/app/robots.test.ts
@@ -27,6 +27,7 @@ describe('robots metadata route', () => {
         '/oauth/',
         '/search',
         '/settings',
+        '/tags',
         '/users/'
       ]
     })

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -24,6 +24,7 @@ export default function robots(): MetadataRoute.Robots {
         '/oauth/',
         '/search',
         '/settings',
+        '/tags',
         '/users/'
       ]
     }


### PR DESCRIPTION
## Summary

Add `/tags` to the `disallow` list in `app/robots.ts` so that search engines and web crawlers are instructed not to crawl `/tags` and any of its subpaths (e.g. `/tags/[tag]`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)