### PR TITLE
Bump version to v1.155.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.4",
+  "version": "1.155.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.4`
- Base main SHA: `1b4808c709defcfbcedfa3d08a443bc0c2b8d087`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
