### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "date-fns": "^4.4.0",
     "fast-xml-parser": "^5.11.1",
     "fit-file-parser": "^5.0.2",
-    "got": "^15.1.0",
+    "got": "^16.0.0",
     "html-react-parser": "^6.1.7",
     "jose": "^6.2.10",
     "jsonld": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,7 +3682,7 @@ __metadata:
     dotenv-flow: "npm:^4.1.0"
     fast-xml-parser: "npm:^5.11.1"
     fit-file-parser: "npm:^5.0.2"
-    got: "npm:^15.1.0"
+    got: "npm:^16.0.0"
     html-react-parser: "npm:^6.1.7"
     husky: "npm:^9.1.7"
     jest-extended: "npm:^7.0.0"
@@ -4098,13 +4098,6 @@ __metadata:
     ssri: "npm:^13.0.0"
     unique-filename: "npm:^5.0.0"
   checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
-  languageName: node
-  linkType: hard
-
-"cacheable-lookup@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "cacheable-lookup@npm:7.0.0"
-  checksum: 10c0/63a9c144c5b45cb5549251e3ea774c04d63063b29e469f7584171d059d3a88f650f47869a974e2d07de62116463d742c287a81a625e791539d987115cb081635
   languageName: node
   linkType: hard
 
@@ -4916,23 +4909,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^15.1.0":
-  version: 15.1.0
-  resolution: "got@npm:15.1.0"
+"got@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "got@npm:16.0.0"
   dependencies:
     "@sindresorhus/is": "npm:^8.0.0"
     byte-counter: "npm:^0.1.0"
-    cacheable-lookup: "npm:^7.0.0"
     cacheable-request: "npm:^13.0.18"
     chunk-data: "npm:^0.1.0"
     decompress-response: "npm:^10.0.0"
-    http2-wrapper: "npm:^2.2.1"
     keyv: "npm:^5.6.0"
     lowercase-keys: "npm:^4.0.1"
     responselike: "npm:^4.0.2"
     type-fest: "npm:^5.6.0"
     uint8array-extras: "npm:^1.5.0"
-  checksum: 10c0/3d506d6d0593ffa56eb0bb5826ca1dce237f6d440d61029d76e07de10dacffae15a49685a949e71e33922a8965a7edce80b1d8300f1b5598eb5a0ac63db6b760
+  checksum: 10c0/1d4d4c0900f808cf0e5ef661cf66ef45864e3f6abdc54fd01fae64cefce80fb15a94bde950c31450a494dd86d6d09c0c8f8099b3c6f63409eef23f523ecf82f7
   languageName: node
   linkType: hard
 
@@ -5048,16 +5039,6 @@ __metadata:
     agent-base: "npm:^7.1.0"
     debug: "npm:^4.3.4"
   checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
-  languageName: node
-  linkType: hard
-
-"http2-wrapper@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "http2-wrapper@npm:2.2.1"
-  dependencies:
-    quick-lru: "npm:^5.1.1"
-    resolve-alpn: "npm:^1.2.0"
-  checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
   languageName: node
   linkType: hard
 
@@ -6749,13 +6730,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quick-lru@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "quick-lru@npm:5.1.1"
-  checksum: 10c0/a24cba5da8cec30d70d2484be37622580f64765fb6390a928b17f60cd69e8dbd32a954b3ff9176fa1b86d86ff2ba05252fae55dc4d40d0291c60412b0ad096da
-  languageName: node
-  linkType: hard
-
 "rdf-canonize@npm:^5.0.0":
   version: 5.0.0
   resolution: "rdf-canonize@npm:5.0.0"
@@ -6957,13 +6931,6 @@ __metadata:
     "@react-email/render":
       optional: true
   checksum: 10c0/8d5874a4ce8b09ecb10c6d09612f6a664b5aaf4dbeed60a1e5c7e543babc1da43a673cb09147d56d0fb2944d18e340e6634a0089fbeb2ba153d9564d31773806
-  languageName: node
-  linkType: hard
-
-"resolve-alpn@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "resolve-alpn@npm:1.2.1"
-  checksum: 10c0/b70b29c1843bc39781ef946c8cd4482e6d425976599c0f9c138cec8209e4e0736161bf39319b01676a847000085dfdaf63583c6fb4427bf751a10635bd2aa0c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Checked all direct dependencies and devDependencies in package.json against npm registry publication dates. `got` v16.0.0 (published 2026-08-30, >3 days ago) was identified as the only eligible update. Updated package.json and yarn.lock, and verified that prettier, lint, typecheck, build, and test suites pass cleanly.

---
*PR created automatically by Jules for task [17175661643704456774](https://jules.google.com/task/17175661643704456774) started by @llun*