### PR TITLE
Bump version to v1.155.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.5",
+  "version": "1.155.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.5`
- Base main SHA: `0cb8d168e659ede0a0e41bd8d9919d67a0e0bc41`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
