### PR TITLE
Bump version to v1.155.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.7",
+  "version": "1.155.8",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.155.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.155.7`
- Base main SHA: `1f3d7866a77fa7bff4b31c991de1b97675136570`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
