### PR TITLE
fix: strip HTML tags from user summary in follower and following lists

### DIFF
--- a/app/(timeline)/[actor]/FollowList.test.tsx
+++ b/app/(timeline)/[actor]/FollowList.test.tsx
@@ -105,4 +105,23 @@ describe('FollowList', () => {
 
     expect(screen.getByText('Hello world biography')).toBeInTheDocument()
   })
+
+  it('strips html tags and decodes entities from summary', () => {
+    const user = actorProfile('https://example.test/users/bio', 'bio')
+    user.summary =
+      '<p>I write curl. I don&#39;t know anything &amp; <a href="https://example.com">more</a>.</p>'
+    render(<FollowList users={[user]} isLoggedIn />)
+
+    expect(
+      screen.getByText("I write curl. I don't know anything & more.")
+    ).toBeInTheDocument()
+  })
+
+  it('does not render summary element when summary consists only of empty html tags', () => {
+    const user = actorProfile('https://example.test/users/bio', 'bio')
+    user.summary = '<p>   </p>'
+    const { container } = render(<FollowList users={[user]} isLoggedIn />)
+
+    expect(container.querySelector('.line-clamp-1')).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/FollowList.tsx
+++ b/app/(timeline)/[actor]/FollowList.tsx
@@ -6,6 +6,7 @@ import { FC, useMemo } from 'react'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { ActorProfile } from '@/lib/types/domain/actor'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
 interface Props {
   users: ActorProfile[]
@@ -42,6 +43,7 @@ export const FollowList: FC<Props> = ({
           .map((n) => n[0])
           .join('')
           .toUpperCase()
+        const summary = htmlToPlainText(user.summary)
 
         return (
           <div key={user.id} className="flex items-center gap-3 px-5 py-4">
@@ -63,9 +65,9 @@ export const FollowList: FC<Props> = ({
               <div className="truncate text-sm text-muted-foreground">
                 @{user.username}@{user.domain}
               </div>
-              {user.summary ? (
+              {summary ? (
                 <div className="mt-1 line-clamp-1 text-sm text-muted-foreground">
-                  {user.summary}
+                  {summary}
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## Summary
Fixes an issue in the followers and following lists where user biographies/summaries were rendered with raw HTML tags (e.g. `<p>`, `<a>`) and unescaped HTML entities (e.g. `&#39;`).

## Root Cause
In `app/(timeline)/[actor]/FollowList.tsx`, `user.summary` was directly passed as a child inside the line-clamped `div` (`{user.summary ? <div>{user.summary}</div> : null}`). Because ActivityPub and Mastodon actor summaries contain HTML content, React rendered the HTML tags and entities as raw text rather than formatting or plain text.

## Fix
- Used `htmlToPlainText(user.summary)` to strip HTML tags, decode HTML entities, and collapse/trim whitespace before rendering.
- Only renders the summary preview container when non-empty plain text content is present (preventing empty rows from empty tags like `<p> </p>`).
- Added unit tests in `FollowList.test.tsx` ensuring HTML tags are stripped, entities are decoded, and empty HTML summaries are ignored.

## Verification
- `yarn run prettier --write .`
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (succeeded)
- `yarn test` (all 940 test files, 12,661 tests passed)
