### PR TITLE
fix: adjust followers and following header layout for signed-in and anonymous visitors

### DIFF
--- a/app/(timeline)/[actor]/followers/page.test.tsx
+++ b/app/(timeline)/[actor]/followers/page.test.tsx
@@ -263,4 +263,81 @@ describe('[actor] followers page', () => {
     expect(followList).toBeInTheDocument()
     expect(followList).toHaveAttribute('data-empty-message', 'No followers yet')
   })
+
+  it('renders PageHeader when user is logged in', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.test' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.test/users/llun',
+        preferredUsername: 'llun'
+      } as unknown as Parameters<typeof getProfileData>[0] extends never
+        ? never
+        : NonNullable<Awaited<ReturnType<typeof getProfileData>>>['person'],
+      statuses: [],
+      statusesCount: 0,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 0,
+      followersCount: 42,
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+    mockDatabase.getFollowers.mockResolvedValue([])
+
+    const result = await Page({
+      params: Promise.resolve({ actor: '@llun@llun.test' })
+    })
+
+    const { render, screen } = await import('@testing-library/react')
+    const { container } = render(result as React.ReactElement)
+
+    expect(container.querySelector('.sticky')).toBeInTheDocument()
+    expect(screen.getByText('Followers')).toBeInTheDocument()
+    expect(screen.getByText('42 accounts')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Back to profile' })
+    ).toHaveAttribute('href', '/@llun@llun.test')
+  })
+
+  it('renders navigation text and follower count on the same line without PageHeader when anonymous', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.test/users/llun',
+        preferredUsername: 'llun'
+      } as unknown as Parameters<typeof getProfileData>[0] extends never
+        ? never
+        : NonNullable<Awaited<ReturnType<typeof getProfileData>>>['person'],
+      statuses: [],
+      statusesCount: 0,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 0,
+      followersCount: 42,
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+    mockDatabase.getFollowers.mockResolvedValue([])
+
+    const result = await Page({
+      params: Promise.resolve({ actor: '@llun@llun.test' })
+    })
+
+    const { render, screen } = await import('@testing-library/react')
+    const { container } = render(result as React.ReactElement)
+
+    expect(container.querySelector('.sticky')).not.toBeInTheDocument()
+    const heading = screen.getByRole('heading', { name: 'Followers' })
+    expect(heading).toBeInTheDocument()
+    const count = screen.getByText('42 accounts')
+    expect(count).toBeInTheDocument()
+    expect(heading.parentElement).toBe(count.parentElement)
+    expect(
+      screen.getByRole('link', { name: 'Back to profile' })
+    ).toHaveAttribute('href', '/@llun@llun.test')
+  })
 })

--- a/app/(timeline)/[actor]/followers/page.test.tsx
+++ b/app/(timeline)/[actor]/followers/page.test.tsx
@@ -302,7 +302,7 @@ describe('[actor] followers page', () => {
     ).toHaveAttribute('href', '/@llun@llun.test')
   })
 
