### PR TITLE
docs: audit and update project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,13 +339,18 @@ activities.next/
 ├── app/                       # Next.js App Router
 │   ├── (timeline)/            # Timeline routes (with sidebar)
 │   ├── (nosidebar)/           # Auth routes (no sidebar)
+│   ├── embed/                 # Public embed widgets (heatmaps)
+│   ├── health/                # Health liveness probe
 │   ├── api/                   # API routes
 │   │   ├── auth/              #   Authentication (better-auth)
-│   │   ├── v1/               #   Mastodon-compatible API v1
-│   │   ├── v2/               #   Mastodon-compatible API v2
-│   │   ├── users/            #   ActivityPub actor endpoints
-│   │   ├── oauth/            #   OAuth 2.0 provider
-│   │   └── well-known/       #   Federation discovery
+│   │   ├── inbox/             #   Shared ActivityPub inbox
+│   │   ├── nodeinfo/          #   NodeInfo 2.0 / 2.1 metadata
+│   │   ├── oauth/             #   OAuth 2.0 provider
+│   │   ├── oembed/            #   Public oEmbed endpoint
+│   │   ├── users/             #   ActivityPub actor endpoints
+│   │   ├── v1/                #   Mastodon-compatible API v1
+│   │   ├── v2/                #   Mastodon-compatible API v2
+│   │   └── well-known/        #   Federation discovery
 │   └── layout.tsx             # Root layout
 ├── lib/                       # Core application logic
 │   ├── actions/               # Server actions
@@ -361,7 +366,7 @@ activities.next/
 ├── docs/                      # Documentation
 ├── lint/                      # Local Oxlint JS plugin (AGENTS.md conventions)
 ├── public/                    # Static assets
