### PR TITLE
feat: enable HTTP/2 auto-detection in safe remote fetch

### DIFF
--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -826,4 +826,36 @@ describe('safeRemoteFetch', () => {
       [null, addresses[0]?.address, addresses[0]?.family]
     ])
   })
+
+  it('enables HTTP/2 auto-detection when delegating to got transport', async () => {
+    let observedOptions: { http2?: boolean } | undefined
+    mockGotStream.mockImplementationOnce((_url: string, options: unknown) => {
+      observedOptions = options as { http2?: boolean }
+      const stream = new Readable({
+        read() {}
+      })
+      process.nextTick(() => {
+        stream.emit('response', {
+          headers: {},
+          statusCode: 200
+        })
+        stream.push('ok')
+        stream.push(null)
+      })
+      return stream
+    })
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS]
+    })
+
+    await expect(
+      safeRemoteFetch({ url: 'https://safe.example/actor' })
+    ).resolves.toMatchObject({
+      body: 'ok',
+      statusCode: 200
+    })
+    expect(observedOptions).toMatchObject({
+      http2: true
+    })
+  })
 })

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -246,6 +246,7 @@ const gotTransport: SafeRemoteFetchTransport = async ({
       dnsLookup: createFixedDnsLookup(resolvedAddresses),
       followRedirect: false,
       headers,
+      http2: true,
       method,
       retry: RETRY_DISABLED,
       throwHttpErrors: false,


### PR DESCRIPTION
## Summary

Enables HTTP/2 auto-detection via TLS ALPN in `safeRemoteFetch`'s default `gotTransport`.

With Got 16 (`got@16.0.0`), setting `http2: true` activates Got's built-in `http2Client.auto`:
- For HTTPS requests to servers that support HTTP/2, it negotiates `h2` and multiplexes requests over native HTTP/2 sessions.
- For HTTPS requests to servers that only support HTTP/1.1 (or do not support ALPN), it negotiates `http/1.1` and automatically falls back to HTTP/1.1.
- For plaintext `http://` requests, it falls back to standard HTTP/1.1.
- Preserves existing SSRF defenses: DNS pinning (`dnsLookup: createFixedDnsLookup(resolvedAddresses)`) is passed through to Node's `tls.connect` during ALPN resolution, keeping connections bound to pre-validated IP addresses.
- Preserves response body streaming and byte limit enforcement (`maxBodyBytes`).

Adds unit test coverage in `lib/utils/safeRemoteFetch.test.ts` verifying that `http2: true` is configured when delegating to `got.stream`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
