### PR TITLE
fix: align federated status update delivery and span error tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1925,10 +1925,11 @@ system's `Attachments` component.
   uses a statusId that is deliberately NOT in the database for that reason.
 - **The dedup id is `getHashFromString(`${statusId}#delete`)`, and the suffix is
   correctness.** The queue deduplicates globally on `message.id` across job
-  names, with a window that outlives consumption, and `SendNoteJob` /
-  `SendUpdateNoteJob` already publish under the bare `getHashFromString(statusId)`
-  — without the suffix, deleting a status posted or edited inside that window is
-  silently dropped and never federates.
+  names, with a window that outlives consumption (`SendNoteJob` publishes under
+  bare `getHashFromString(statusId)` and `SendUpdateNoteJob` under
+  `getHashFromString(`${statusId}#update/${updatedStatus.updatedAt}`)`) — without
+  the suffix, deleting a status posted or edited inside that window is silently
+  dropped and never federates.
 - **Unboost carries more than the audience, because its activity embeds the
   Announce.** `undoAnnounce` (`lib/activities/index.ts`) builds its object from
   `id`, `actorId`, `createdAt`, `to`, `cc` and `originalStatus.id`, so the job

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -76,7 +76,7 @@ describe('Update note action', () => {
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: getHashFromString(statusId),
+        id: getHashFromString(`${statusId}#update/${status?.updatedAt}`),
         name: SEND_UPDATE_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,
@@ -164,7 +164,7 @@ describe('Update note action', () => {
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: getHashFromString(statusId),
+        id: getHashFromString(`${statusId}#update/${status?.updatedAt}`),
         name: SEND_UPDATE_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -99,7 +99,7 @@ export const updateNoteFromUserInput = async ({
 
     if (publish) {
       await getQueue().publish({
-        id: getHashFromString(statusId),
+        id: getHashFromString(`${statusId}#update/${updatedStatus.updatedAt}`),
         name: SEND_UPDATE_NOTE_JOB_NAME,
         data: {
           actorId: currentActor.id,

--- a/lib/actions/updateNoteVisibility.test.ts
+++ b/lib/actions/updateNoteVisibility.test.ts
@@ -111,7 +111,9 @@ describe('Update note visibility action', () => {
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: getHashFromString(`${ACTOR1_ID}/statuses/post-2`),
+        id: getHashFromString(
+          `${ACTOR1_ID}/statuses/post-2#update/${result?.updatedAt}`
+        ),
         name: SEND_UPDATE_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,

--- a/lib/actions/updateNoteVisibility.ts
+++ b/lib/actions/updateNoteVisibility.ts
@@ -83,7 +83,9 @@ export const updateNoteVisibilityFromUserInput = async ({
 
       if (publish) {
         await getQueue().publish({
-          id: getHashFromString(statusId),
+          id: getHashFromString(
+            `${statusId}#update/${updatedStatus.updatedAt}`
+          ),
           name: SEND_UPDATE_NOTE_JOB_NAME,
           data: { actorId: currentActor.id, statusId }
         })

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -65,6 +65,7 @@ interface PostActivityToInboxParams {
   activity: object
   logPrefix: string
   silenceTimeout?: boolean
+  recordOnlyErrorOnSpan?: boolean
 }
 
 /**
@@ -80,7 +81,8 @@ const postActivityToInbox = async ({
   currentActor,
   activity,
   logPrefix,
-  silenceTimeout = false
+  silenceTimeout = false,
+  recordOnlyErrorOnSpan = false
 }: PostActivityToInboxParams): Promise<number | undefined> => {
   const method = 'POST'
   try {
@@ -106,7 +108,9 @@ const postActivityToInbox = async ({
     // Normalize non-Error throws so recording/logging can't itself throw.
     const exception = error instanceof Error ? error : new Error(String(error))
     span.recordException(exception)
-    logger.error(`[${logPrefix}] ${exception.message}`)
+    if (!recordOnlyErrorOnSpan) {
+      logger.error(`[${logPrefix}] ${exception.message}`)
+    }
     return undefined
   }
 }
@@ -221,14 +225,21 @@ export const sendUpdateNote = async ({
         cc: note.cc,
         object: note
       }
-      await postActivityToInbox({
+      const statusCode = await postActivityToInbox({
         span,
         inbox,
         currentActor,
         activity,
         logPrefix: 'sendUpdateNote',
-        silenceTimeout: true
+        silenceTimeout: true,
+        recordOnlyErrorOnSpan: true
       })
+      if (statusCode !== undefined && !isAcceptedStatusCode(statusCode)) {
+        const error = new Error(`Failed to update note: HTTP ${statusCode}`)
+        span.recordException(error)
+        span.setAttribute('http.status_code', statusCode)
+        throw error
+      }
     }
   )
 

--- a/lib/jobs/sendUpdateNoteJob.test.ts
+++ b/lib/jobs/sendUpdateNoteJob.test.ts
@@ -11,6 +11,7 @@ import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
+import { logger } from '@/lib/utils/logger'
 
 enableFetchMocks()
 
@@ -104,5 +105,55 @@ describe('Send update note job', () => {
     })
 
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not log to logger.error when inbox request fails with network error', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const status = (await database.getStatus({
+      statusId: `${actor1.id}/statuses/post-1`,
+      withReplies: false
+    })) as Status
+
+    fetchMock.mockRejectOnce(new Error('Network error'))
+    const loggerErrorSpy = vi.spyOn(logger, 'error')
+
+    await sendUpdateNoteJob(database, {
+      id: 'job-id',
+      name: 'SendUpdateNoteJob',
+      data: {
+        actorId: actor1.id,
+        statusId: status.id
+      }
+    })
+
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+    loggerErrorSpy.mockRestore()
+  })
+
+  it('does not log to logger.error when inbox responds with HTTP error status code', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const status = (await database.getStatus({
+      statusId: `${actor1.id}/statuses/post-1`,
+      withReplies: false
+    })) as Status
+
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Unprocessable' }), {
+      status: 422
+    })
+    const loggerErrorSpy = vi.spyOn(logger, 'error')
+
+    await sendUpdateNoteJob(database, {
+      id: 'job-id',
+      name: 'SendUpdateNoteJob',
+      data: {
+        actorId: actor1.id,
+        statusId: status.id
+      }
+    })
+
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+    loggerErrorSpy.mockRestore()
   })
 })

--- a/lib/jobs/sendUpdateNoteJob.ts
+++ b/lib/jobs/sendUpdateNoteJob.ts
@@ -8,7 +8,6 @@ import { getFederatedStatusDeliveryInboxes } from '@/lib/services/federation/sta
 import { JobHandle } from '@/lib/services/queue/type'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
-import { logger } from '@/lib/utils/logger'
 import { UNFOLLOW_NETWORK_ERROR_CODES } from '@/lib/utils/response'
 import { withSpan } from '@/lib/utils/trace'
 
@@ -49,7 +48,8 @@ export const sendUpdateNoteJob: JobHandle = createJobHandle(
       const uniqueInboxes = await getFederatedStatusDeliveryInboxes({
         database,
         currentActor: actor,
-        status
+        status,
+        statusId: status.id
       })
       await Promise.all(
         uniqueInboxes.map(async (inbox) => {
@@ -61,14 +61,8 @@ export const sendUpdateNoteJob: JobHandle = createJobHandle(
             })
           } catch (e) {
             const nodeError = e as NodeJS.ErrnoException
-            logger.error(
-              {
-                inbox,
-                error: nodeError.message,
-                code: nodeError.code
-              },
-              'Failed to update note'
-            )
+            span.recordException(nodeError)
+            span.setAttribute('error.inbox', inbox)
             if (UNFOLLOW_NETWORK_ERROR_CODES.includes(nodeError.code ?? '')) {
               const follows = await database.getLocalFollowsFromInboxUrl({
                 followerInboxUrl: inbox,

--- a/lib/services/federation/statusDelivery.test.ts
+++ b/lib/services/federation/statusDelivery.test.ts
@@ -216,6 +216,81 @@ describe('getFederatedStatusDeliveryInboxes', () => {
 
     expect(maxActiveLookups).toBeLessThanOrEqual(8)
   })
+
+  it('delivers to inboxes of remote accounts that interacted with the status when statusId is provided', async () => {
+    const currentActor = makeActor('https://local.test/users/alice', {
+      privateKey: 'private-key'
+    })
+    const liker = makeActor('https://remote-like.test/users/bob')
+    const reblogger = makeActor('https://remote-reblog.test/users/carol')
+    const replier = makeActor('https://remote-reply.test/users/dave')
+    const quoter = makeActor('https://remote-quote.test/users/eve')
+    const statusId = 'https://local.test/users/alice/statuses/1'
+
+    const database = makeDatabase({
+      getFavouritedBy: vi
+        .fn()
+        .mockResolvedValue([{ actorId: liker.id, createdAt: 1 }]),
+      getRebloggedBy: vi
+        .fn()
+        .mockResolvedValue([{ actorId: reblogger.id, statusId: 's1' }]),
+      getStatusReplies: vi
+        .fn()
+        .mockResolvedValue([
+          makeStatus({ id: 'reply-1', actorId: replier.id })
+        ]),
+      getQuotingStatusIds: vi.fn().mockResolvedValue(['quote-1']),
+      getStatusesByIds: vi
+        .fn()
+        .mockResolvedValue([makeStatus({ id: 'quote-1', actorId: quoter.id })]),
+      getActorsFromIds: vi.fn(async ({ ids }) => {
+        const actorMap: Record<string, Actor> = {
+          [liker.id]: liker,
+          [reblogger.id]: reblogger,
+          [replier.id]: replier,
+          [quoter.id]: quoter
+        }
+        return ids.map((id) => actorMap[id]).filter((a): a is Actor => !!a)
+      })
+    })
+
+    const inboxes = await getFederatedStatusDeliveryInboxes({
+      database,
+      currentActor,
+      status: makeStatus({ to: [ACTIVITY_STREAM_PUBLIC] }),
+      statusId
+    })
+
+    expect(inboxes).toContain(liker.sharedInboxUrl)
+    expect(inboxes).toContain(reblogger.sharedInboxUrl)
+    expect(inboxes).toContain(replier.sharedInboxUrl)
+    expect(inboxes).toContain(quoter.sharedInboxUrl)
+  })
+
+  it('does not fan out to interacted accounts for private statuses even if statusId is provided', async () => {
+    const currentActor = makeActor('https://local.test/users/alice', {
+      privateKey: 'private-key'
+    })
+    const liker = makeActor('https://remote-like.test/users/bob')
+    const statusId = 'https://local.test/users/alice/statuses/1'
+    const getFavouritedBy = vi
+      .fn()
+      .mockResolvedValue([{ actorId: liker.id, createdAt: 1 }])
+
+    const database = makeDatabase({
+      getFavouritedBy
+    })
+
+    const inboxes = await getFederatedStatusDeliveryInboxes({
+      database,
+      currentActor,
+      status: makeStatus({ to: [`${currentActor.id}/followers`] }),
+      statusId
+    })
+
+    expect(inboxes).not.toContain(liker.sharedInboxUrl)
+    expect(getFavouritedBy).not.toHaveBeenCalled()
+  })
 })
 
 describe('getExplicitRecipientInboxes', () => {

--- a/lib/services/federation/statusDelivery.ts
+++ b/lib/services/federation/statusDelivery.ts
@@ -117,14 +117,73 @@ export const getExplicitRecipientInboxes = async ({
   ])
 }
 
+const getInteractedActorIds = async ({
+  database,
+  statusId,
+  currentActor
+}: {
+  database: Database
+  statusId: string
+  currentActor: Actor
+}): Promise<string[]> => {
+  const actorIds: string[] = []
+
+  try {
+    const [favourites, reblogs, replies, quotingStatusIds] = await Promise.all([
+      database.getFavouritedBy
+        ? database.getFavouritedBy({ statusId, limit: 100 })
+        : [],
+      database.getRebloggedBy
+        ? database.getRebloggedBy({ statusId, limit: 100 })
+        : [],
+      database.getStatusReplies
+        ? database.getStatusReplies({ statusId, limit: 100 })
+        : [],
+      database.getQuotingStatusIds
+        ? database.getQuotingStatusIds({
+            quotedStatusId: statusId,
+            state: 'accepted',
+            limit: 100
+          })
+        : []
+    ])
+
+    for (const fav of favourites) {
+      actorIds.push(fav.actorId)
+    }
+    for (const reb of reblogs) {
+      actorIds.push(reb.actorId)
+    }
+    for (const rep of replies) {
+      actorIds.push(rep.actorId)
+    }
+
+    if (quotingStatusIds.length > 0 && database.getStatusesByIds) {
+      const quotingStatuses = await database.getStatusesByIds({
+        statusIds: quotingStatusIds,
+        withReplies: false
+      })
+      for (const quote of quotingStatuses) {
+        actorIds.push(quote.actorId)
+      }
+    }
+  } catch {
+    // Interacted account discovery is best-effort
+  }
+
+  return [...new Set(actorIds)].filter((id) => id !== currentActor.id)
+}
+
 export const getFederatedStatusDeliveryInboxes = async ({
   database,
   currentActor,
-  status
+  status,
+  statusId
 }: {
   database: Database
   currentActor: Actor
   status: StatusAudience
+  statusId?: string
 }) => {
   const inboxes: string[] = []
 
@@ -154,6 +213,25 @@ export const getFederatedStatusDeliveryInboxes = async ({
     currentActor
   })
   inboxes.push(...recipientInboxes.filter((inbox): inbox is string => !!inbox))
+
+  // For public and unlisted statuses, fan updates out to third-party accounts
+  // that interacted with the status (reblogged, liked, replied, or quoted),
+  // matching Mastodon's StatusReachFinder.
+  if (statusId && hasPublicAudience(status)) {
+    const interactedActorIds = await getInteractedActorIds({
+      database,
+      statusId,
+      currentActor
+    })
+    const interactedInboxes = await getRemoteActorInboxes({
+      database,
+      actorIds: interactedActorIds,
+      currentActor
+    })
+    inboxes.push(
+      ...interactedInboxes.filter((inbox): inbox is string => !!inbox)
+    )
+  }
 
   return filterFederatedUrls(database, [...new Set(inboxes)])
 }


### PR DESCRIPTION
## Summary
Resolves status update delivery failures to federated Mastodon and fediverse instances:
1. **Queue Deduplication Collision**: Previously, `createNoteFromUserInput` and `updateNoteFromUserInput` published jobs with the same ID (`getHashFromString(statusId)`). QStash deduplicates messages over a 10-minute window, silently dropping status edits submitted within 10 minutes of creation or another edit. This changes the deduplication ID for `SEND_UPDATE_NOTE_JOB_NAME` to `getHashFromString(`${statusId}#update/${updatedStatus.updatedAt}`)`.
2. **Federation Delivery Reach**: Aligned update delivery with Mastodon's `StatusReachFinder` by fanning out `Update(Note)` activities to remote accounts that interacted with the status (liked, reblogged, replied, quoted).
3. **OpenTelemetry Error Tracing**: Delivery errors in `sendUpdateNoteJob` / `sendUpdateNote` are recorded on the active OpenTelemetry span rather than logged to `logger.error`.

## Verification
Executed all quality checks per repository guidelines:
- `yarn run prettier --write .` (clean)
- `yarn lint` (0 errors, 0 warnings across 2323 files)
- `yarn typecheck` (passed)
- `yarn build` (passed)
- `yarn test` (all 938 test files, 12,627 tests passed)