-└── scripts/                   # Development/admin scripts
+└── scripts/                   # Development/admin scripts (backup/, fitness/, maintenance/, mock/)
 ```
 
 ### Important Files

--- a/README.md
+++ b/README.md
@@ -136,18 +136,19 @@ For PostgreSQL or advanced Docker setups, see:
 
 ## 📚 Documentation
 
-| Document                                               | Description                                             |
-| ------------------------------------------------------ | ------------------------------------------------------- |
-| [Quickstart](docs/quickstart.md)                       | Fastest minimal local setup (SQLite, 3 core settings)   |
-| [Setup Guide](docs/setup.md)                           | General configuration and first-time setup              |
-| [Architecture](docs/architecture.md)                   | System architecture, data flow, and design decisions    |
-| [SQLite Setup](docs/sqlite-setup.md)                   | SQLite database configuration and Docker deployment     |
-| [PostgreSQL Setup](docs/postgresql-setup.md)           | PostgreSQL database configuration and Docker deployment |
-| [Environment Variables](docs/environment-variables.md) | Complete reference for all configuration options        |
-| [Feature Roadmap](docs/features.md)                    | Current and planned features                            |
-| [Fitness File Storage](docs/fitness-file-storage.md)   | Fitness upload, processing, Strava, and heatmap details |
-| [Maintenance Scripts](docs/maintenance.md)             | Admin scripts for media cleanup and user management     |
-| [Contributing](CONTRIBUTING.md)                        | Guidelines for contributors                             |
+| Document                                                         | Description                                                      |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Quickstart](docs/quickstart.md)                                 | Fastest minimal local setup (SQLite, 3 core settings)            |
+| [Setup Guide](docs/setup.md)                                     | General configuration and first-time setup                       |
+| [Architecture](docs/architecture.md)                             | System architecture, data flow, and design decisions             |
+| [SQLite Setup](docs/sqlite-setup.md)                             | SQLite database configuration and Docker deployment              |
+| [PostgreSQL Setup](docs/postgresql-setup.md)                     | PostgreSQL database configuration and Docker deployment          |
+| [Environment Variables](docs/environment-variables.md)           | Complete reference for all configuration options                 |
+| [Feature Roadmap](docs/features.md)                              | Current and planned features                                     |
+| [Fitness File Storage](docs/fitness-file-storage.md)             | Fitness upload, processing, Strava, and heatmap details          |
+| [Maintenance Scripts](docs/maintenance.md)                       | Admin scripts for media cleanup and user management              |
+| [Mastodon API Compatibility](docs/mastodon-api-compatibility.md) | Compatibility reference, intentional divergences, and extensions |
+| [Contributing](CONTRIBUTING.md)                                  | Guidelines for contributors                                      |
 
 ## 🤝 Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,14 +86,17 @@ The frontend and API layer, organized using Next.js route groups:
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `app/(timeline)/`     | Main app pages with sidebar (home, profile, notifications, settings)                                                                                                     |
 | `app/(nosidebar)/`    | Authentication pages without sidebar (login, signup, OAuth consent)                                                                                                      |
+| `app/embed/`          | Public embed widgets (framable interactive heatmap embeds and static share images)                                                                                       |
+| `app/health/`         | Unauthenticated `GET /health` liveness probe returning `{"status":"UP"}`                                                                                                 |
 | `app/api/auth/`       | Authentication endpoints (better-auth)                                                                                                                                   |
-| `app/api/v1/`         | Mastodon-compatible API v1 (statuses, timelines, accounts, notifications)                                                                                                |
-| `app/api/v2/`         | Mastodon-compatible API v2 (instance info, media, search)                                                                                                                |
-| `app/api/users/`      | ActivityPub actor endpoints (inbox, outbox, followers, following)                                                                                                        |
+| `app/api/inbox/`      | Shared ActivityPub inbox receiving federated activities (rewritten from `/inbox`)                                                                                        |
+| `app/api/nodeinfo/`   | NodeInfo 2.0 and 2.1 documents and discovery (rewritten from `/.well-known/nodeinfo`)                                                                                    |
 | `app/api/oauth/`      | OAuth 2.0 provider endpoints (authorize, userinfo, revoke) — the token endpoint lives at `app/(nosidebar)/oauth/token/`, serving `/oauth/token`                          |
 | `app/api/oembed/`     | Public oEmbed provider (`GET /api/oembed`) returning rich embed metadata for this instance's public/unlisted status pages                                                |
+| `app/api/users/`      | ActivityPub actor endpoints (inbox, outbox, followers, following)                                                                                                        |
+| `app/api/v1/`         | Mastodon-compatible API v1 (statuses, timelines, accounts, notifications)                                                                                                |
+| `app/api/v2/`         | Mastodon-compatible API v2 (instance info, media, search)                                                                                                                |
 | `app/api/well-known/` | Federation discovery (WebFinger, host-meta, OAuth/OIDC metadata) — NodeInfo is served from `app/api/nodeinfo/` via a `next.config.ts` rewrite of `/.well-known/nodeinfo` |
-| `app/health/`         | Unauthenticated `GET /health` liveness probe returning `{"status":"UP"}`                                                                                                 |
 
 ### `lib/` — Core Business Logic
 
@@ -402,15 +405,20 @@ Other tables: sessions, notifications, medias, fitness_files,
               fitness_settings, strava_archive_imports,
               fitness_route_heatmaps, fitness_route_heatmap_region_names,
               fitness_route_heatmap_pyramids, fitness_route_heatmap_tiles,
-              fitness_file_routes,
+              fitness_file_routes, fitness_import_locks,
               fitness_gears, fitness_gear_components,
+              fitness_gear_component_periods,
               collections, collection_members, collection_timeline,
               blocks, mutes, actor_domain_blocks, filters, reports,
+              moderation_actions, server_filters, server_filter_keywords,
               markers, endorsements,
               lists, featured_tags, customEmojis, translation_cache,
-              link_previews, status_link_previews,
-              domain federation rules, recipients, counters, poll_choices,
-              clients, tokens, auth_codes (Mastodon API OAuth),
+              link_previews, status_link_previews, status_quotes,
+              status_reactions, announcements, announcement_reads,
+              announcement_reactions, instance_rules, suggestion_dismissals,
+              domain federation rules, relays, federated_timeline,
+              status_detected_languages, recipients, counters, poll_choices,
+              server_settings, clients, tokens, auth_codes (Mastodon API OAuth),
               oauthClient, oauthAccessToken, oauthRefreshToken,
               oauthConsent (better-auth OAuth provider)
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **ActivityPub federation** — Send and receive activities with other Fediverse servers
 - ✅ **Notes** — Create, receive, edit, and delete posts
 - ✅ **Replies** — Threaded conversation support, including on-demand fetching of full remote reply threads when viewing a remote status
-- ✅ **Image attachments** — Upload and display images in posts
+- ✅ **Image and video attachments** — Upload and display images and video in posts (with automatic preview frames and blurhash)
 - ✅ **Boost / Repost** — Share other users' posts (with undo)
 - ✅ **Like / Favorite** — React to posts (with undo)
 - ✅ **Polls** — Create, vote on, and view poll results (single and multiple choice)

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -115,6 +115,71 @@ The script includes several safety features:
 
 **Warning**: Always run with `--dry-run` first to verify the files to be deleted are indeed orphaned.
 
+## Production Snapshot Backup and Restore
+
+Activity.next provides scripts to create a full, standalone archive of a production instance (database rows and storage files) and to restore that snapshot into a local development environment.
+
+### Downloading a Production Archive
+
+The `downloadProductionArchive.ts` script connects to your production database, exports all table data (chunked in pages), and packages referenced media/fitness files into a gzip-compressed tar archive (`.tar.gz`):
+
+```bash
+# Download production archive with referenced media/fitness files (default)
+NODE_ENV=production ./scripts/backup/downloadProductionArchive.ts
+
+# Include all files in storage, even unreferenced ones
+NODE_ENV=production ./scripts/backup/downloadProductionArchive.ts --storage-scope all
+
+# Export database rows only (skip storage files)
+NODE_ENV=production ./scripts/backup/downloadProductionArchive.ts --skip-storage
+
+# Show help and available options
+./scripts/backup/downloadProductionArchive.ts --help
+```
+
+#### Options
+
+- `--env-file <path>` — Path to the environment configuration file to load (default: `.env.production`).
+- `--output-dir <path>` — Destination directory for archives (default: `backups/production-archives`).
+- `--storage-scope <referenced|all>` — Scope of files to include: `referenced` (default; only files linked to database rows) or `all` (every object in storage).
+- `--allow-missing-storage` — Warn and continue if a referenced storage object cannot be fetched, recording missing items in the archive manifest.
+- `--skip-database` — Package storage files only without exporting database tables.
+- `--skip-storage` — Export database tables only without packaging storage files.
+
+### Restoring a Production Archive into Local Development
+
+The `restoreProductionArchive.ts` script restores a downloaded archive into your local development environment: it validates local database connectivity, imports database tables in topological foreign-key order, runs Knex migrations to ensure schema currency, and extracts storage files into your local storage directory.
+
+```bash
+# Restore an archive into your local environment
+./scripts/backup/restoreProductionArchive.ts \
+  --archive backups/production-archives/activitynext-production-2026-09-01T12-00-00.tar.gz \
+  --yes
+
+# Restore only the database tables
+./scripts/backup/restoreProductionArchive.ts \
+  --archive backups/production-archives/activitynext-production-2026-09-01T12-00-00.tar.gz \
+  --database-only \
+  --yes
+```
+
+#### Options
+
+- `--archive <path>` — **Required.** Path to the `.tar.gz` production archive to restore.
+- `--yes` — **Required.** Confirmation flag acknowledging that restoring overwrites local data.
+- `--env-file <path>` — Environment file to load for local target settings (default: `.env.local`).
+- `--database-only` — Restore database tables only; skip extracting files.
+- `--files-only` — Extract storage files only; skip restoring database tables.
+- `--preserve-files` — Keep existing local files instead of replacing them during file extraction.
+- `--allow-non-local-database` — Override the safety guard that prevents restoring to non-local databases (use with extreme caution).
+
+#### Safety
+
+To prevent accidental data loss or clobbering of a live instance:
+
+- `restoreProductionArchive.ts` strictly refuses to run when `NODE_ENV=production`.
+- The script checks that the target database hostname is a local address (e.g. `localhost`, `127.0.0.1`, `::1`, or SQLite file) and refuses remote hostnames unless `--allow-non-local-database` is explicitly passed.
+
 ## Actor Archive Export
 
 The `exportActorArchive.ts` script exports everything belonging to one **local**
@@ -320,6 +385,51 @@ code at `1`.
 - Stops instead of looping when a pass selects rows but changes none of them
   (its `UPDATE`s are not taking effect), and says so.
 
+## Search Index Rebuild
+
+The `rebuildSearchIndex.ts` script rebuilds full-text search indexes for accounts, hashtags, and statuses. It scans records, regenerates search tokens and searchable text, and updates the search documents table in batches.
+
+You can run it directly or via the convenience package script:
+
+```bash
+# Using the yarn script
+yarn search:reindex
+
+# Or directly through node
+node scripts/run.cjs scripts/maintenance/rebuildSearchIndex.ts
+```
+
+Batch sizing can be controlled with the `SEARCH_REINDEX_BATCH_SIZE` environment variable (default: `500`):
+
+```bash
+SEARCH_REINDEX_BATCH_SIZE=1000 yarn search:reindex
+```
+
+## Fixing Attachment URLs
+
+The `fixAttachmentUrls.ts` script fixes attachment URLs that were mistakenly stored with a local or incorrect host (such as `localhost:3000`) instead of your production domain. It inspects `attachments.url` and replaces the mismatched host with the target domain.
+
+### Usage
+
+```bash
+# Preview changes without modifying any records (recommended first)
+NODE_ENV=production ./scripts/maintenance/fixAttachmentUrls.ts --wrong-host localhost:3000 --dry-run
+
+# Run the replacement
+NODE_ENV=production ./scripts/maintenance/fixAttachmentUrls.ts --wrong-host localhost:3000
+
+# Explicitly override the target replacement host (defaults to ACTIVITIES_HOST from config)
+NODE_ENV=production ./scripts/maintenance/fixAttachmentUrls.ts \
+  --wrong-host localhost:3000 \
+  --correct-host your-domain.tld
+```
+
+### Options
+
+- `--wrong-host <host>` — The bad host to find and replace (default: `localhost:3000`).
+- `--correct-host <host>` — The replacement host (defaults to `ACTIVITIES_HOST` read from configuration).
+- `--dry-run` — Print rows that would be modified without updating the database.
+
 ## Other Scripts
 
 ### Create Mock User
@@ -331,6 +441,26 @@ Creates a test user for development/testing:
 ```
 
 > **Note:** This script is for development and testing purposes only. In production, users should register through the web interface at `/auth/signup`.
