### PR TITLE
fix: align profile, followers, and following skeleton top spacing with loaded pages

### DIFF
--- a/app/(timeline)/PublicShell.tsx
+++ b/app/(timeline)/PublicShell.tsx
@@ -21,7 +21,7 @@ export const PublicShell: FC<PublicShellProps> = ({ children }) => (
   // min-h-dvh (dynamic viewport height) rather than min-h-screen/100vh so the
   // footer stays at the bottom without a mobile address-bar gap — same
   // rationale as the public error pages (lib/components/error-page.tsx).
-  <div className="flex min-h-dvh flex-col">
+  <div data-shell="public" className="group/shell flex min-h-dvh flex-col">
     <PublicTopBar />
     <main className="flex flex-1 flex-col overflow-x-clip">
       <div className="mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 py-6">

--- a/app/(timeline)/[actor]/FollowListLoadingSkeleton.test.tsx
+++ b/app/(timeline)/[actor]/FollowListLoadingSkeleton.test.tsx
@@ -31,4 +31,20 @@ describe('FollowListLoadingSkeleton', () => {
     leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
+
+  it('renders dual header variants for signed-in and anonymous shells', () => {
+    const { container } = render(
+      <FollowListLoadingSkeleton label="Loading followers" />
+    )
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader).toHaveClass('group-data-[shell=public]/shell:hidden')
+
+    const anonHeader = container.querySelector(
+      '.group-data-\\[shell\\=public\\]\\/shell\\:flex'
+    )
+    expect(anonHeader).toBeInTheDocument()
+    expect(anonHeader).toHaveClass('hidden')
+  })
 })

--- a/app/(timeline)/[actor]/FollowListLoadingSkeleton.tsx
+++ b/app/(timeline)/[actor]/FollowListLoadingSkeleton.tsx
@@ -1,7 +1,12 @@
-import { FC } from 'react'
+import { CSSProperties, FC } from 'react'
 
 interface FollowListLoadingSkeletonProps {
   label: string
+}
+
+const breakoutStyle: CSSProperties = {
+  marginLeft: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)',
+  marginRight: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)'
 }
 
 /**
@@ -18,11 +23,28 @@ export const FollowListLoadingSkeleton: FC<FollowListLoadingSkeletonProps> = ({
 }) => {
   return (
     <div aria-busy="true" aria-label={label} className="space-y-6">
-      <div className="flex items-start gap-3">
-        <div className="skeleton h-9 w-9 shrink-0 rounded-md" />
+      {/* Signed-in header: mirrors PageHeader (sticky top-0, breakout, py-4) */}
+      <div
+        className="sticky top-0 z-20 border-b bg-background/85 backdrop-blur group-data-[shell=public]/shell:hidden"
+        style={breakoutStyle}
+      >
+        <div className="mx-auto max-w-content px-4 py-4">
+          <div className="flex items-start gap-2">
+            <div className="skeleton mt-0.5 size-5 shrink-0 rounded-md" />
+            <div className="space-y-1">
+              <div className="skeleton h-6 w-28 rounded-md" />
+              <div className="skeleton h-3.5 w-24 rounded" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Anonymous header: mirrors the non-sticky header inside PublicShell */}
+      <div className="hidden items-start gap-2 group-data-[shell=public]/shell:flex">
+        <div className="skeleton mt-0.5 size-5 shrink-0 rounded-md" />
         <div className="space-y-1">
-          <div className="skeleton h-7 w-32 rounded-md" />
-          <div className="skeleton h-4 w-24 rounded" />
+          <div className="skeleton h-6 w-28 rounded-md" />
+          <div className="skeleton h-3.5 w-24 rounded" />
         </div>
       </div>
 

--- a/app/(timeline)/[actor]/loading.test.tsx
+++ b/app/(timeline)/[actor]/loading.test.tsx
@@ -35,4 +35,12 @@ describe('[actor] loading', () => {
     leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
   })
+
+  it('renders with signed-in top padding that resets under public shell', () => {
+    const { container } = render(<Loading />)
+    const root = container.firstElementChild
+    expect(root).toHaveClass('pt-6')
+    expect(root).toHaveClass('sm:pt-8')
+    expect(root).toHaveClass('group-data-[shell=public]/shell:pt-0')
+  })
 })

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -2,7 +2,11 @@ import { FC } from 'react'
 
 export const ProfileLoading: FC = () => {
   return (
-    <div aria-busy="true" aria-label="Loading profile" className="space-y-6">
+    <div
+      aria-busy="true"
+      aria-label="Loading profile"
+      className="space-y-6 pt-6 sm:pt-8 group-data-[shell=public]/shell:pt-0"
+    >
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <div className="skeleton h-36 md:h-52" />
 


### PR DESCRIPTION
## Summary

- Aligns the top spacing of loading skeleton screens for profile, followers, and following pages with the actual loaded pages when a user is signed in:
  - `ProfileLoading` now includes `pt-6 sm:pt-8` when rendered in the signed-in shell, matching `page.tsx`'s `isLoggedIn && 'pt-6 sm:pt-8'`.
  - `FollowListLoadingSkeleton` now includes a `PageHeader` skeleton variant with sticky `top-0`, `border-b`, breakout margins, and `px-4 py-4` for signed-in viewers, matching the loaded `PageHeader` in `followers/page.tsx` and `following/page.tsx`.
- Strictly preserves top spacing for anonymous (logged-out) visitors:
  - `PublicShell` carries `data-shell="public"` and `group/shell`.
  - In `ProfileLoading`, `group-data-[shell=public]/shell:pt-0` zeroes out the extra top padding under `PublicShell`, ensuring anonymous viewers retain only `PublicShell`'s `py-6` (24px) padding with zero layout change.
  - In `FollowListLoadingSkeleton`, the signed-in sticky `PageHeader` is hidden (`group-data-[shell=public]/shell:hidden`) and the non-sticky header is shown (`group-data-[shell=public]/shell:flex`), matching the anonymous layout in `followers/page.tsx` and `following/page.tsx`.
- Verified in a real browser using Playwright across signed-in and anonymous states:
  - Signed-in profile loaded & skeleton: both `top: 32px`.
  - Signed-in followers loaded & skeleton: both sticky `top: 0px`.
  - Anonymous profile loaded & skeleton: both `paddingTop: 24px` (`top: 89px` with public topbar).
  - Anonymous followers/following loaded & skeleton: both `paddingTop: 24px` (`top: 89px` with public topbar).

## Screenshots

| Page | Skeleton (Signed In) | Loaded (Signed In) |
| --- | --- | --- |
| Profile | Top spacing matches (32px padding) | Top spacing 32px |
| Followers | Sticky PageHeader skeleton at top-0 | Sticky PageHeader at top-0 |
| Following | Sticky PageHeader skeleton at top-0 | Sticky PageHeader at top-0 |

| Page | Skeleton (Anonymous) | Loaded (Anonymous) |
| --- | --- | --- |
| Profile | 24px top padding (PublicShell py-6) | 24px top padding (PublicShell py-6) |
| Followers | 24px top padding (PublicShell py-6) | 24px top padding (PublicShell py-6) |
| Following | 24px top padding (PublicShell py-6) | 24px top padding (PublicShell py-6) |

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)