### PR TITLE
Bump version to v1.155.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.0",
+  "version": "1.155.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.0`
- Base main SHA: `2fdf2287be960128ad9d6718d9f1e79c0db036f2`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
