### PR TITLE
fix: keep desktop profile header action buttons on one line

### DIFF
--- a/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
@@ -59,6 +59,7 @@ const relationship = (
   blocked_by: false,
   muting: false,
   muting_notifications: false,
+  muting_expires_at: null,
   requested: false,
   requested_by: false,
   domain_blocking: false,
@@ -69,6 +70,22 @@ const relationship = (
 })
 
 describe('ProfileRelationshipActions', () => {
+  it('applies shrink-0 and sm:flex-nowrap to keep action buttons on one line on desktop', () => {
+    const { container } = render(
+      <ProfileRelationshipActions
+        targetActorId="https://remote.test/users/open"
+        targetHandle="open@remote.test"
+        isLoggedIn
+        relationship={relationship()}
+        className="custom-actions-class"
+      />
+    )
+
+    const actionContainer = container.firstElementChild
+    expect(actionContainer).toHaveClass('shrink-0')
+    expect(actionContainer).toHaveClass('sm:flex-nowrap')
+    expect(actionContainer).toHaveClass('custom-actions-class')
+  })
   it('offers the remote follow dialog to a logged out visitor', () => {
     render(
       <ProfileRelationshipActions

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
@@ -5,8 +5,10 @@ import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { MuteAction } from '@/lib/components/mute-action/mute-action'
 import { RemoteFollowDialog } from '@/lib/components/remote-follow/remote-follow-dialog'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+import { cn } from '@/lib/utils'
 
 interface ProfileRelationshipActionsProps {
+  className?: string
   targetActorId: string
   targetHandle: string
   isLoggedIn: boolean
@@ -19,20 +21,27 @@ export const isBlockedRelationship = (
 
 export const ProfileRelationshipActions: FC<
   ProfileRelationshipActionsProps
-> = ({ targetActorId, targetHandle, isLoggedIn, relationship }) => {
+> = ({ className, targetActorId, targetHandle, isLoggedIn, relationship }) => {
   // Every action below renders nothing without a session. A logged-out visitor
   // gets the remote-follow dialog instead, so they can follow from their own
   // server the way Mastodon offers.
   if (!isLoggedIn) {
     return (
-      <div className="flex flex-wrap gap-2">
+      <div
+        className={cn(
+          'flex shrink-0 flex-wrap gap-2 sm:flex-nowrap',
+          className
+        )}
+      >
         <RemoteFollowDialog targetHandle={targetHandle} />
       </div>
     )
   }
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div
+      className={cn('flex shrink-0 flex-wrap gap-2 sm:flex-nowrap', className)}
+    >
       {!isBlockedRelationship(relationship) ? (
         <>
           <FollowAction

--- a/app/(timeline)/[actor]/loading.tsx
+++ b/app/(timeline)/[actor]/loading.tsx
@@ -13,12 +13,12 @@ export const ProfileLoading: FC = () => {
         <div className="relative px-6 pb-6">
           <div className="skeleton -mt-10 h-20 w-20 rounded-full border-4 border-background" />
 
-          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-2">
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0 space-y-2">
               <div className="skeleton h-7 w-48 rounded-md" />
               <div className="skeleton h-4 w-32 rounded-md" />
             </div>
-            <div className="skeleton h-9 w-28 rounded-md" />
+            <div className="skeleton h-9 w-28 shrink-0 rounded-md" />
           </div>
 
           <div className="mt-4 space-y-2">

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -208,15 +208,17 @@ const Page: FC<Props> = async ({ params }) => {
             <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
 
-          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold">{person.name}</h1>
-              <p className="text-muted-foreground">
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold break-words">
+                {person.name}
+              </h1>
+              <p className="truncate text-muted-foreground">
                 @{person.preferredUsername}
               </p>
             </div>
             {isCurrentUser ? (
-              <Button variant="outline" asChild>
+              <Button variant="outline" asChild className="shrink-0">
                 <Link href="/settings">Edit Profile</Link>
               </Button>
             ) : (

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -21,7 +21,6 @@
     "app/(nosidebar)/oauth/authorize/page.test.tsx",
     "app/(timeline)/MainPageTimeline.test.tsx",
     "app/(timeline)/[actor]/ActorTimelines.test.tsx",
-    "app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx",
     "app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx",
     "app/(timeline)/[actor]/[status]/StatusBox.test.tsx",
     "app/(timeline)/[actor]/[status]/page.layout.test.tsx",


### PR DESCRIPTION
## Summary
Fixes an issue in the desktop profile header where long display names cause the action buttons (Follow, Mute, Block) to wrap onto multiple lines.

## Root Cause
In `app/(timeline)/[actor]/page.tsx`, the profile header used `sm:flex-row sm:items-start sm:justify-between` without `min-w-0` on the display name container, allowing long display names to consume horizontal space and shrink the action buttons container. Additionally, `ProfileRelationshipActions` used `flex flex-wrap gap-2` without `shrink-0` or `sm:flex-nowrap`, causing action buttons to wrap onto two lines when compressed.

## Fix
- Added `min-w-0` and `break-words` to the display name container and heading in `app/(timeline)/[actor]/page.tsx`.
- Updated `ProfileRelationshipActions.tsx` to apply `shrink-0` and `sm:flex-nowrap` (`flex shrink-0 flex-wrap gap-2 sm:flex-nowrap`) and support an optional `className` prop.
- Added `shrink-0` to the profile edit button in `app/(timeline)/[actor]/page.tsx` and the skeleton loading state in `app/(timeline)/[actor]/loading.tsx`.
- Updated `ProfileRelationshipActions.test.tsx` with assertions verifying that `shrink-0` and `sm:flex-nowrap` are applied.
- Made `ProfileRelationshipActions.test.tsx` type-clean by specifying `muting_expires_at: null` and removed it from `tsconfig.typecheck.json`'s ratchet exclude list.

## Checklist
- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: No documentation impacted
- [x] If migrations changed: No migrations changed
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description