### PR TITLE
minor: redesign Pixelfed profile view and add media grid hover overlay

### DIFF
--- a/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
@@ -90,4 +90,176 @@ describe('ActorMediaGallery', () => {
       'focus-visible:outline-primary'
     )
   })
+
+  it('renders engagement counts overlay with favorite, comment, and repost counts', () => {
+    const attachment = buildAttachment({
+      id: 'attachment-1',
+      statusId: 'https://activities.local/users/llun/statuses/post-1'
+    })
+
+    const status = {
+      id: 'https://activities.local/users/llun/statuses/post-1',
+      url: 'https://activities.local/users/llun/statuses/post-1',
+      actorId: 'https://activities.local/users/llun',
+      actor: null,
+      type: 'Note' as const,
+      text: 'Photo post',
+      to: [],
+      cc: [],
+      edits: [],
+      reply: '',
+      replies: [],
+      totalReplies: 14,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      isActorBookmarked: false,
+      totalLikes: 42,
+      totalShares: 7,
+      attachments: [attachment],
+      tags: [],
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      isLocalActor: true
+    }
+
+    render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[attachment]}
+        statuses={[status]}
+      />
+    )
+
+    const overlay = screen.getByTestId('media-overlay-attachment-1')
+    expect(overlay).toBeInTheDocument()
+    expect(screen.getByTitle('42 favorites')).toBeInTheDocument()
+    expect(screen.getByTitle('14 comments')).toBeInTheDocument()
+    expect(screen.getByTitle('7 reposts')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('14')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('renders album indicator for multi-photo statuses and video indicator for video attachments', () => {
+    const photo1 = buildAttachment({
+      id: 'photo-1',
+      statusId: 'https://activities.local/users/llun/statuses/post-multi'
+    })
+    const photo2 = buildAttachment({
+      id: 'photo-2',
+      statusId: 'https://activities.local/users/llun/statuses/post-multi'
+    })
+    const video = buildAttachment({
+      id: 'video-1',
+      mediaType: 'video/mp4',
+      statusId: 'https://activities.local/users/llun/statuses/post-video'
+    })
+
+    const multiStatus = {
+      id: 'https://activities.local/users/llun/statuses/post-multi',
+      url: 'https://activities.local/users/llun/statuses/post-multi',
+      actorId: 'https://activities.local/users/llun',
+      actor: null,
+      type: 'Note' as const,
+      text: 'Multi photo',
+      to: [],
+      cc: [],
+      edits: [],
+      reply: '',
+      replies: [],
+      totalReplies: 0,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      isActorBookmarked: false,
+      totalLikes: 0,
+      totalShares: 0,
+      attachments: [photo1, photo2],
+      tags: [],
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      isLocalActor: true
+    }
+
+    const videoStatus = {
+      id: 'https://activities.local/users/llun/statuses/post-video',
+      url: 'https://activities.local/users/llun/statuses/post-video',
+      actorId: 'https://activities.local/users/llun',
+      actor: null,
+      type: 'Note' as const,
+      text: 'Video post',
+      to: [],
+      cc: [],
+      edits: [],
+      reply: '',
+      replies: [],
+      totalReplies: 0,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      isActorBookmarked: false,
+      totalLikes: 0,
+      totalShares: 0,
+      attachments: [video],
+      tags: [],
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      isLocalActor: true
+    }
+
+    render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[photo1, video]}
+        statuses={[multiStatus, videoStatus]}
+      />
+    )
+
+    expect(screen.getByTestId('album-indicator')).toBeInTheDocument()
+    expect(screen.getByTestId('video-indicator')).toBeInTheDocument()
+  })
+
+  it('derives attachments from statuses and hides standalone load more button when isPixelfed is true', () => {
+    const attachment = buildAttachment({
+      id: 'pixelfed-att-1',
+      name: 'Pixelfed photo'
+    })
+
+    const pixelfedStatus = {
+      id: 'https://pixelfed.example/p/user/1',
+      url: 'https://pixelfed.example/p/user/1',
+      actorId: 'https://pixelfed.example/users/user',
+      actor: null,
+      type: 'Note' as const,
+      text: 'Pixelfed photo',
+      to: [],
+      cc: [],
+      edits: [],
+      reply: '',
+      replies: [],
+      totalReplies: 2,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      isActorBookmarked: false,
+      totalLikes: 10,
+      totalShares: 3,
+      attachments: [attachment],
+      tags: [],
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      isLocalActor: false
+    }
+
+    render(
+      <ActorMediaGallery
+        actorId="https://pixelfed.example/users/user"
+        initialAttachments={[]}
+        statuses={[pixelfedStatus]}
+        isPixelfed={true}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Open media: Pixelfed photo' })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -1,21 +1,35 @@
 'use client'
 
-import { FC, useState } from 'react'
+import { Copy, Heart, MessageCircle, Repeat2, Video } from 'lucide-react'
+import { FC, useEffect, useMemo, useState } from 'react'
 
 import { getActorMedia } from '@/lib/client'
 import { MediasModal } from '@/lib/components/medias-modal/medias-modal'
 import { Media } from '@/lib/components/posts/media'
 import { Button } from '@/lib/components/ui/button'
 import { Attachment } from '@/lib/types/domain/attachment'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
+
+const compactNumberFormatter = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1
+})
+
+export const formatCount = (count: number): string =>
+  compactNumberFormatter.format(count)
 
 interface Props {
   actorId: string
   initialAttachments: Attachment[]
+  statuses?: Status[]
+  isPixelfed?: boolean
 }
 
 export const ActorMediaGallery: FC<Props> = ({
   actorId,
-  initialAttachments
+  initialAttachments,
+  statuses,
+  isPixelfed = false
 }) => {
   const [modalIndex, setModalIndex] = useState<number | null>(null)
   const [attachments, setAttachments] =
@@ -23,6 +37,34 @@ export const ActorMediaGallery: FC<Props> = ({
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [hasMore, setHasMore] = useState(initialAttachments.length >= 25)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isPixelfed && statuses && statuses.length > 0) {
+      const derived = statuses.flatMap((s) =>
+        s.type === StatusType.enum.Note ? s.attachments : []
+      )
+      if (derived.length > 0) {
+        setAttachments(derived)
+      }
+    } else if (initialAttachments.length > 0) {
+      setAttachments(initialAttachments)
+    }
+  }, [isPixelfed, statuses, initialAttachments])
+
+  const statusMap = useMemo(() => {
+    const map = new Map<string, StatusNote>()
+    if (statuses) {
+      for (const status of statuses) {
+        if (status.type === StatusType.enum.Note) {
+          map.set(status.id, status)
+          if (status.url) {
+            map.set(status.url, status)
+          }
+        }
+      }
+    }
+    return map
+  }, [statuses])
 
   const handleLoadMore = async () => {
     setIsLoadingMore(true)
@@ -46,32 +88,105 @@ export const ActorMediaGallery: FC<Props> = ({
   return (
     <>
       <div className="grid grid-cols-3 gap-1 sm:gap-2">
-        {attachments.map((attachment, index) => (
-          <button
-            key={attachment.id}
-            type="button"
-            className="group relative aspect-square overflow-hidden bg-muted/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
-            onClick={() => setModalIndex(index)}
-            aria-label={
-              attachment.name
-                ? `Open media: ${attachment.name}`
-                : `Open media ${index + 1}`
-            }
-          >
-            <Media
-              attachment={attachment}
-              className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
-            />
-            {attachment.name?.trim() ? (
-              <span
-                className="pointer-events-none absolute bottom-1.5 left-1.5 flex items-center rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-white shadow-sm backdrop-blur-xs"
-                aria-hidden="true"
+        {attachments.map((attachment, index) => {
+          const parentStatus = statusMap.get(attachment.statusId)
+          const totalLikes = parentStatus?.totalLikes ?? 0
+          const totalShares = parentStatus?.totalShares ?? 0
+          const totalReplies =
+            parentStatus?.totalReplies ?? parentStatus?.replies.length ?? 0
+          const attachmentCount = parentStatus?.attachments.length ?? 1
+          const isVideo =
+            attachment.mediaType.startsWith('video') ||
+            attachment.url.endsWith('.mp4') ||
+            attachment.url.endsWith('.webm')
+
+          return (
+            <button
+              key={attachment.id}
+              type="button"
+              className="group relative aspect-square overflow-hidden bg-muted/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
+              onClick={() => setModalIndex(index)}
+              aria-label={
+                attachment.name
+                  ? `Open media: ${attachment.name}`
+                  : `Open media ${index + 1}`
+              }
+            >
+              <Media
+                attachment={attachment}
+                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
+              />
+
+              {/* Multiple attachments badge */}
+              {attachmentCount > 1 ? (
+                <span
+                  className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
+                  aria-label="Multiple items"
+                  data-testid="album-indicator"
+                >
+                  <Copy className="size-3.5 sm:size-4" aria-hidden="true" />
+                </span>
+              ) : isVideo ? (
+                <span
+                  className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
+                  aria-label="Video"
+                  data-testid="video-indicator"
+                >
+                  <Video className="size-3.5 sm:size-4" aria-hidden="true" />
+                </span>
+              ) : null}
+
+              {/* Alt text badge */}
+              {attachment.name?.trim() ? (
+                <span
+                  className="pointer-events-none absolute bottom-1.5 left-1.5 z-10 flex items-center rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-white shadow-sm backdrop-blur-xs"
+                  aria-hidden="true"
+                >
+                  ALT
+                </span>
+              ) : null}
+
+              {/* Engagement counts overlay on hover/focus */}
+              <div
+                className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                data-testid={`media-overlay-${attachment.id}`}
               >
-                ALT
-              </span>
-            ) : null}
-          </button>
-        ))}
+                <div className="flex flex-wrap items-center justify-center gap-3 px-2 text-white font-semibold text-sm sm:gap-4 sm:text-base">
+                  <span
+                    className="flex items-center gap-1.5"
+                    title={`${totalLikes} favorites`}
+                  >
+                    <Heart
+                      className="size-4 sm:size-5 fill-white text-white"
+                      aria-hidden="true"
+                    />
+                    <span>{formatCount(totalLikes)}</span>
+                  </span>
+                  <span
+                    className="flex items-center gap-1.5"
+                    title={`${totalReplies} comments`}
+                  >
+                    <MessageCircle
+                      className="size-4 sm:size-5 fill-white text-white"
+                      aria-hidden="true"
+                    />
+                    <span>{formatCount(totalReplies)}</span>
+                  </span>
+                  <span
+                    className="flex items-center gap-1.5"
+                    title={`${totalShares} reposts`}
+                  >
+                    <Repeat2
+                      className="size-4 sm:size-5 text-white"
+                      aria-hidden="true"
+                    />
+                    <span>{formatCount(totalShares)}</span>
+                  </span>
+                </div>
+              </div>
+            </button>
+          )
+        })}
       </div>
 
       {error && (
@@ -80,7 +195,7 @@ export const ActorMediaGallery: FC<Props> = ({
         </div>
       )}
 
-      {hasMore && (
+      {!isPixelfed && hasMore && (
         <div className="mt-4 text-center">
           <Button
             variant="outline"

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -115,12 +115,18 @@ vi.mock('./ActorMediaGallery', () => ({
 }))
 
 vi.mock('@/lib/components/ui/tabs', () => ({
-  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tabs: ({ children, value }: { children: ReactNode; value?: string }) => (
+    <div data-active-tab={value}>{children}</div>
+  ),
   TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  TabsTrigger: ({ children }: { children: ReactNode }) => (
-    <button>{children}</button>
-  )
+  TabsTrigger: ({
+    children,
+    value
+  }: {
+    children: ReactNode
+    value?: string
+  }) => <button data-value={value}>{children}</button>
 }))
 
 vi.mock('@/lib/components/ui/button', () => ({
@@ -689,5 +695,102 @@ describe('ActorTimelines', () => {
 
     expect(screen.queryByText(boostId)).not.toBeInTheDocument()
     expect(screen.queryByText(originalId)).not.toBeInTheDocument()
+  })
+
+  describe('Pixelfed profile timeline view', () => {
+    it('renders only the Media tab as default when isPixelfed is true', () => {
+      const { container } = render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://pixelfed.social/users/dansup"
+          statuses={[]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isPixelfed={true}
+          statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Media' })).toBeInTheDocument()
+      expect(
+        container
+          .querySelector('[data-active-tab]')
+          ?.getAttribute('data-active-tab')
+      ).toBe('media')
+      expect(
+        screen.queryByRole('button', { name: 'Posts' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Replies' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Fitness' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders standard Posts, Replies, and Media tabs when isPixelfed is false', () => {
+      const { container } = render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://mastodon.social/users/someone"
+          statuses={[]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isPixelfed={false}
+          statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Posts' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Replies' })
+      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Media' })).toBeInTheDocument()
+      expect(
+        container
+          .querySelector('[data-active-tab]')
+          ?.getAttribute('data-active-tab')
+      ).toBe('posts')
+    })
+
+    it('enables load more on the Media tab when isPixelfed is true', async () => {
+      const mockGetActorStatuses = vi.mocked(getActorStatuses)
+      const nextPageUrl = 'https://pixelfed.social/api/page2'
+      const newStatus = createStatus('https://pixelfed.social/p/dansup/999')
+
+      mockGetActorStatuses.mockResolvedValueOnce({
+        statuses: [newStatus],
+        statusesCount: 1,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://pixelfed.social/users/dansup"
+          statuses={[]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isPixelfed={true}
+          statusPagination={{ nextPageUrl, prevPageUrl: null }}
+        />
+      )
+
+      const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+      expect(loadMoreButton).toBeInTheDocument()
+
+      fireEvent.click(loadMoreButton)
+
+      await waitFor(() => {
+        expect(mockGetActorStatuses).toHaveBeenCalledWith({
+          actorId: 'https://pixelfed.social/users/dansup',
+          pageUrl: nextPageUrl
+        })
+      })
+    })
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -698,7 +698,7 @@ describe('ActorTimelines', () => {
   })
 
   describe('Pixelfed profile timeline view', () => {
-    it('renders only the Media tab as default when isPixelfed is true', () => {
+    it('removes the tab bar completely when isPixelfed is true', () => {
       const { container } = render(
         <ActorTimelines
           host="localhost:3000"
@@ -712,12 +712,12 @@ describe('ActorTimelines', () => {
         />
       )
 
-      expect(screen.getByRole('button', { name: 'Media' })).toBeInTheDocument()
       expect(
-        container
-          .querySelector('[data-active-tab]')
-          ?.getAttribute('data-active-tab')
-      ).toBe('media')
+        screen.queryByRole('button', { name: 'Media' })
+      ).not.toBeInTheDocument()
+      expect(
+        container.querySelector('[data-active-tab]')
+      ).not.toBeInTheDocument()
       expect(
         screen.queryByRole('button', { name: 'Posts' })
       ).not.toBeInTheDocument()

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -360,6 +360,43 @@ export const ActorTimelines: FC<Props> = ({
       <EmptyState>{emptyMessage}</EmptyState>
     )
 
+  if (isPixelfed) {
+    return (
+      <div className="space-y-4">
+        {attachments.length > 0 ||
+        currentStatuses.some(
+          (s) => s.type === StatusType.enum.Note && s.attachments.length > 0
+        ) ? (
+          <ActorMediaGallery
+            actorId={actorId}
+            initialAttachments={attachments}
+            statuses={currentStatuses}
+            isPixelfed={true}
+          />
+        ) : (
+          <EmptyState>No media yet</EmptyState>
+        )}
+
+        {canLoadMore && (
+          <div ref={loadMoreRef} className="text-center">
+            {loadMoreError && (
+              <p className="mb-3 text-sm text-destructive" role="alert">
+                {loadMoreError}
+              </p>
+            )}
+            <Button
+              variant="outline"
+              disabled={isLoadingMoreStatuses}
+              onClick={loadMoreStatuses}
+            >
+              {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-4">
       <Tabs
@@ -368,50 +405,38 @@ export const ActorTimelines: FC<Props> = ({
         className="w-full gap-4"
       >
         <TabsList className="w-full sm:w-fit" aria-label="Profile sections">
-          {!isPixelfed && (
-            <>
-              <TabsTrigger value="posts" className="flex-1 sm:flex-none">
-                Posts
-              </TabsTrigger>
-              <TabsTrigger value="replies" className="flex-1 sm:flex-none">
-                Replies
-              </TabsTrigger>
-            </>
-          )}
+          <TabsTrigger value="posts" className="flex-1 sm:flex-none">
+            Posts
+          </TabsTrigger>
+          <TabsTrigger value="replies" className="flex-1 sm:flex-none">
+            Replies
+          </TabsTrigger>
           <TabsTrigger value="media" className="flex-1 sm:flex-none">
             Media
           </TabsTrigger>
-          {showFitnessTab && !isPixelfed && (
+          {showFitnessTab && (
             <TabsTrigger value="fitness" className="flex-1 sm:flex-none">
               Fitness
             </TabsTrigger>
           )}
         </TabsList>
 
-        {!isPixelfed && (
-          <>
-            <TabsContent value="posts" className="mt-0">
-              {renderFeed(postStatuses, 'No posts yet')}
-            </TabsContent>
+        <TabsContent value="posts" className="mt-0">
+          {renderFeed(postStatuses, 'No posts yet')}
+        </TabsContent>
 
-            <TabsContent value="replies" className="mt-0">
-              {renderFeed(replyStatuses, 'No replies yet')}
-            </TabsContent>
-          </>
-        )}
+        <TabsContent value="replies" className="mt-0">
+          {renderFeed(replyStatuses, 'No replies yet')}
+        </TabsContent>
 
         <TabsContent value="media" className="mt-0">
-          {attachments.length > 0 ||
-          (isPixelfed &&
-            currentStatuses.some(
-              (s) => s.type === StatusType.enum.Note && s.attachments.length > 0
-            )) ? (
+          {attachments.length > 0 ? (
             <div className="rounded-xl border bg-card p-2 shadow-sm sm:p-4">
               <ActorMediaGallery
                 actorId={actorId}
                 initialAttachments={attachments}
                 statuses={currentStatuses}
-                isPixelfed={isPixelfed}
+                isPixelfed={false}
               />
             </div>
           ) : (
@@ -419,7 +444,7 @@ export const ActorTimelines: FC<Props> = ({
           )}
         </TabsContent>
 
-        {showFitnessTab && !isPixelfed && (
+        {showFitnessTab && (
           <TabsContent value="fitness" className="mt-0 space-y-4">
             {isCurrentUser && (
               <div className="flex justify-end">

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -51,6 +51,7 @@ interface Props {
    */
   hasFitnessData?: boolean
   isMediaUploadEnabled?: boolean
+  isPixelfed?: boolean
 }
 
 const LOAD_MORE_PAGE_LIMIT = 5
@@ -127,9 +128,12 @@ export const ActorTimelines: FC<Props> = ({
   currentActor,
   isCurrentUser = false,
   hasFitnessData = false,
-  isMediaUploadEnabled
+  isMediaUploadEnabled,
+  isPixelfed = false
 }) => {
-  const [activeTab, setActiveTab] = useState<ProfileTab>('posts')
+  const [activeTab, setActiveTab] = useState<ProfileTab>(
+    isPixelfed ? 'media' : 'posts'
+  )
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,
@@ -159,12 +163,14 @@ export const ActorTimelines: FC<Props> = ({
 
   // The outbox cursor feeds the post/reply/fitness feeds (all derived from the
   // loaded status list), so the standalone load more control is offered on
-  // those tabs. The media tab paginates separately via its own gallery loader.
+  // those tabs. For Pixelfed profiles, the media grid is the status feed, so it
+  // also paginates via this outbox cursor.
   const canLoadMore =
     Boolean(currentStatusPagination.nextPageUrl) &&
     (activeTab === 'posts' ||
       activeTab === 'replies' ||
-      activeTab === 'fitness')
+      activeTab === 'fitness' ||
+      (isPixelfed && activeTab === 'media'))
 
   const handleStatusCreated = useCallback(
     (status: Status) => {
@@ -362,36 +368,50 @@ export const ActorTimelines: FC<Props> = ({
         className="w-full gap-4"
       >
         <TabsList className="w-full sm:w-fit" aria-label="Profile sections">
-          <TabsTrigger value="posts" className="flex-1 sm:flex-none">
-            Posts
-          </TabsTrigger>
-          <TabsTrigger value="replies" className="flex-1 sm:flex-none">
-            Replies
-          </TabsTrigger>
+          {!isPixelfed && (
+            <>
+              <TabsTrigger value="posts" className="flex-1 sm:flex-none">
+                Posts
+              </TabsTrigger>
+              <TabsTrigger value="replies" className="flex-1 sm:flex-none">
+                Replies
+              </TabsTrigger>
+            </>
+          )}
           <TabsTrigger value="media" className="flex-1 sm:flex-none">
             Media
           </TabsTrigger>
-          {showFitnessTab && (
+          {showFitnessTab && !isPixelfed && (
             <TabsTrigger value="fitness" className="flex-1 sm:flex-none">
               Fitness
             </TabsTrigger>
           )}
         </TabsList>
 
-        <TabsContent value="posts" className="mt-0">
-          {renderFeed(postStatuses, 'No posts yet')}
-        </TabsContent>
+        {!isPixelfed && (
+          <>
+            <TabsContent value="posts" className="mt-0">
+              {renderFeed(postStatuses, 'No posts yet')}
+            </TabsContent>
 
-        <TabsContent value="replies" className="mt-0">
-          {renderFeed(replyStatuses, 'No replies yet')}
-        </TabsContent>
+            <TabsContent value="replies" className="mt-0">
+              {renderFeed(replyStatuses, 'No replies yet')}
+            </TabsContent>
+          </>
+        )}
 
         <TabsContent value="media" className="mt-0">
-          {attachments.length > 0 ? (
+          {attachments.length > 0 ||
+          (isPixelfed &&
+            currentStatuses.some(
+              (s) => s.type === StatusType.enum.Note && s.attachments.length > 0
+            )) ? (
             <div className="rounded-xl border bg-card p-2 shadow-sm sm:p-4">
               <ActorMediaGallery
                 actorId={actorId}
                 initialAttachments={attachments}
+                statuses={currentStatuses}
+                isPixelfed={isPixelfed}
               />
             </div>
           ) : (
@@ -399,7 +419,7 @@ export const ActorTimelines: FC<Props> = ({
           )}
         </TabsContent>
 
-        {showFitnessTab && (
+        {showFitnessTab && !isPixelfed && (
           <TabsContent value="fitness" className="mt-0 space-y-4">
             {isCurrentUser && (
               <div className="flex justify-end">

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -5,6 +5,7 @@ import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
@@ -21,6 +22,9 @@ vi.mock('@/lib/activities/getActorPosts')
 vi.mock('@/lib/activities/getWebfingerSelf')
 vi.mock('@/lib/services/federation/domainPolicy')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
+vi.mock('@/lib/services/federation/serverSoftware', () => ({
+  isPixelfedActor: vi.fn().mockResolvedValue(false)
+}))
 vi.mock('@/lib/utils/getPersonFromActor')
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
@@ -598,6 +602,64 @@ describe('getProfileData', () => {
 
       expect(result).not.toBeNull()
       expect(result?.hasFitnessData).toBe(false)
+    })
+
+    it('returns isPixelfed as true and falls back to status attachments when DB attachments are empty', async () => {
+      vi.mocked(isPixelfedActor).mockResolvedValueOnce(true)
+      const mockAttachment: Attachment = {
+        id: 'att-1',
+        actorId: mockPerson.id,
+        statusId: 'status-1',
+        type: 'Document',
+        mediaType: 'image/jpeg',
+        url: 'https://pixelfed.example/image.jpg',
+        name: 'Sample',
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+      vi.mocked(getActorPosts).mockResolvedValueOnce({
+        statuses: [
+          {
+            id: 'status-1',
+            url: 'https://pixelfed.example/p/user/1',
+            actorId: mockPerson.id,
+            actor: null,
+            type: StatusType.enum.Note,
+            text: 'Test',
+            to: [],
+            cc: [],
+            edits: [],
+            reply: '',
+            replies: [],
+            totalReplies: 1,
+            actorAnnounceStatusId: null,
+            isActorLiked: false,
+            isActorBookmarked: false,
+            totalLikes: 5,
+            totalShares: 2,
+            attachments: [mockAttachment],
+            tags: [],
+            createdAt: 1000,
+            updatedAt: 1000,
+            isLocalActor: false
+          }
+        ],
+        statusesCount: 1,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+      vi.mocked(mockDatabase.getAttachmentsForActor).mockResolvedValueOnce([])
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.isPixelfed).toBe(true)
+      expect(result?.attachments).toEqual([mockAttachment])
     })
 
     it('should return null for anonymous user without calling remote APIs', async () => {

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -7,6 +7,7 @@ import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstr
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
+import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
 import {
   canActorReadStatus,
   resolveActorStatusesAudience
@@ -14,7 +15,7 @@ import {
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusType } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
@@ -32,6 +33,7 @@ type ProfileData = {
   followersCount: number
   isInternalAccount: boolean
   hasFitnessData: boolean
+  isPixelfed?: boolean
 }
 
 type ProfileDataOptions = {
@@ -151,7 +153,8 @@ export const getProfileData = async (
       followingCount,
       followersCount,
       isInternalAccount: true,
-      hasFitnessData
+      hasFitnessData,
+      isPixelfed: false
     }
   }
 
@@ -297,10 +300,16 @@ export const getProfileData = async (
       nextPageUrl: actorPostsResponse.nextPageUrl ?? null,
       prevPageUrl: actorPostsResponse.prevPageUrl ?? null
     },
-    attachments,
+    attachments:
+      attachments.length > 0
+        ? attachments
+        : actorPostsResponse.statuses.flatMap((status) =>
+            status.type === StatusType.enum.Note ? status.attachments : []
+          ),
     followingCount: collectionCounts.followingCount ?? 0,
     followersCount: collectionCounts.followersCount ?? 0,
     isInternalAccount: false,
-    hasFitnessData: false
+    hasFitnessData: false,
+    isPixelfed: await isPixelfedActor(person)
   }
 }

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -135,7 +135,8 @@ const Page: FC<Props> = async ({ params }) => {
     statusPagination,
     followingCount,
     followersCount,
-    hasFitnessData
+    hasFitnessData,
+    isPixelfed
   } = actorProfile
 
   const isCurrentUser = currentActor?.id === person.id
@@ -268,6 +269,7 @@ const Page: FC<Props> = async ({ params }) => {
         postLineLimit={actorSettings?.postLineLimit}
         currentActor={currentActor ? getActorProfile(currentActor) : undefined}
         isCurrentUser={isCurrentUser}
+        isPixelfed={isLoggedIn && Boolean(isPixelfed)}
         hasFitnessData={hasFitnessData}
         isMediaUploadEnabled={Boolean(mediaStorage)}
       />

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -26,11 +26,13 @@ import {
   isOpaqueActorUsername
 } from '@/lib/utils/activitypubActor'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
 import { getActorPerson } from './getActorPerson'
 import { getActorPostsFromAtomFeed } from './getActorPostsFromAtomFeed'
+import { getPixelfedPosts } from './getPixelfedPosts'
 
 type GetActorPostsFunction = (params: {
   database: Database
@@ -202,14 +204,34 @@ export const getActorPosts: GetActorPostsFunction = async ({
         (item): item is NonNullable<typeof item> => item !== null
       )
 
-      if (validStatuses.length === 0 && !pageUrl) {
+      if (validStatuses.length === 0) {
         const isPixelfed = await isPixelfedActor(person)
         if (isPixelfed) {
-          validStatuses = await getActorPostsFromAtomFeed({
-            person,
-            signingActor,
-            actor
-          })
+          try {
+            const pixelfedResult = await getPixelfedPosts({
+              person,
+              pageUrl,
+              actor
+            })
+            if (pixelfedResult && pixelfedResult.statuses.length > 0) {
+              return pixelfedResult
+            }
+          } catch (err) {
+            logger.warn({
+              message:
+                'Failed to fetch Pixelfed posts via API, falling back to Atom feed',
+              actorId: person.id,
+              err: toLoggableError(err)
+            })
+          }
+
+          if (!pageUrl) {
+            validStatuses = await getActorPostsFromAtomFeed({
+              person,
+              signingActor,
+              actor
+            })
+          }
         }
       }
 

--- a/lib/activities/getPixelfedPosts.test.ts
+++ b/lib/activities/getPixelfedPosts.test.ts
@@ -1,0 +1,148 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { Actor } from '@/lib/types/activitypub'
+import { StatusType } from '@/lib/types/domain/status'
+
+import {
+  fromPixelfedStatus,
+  getPixelfedAccountId,
+  getPixelfedPosts
+} from './getPixelfedPosts'
+
+enableFetchMocks()
+
+describe('getPixelfedPosts', () => {
+  const actorId = 'https://pixelfed.example/users/dansup'
+  const person = MockActivityPubPerson({
+    id: actorId,
+    withContext: true
+  }) as Actor
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getPixelfedAccountId', () => {
+    it('returns account id when lookup succeeds', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ id: '42' }))
+      const accountId = await getPixelfedAccountId('pixelfed.example', 'dansup')
+      expect(accountId).toBe('42')
+    })
+
+    it('returns null when lookup returns non-200 or error', async () => {
+      fetchMock.mockResponseOnce('Not Found', { status: 404 })
+      const accountId = await getPixelfedAccountId('pixelfed.example', 'dansup')
+      expect(accountId).toBeNull()
+    })
+  })
+
+  describe('fromPixelfedStatus', () => {
+    it('correctly maps Pixelfed status fields to StatusNote', () => {
+      const pixelfedStatus = {
+        id: '1001',
+        uri: 'https://pixelfed.example/p/dansup/1001',
+        url: 'https://pixelfed.example/p/dansup/1001',
+        content: '<p>A beautiful sunset #nature</p>',
+        created_at: '2026-08-31T17:15:56.000Z',
+        favourites_count: 62,
+        reblogs_count: 9,
+        reply_count: 4,
+        media_attachments: [
+          {
+            id: '501',
+            type: 'image',
+            url: 'https://pixelfed.example/storage/1.jpg',
+            preview_url: 'https://pixelfed.example/storage/1_thumb.jpg',
+            description: 'Sunset over mountains',
+            blurhash: 'U123456',
+            meta: {
+              original: { width: 1920, height: 1080 }
+            }
+          }
+        ],
+        tags: [{ name: 'nature', url: 'https://pixelfed.example/tags/nature' }]
+      }
+
+      const status = fromPixelfedStatus(pixelfedStatus, person, null)
+      expect(status.type).toBe(StatusType.enum.Note)
+      if (status.type === StatusType.enum.Note) {
+        expect(status.id).toBe('https://pixelfed.example/p/dansup/1001')
+        expect(status.totalLikes).toBe(62)
+        expect(status.totalShares).toBe(9)
+        expect(status.totalReplies).toBe(4)
+        expect(status.attachments).toHaveLength(1)
+        expect(status.attachments[0]).toMatchObject({
+          url: 'https://pixelfed.example/storage/1.jpg',
+          thumbnailUrl: 'https://pixelfed.example/storage/1_thumb.jpg',
+          name: 'Sunset over mountains',
+          blurhash: 'U123456',
+          width: 1920,
+          height: 1080
+        })
+      }
+    })
+  })
+
+  describe('getPixelfedPosts', () => {
+    it('fetches statuses from Pixelfed API and resolves pagination', async () => {
+      const mockStatuses = Array.from({ length: 20 }, (_, i) => ({
+        id: String(2000 - i),
+        uri: `https://pixelfed.example/p/dansup/${2000 - i}`,
+        url: `https://pixelfed.example/p/dansup/${2000 - i}`,
+        content: `<p>Post ${i}</p>`,
+        created_at: '2026-08-31T17:15:56.000Z',
+        favourites_count: i * 5,
+        reblogs_count: i,
+        reply_count: i * 2,
+        media_attachments: [
+          {
+            id: `media-${i}`,
+            type: 'image',
+            url: `https://pixelfed.example/storage/${i}.jpg`
+          }
+        ]
+      }))
+
+      fetchMock.mockResponse(async (req) => {
+        if (
+          req.url ===
+          'https://pixelfed.example/api/v1/accounts/lookup?acct=dansup'
+        ) {
+          return {
+            status: 200,
+            body: JSON.stringify({ id: '2' })
+          }
+        }
+        if (
+          req.url ===
+          'https://pixelfed.example/api/pixelfed/v1/accounts/2/statuses?limit=20'
+        ) {
+          return {
+            status: 200,
+            body: JSON.stringify(mockStatuses)
+          }
+        }
+        return { status: 404, body: 'Not found' }
+      })
+
+      const result = await getPixelfedPosts({ person })
+      expect(result).not.toBeNull()
+      expect(result?.statuses).toHaveLength(20)
+      expect(result?.statusesCount).toBe(20)
+      expect(result?.nextPageUrl).toBe(
+        'https://pixelfed.example/api/pixelfed/v1/accounts/2/statuses?limit=20&max_id=1981'
+      )
+    })
+
+    it('returns null when account lookup fails', async () => {
+      fetchMock.mockResponse(async () => ({
+        status: 404,
+        body: 'Not found'
+      }))
+
+      const result = await getPixelfedPosts({ person })
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/lib/activities/getPixelfedPosts.ts
+++ b/lib/activities/getPixelfedPosts.ts
@@ -1,0 +1,249 @@
+import { detectLanguageFromHtml } from '@/lib/services/language-detection'
+import { Actor } from '@/lib/types/activitypub'
+import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
+import { Attachment } from '@/lib/types/domain/attachment'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/domain/tag'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+import { withSpan } from '@/lib/utils/trace'
+
+export const PIXELFED_PAGE_LIMIT = 20
+
+export interface PixelfedMediaAttachment {
+  id: string | number
+  type: string
+  url: string
+  remote_url?: string | null
+  preview_url?: string | null
+  text_url?: string | null
+  meta?: {
+    focus?: { x: number; y: number }
+    original?: {
+      width?: number
+      height?: number
+      size?: string
+      aspect?: number
+    }
+  }
+  description?: string | null
+  blurhash?: string | null
+  mime?: string | null
+}
+
+export interface PixelfedTag {
+  name: string
+  url: string
+}
+
+export interface PixelfedStatus {
+  id: string
+  uri?: string
+  url?: string
+  in_reply_to_id?: string | null
+  content?: string
+  created_at: string
+  reblogs_count?: number
+  favourites_count?: number
+  reply_count?: number
+  sensitive?: boolean
+  spoiler_text?: string
+  language?: string | null
+  media_attachments?: PixelfedMediaAttachment[]
+  tags?: PixelfedTag[]
+  favourited?: boolean | null
+  reblogged?: boolean | null
+  bookmarked?: boolean | null
+}
+
+export interface GetPixelfedPostsParams {
+  person: Actor
+  pageUrl?: string | null
+  actor?: ActorProfile | DomainActor | null
+}
+
+export interface GetPixelfedPostsResult {
+  statusesCount: number
+  statuses: Status[]
+  nextPageUrl: string | null
+  prevPageUrl: string | null
+}
+
+export const getPixelfedAccountId = async (
+  domain: string,
+  username: string
+): Promise<string | null> => {
+  try {
+    const { statusCode, body } = await request({
+      url: `https://${domain}/api/v1/accounts/lookup?acct=${encodeURIComponent(username)}`,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'activities.next'
+      }
+    })
+    if (statusCode !== 200 || !body || typeof body !== 'string') {
+      return null
+    }
+    const data = JSON.parse(body) as { id?: string | number }
+    return data.id ? String(data.id) : null
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to lookup Pixelfed account id',
+      domain,
+      username,
+      err: toLoggableError(error)
+    })
+    return null
+  }
+}
+
+export const fromPixelfedStatus = (
+  item: PixelfedStatus,
+  person: Actor,
+  actorProfile: ActorProfile | null
+): Status => {
+  const domain = new URL(person.id).host
+  const statusId =
+    item.uri ||
+    item.url ||
+    `https://${domain}/p/${person.preferredUsername}/${item.id}`
+  const statusUrl =
+    item.url || `https://${domain}/p/${person.preferredUsername}/${item.id}`
+  const createdAtTime = new Date(item.created_at).getTime() || Date.now()
+  const content = item.content || ''
+
+  const attachments: Attachment[] = (item.media_attachments || []).map(
+    (media, index) => ({
+      id: String(media.id || `${item.id}-${index}`),
+      actorId: person.id,
+      statusId,
+      type: 'Document',
+      mediaType:
+        media.type === 'video' ? 'video/mp4' : media.mime || 'image/jpeg',
+      url: media.url,
+      name: media.description || '',
+      width: media.meta?.original?.width,
+      height: media.meta?.original?.height,
+      blurhash: media.blurhash || null,
+      thumbnailUrl: media.preview_url || null,
+      focus: media.meta?.focus || null,
+      createdAt: createdAtTime,
+      updatedAt: createdAtTime
+    })
+  )
+
+  const tags: Tag[] = (item.tags || []).map((tag, tagIndex) => ({
+    id: `${statusId}-tag-${tagIndex}`,
+    statusId,
+    type: 'hashtag',
+    name: tag.name.startsWith('#') ? tag.name : `#${tag.name}`,
+    value: tag.url,
+    createdAt: createdAtTime,
+    updatedAt: createdAtTime
+  }))
+
+  return StatusNote.parse({
+    id: statusId,
+    url: statusUrl,
+    actorId: person.id,
+    actor: actorProfile,
+    type: StatusType.enum.Note,
+    text: content,
+    summary: item.spoiler_text || null,
+    sensitive: Boolean(item.sensitive),
+    language: item.language || null,
+    detectedLanguage: detectLanguageFromHtml(content)?.language ?? null,
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [person.followers || `${person.id}/followers`],
+    edits: [],
+    reply: item.in_reply_to_id ? String(item.in_reply_to_id) : '',
+    replies: [],
+    totalReplies: item.reply_count ?? 0,
+    actorAnnounceStatusId: null,
+    isActorLiked: Boolean(item.favourited),
+    isActorBookmarked: Boolean(item.bookmarked),
+    totalLikes: item.favourites_count ?? 0,
+    totalShares: item.reblogs_count ?? 0,
+    attachments,
+    tags,
+    createdAt: createdAtTime,
+    updatedAt: createdAtTime,
+    isLocalActor: false
+  })
+}
+
+export const getPixelfedPosts = async ({
+  person,
+  pageUrl,
+  actor
+}: GetPixelfedPostsParams): Promise<GetPixelfedPostsResult | null> =>
+  withSpan('activity', 'getPixelfedPosts', { actorId: person.id }, async () => {
+    try {
+      const domain = new URL(person.id).host
+      let fetchUrl: string
+
+      let accountId: string | null = null
+      if (pageUrl) {
+        fetchUrl = pageUrl
+      } else {
+        accountId = await getPixelfedAccountId(domain, person.preferredUsername)
+        if (!accountId) return null
+        fetchUrl = `https://${domain}/api/pixelfed/v1/accounts/${accountId}/statuses?limit=${PIXELFED_PAGE_LIMIT}`
+      }
+
+      const { statusCode, body } = await request({
+        url: fetchUrl,
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'activities.next'
+        }
+      })
+
+      if (statusCode !== 200 || !body || typeof body !== 'string') {
+        return null
+      }
+
+      const items = JSON.parse(body)
+      if (!Array.isArray(items)) {
+        return null
+      }
+
+      const actorProfile = actor
+        ? (ActorProfile.safeParse(actor).data ?? null)
+        : null
+
+      const statuses: Status[] = items.map((item) =>
+        fromPixelfedStatus(item, person, actorProfile)
+      )
+
+      let nextPageUrl: string | null = null
+      if (items.length >= PIXELFED_PAGE_LIMIT) {
+        const lastItem = items[items.length - 1]
+        if (lastItem?.id) {
+          if (!accountId) {
+            // If fetching from a pageUrl, extract or resolve accountId
+            const match = fetchUrl.match(/\/accounts\/([^/]+)\/statuses/)
+            accountId = match ? match[1] : null
+          }
+          if (accountId) {
+            nextPageUrl = `https://${domain}/api/pixelfed/v1/accounts/${accountId}/statuses?limit=${PIXELFED_PAGE_LIMIT}&max_id=${lastItem.id}`
+          }
+        }
+      }
+
+      return {
+        statusesCount: statuses.length,
+        statuses,
+        nextPageUrl,
+        prevPageUrl: null
+      }
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to fetch Pixelfed posts',
+        actorId: person.id,
+        err: toLoggableError(error)
+      })
+      return null
+    }
+  })

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -190,6 +190,7 @@ export const StatusNote = StatusBase.extend({
   applicationWebsite: z.string().nullable().optional(),
   reply: z.string(),
   replies: z.looseObject(StatusBase.shape).array(),
+  totalReplies: z.number().optional(),
 
   actorAnnounceStatusId: z.string().nullable(),
   isActorLiked: z.boolean(),


### PR DESCRIPTION
## Summary

Redesigns the Pixelfed profile timeline view when accessed by a logged-in user, and adds an Instagram/Pixelfed-style hover overlay to the media grid across all profiles.

### Key Changes

1. **Pixelfed Public API Integration**:
   - Added `lib/activities/getPixelfedPosts.ts` to lookup accounts via `https://${domain}/api/v1/accounts/lookup?acct=${username}` and fetch public statuses with interaction counts and media attachments via `https://${domain}/api/pixelfed/v1/accounts/${accountId}/statuses?limit=20`.
   - Wired `getPixelfedPosts` into `getActorPosts.ts` as the primary fetcher when a Pixelfed actor's outbox returns an empty item collection, with fallback to `getActorPostsFromAtomFeed`.
   - Added optional `totalReplies` to `StatusNote` in `lib/types/domain/status.ts`.

2. **Clean Media-Only Layout for Pixelfed Profiles**:
   - Updated `app/(timeline)/[actor]/getProfileData.ts` to identify Pixelfed actors via `isPixelfedActor(person)` and extract attachments from `actorPostsResponse.statuses` when database attachments are empty.
   - For logged-in users viewing Pixelfed profiles, the tab bar is removed completely and the image grid is borderless (without the card border wrapper), directly matching Pixelfed's native layout.
   - Non-Pixelfed profiles retain their standard tab list (`Posts`, `Replies`, `Media`, and `Fitness`) and card border on the media tab.
   - Enabled status-based pagination on the Media grid for Pixelfed actors.

3. **Media Grid Hover Overlay & Indicators (All Profiles)**:
   - In `ActorMediaGallery.tsx`, added a hover/focus overlay showing:
     - **Favorites** (`Heart` icon + compact count)
     - **Comments** (`MessageCircle` icon + compact count)
     - **Reposts** (`Repeat2` icon + compact count)
   - Added badges for multiple photos / albums (`Copy` icon) and videos (`Video` icon) in the top-right corner.
   - Applied this overlay across both Pixelfed and non-Pixelfed profiles.

### Automated Tests
- Full Vitest suite: 941 test files passed (12,671 tests).
- Added `lib/activities/getPixelfedPosts.test.ts`.
- Added test coverage in `app/(timeline)/[actor]/ActorMediaGallery.test.tsx`, `app/(timeline)/[actor]/ActorTimelines.test.tsx`, and `app/(timeline)/[actor]/getProfileData.test.ts`.
- `yarn run prettier --check .`, `yarn lint`, `yarn typecheck`, and `yarn build` all passed.

### Browser Verification
- Tested locally with Playwright against live `@dansup@pixelfed.social` and local test user.
