### PR TITLE
Bump version to v1.155.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.2",
+  "version": "1.155.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.2`
- Base main SHA: `a243ab4b5bb96727f24d14e4085b55e975258ad5`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
