### PR TITLE
Bump version to v1.156.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.156.0",
+  "version": "1.156.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.156.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.156.0`
- Base main SHA: `d63e2742ae4cb27d4d7cdaeaf0730e1cf89692ea`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