-  it('renders navigation text and follower count on the same line without PageHeader when anonymous', async () => {
+  it('renders navigation text and follower count on a new line without PageHeader when anonymous', async () => {
     mockGetServerAuthSession.mockResolvedValue(null)
     mockIsLocalFederationDomain.mockResolvedValue(true)
     mockGetProfileData.mockResolvedValue({

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -120,22 +120,39 @@ const Page: FC<Props> = async ({ params }) => {
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title={
-          <span className="flex items-center gap-2">
-            <Link
-              href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-              prefetch={false}
-              aria-label="Back to profile"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-            <span className="truncate">Followers</span>
+      {isLoggedIn ? (
+        <PageHeader
+          title={
+            <span className="flex items-center gap-2">
+              <Link
+                href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+                prefetch={false}
+                aria-label="Back to profile"
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+              <span className="truncate">Followers</span>
+            </span>
+          }
+          description={`${actorProfile.followersCount.toLocaleString()} accounts`}
+        />
+      ) : (
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+            prefetch={false}
+            aria-label="Back to profile"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-xl font-semibold tracking-tight">Followers</h1>
+          <span className="text-sm text-muted-foreground">
+            {actorProfile.followersCount.toLocaleString()} accounts
           </span>
-        }
-        description={`${actorProfile.followersCount.toLocaleString()} accounts`}
-      />
+        </div>
+      )}
 
       <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <FollowList

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -138,19 +138,21 @@ const Page: FC<Props> = async ({ params }) => {
           description={`${actorProfile.followersCount.toLocaleString()} accounts`}
         />
       ) : (
-        <div className="flex items-center gap-2">
+        <div className="flex items-start gap-2">
           <Link
             href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
             prefetch={false}
             aria-label="Back to profile"
-            className="text-muted-foreground transition-colors hover:text-foreground"
+            className="mt-0.5 text-muted-foreground transition-colors hover:text-foreground"
           >
             <ArrowLeft className="h-5 w-5" />
           </Link>
-          <h1 className="text-xl font-semibold tracking-tight">Followers</h1>
-          <span className="text-sm text-muted-foreground">
-            {actorProfile.followersCount.toLocaleString()} accounts
-          </span>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">Followers</h1>
+            <p className="text-sm text-muted-foreground">
+              {actorProfile.followersCount.toLocaleString()} accounts
+            </p>
+          </div>
         </div>
       )}
 

--- a/app/(timeline)/[actor]/following/page.test.tsx
+++ b/app/(timeline)/[actor]/following/page.test.tsx
@@ -266,4 +266,81 @@ describe('[actor] following page', () => {
       'Not following anyone yet'
     )
   })
+
+  it('renders PageHeader when user is logged in', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.test' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.test/users/llun',
+        preferredUsername: 'llun'
+      } as unknown as Parameters<typeof getProfileData>[0] extends never
+        ? never
+        : NonNullable<Awaited<ReturnType<typeof getProfileData>>>['person'],
+      statuses: [],
+      statusesCount: 0,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 42,
+      followersCount: 0,
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+    mockDatabase.getFollowing.mockResolvedValue([])
+
+    const result = await Page({
+      params: Promise.resolve({ actor: '@llun@llun.test' })
+    })
+
+    const { render, screen } = await import('@testing-library/react')
+    const { container } = render(result as React.ReactElement)
+
+    expect(container.querySelector('.sticky')).toBeInTheDocument()
+    expect(screen.getByText('Following')).toBeInTheDocument()
+    expect(screen.getByText('42 accounts')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Back to profile' })
+    ).toHaveAttribute('href', '/@llun@llun.test')
+  })
+
+  it('renders navigation text and following count on the same line without PageHeader when anonymous', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.test/users/llun',
+        preferredUsername: 'llun'
+      } as unknown as Parameters<typeof getProfileData>[0] extends never
+        ? never
+        : NonNullable<Awaited<ReturnType<typeof getProfileData>>>['person'],
+      statuses: [],
+      statusesCount: 0,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 42,
+      followersCount: 0,
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+    mockDatabase.getFollowing.mockResolvedValue([])
+
+    const result = await Page({
+      params: Promise.resolve({ actor: '@llun@llun.test' })
+    })
+
+    const { render, screen } = await import('@testing-library/react')
+    const { container } = render(result as React.ReactElement)
+
+    expect(container.querySelector('.sticky')).not.toBeInTheDocument()
+    const heading = screen.getByRole('heading', { name: 'Following' })
+    expect(heading).toBeInTheDocument()
+    const count = screen.getByText('42 accounts')
+    expect(count).toBeInTheDocument()
+    expect(heading.parentElement).toBe(count.parentElement)
+    expect(
+      screen.getByRole('link', { name: 'Back to profile' })
+    ).toHaveAttribute('href', '/@llun@llun.test')
+  })
 })

--- a/app/(timeline)/[actor]/following/page.test.tsx
+++ b/app/(timeline)/[actor]/following/page.test.tsx
@@ -305,7 +305,7 @@ describe('[actor] following page', () => {
     ).toHaveAttribute('href', '/@llun@llun.test')
   })
 
