### PR TITLE
Bump version to v1.155.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.6",
+  "version": "1.155.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.6`
- Base main SHA: `8f3e44f5bdebdd42cf73ee185768697f1c09b17d`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
