### PR TITLE
feat: display media alt text in timeline and gallery

### DIFF
--- a/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
@@ -67,4 +67,27 @@ describe('ActorMediaGallery', () => {
     const descriptions = screen.getAllByText('Cat in the garden')
     expect(descriptions[0]).toBeInTheDocument()
   })
+
+  it('applies keyboard focus-visible outline classes on thumbnail buttons', () => {
+    const attachment = buildAttachment({
+      id: 'attachment-1',
+      name: 'Cat'
+    })
+
+    render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[attachment]}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: 'Open media: Cat'
+    })
+    expect(button).toHaveClass(
+      'focus-visible:outline-2',
+      'focus-visible:outline-offset-[-2px]',
+      'focus-visible:outline-primary'
+    )
+  })
 })

--- a/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { Attachment } from '@/lib/types/domain/attachment'
+
+import { ActorMediaGallery } from './ActorMediaGallery'
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const buildAttachment = (overrides: Partial<Attachment> = {}): Attachment => ({
+  id: 'attachment-1',
+  actorId: 'https://activities.local/users/llun',
+  statusId: 'https://activities.local/users/llun/statuses/post-1',
+  type: 'Document',
+  mediaType: 'image/jpeg',
+  url: 'https://activities.local/media/1.jpg',
+  name: '',
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  ...overrides
+})
+
+describe('ActorMediaGallery', () => {
+  it('renders an ALT badge on thumbnails with descriptions and none on undescribed ones', () => {
+    const described = buildAttachment({
+      id: 'attachment-1',
+      name: 'Cat in the garden'
+    })
+    const undescribed = buildAttachment({
+      id: 'attachment-2',
+      name: ''
+    })
+
+    render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[described, undescribed]}
+      />
+    )
+
+    // Only one ALT badge should be rendered
+    const altBadges = screen.getAllByText('ALT')
+    expect(altBadges).toHaveLength(1)
+  })
+
+  it('opens MediasModal when a thumbnail is clicked and shows the alt text', () => {
+    const attachment = buildAttachment({
+      id: 'attachment-1',
+      name: 'Cat in the garden'
+    })
+
+    render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[attachment]}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: 'Open media: Cat in the garden'
+    })
+    fireEvent.click(button)
+
+    const descriptions = screen.getAllByText('Cat in the garden')
+    expect(descriptions[0]).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -62,6 +62,14 @@ export const ActorMediaGallery: FC<Props> = ({
               attachment={attachment}
               className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
             />
+            {attachment.name?.trim() ? (
+              <span
+                className="pointer-events-none absolute bottom-1.5 left-1.5 flex items-center rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-white shadow-sm backdrop-blur-xs"
+                aria-hidden="true"
+              >
+                ALT
+              </span>
+            ) : null}
           </button>
         ))}
       </div>