-  it('renders navigation text and following count on the same line without PageHeader when anonymous', async () => {
+  it('renders navigation text and following count on a new line without PageHeader when anonymous', async () => {
     mockGetServerAuthSession.mockResolvedValue(null)
     mockIsLocalFederationDomain.mockResolvedValue(true)
     mockGetProfileData.mockResolvedValue({

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -138,19 +138,21 @@ const Page: FC<Props> = async ({ params }) => {
           description={`${actorProfile.followingCount.toLocaleString()} accounts`}
         />
       ) : (
-        <div className="flex items-center gap-2">
+        <div className="flex items-start gap-2">
           <Link
             href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
             prefetch={false}
             aria-label="Back to profile"
-            className="text-muted-foreground transition-colors hover:text-foreground"
+            className="mt-0.5 text-muted-foreground transition-colors hover:text-foreground"
           >
             <ArrowLeft className="h-5 w-5" />
           </Link>
-          <h1 className="text-xl font-semibold tracking-tight">Following</h1>
-          <span className="text-sm text-muted-foreground">
-            {actorProfile.followingCount.toLocaleString()} accounts
-          </span>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">Following</h1>
+            <p className="text-sm text-muted-foreground">
+              {actorProfile.followingCount.toLocaleString()} accounts
+            </p>
+          </div>
         </div>
       )}
 

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -120,22 +120,39 @@ const Page: FC<Props> = async ({ params }) => {
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title={
-          <span className="flex items-center gap-2">
-            <Link
-              href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-              prefetch={false}
-              aria-label="Back to profile"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-            <span className="truncate">Following</span>
+      {isLoggedIn ? (
+        <PageHeader
+          title={
+            <span className="flex items-center gap-2">
+              <Link
+                href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+                prefetch={false}
+                aria-label="Back to profile"
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+              <span className="truncate">Following</span>
+            </span>
+          }
+          description={`${actorProfile.followingCount.toLocaleString()} accounts`}
+        />
+      ) : (
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+            prefetch={false}
+            aria-label="Back to profile"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-xl font-semibold tracking-tight">Following</h1>
+          <span className="text-sm text-muted-foreground">
+            {actorProfile.followingCount.toLocaleString()} accounts
           </span>
-        }
-        description={`${actorProfile.followingCount.toLocaleString()} accounts`}
-      />
+        </div>
+      )}
 
       <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <FollowList

--- a/app/(timeline)/[actor]/layout.tsx
+++ b/app/(timeline)/[actor]/layout.tsx
@@ -24,7 +24,7 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
 
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)
-  if (actor) return <div className="pt-6 sm:pt-8">{children}</div>
+  if (actor) return <>{children}</>
 
   return <PublicShell>{children}</PublicShell>
 }

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -13,6 +13,7 @@ import { getRelationship } from '@/lib/services/accounts/relationship'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorProfile } from '@/lib/types/domain/actor'
+import { cn } from '@/lib/utils'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { ActorRedirectCard } from './ActorRedirectCard'
@@ -192,7 +193,7 @@ const Page: FC<Props> = async ({ params }) => {
   const iconImageUrl = getIconImage()
 
   return (
-    <div className="space-y-6">
+    <div className={cn('space-y-6', isLoggedIn && 'pt-6 sm:pt-8')}>
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <ProfileHeaderImage
           actorId={person.id}


### PR DESCRIPTION
## Summary

Fixes the header layout on the followers and following pages (`app/(timeline)/[actor]/followers` and `app/(timeline)/[actor]/following`):
1. **Signed-in accounts**: Removes the empty gap above the `PageHeader` navigation bar so it sits flush at the top of the viewport (`top-0`), matching all other authenticated timeline pages.
2. **Anonymous visitors**: Removes the `PageHeader` bar entirely on public views, displaying an inline navigation header with the back arrow and section heading (`Followers` / `Following`), with the account count on a new line below it like before.

## Root Cause & Changes

1. **Top Spacing on Authenticated Subroutes** (`app/(timeline)/[actor]/layout.tsx`):
   - `[actor]/layout.tsx` previously wrapped children in `<div className="pt-6 sm:pt-8">{children}</div>` when an actor was signed in.
   - For subroutes that render `PageHeader` (which has `sticky top-0` and negative breakout margins), this wrapper created an unwanted 24px/32px blank gap above the navigation bar.
   - Changed `[actor]/layout.tsx` to pass children through directly (`<>{children}</>`), matching `tags/layout.tsx`.
   - Moved `isLoggedIn && 'pt-6 sm:pt-8'` directly onto the profile page container (`app/(timeline)/[actor]/page.tsx`) so that profile cards continue to receive top padding when signed in.

2. **Inline Header for Anonymous Visitors** (`app/(timeline)/[actor]/followers/page.tsx` & `following/page.tsx`):
   - When visited while logged out (`!isLoggedIn`), `PageHeader` rendered an unnecessary full-bleed breakout bar underneath `PublicTopBar`.
   - Conditioned `PageHeader` on `isLoggedIn`.
   - When anonymous, render a clean inline section (`<div className="flex items-start gap-2">`) with the profile back link, heading (`Followers` or `Following`), and the account count on a new line below it.

3. **Tests**:
   - Added unit tests in `followers/page.test.tsx` and `following/page.test.tsx` covering both signed-in (`PageHeader`) and anonymous (inline header without `PageHeader`) states.

## Verification

- `yarn run prettier --write .` (clean)
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (succeeded)
- `yarn test` (all 937 test files, 12,623 tests passed)
- Verified with Playwright in a real Chrome browser across signed-in and anonymous followers/following pages.
