### PR TITLE
feat: add option to collapse and expand multi-image alt text

### DIFF
--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -296,8 +296,11 @@ describe('Attachments', () => {
       const alt = screen.getByText('A mountaineer hiking on a ridge')
       expect(alt).toBeInTheDocument()
       expect(alt).toHaveClass('text-muted-foreground', 'text-sm')
-      // Single image should not render an ALT badge
+      // Single image should not render an ALT badge or collapse/expand toggle button
       expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /alt text/i })
+      ).not.toBeInTheDocument()
     })
 
     it('does not render alt text underneath when name is empty or whitespace', () => {
@@ -603,6 +606,76 @@ describe('Attachments', () => {
       )
 
       fireEvent.click(screen.getByText('Cat photo'))
+      expect(parentOnClick).not.toHaveBeenCalled()
+    })
+
+    it('expands alt text by default and allows collapsing and re-expanding', () => {
+      const first = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'First description'
+      })
+      const second = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Second description'
+      })
+
+      render(
+        <Attachments
+          status={buildNoteStatus([first, second])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      const toggleButton = screen.getByRole('button', {
+        name: 'Collapse alt text'
+      })
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText('First description')).toBeInTheDocument()
+      expect(screen.getByText('Second description')).toBeInTheDocument()
+
+      // Collapse
+      fireEvent.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Expand alt text')
+      expect(screen.queryByText('First description')).not.toBeInTheDocument()
+      expect(screen.queryByText('Second description')).not.toBeInTheDocument()
+
+      // Re-expand
+      fireEvent.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
+      expect(screen.getByText('First description')).toBeInTheDocument()
+      expect(screen.getByText('Second description')).toBeInTheDocument()
+    })
+
+    it('stops click propagation when clicking on the collapse/expand button', () => {
+      const parentOnClick = vi.fn()
+      const first = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Cat photo'
+      })
+      const second = buildAttachment({
+        width: 800,
+        height: 600,
+        name: 'Dog photo'
+      })
+
+      render(
+        <div onClick={parentOnClick}>
+          <Attachments
+            status={buildNoteStatus([first, second])}
+            onMediaSelected={vi.fn()}
+          />
+        </div>
+      )
+
+      const toggleButton = screen.getByRole('button', {
+        name: 'Collapse alt text'
+      })
+      fireEvent.click(toggleButton)
       expect(parentOnClick).not.toHaveBeenCalled()
     })
   })

--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -581,6 +581,9 @@ describe('Attachments', () => {
       )
 
       expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /alt text/i })
+      ).not.toBeInTheDocument()
     })
 
     it('stops click propagation when clicking on the alt text list item', () => {
@@ -632,6 +635,7 @@ describe('Attachments', () => {
         name: 'Collapse alt text'
       })
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(toggleButton).toHaveAttribute('aria-controls')
       expect(screen.getByText('First description')).toBeInTheDocument()
       expect(screen.getByText('Second description')).toBeInTheDocument()
 
@@ -639,12 +643,14 @@ describe('Attachments', () => {
       fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
       expect(toggleButton).toHaveAttribute('aria-label', 'Expand alt text')
+      expect(toggleButton).not.toHaveAttribute('aria-controls')
       expect(screen.queryByText('First description')).not.toBeInTheDocument()
       expect(screen.queryByText('Second description')).not.toBeInTheDocument()
 
       // Re-expand
       fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(toggleButton).toHaveAttribute('aria-controls')
       expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
       expect(screen.getByText('First description')).toBeInTheDocument()
       expect(screen.getByText('Second description')).toBeInTheDocument()

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -422,7 +422,7 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               <button
                 type="button"
                 aria-expanded={isAltExpanded}
-                aria-controls={altListId}
+                aria-controls={isAltExpanded ? altListId : undefined}
                 aria-label={
                   isAltExpanded ? 'Collapse alt text' : 'Expand alt text'
                 }

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { CSSProperties, FC, MouseEvent, useMemo } from 'react'
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
+import { CSSProperties, FC, MouseEvent, useId, useMemo, useState } from 'react'
 
 import {
   Attachment,
@@ -179,6 +179,8 @@ interface Props {
 }
 
 export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
+  const [isAltExpanded, setIsAltExpanded] = useState(true)
+  const altListId = useId()
   const attachments = useMemo(
     () => (status.type === StatusType.enum.Note ? status.attachments : []),
     [status]
@@ -417,17 +419,43 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
               onClick={(e) => e.stopPropagation()}
             >
-              {altEntries.map((entry) => (
-                <div
-                  key={entry.indices.join('-')}
-                  className="flex items-start gap-1 leading-relaxed"
-                >
-                  <sup className="shrink-0 pt-0.5 text-xs font-semibold select-none">
-                    {entry.indices.join(' ')}
-                  </sup>
-                  <span className="break-words">{entry.text}</span>
+              <button
+                type="button"
+                aria-expanded={isAltExpanded}
+                aria-controls={altListId}
+                aria-label={
+                  isAltExpanded ? 'Collapse alt text' : 'Expand alt text'
+                }
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setIsAltExpanded((prev) => !prev)
+                }}
+                className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none"
+              >
+                <span>Alt text</span>
+                <ChevronDown
+                  className={cn(
+                    'size-3.5 transition-transform duration-200',
+                    isAltExpanded && 'rotate-180'
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+              {isAltExpanded ? (
+                <div id={altListId} className="flex flex-col gap-1">
+                  {altEntries.map((entry) => (
+                    <div
+                      key={entry.indices.join('-')}
+                      className="flex items-start gap-1 leading-relaxed"
+                    >
+                      <sup className="shrink-0 pt-0.5 text-xs font-semibold select-none">
+                        {entry.indices.join(' ')}
+                      </sup>
+                      <span className="break-words">{entry.text}</span>
+                    </div>
+                  ))}
                 </div>
-              ))}
+              ) : null}
             </div>
           ) : null}
         </>


### PR DESCRIPTION
## Summary

Adds an option to collapse and expand alt text descriptions underneath multi-image posts in the timeline. Alt text remains expanded by default, matching existing behavior while allowing users to collapse descriptions.

Single image posts continue to display their alt text directly underneath without a toggle, strictly adhering to the requirement for multi-image posts.

## Changes

1. **Timeline Multiple Media** (`lib/components/posts/attachments.tsx`):
   - Added state (`isAltExpanded`, defaults to `true`) and an accessible toggle button above the alt text list.
   - Button renders `Alt text` with a rotating chevron (`ChevronDown`, rotated 180° when expanded).
   - Accessibility attributes: `aria-expanded`, `aria-controls`, and `aria-label` ("Collapse alt text" / "Expand alt text").
   - Click handler stops propagation (`e.stopPropagation()`) so clicking the toggle does not navigate to the status page.
   - When collapsed, the alt text list items are hidden.
   - Single image posts continue to display alt text directly underneath without a toggle.

2. **Unit Tests** (`lib/components/posts/attachments.test.tsx`):
   - Added unit test verifying multi-image alt text is expanded by default with `aria-expanded="true"`.
   - Added unit test verifying clicking the button collapses the descriptions, updates `aria-expanded` and `aria-label`, and clicking again re-expands.
   - Added unit test verifying click propagation is stopped on the toggle button.
   - Added assertion that single image posts do not render a collapse/expand toggle button.

## Verification

- `yarn run prettier --write .`
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (succeeded)
- `yarn test` (all 940 test files, 12,644 tests passed)
- Verified visually in a real browser using seeded mock data; verified expanded and collapsed states and click interactions.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: No doc updates needed (UI feature)
- [x] If migrations changed: No migrations added
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description