### PR TITLE
fix: allow lockfile update with no-immutable in sync-main-to-oltp workflow

### DIFF
--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
   MAIN_SHA: ${{ github.event.client_payload.main_sha }}
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
 
 jobs:
   sync:
@@ -155,7 +156,7 @@ jobs:
             git add "${code_files[@]}"
           fi
 
-          yarn install
+          yarn install --no-immutable
           git add yarn.lock
 
       - name: Verify merge is still pending
@@ -180,7 +181,7 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
-          yarn install
+          yarn install --no-immutable
 
           heal_attempts=2
           for attempt in $(seq 1 $heal_attempts); do


### PR DESCRIPTION
## Summary

When `main` is merged into `oltp` in the `sync-main-to-oltp` workflow and a merge conflict occurs in `package.json` / `yarn.lock`, the workflow checks out `yarn.lock` from `main` and resolves `package.json` with Gemini. It then runs `yarn install` to reconcile the lockfile against the merged dependencies.

However, in GitHub Actions (`CI=true`), Yarn Berry defaults to `--immutable` mode, causing `yarn install` to fail with:
```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

This PR:
- Sets `YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'` in the workflow environment.
- Explicitly passes `--no-immutable` to `yarn install` in the conflict reconciliation step and the subsequent validation step so that `yarn.lock` can be updated cleanly as intended.

Relates to failed run: https://github.com/llun/activities.next/actions/runs/33784015215/job/100745101946

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
