### PR TITLE
Bump version to v1.155.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.1",
+  "version": "1.155.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.1`
- Base main SHA: `44f940b21c89b69ff9fc284b96eab71c4d6365f2`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