+
+### Create Mock Statuses
+
+Creates realistic mock statuses (including threaded conversations, polls, mentions, and image attachments) for a local test user to populate timelines for development:
+
+```bash
+node scripts/run.cjs scripts/mock/createMockStatuses.ts [username]
+```
+
+Defaults to `testuser` if omitted. Run after `createMockUser.ts`.
+
+### Create Mock Fitness Data
+
+Seeds completed primary fitness files (runs, rides, walks with realistic GPS tracks and device metadata) and linked fitness posts for a local test user, so the `/fitness` Overview, calendar, and Recent activities feeds render with realistic data:
+
+```bash
+node scripts/run.cjs scripts/mock/createMockFitnessData.ts [username]
+```
+
+Defaults to `testuser` if omitted. Run after `createMockUser.ts`.
 
 ### Render Email Previews
 
@@ -391,6 +521,7 @@ Useful scripts for interrupted imports, route heatmap rebuilds, and Strava maint
 
 ```bash
 NODE_ENV=production ./scripts/fitness/fixStuckFitnessProcessing.ts --actor-id https://your-domain.tld/users/username
+NODE_ENV=production ./scripts/fitness/repairFailedFitnessImports.ts --actor-id https://your-domain.tld/users/username --dry-run
 NODE_ENV=production ./scripts/fitness/recreateFitnessRouteHeatmaps.ts --actor-id https://your-domain.tld/users/username --dry-run
 NODE_ENV=production ./scripts/fitness/repairStravaActivityFiles.ts --actor-id https://your-domain.tld/users/username --dry-run
 NODE_ENV=production ./scripts/fitness/backfillFitnessMovingTime.ts --actor-id https://your-domain.tld/users/username --dry-run
@@ -626,6 +757,14 @@ single post instead of duplicates. To consolidate existing duplicate posts,
 delete them first (deleting a status detaches its files back to orphans), then
 re-run with all the activity ids.
 
+To recover all failed or orphaned imports for an actor without re-triggering each activity individually, run `repairFailedFitnessImports.ts`. It re-executes the appropriate background importer directly from stored files:
+
+```bash
+NODE_ENV=production ./scripts/fitness/repairFailedFitnessImports.ts \
+  --actor-id https://your-domain.tld/users/username \
+  [--batch-id <batch-id>] [--visibility public] [--dry-run]
+```
+
 > **Important — run these against the right database.** `@next/env` loads
 > `.env.local` at higher precedence than `.env.production` **even under**
 > `NODE_ENV=production`, so a stray `.env.local` silently points every recovery
@@ -640,14 +779,6 @@ For local archive or one-off activity imports, see the `--help` output from:
 ./scripts/fitness/importStravaArchive.ts --help
 ./scripts/fitness/resumeStravaProcessing.ts --help
 ./scripts/fitness/runImportStravaActivity.ts --help
-```
-
-Additional utility scripts:
-
-```bash
-NODE_ENV=production ./scripts/maintenance/backfillMediaBlurhash.ts --dry-run
-NODE_ENV=production ./scripts/maintenance/fixAttachmentUrls.ts --dry-run
-NODE_ENV=development ./scripts/mock/createMockStatuses.ts
 ```
 
 ## Blurhash & Smart Focus Backfill


