### PR TITLE
Bump version to v1.156.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.155.8",
+  "version": "1.156.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.156.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.155.8`
- Base main SHA: `7ce2026a206a239919c932cda20b11346c7370fc`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
