### PR TITLE
fix: resolve merge conflicts reliably with gemini in sync-main-to-oltp workflow

### DIFF
--- a/.github/aider/model-metadata.json
+++ b/.github/aider/model-metadata.json
@@ -1,0 +1,20 @@
+{
+  "gemini/gemini-3.8-flash": {
+    "max_tokens": 65536,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000075,
+    "output_cost_per_token": 0.00000375,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini/gemini-3.7-flash": {
+    "max_tokens": 65536,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000075,
+    "output_cost_per_token": 0.00000375,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  }
+}

--- a/.github/aider/model-settings.yml
+++ b/.github/aider/model-settings.yml
@@ -1,0 +1,4 @@
+- name: gemini/gemini-3.8-flash
+  edit_format: diff-fenced
+- name: gemini/gemini-3.7-flash
+  edit_format: diff-fenced

--- a/.github/scripts/resolve-merge-conflicts.py
+++ b/.github/scripts/resolve-merge-conflicts.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+MODELS = [
+    "gemini-3.8-flash",
+    "gemini-3.7-flash",
+    "gemini-2.5-flash",
+]
+
+MAX_RETRIES = 4
+BASE_RETRY_DELAY = 2.0
+
+
+def call_gemini(prompt: str, system_instruction: str = "", api_key: str = "") -> str:
+    """Call Google Gemini generateContent API with fallback across model versions and retries."""
+    if not api_key:
+        api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is not set or is empty.")
+
+    payload = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": prompt}],
+            }
+        ],
+        "generationConfig": {
+            "temperature": 0.1,
+            "maxOutputTokens": 8192,
+        },
+    }
+
+    if system_instruction:
+        payload["systemInstruction"] = {
+            "parts": [{"text": system_instruction}]
+        }
+
+    last_error = None
+    for model in MODELS:
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+        headers = {"Content-Type": "application/json"}
+        data = json.dumps(payload).encode("utf-8")
+
+        for attempt in range(MAX_RETRIES):
+            req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    resp_data = json.loads(resp.read().decode("utf-8"))
+
+                candidates = resp_data.get("candidates", [])
+                if not candidates:
+                    raise RuntimeError(f"No candidates returned by Gemini ({model}): {resp_data}")
+
+                parts = candidates[0].get("content", {}).get("parts", [])
+                # Filter out thinking/reasoning parts
+                text_parts = [
+                    p.get("text", "")
+                    for p in parts
+                    if not p.get("thought", False) and "text" in p
+                ]
+                output = "".join(text_parts).strip()
+                if not output and parts:
+                    # Fallback if thought filtering was overly strict
+                    output = "".join(p.get("text", "") for p in parts if "text" in p).strip()
+
+                return output
+
+            except urllib.error.HTTPError as e:
+                status = e.code
+                err_body = ""
+                try:
+                    err_body = e.read().decode("utf-8")
+                except Exception:
+                    pass
+
+                last_error = f"HTTP {status} from {model}: {err_body}"
+                # Rate limit (429) or server errors (5xx): retry with exponential backoff
+                if status in (429, 500, 502, 503, 504) and attempt < MAX_RETRIES - 1:
+                    sleep_time = BASE_RETRY_DELAY * (2 ** attempt)
+                    print(f"Warning: {model} returned {status}. Retrying in {sleep_time:.1f}s...", file=sys.stderr)
+                    time.sleep(sleep_time)
+                    continue
+                else:
+                    # Non-retryable or retries exhausted for this model, try next model
+                    print(f"Warning: {model} failed with {status}. Trying next model...", file=sys.stderr)
+                    break
+
+            except urllib.error.URLError as e:
+                last_error = f"URLError for {model}: {e.reason}"
+                if attempt < MAX_RETRIES - 1:
+                    sleep_time = BASE_RETRY_DELAY * (2 ** attempt)
+                    print(f"Warning: Network error for {model}: {e.reason}. Retrying in {sleep_time:.1f}s...", file=sys.stderr)
+                    time.sleep(sleep_time)
+                    continue
+                else:
+                    break
+
+            except Exception as e:
+                last_error = f"Unexpected error with {model}: {e}"
+                break
+
+    raise RuntimeError(f"All Gemini models failed. Last error: {last_error}")
+
+
+def strip_markdown_fences(text: str) -> str:
+    """Strip markdown code fence wrapper if the model returned code enclosed in ```."""
+    lines = text.splitlines()
+    if len(lines) >= 2 and lines[0].startswith("```") and lines[-1].startswith("```"):
+        return "\n".join(lines[1:-1])
+    return text
+
+
+class ConflictHunk:
+    def __init__(self, start_idx: int, end_idx: int, our_lines: list[str], their_lines: list[str]):
+        self.start_idx = start_idx  # line index of <<<<<<<
+        self.end_idx = end_idx      # line index of >>>>>>>
+        self.our_lines = our_lines
+        self.their_lines = their_lines
+
+
+def find_conflict_hunks(lines: list[str]) -> list[ConflictHunk]:
+    """Parse git conflict markers line by line."""
+    hunks = []
+    state = "NORMAL"
+    start_idx = -1
+    our_lines = []
+    their_lines = []
+
+    for i, line in enumerate(lines):
+        if line.startswith("<<<<<<<"):
+            state = "OURS"
+            start_idx = i
+            our_lines = []
+            their_lines = []
+        elif line.startswith("|||||||") and state == "OURS":
+            state = "BASE"
+        elif line.startswith("=======") and state in ("OURS", "BASE"):
+            state = "THEIRS"
+        elif line.startswith(">>>>>>>") and state == "THEIRS":
+            hunks.append(ConflictHunk(start_idx, i, our_lines, their_lines))
+            state = "NORMAL"
+        else:
+            if state == "OURS":
+                our_lines.append(line)
+            elif state == "THEIRS":
+                their_lines.append(line)
+
+    return hunks
+
+
+def resolve_hunk(
+    filepath: str,
+    hunk: ConflictHunk,
+    all_lines: list[str],
+    main_sha: str
+) -> str:
+    """Resolve a single conflict hunk using Gemini with surrounding context."""
+    context_before = "".join(all_lines[max(0, hunk.start_idx - 25) : hunk.start_idx])
+    context_after = "".join(all_lines[hunk.end_idx + 1 : min(len(all_lines), hunk.end_idx + 26)])
+    our_code = "".join(hunk.our_lines)
+    their_code = "".join(hunk.their_lines)
+
+    system_instruction = (
+        "You are an automated Git merge conflict resolver for the repository activities.next.\n"
+        "You are merging commit from 'main' into 'oltp' (HEAD).\n"
+        "Guidelines:\n"
+        "- Follow repository conventions from AGENTS.md.\n"
+        "- Retain valid syntax, correct imports, and proper typing.\n"
+        "- Combine conflicting additions or changes logically so both features/fixes work.\n"
+        "- If both modified a dependency or version, take the newer version or main's update unless oltp added a specific feature.\n"
+        "- Return ONLY the replacement code lines that will replace the entire conflict block (between <<<<<<< and >>>>>>>).\n"
+        "- Do NOT output <<<<<<<, =======, or >>>>>>> markers.\n"
+        "- Do NOT output the surrounding context lines.\n"
+        "- Do NOT include explanations or conversational filler.\n"
+        "- Do NOT wrap in markdown ``` fences unless the code itself contains them."
+    )
+
+    prompt = f"""File: {filepath}
+Merging: 'main' commit ({main_sha}) into branch 'oltp' (HEAD).
+
+--- Surrounding Context Before ---
+{context_before}
+
+--- Conflict Block ---
+<<<<<<< HEAD (oltp)
+{our_code}======= (main)
+{their_code}>>>>>>> main
+
+--- Surrounding Context After ---
+{context_after}
+
+Provide ONLY the exact replacement code for the Conflict Block:"""
+
+    raw_response = call_gemini(prompt, system_instruction=system_instruction)
+    cleaned = strip_markdown_fences(raw_response)
+
+    # If the response doesn't end with a newline and was non-empty, ensure a newline
+    if cleaned and not cleaned.endswith("\n"):
+        cleaned += "\n"
+
+    return cleaned
+
+
+def resolve_package_json(filepath: str, content: str, main_sha: str) -> str:
+    """Resolve package.json specifically, validating that resulting content is valid JSON."""
+    lines = content.splitlines(keepends=True)
+    hunks = find_conflict_hunks(lines)
+    if not hunks:
+        return content
+
+    print(f"Resolving {len(hunks)} conflict block(s) in {filepath}...", file=sys.stderr)
+
+    # Replace hunks from bottom to top so line indices remain stable
+    for hunk in reversed(hunks):
+        resolved_chunk = resolve_hunk(filepath, hunk, lines, main_sha)
+        lines[hunk.start_idx : hunk.end_idx + 1] = [resolved_chunk]
+
+    resolved_content = "".join(lines)
+
+    # Validate JSON syntax
+    try:
+        json.loads(resolved_content)
+        return resolved_content
+    except json.JSONDecodeError as e:
+        print(f"Warning: JSON validation failed on block replacement ({e}). Asking Gemini for full JSON reconciliation...", file=sys.stderr)
+
+    # If hunk replacement resulted in JSON syntax errors (e.g. comma placement),
+    # ask Gemini to reconcile the full package.json cleanly
+    prompt = f"""The following package.json contains merge conflict markers or syntax errors resulting from merging 'main' ({main_sha}) into 'oltp' (HEAD).
+
+Resolve all conflicts and syntax errors.
+Rules:
+1. Return valid JSON only.
+2. Ensure both sets of dependencies and scripts are properly preserved without duplicates.
+3. Completely remove all conflict markers (<<<<<<<, =======, >>>>>>>).
+4. No markdown formatting, no explanations, only the raw JSON text.
+
+Content:
+{content}
+"""
+    system_instruction = "You are a JSON formatter and merge resolver. Return ONLY valid JSON with no markdown and no explanation."
+    full_resolved = call_gemini(prompt, system_instruction=system_instruction)
+    full_resolved = strip_markdown_fences(full_resolved)
+
+    try:
+        # Validate and re-format cleanly with 2-space indentation
+        parsed = json.loads(full_resolved)
+        return json.dumps(parsed, indent=2) + "\n"
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to produce valid JSON for package.json: {e}\nRaw output:\n{full_resolved}")
+
+
+def resolve_file(filepath: str, main_sha: str) -> None:
+    """Resolve merge conflict markers in a single file."""
+    if not os.path.isfile(filepath):
+        print(f"Skipping {filepath}: not a regular file", file=sys.stderr)
+        return
+
+    with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+        content = f.read()
+
+    if not re.search(r"^(<{7}|={7}|>{7})", content, re.MULTILINE):
+        print(f"No conflict markers found in {filepath}.", file=sys.stderr)
+        return
+
+    print(f"Resolving conflicts in {filepath}...", file=sys.stderr)
+
+    if os.path.basename(filepath) == "package.json":
+        resolved_content = resolve_package_json(filepath, content, main_sha)
+    else:
+        lines = content.splitlines(keepends=True)
+        hunks = find_conflict_hunks(lines)
+        if not hunks:
+            print(f"No parseable conflict hunks in {filepath}.", file=sys.stderr)
+            return
+
+        print(f"Found {len(hunks)} conflict hunk(s) in {filepath}.", file=sys.stderr)
+        # Replace from bottom to top
+        for hunk in reversed(hunks):
+            resolved_chunk = resolve_hunk(filepath, hunk, lines, main_sha)
+            lines[hunk.start_idx : hunk.end_idx + 1] = [resolved_chunk]
+
+        resolved_content = "".join(lines)
+
+    # Double check for leftover conflict markers
+    leftover = re.findall(r"^(<{7}[^\n]*|={7}|>{7}[^\n]*)", resolved_content, re.MULTILINE)
+    if leftover:
+        raise RuntimeError(
+            f"Conflict markers still remain in {filepath} after Gemini resolution:\n"
+            + "\n".join(leftover[:10])
+        )
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(resolved_content)
+
+    print(f"Successfully resolved and updated {filepath}.", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: resolve-merge-conflicts.py <file1> [<file2> ...]", file=sys.stderr)
+        sys.exit(1)
+
+    files = sys.argv[1:]
+    main_sha = os.environ.get("MAIN_SHA", "main").strip() or "main"
+
+    print(f"Starting Gemini conflict resolution for {len(files)} file(s). Target commit: {main_sha}", file=sys.stderr)
+
+    failed_files = []
+    for f in files:
+        try:
+            resolve_file(f, main_sha)
+        except Exception as e:
+            print(f"::error::Failed resolving {f}: {e}", file=sys.stderr)
+            failed_files.append((f, str(e)))
+
+    if failed_files:
+        print(f"Failed to resolve {len(failed_files)} file(s):", file=sys.stderr)
+        for f, err in failed_files:
+            print(f"  - {f}: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    print("All conflicted files resolved successfully.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_resolve_merge_conflicts.py
+++ b/.github/scripts/test_resolve_merge_conflicts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location(
+    "resolver",
+    os.path.join(os.path.dirname(__file__), "resolve-merge-conflicts.py"),
+)
+resolver = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(resolver)
+
+
+class TestResolveMergeConflicts(unittest.TestCase):
+    def test_strip_markdown_fences(self):
+        self.assertEqual(
+            resolver.strip_markdown_fences("```json\n{\"a\": 1}\n```"),
+            "{\"a\": 1}",
+        )
+        self.assertEqual(
+            resolver.strip_markdown_fences("const x = 10;"),
+            "const x = 10;",
+        )
+
+    def test_find_conflict_hunks_standard(self):
+        sample = """line 1
+<<<<<<< HEAD
+our code
+=======
+their code
+>>>>>>> main
+line 2
+"""
+        lines = sample.splitlines(keepends=True)
+        hunks = resolver.find_conflict_hunks(lines)
+        self.assertEqual(len(hunks), 1)
+        self.assertEqual(hunks[0].start_idx, 1)
+        self.assertEqual(hunks[0].end_idx, 5)
+        self.assertEqual(hunks[0].our_lines, ["our code\n"])
+        self.assertEqual(hunks[0].their_lines, ["their code\n"])
+
+    def test_find_conflict_hunks_diff3(self):
+        sample = """line 1
+<<<<<<< HEAD
+our code
+||||||| base
+base code
+=======
+their code
+>>>>>>> main
+line 2
+"""
+        lines = sample.splitlines(keepends=True)
+        hunks = resolver.find_conflict_hunks(lines)
+        self.assertEqual(len(hunks), 1)
+        self.assertEqual(hunks[0].our_lines, ["our code\n"])
+        self.assertEqual(hunks[0].their_lines, ["their code\n"])
+
+    def test_resolve_package_json(self):
+        conflicted = """{
+  "name": "activities.next",
+  "dependencies": {
+<<<<<<< HEAD
+    "google-auth-library": "^11.0.2",
+    "got": "^15.1.0",
+=======
+    "got": "^16.0.0",
+>>>>>>> main
+    "next": "^16.3.3"
+  }
+}
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "package.json")
+            with open(path, "w") as f:
+                f.write(conflicted)
+
+            with patch.object(
+                resolver,
+                "call_gemini",
+                return_value='    "google-auth-library": "^11.0.2",\n    "got": "^16.0.0",\n',
+            ):
+                resolver.resolve_file(path, "test_sha")
+
+            with open(path) as f:
+                data = json.load(f)
+
+            self.assertEqual(data["dependencies"]["google-auth-library"], "^11.0.2")
+            self.assertEqual(data["dependencies"]["got"], "^16.0.0")
+            self.assertEqual(data["dependencies"]["next"], "^16.3.3")
+
+    def test_resolve_code_file(self):
+        conflicted = """import { describe, it } from 'vitest'
+
+describe('test', () => {
+<<<<<<< HEAD
+  const a = 1
+=======
+  const a = 2
+>>>>>>> main
+})
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "test.ts")
+            with open(path, "w") as f:
+                f.write(conflicted)
+
+            with patch.object(
+                resolver,
+                "call_gemini",
+                return_value="  const a = 2\n",
+            ):
+                resolver.resolve_file(path, "test_sha")
+
+            with open(path) as f:
+                content = f.read()
+
+            self.assertIn("const a = 2", content)
+            self.assertNotIn("<<<<<<<", content)
+            self.assertNotIn("=======", content)
+            self.assertNotIn(">>>>>>>", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -142,24 +142,8 @@ jobs:
           done
 
           if [ ${#code_files[@]} -gt 0 ]; then
-            echo "Resolving code conflicts with Aider: ${code_files[*]}"
-            aider \
-              --model gemini/gemini-3.8-flash \
-              --no-auto-commits \
-              --yes \
-              --message "
-              Resolve all git merge conflict markers in the specified files.
-
-              Context:
-              - Merging 'main' commit ${{ env.MAIN_SHA }} into branch 'oltp'.
-              - Follow the repository guidelines in AGENTS.md.
-
-              Requirements:
-              - Completely remove all conflict markers (<<<<<<<, =======, >>>>>>>).
-              - Maintain valid syntax and ensure all imports and type definitions are correct.
-              - For package.json, ensure valid JSON and merge dependencies properly without duplicates.
-              " \
-              "${code_files[@]}"
+            echo "Resolving code conflicts with Gemini: ${code_files[*]}"
+            python3 .github/scripts/resolve-merge-conflicts.py "${code_files[@]}"
 
             for f in "${code_files[@]}"; do
               if grep -qE '^(<{7}|={7}|>{7})' "$f"; then
@@ -225,7 +209,10 @@ jobs:
 
                 if [ ${#target_files[@]} -gt 0 ]; then
                   aider \
-                    --model gemini/gemini-3.7-flash \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
                     --no-auto-commits \
                     --yes \
                     --message "Fix the following lint errors according to AGENTS.md:
@@ -261,7 +248,10 @@ jobs:
 
                 if [ ${#target_files[@]} -gt 0 ]; then
                   aider \
-                    --model gemini/gemini-3.7-flash \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
                     --no-auto-commits \
                     --yes \
                     --message "Fix the following TypeScript typecheck errors according to AGENTS.md:
@@ -297,7 +287,10 @@ jobs:
 
                 if [ ${#target_files[@]} -gt 0 ]; then
                   aider \
-                    --model gemini/gemini-3.7-flash \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
                     --no-auto-commits \
                     --yes \
                     --message "Fix the following build errors according to AGENTS.md:

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ pglite-debug.log*
 # temporary files
 prompt.txt
 *.tmp
+__pycache__/
+*.pyc
 
 # local env files
 .env*.local


### PR DESCRIPTION
## Summary

Fixes automated sync failures in `.github/workflows/sync-main-to-oltp.yml` (e.g. run [33780308076](https://github.com/llun/activities.next/actions/runs/33780308076/job/100732069311)).

### Root Cause
1. **Aider Model Registry Gap**: `gemini-3.8-flash` was recently released (September 2, 2026). Aider v0.86.2 does not have it pre-registered, causing it to fall back to `whole` edit format and a conservative 2,048 token limit.
2. **Truncation & Diff Format Mismatch**: In `whole` edit format, Aider expects the full file contents back. Gemini 3.8 Flash (with reasoning/thinking tokens enabled) formatted the conflict resolution as an explanation followed by a unified diff (`@@ -2,5 +2,6 @@ ...`), getting truncated at line 95 (58% of `package.json`). Aider rejected the truncated diff.
3. **Interactive Misdirection**: Aider scanned Gemini's response for referenced filenames (`.oxlintrc.scripts.json`, `migration.stub`, etc. from `package.json`'s scripts), added them to the chat, and exited with code 0 without applying changes to `package.json`.
4. **Delimiter Clash**: Aider's `diff` / `diff-fenced` format uses `=======` as the SEARCH/REPLACE delimiter, colliding directly with Git's conflict marker `=======`.

### Solution
- **Dedicated Conflict Resolver**: Added `.github/scripts/resolve-merge-conflicts.py`:
  - Parses conflict hunks (`<<<<<<<` ... `=======` ... `>>>>>>>`) deterministically.
  - Sends only the conflict block with surrounding context (25 lines before/after) to Gemini API (`gemini-3.8-flash`, with fallback to `gemini-3.7-flash` and `gemini-2.5-flash`).
  - Atomically replaces only the conflict block, ensuring untouched code remains 100% intact.
  - Reconciles `package.json` dependencies and validates JSON syntax with `json.loads`.
  - Added unit test suite `.github/scripts/test_resolve_merge_conflicts.py`.
- **Aider Model Settings**: Added `.github/aider/model-metadata.json` and `.github/aider/model-settings.yml` to specify 65k output tokens and `diff-fenced` format for `gemini-3.8-flash` when the validation healing step runs.
- **Workflow Update**: Updated `sync-main-to-oltp.yml` to use `resolve-merge-conflicts.py` for conflict resolution and pass the new model settings to Aider during validation healing.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