--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -50,7 +50,7 @@ export const ActorMediaGallery: FC<Props> = ({
           <button
             key={attachment.id}
             type="button"
-            className="group relative aspect-square overflow-hidden bg-muted/20"
+            className="group relative aspect-square overflow-hidden bg-muted/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
             onClick={() => setModalIndex(index)}
             aria-label={
               attachment.name

--- a/lib/components/medias-modal/medias-modal.test.tsx
+++ b/lib/components/medias-modal/medias-modal.test.tsx
@@ -85,4 +85,44 @@ describe('MediasModal', () => {
 
     expect(screen.getByText('Second photo description')).toBeInTheDocument()
   })
+
+  it('marks off-screen carousel panels as aria-hidden and active panel as visible', () => {
+    const attachment = buildAttachment({
+      name: 'Ridge view'
+    })
+
+    render(
+      <MediasModal
+        medias={[attachment]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    const panels = document.body.querySelectorAll('.w-\\[300\\%\\] > div')
+    expect(panels[0]).toHaveAttribute('aria-hidden', 'true')
+    expect(panels[1]).toHaveAttribute('aria-hidden', 'false')
+    expect(panels[2]).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('stops touch event propagation on alt text paragraph', () => {
+    const attachment = buildAttachment({
+      name: 'Touch description'
+    })
+
+    render(
+      <MediasModal
+        medias={[attachment]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    const altElements = screen.getAllByText('Touch description')
+    const touchStartEvent = new Event('touchstart', { bubbles: true })
+    const stopPropagationSpy = vi.spyOn(touchStartEvent, 'stopPropagation')
+
+    altElements[1].dispatchEvent(touchStartEvent)
+    expect(stopPropagationSpy).toHaveBeenCalled()
+  })
 })

--- a/lib/components/medias-modal/medias-modal.test.tsx
+++ b/lib/components/medias-modal/medias-modal.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { Attachment } from '@/lib/types/domain/attachment'
+
+import { MediasModal } from './medias-modal'
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const buildAttachment = (overrides: Partial<Attachment> = {}): Attachment => ({
+  id: 'attachment-1',
+  actorId: 'https://activities.local/users/llun',
+  statusId: 'https://activities.local/users/llun/statuses/post-1',
+  type: 'Document',
+  mediaType: 'image/jpeg',
+  url: 'https://activities.local/media/1.jpg',
+  name: '',
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  ...overrides
+})
+
+describe('MediasModal', () => {
+  it('renders alt text underneath image when description exists', () => {
+    const attachment = buildAttachment({
+      name: 'A mountaineer walking along a ridge'
+    })
+
+    render(
+      <MediasModal
+        medias={[attachment]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    const alts = screen.getAllByText('A mountaineer walking along a ridge')
+    expect(alts[0]).toBeInTheDocument()
+    expect(alts[0]).toHaveClass('text-white/85', 'text-sm')
+  })
+
+  it('does not render alt text paragraph when description is empty or whitespace', () => {
+    const attachment = buildAttachment({
+      name: '   '
+    })
+
+    const { container } = render(
+      <MediasModal
+        medias={[attachment]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector('p')).not.toBeInTheDocument()
+  })
+
+  it('shows the corresponding alt text when navigating between media items', () => {
+    const first = buildAttachment({
+      id: 'attachment-1',
+      name: 'First photo description'
+    })
+    const second = buildAttachment({
+      id: 'attachment-2',
+      name: 'Second photo description'
+    })
+
+    render(
+      <MediasModal
+        medias={[first, second]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('First photo description')).toBeInTheDocument()
+
+    const secondThumbnail = screen.getByRole('button', {
+      name: /Second photo description/i
+    })
+    fireEvent.click(secondThumbnail)
+
+    expect(screen.getByText('Second photo description')).toBeInTheDocument()
+  })
+})

--- a/lib/components/medias-modal/medias-modal.tsx
+++ b/lib/components/medias-modal/medias-modal.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 
 const MIN_SWIPE_DISTANCE = 50 // Minimum distance in pixels for a swipe to be recognized
 const INTERACTIVE_SWIPE_IGNORE_SELECTOR =
-  'button, a, input, textarea, select, label, [role="button"], video, audio'
+  'button, a, input, textarea, select, label, [role="button"], video, audio, .select-text'
 
 interface Props {
   medias: Attachment[] | null
@@ -278,6 +278,7 @@ export const MediasModal: FC<Props> = ({
                       ? `${medias[index].id}-${panelIndex}`
                       : medias[index].id
                   }
+                  aria-hidden={panelIndex !== 1}
                   className="flex h-full w-full shrink-0 items-center justify-center"
                 >
                   <div
@@ -295,7 +296,10 @@ export const MediasModal: FC<Props> = ({
                       attachment={medias[index]}
                     />
                     {medias[index].name?.trim() ? (
-                      <p className="mt-2 max-h-24 max-w-2xl overflow-y-auto px-4 text-center text-sm leading-relaxed text-white/85 select-text">
+                      <p
+                        onTouchStart={(e) => e.stopPropagation()}
+                        className="mt-2 max-h-24 max-w-2xl overflow-y-auto px-4 text-center text-sm leading-relaxed text-white/85 select-text"
+                      >
                         {medias[index].name.trim()}
                       </p>
                     ) : null}

--- a/lib/components/medias-modal/medias-modal.tsx
+++ b/lib/components/medias-modal/medias-modal.tsx
@@ -282,13 +282,23 @@ export const MediasModal: FC<Props> = ({
                 >
                   <div
                     onClick={(e) => e.stopPropagation()}
-                    className="flex max-h-[80vh] max-w-full items-center justify-center cursor-default"
+                    className="flex max-h-[80vh] max-w-full flex-col items-center justify-center cursor-default"
                   >
                     <Media
                       showVideoControl
-                      className="max-h-[80vh] max-w-full object-contain"
+                      className={cn(
+                        'max-w-full object-contain',
+                        medias[index].name?.trim()
+                          ? 'max-h-[72vh]'
+                          : 'max-h-[80vh]'
+                      )}
                       attachment={medias[index]}
                     />
+                    {medias[index].name?.trim() ? (
+                      <p className="mt-2 max-h-24 max-w-2xl overflow-y-auto px-4 text-center text-sm leading-relaxed text-white/85 select-text">
+                        {medias[index].name.trim()}
+                      </p>
+                    ) : null}
                   </div>
                 </div>
               ))}

--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -278,6 +278,65 @@ describe('Attachments', () => {
         screen.queryByLabelText(/media attachments/)
       ).not.toBeInTheDocument()
     })
+
+    it('renders subtle alt text underneath a single image when name is provided', () => {
+      render(
+        <Attachments
+          status={buildNoteStatus([
+            buildAttachment({
+              width: 800,
+              height: 600,
+              name: 'A mountaineer hiking on a ridge'
+            })
+          ])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      const alt = screen.getByText('A mountaineer hiking on a ridge')
+      expect(alt).toBeInTheDocument()
+      expect(alt).toHaveClass('text-muted-foreground', 'text-sm')
+      // Single image should not render an ALT badge
+      expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+    })
+
+    it('does not render alt text underneath when name is empty or whitespace', () => {
+      const { container } = render(
+        <Attachments
+          status={buildNoteStatus([
+            buildAttachment({
+              width: 800,
+              height: 600,
+              name: '   '
+            })
+          ])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      expect(container.querySelector('p')).not.toBeInTheDocument()
+    })
+
+    it('stops click propagation when clicking on the alt text', () => {
+      const parentOnClick = vi.fn()
+      render(
+        <div onClick={parentOnClick}>
+          <Attachments
+            status={buildNoteStatus([
+              buildAttachment({
+                width: 800,
+                height: 600,
+                name: 'Description'
+              })
+            ])}
+            onMediaSelected={vi.fn()}
+          />
+        </div>
+      )
+
+      fireEvent.click(screen.getByText('Description'))
+      expect(parentOnClick).not.toHaveBeenCalled()
+    })
   })
 
   describe('two or more images', () => {
@@ -413,6 +472,138 @@ describe('Attachments', () => {
 
       expect(screen.getAllByRole('button')).toHaveLength(7)
       expect(screen.queryByText(/^\+\d/)).not.toBeInTheDocument()
+    })
+
+    it('renders ALT badges and numbered alt text list for multiple images with descriptions', () => {
+      const first = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'First cat eating'
+      })
+      const second = buildAttachment({
+        width: 600,
+        height: 900,
+        name: 'Second cat resting'
+      })
+      const third = buildAttachment({
+        width: 1200,
+        height: 500,
+        name: ''
+      })
+
+      render(
+        <Attachments
+          status={buildNoteStatus([first, second, third])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      // First and second have alt text -> ALT¹ and ALT² badges
+      expect(
+        screen.getByText(
+          (_content, element) =>
+            element?.tagName.toLowerCase() === 'span' &&
+            element.textContent === 'ALT1'
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          (_content, element) =>
+            element?.tagName.toLowerCase() === 'span' &&
+            element.textContent === 'ALT2'
+        )
+      ).toBeInTheDocument()
+      // Third has no alt text -> no ALT³ badge
+      expect(
+        screen.queryByText(
+          (_content, element) =>
+            element?.tagName.toLowerCase() === 'span' &&
+            element.textContent === 'ALT3'
+        )
+      ).not.toBeInTheDocument()
+
+      // Numbered alt text list underneath
+      expect(screen.getByText('First cat eating')).toBeInTheDocument()
+      expect(screen.getByText('Second cat resting')).toBeInTheDocument()
+    })
+
+    it('groups indices when multiple images share identical alt text', () => {
+      const first = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Same landscape view'
+      })
+      const second = buildAttachment({
+        width: 600,
+        height: 900,
+        name: 'Same landscape view'
+      })
+
+      render(
+        <Attachments
+          status={buildNoteStatus([first, second])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      expect(
+        screen.getByText(
+          (_content, element) =>
+            element?.tagName.toLowerCase() === 'span' &&
+            element.textContent === 'ALT1'
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          (_content, element) =>
+            element?.tagName.toLowerCase() === 'span' &&
+            element.textContent === 'ALT2'
+        )
+      ).toBeInTheDocument()
+
+      // The grouped item shows indices "1 2" together
+      expect(screen.getByText('1 2')).toBeInTheDocument()
+      expect(screen.getByText('Same landscape view')).toBeInTheDocument()
+    })
+
+    it('does not render alt text section or badges if none have descriptions', () => {
+      const first = buildAttachment({ width: 800, height: 600 })
+      const second = buildAttachment({ width: 800, height: 600 })
+
+      render(
+        <Attachments
+          status={buildNoteStatus([first, second])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+    })
+
+    it('stops click propagation when clicking on the alt text list item', () => {
+      const parentOnClick = vi.fn()
+      const first = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Cat photo'
+      })
+      const second = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Dog photo'
+      })
+
+      render(
+        <div onClick={parentOnClick}>
+          <Attachments
+            status={buildNoteStatus([first, second])}
+            onMediaSelected={vi.fn()}
+          />
+        </div>
+      )
+
+      fireEvent.click(screen.getByText('Cat photo'))
+      expect(parentOnClick).not.toHaveBeenCalled()
     })
   })
 

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -263,9 +263,10 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
         Math.round(SINGLE_MAX_HEIGHT * ratio)
       )
     )
+    const altText = attachment.name?.trim()
     return (
       <>
-        <div className="mt-3 flex justify-start">
+        <div className="mt-3 flex flex-col justify-start">
           <button
             type="button"
             onClick={openMedia(0)}
@@ -278,11 +279,34 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               attachment={attachment}
             />
           </button>
+          {altText ? (
+            <p
+              onClick={(e) => e.stopPropagation()}
+              className="mt-1.5 text-sm leading-relaxed text-muted-foreground break-words select-text"
+            >
+              {altText}
+            </p>
+          ) : null}
         </div>
         {audioPlayers}
       </>
     )
   }
+
+  const altEntries = useMemo(() => {
+    const entries: { indices: number[]; text: string }[] = []
+    pictures.forEach((pic, i) => {
+      const text = pic.name?.trim()
+      if (!text) return
+      const existing = entries.find((e) => e.text === text)
+      if (existing) {
+        existing.indices.push(i + 1)
+      } else {
+        entries.push({ indices: [i + 1], text })
+      }
+    })
+    return entries
+  }, [pictures])
 
   const stripStyle: CSSProperties = {
     height: STRIP_ROW_HEIGHT,
@@ -294,88 +318,119 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
   return (
     <>
       {items.length ? (
-        <div className="group/media relative mt-3">
-          <div
-            ref={strip.ref}
-            onScroll={strip.measure}
-            role="group"
-            // Only promise more once the measurement says there is more: a
-            // strip whose items all fit tells a screen-reader user to scroll to
-            // content that does not exist.
-            aria-label={
-              canScrollLeft || canScrollRight
-                ? `${items.length} media attachments, scroll for more`
-                : `${items.length} media attachments`
-            }
-            className="no-scrollbar flex gap-1.5 overflow-x-auto"
-            style={stripStyle}
-          >
-            {items.map(({ attachment, width }, index) => (
+        <>
+          <div className="group/media relative mt-3">
+            <div
+              ref={strip.ref}
+              onScroll={strip.measure}
+              role="group"
+              // Only promise more once the measurement says there is more: a
+              // strip whose items all fit tells a screen-reader user to scroll to
+              // content that does not exist.
+              aria-label={
+                canScrollLeft || canScrollRight
+                  ? `${items.length} media attachments, scroll for more`
+                  : `${items.length} media attachments`
+              }
+              className="no-scrollbar flex gap-1.5 overflow-x-auto"
+              style={stripStyle}
+            >
+              {items.map(({ attachment, width }, index) => {
+                const alt = attachment.name?.trim()
+                return (
+                  <button
+                    key={attachment.id}
+                    type="button"
+                    onClick={openMedia(index)}
+                    aria-label={mediaLabel(attachment, index)}
+                    className={cn(
+                      MEDIA_BOX_CLASS,
+                      STRIP_FOCUS_CLASS,
+                      'h-full flex-none'
+                    )}
+                    style={{
+                      width,
+                      maxWidth: STRIP_ITEM_MAX_WIDTH,
+                      scrollSnapAlign: 'start'
+                    }}
+                  >
+                    <Media
+                      className="h-full w-full object-cover"
+                      attachment={attachment}
+                      loading="lazy"
+                    />
+                    {alt ? (
+                      <span
+                        className="pointer-events-none absolute bottom-2 left-2 flex items-center rounded bg-black/60 px-1.5 py-0.5 text-xs font-semibold text-white shadow-sm backdrop-blur-xs"
+                        aria-hidden="true"
+                      >
+                        ALT<sup>{index + 1}</sup>
+                      </span>
+                    ) : null}
+                  </button>
+                )
+              })}
+            </div>
+            {canScrollLeft ? (
               <button
-                key={attachment.id}
                 type="button"
-                onClick={openMedia(index)}
-                aria-label={mediaLabel(attachment, index)}
-                className={cn(
-                  MEDIA_BOX_CLASS,
-                  STRIP_FOCUS_CLASS,
-                  'h-full flex-none'
-                )}
-                style={{
-                  width,
-                  maxWidth: STRIP_ITEM_MAX_WIDTH,
-                  scrollSnapAlign: 'start'
+                tabIndex={-1}
+                aria-label="Previous media"
+                onMouseDown={preventFocusOnPress}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  strip.scrollByPage(-1)
                 }}
+                // Hidden until the strip is hovered — going back is only worth
+                // chrome once you have gone forward. The forward chevron opposite
+                // stays visible so "there is more" is discoverable without a
+                // pointer. `pointer-events-none` while invisible is load-bearing:
+                // `opacity-0` alone still hit-tests, and on a touch screen —
+                // where `group-hover` never latches — that leaves a dead column
+                // swallowing taps on the leftmost photo.
+                className={cn(
+                  CHEVRON_CLASS,
+                  'pointer-events-none left-2 opacity-0 transition-opacity group-hover/media:pointer-events-auto group-hover/media:opacity-100'
+                )}
               >
-                <Media
-                  className="h-full w-full object-cover"
-                  attachment={attachment}
-                  loading="lazy"
-                />
+                <ChevronLeft className="size-4" />
               </button>
-            ))}
+            ) : null}
+            {canScrollRight ? (
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label="More media"
+                onMouseDown={preventFocusOnPress}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  strip.scrollByPage(1)
+                }}
+                className={cn(CHEVRON_CLASS, 'right-2')}
+              >
+                <ChevronRight className="size-4" />
+              </button>
+            ) : null}
           </div>
-          {canScrollLeft ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label="Previous media"
-              onMouseDown={preventFocusOnPress}
-              onClick={(event) => {
-                event.stopPropagation()
-                strip.scrollByPage(-1)
-              }}
-              // Hidden until the strip is hovered — going back is only worth
-              // chrome once you have gone forward. The forward chevron opposite
-              // stays visible so "there is more" is discoverable without a
-              // pointer. `pointer-events-none` while invisible is load-bearing:
-              // `opacity-0` alone still hit-tests, and on a touch screen —
-              // where `group-hover` never latches — that leaves a dead column
-              // swallowing taps on the leftmost photo.
-              className={cn(
-                CHEVRON_CLASS,
-                'pointer-events-none left-2 opacity-0 transition-opacity group-hover/media:pointer-events-auto group-hover/media:opacity-100'
-              )}
+          {altEntries.length ? (
+            <div
+              className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
+              onClick={(e) => e.stopPropagation()}
             >
-              <ChevronLeft className="size-4" />
-            </button>
+              {altEntries.map((entry) => (
+                <div
+                  key={entry.indices.join('-')}
+                  className="flex items-start gap-1 leading-relaxed"
+                >
+                  <sup className="shrink-0 pt-0.5 text-xs font-semibold select-none">
+                    {entry.indices.join(' ')}
+                  </sup>
+                  <span className="break-words">{entry.text}</span>
+                </div>
+              ))}
+            </div>
           ) : null}
-          {canScrollRight ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label="More media"
-              onMouseDown={preventFocusOnPress}
-              onClick={(event) => {
-                event.stopPropagation()
-                strip.scrollByPage(1)
-              }}
-              className={cn(CHEVRON_CLASS, 'right-2')}
-            >
-              <ChevronRight className="size-4" />
-            </button>
-          ) : null}
-        </div>
+        </>
       ) : null}
       {audioPlayers}
     </>


### PR DESCRIPTION
## Summary

Adds subtle alt text display under media attachments in the timeline, shows alt text underneath expanded images in the gallery modal, and displays subtle `ALT` badges on thumbnails in multi-image timeline strips and the profile media gallery tab, matching Phanpy's reference implementation.

## Changes

1. **Timeline Single Media** (`lib/components/posts/attachments.tsx`):
   - Displays subtle alt text (`text-muted-foreground text-sm leading-relaxed`) directly underneath single media when a description is present (`attachment.name?.trim()`).
   - Keeps single media clean without an `ALT` badge.
   - Text is selectable (`select-text`) and clicks stop propagation to avoid unintentionally opening the parent status.

2. **Timeline Multiple Media** (`lib/components/posts/attachments.tsx`):
   - In scrollable multi-media strips, renders a dark pill badge `ALTⁿ` (e.g. `ALT¹`, `ALT²`) at the bottom-left corner of each described attachment.
   - Displays a grouped, numbered alt text list underneath the media strip using superscript numerals (`¹ Image 1 description`, `² Image 2 description`). Identical alt text across multiple photos is grouped (e.g. `¹ ² Shared description`).
   - Places the alt text list outside the media strip container so navigation chevrons remain vertically centered on the media.

3. **Gallery Modal** (`lib/components/medias-modal/medias-modal.tsx`):
   - Renders alt text underneath the active image in `text-white/85 text-sm` with a max height and vertical scrolling (`max-h-24 max-w-2xl overflow-y-auto`).
   - Adjusts maximum image height to `max-h-[72vh]` when alt text is present to leave room for the caption.

4. **Profile Media Gallery** (`app/(timeline)/[actor]/ActorMediaGallery.tsx`):
   - Adds a subtle `ALT` badge at the bottom-left corner of thumbnails that have descriptions.
   - Clicking opens `MediasModal` with the full image and its alt text underneath.

5. **Tests**:
   - Added unit tests in `lib/components/posts/attachments.test.tsx` covering single image alt text, multiple image `ALTⁿ` badges, numbered index list rendering, grouped shared indices, and click propagation.
   - Added unit tests in `lib/components/medias-modal/medias-modal.test.tsx` verifying alt text rendering and carousel navigation.
   - Added unit tests in `app/(timeline)/[actor]/ActorMediaGallery.test.tsx` checking `ALT` badge visibility and modal opening.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: No doc updates needed (UI feature)
- [x] If migrations changed: No migrations added
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description