### PR DESCRIPTION
## Summary

Audited repository documentation against the current codebase and updated stale, incomplete, or omitted sections:

- **`README.md`**: Added `[Mastodon API Compatibility](docs/mastodon-api-compatibility.md)` to the documentation overview table.
- **`CONTRIBUTING.md`**: Updated the project structure tree to reflect `app/embed/`, `app/health/`, `app/api/inbox/`, `app/api/nodeinfo/`, `app/api/oembed/`, and `scripts/` subdirectories (`backup/`, `fitness/`, `maintenance/`, `mock/`).
- **`docs/architecture.md`**: Added `app/embed/`, `app/api/inbox/`, and `app/api/nodeinfo/` to the App Router Directory Structure table; expanded the Database Schema "Other tables" list to include recent tables (`fitness_gear_component_periods`, `server_settings`, `status_reactions`, `status_quotes`, `announcements`, `announcement_reads`, `announcement_reactions`, `instance_rules`, `suggestion_dismissals`, `relays`, `federated_timeline`, `status_detected_languages`, `fitness_import_locks`, `server_filters`, `server_filter_keywords`, and `moderation_actions`).
- **`docs/features.md`**: Updated Core features to reflect image and video attachments (with automated preview frames and blurhash placeholders).
- **`docs/maintenance.md`**:
  - Added full documentation for **Production Snapshot Backup and Restore** (`downloadProductionArchive.ts` and `restoreProductionArchive.ts`), including options and local database safety guards.
  - Added documentation for **Search Index Rebuild** (`rebuildSearchIndex.ts` / `yarn search:reindex`) and batch configuration (`SEARCH_REINDEX_BATCH_SIZE`).
  - Documented **Fixing Attachment URLs** (`fixAttachmentUrls.ts`) with options (`--wrong-host`, `--correct-host`, `--dry-run`).
  - Documented **Repair Failed Fitness Imports** (`repairFailedFitnessImports.ts`) for recovering orphaned/failed imports directly from stored files.
  - Documented mock data seed scripts (`createMockStatuses.ts` and `createMockFitnessData.ts`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR (N/A — no migrations changed)
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)