### PR TITLE
fix: hide following and followers counts when private or inaccessible

### DIFF
--- a/app/(timeline)/[actor]/followers/page.test.tsx
+++ b/app/(timeline)/[actor]/followers/page.test.tsx
@@ -340,4 +340,34 @@ describe('[actor] followers page', () => {
       screen.getByRole('link', { name: 'Back to profile' })
     ).toHaveAttribute('href', '/@llun@llun.test')
   })
+
+  it('renders gracefully without count subtitle when followersCount is null', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/user',
+        preferredUsername: 'user'
+      } as never,
+      followersCount: null,
+      followingCount: 10,
+      statusesCount: 5,
+      attachments: [],
+      isInternalAccount: false,
+      hasFitnessData: false,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null }
+    })
+    mockDatabase.getFollowers.mockResolvedValue([])
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@user@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('Followers')).toBeInTheDocument()
+    expect(screen.queryByText(/accounts/)).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -135,7 +135,11 @@ const Page: FC<Props> = async ({ params }) => {
               <span className="truncate">Followers</span>
             </span>
           }
-          description={`${actorProfile.followersCount.toLocaleString()} accounts`}
+          description={
+            typeof actorProfile.followersCount === 'number'
+              ? `${actorProfile.followersCount.toLocaleString()} accounts`
+              : undefined
+          }
         />
       ) : (
         <div className="flex items-start gap-2">
@@ -149,9 +153,11 @@ const Page: FC<Props> = async ({ params }) => {
           </Link>
           <div>
             <h1 className="text-xl font-semibold tracking-tight">Followers</h1>
-            <p className="text-sm text-muted-foreground">
-              {actorProfile.followersCount.toLocaleString()} accounts
-            </p>
+            {typeof actorProfile.followersCount === 'number' && (
+              <p className="text-sm text-muted-foreground">
+                {actorProfile.followersCount.toLocaleString()} accounts
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/app/(timeline)/[actor]/following/page.test.tsx
+++ b/app/(timeline)/[actor]/following/page.test.tsx
@@ -343,4 +343,34 @@ describe('[actor] following page', () => {
       screen.getByRole('link', { name: 'Back to profile' })
     ).toHaveAttribute('href', '/@llun@llun.test')
   })
+
+  it('renders gracefully without count subtitle when followingCount is null', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/user',
+        preferredUsername: 'user'
+      } as never,
+      followersCount: 10,
+      followingCount: null,
+      statusesCount: 5,
+      attachments: [],
+      isInternalAccount: false,
+      hasFitnessData: false,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null }
+    })
+    mockDatabase.getFollowing.mockResolvedValue([])
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@user@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('Following')).toBeInTheDocument()
+    expect(screen.queryByText(/accounts/)).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -135,7 +135,11 @@ const Page: FC<Props> = async ({ params }) => {
               <span className="truncate">Following</span>
             </span>
           }
-          description={`${actorProfile.followingCount.toLocaleString()} accounts`}
+          description={
+            typeof actorProfile.followingCount === 'number'
+              ? `${actorProfile.followingCount.toLocaleString()} accounts`
+              : undefined
+          }
         />
       ) : (
         <div className="flex items-start gap-2">
@@ -149,9 +153,11 @@ const Page: FC<Props> = async ({ params }) => {
           </Link>
           <div>
             <h1 className="text-xl font-semibold tracking-tight">Following</h1>
-            <p className="text-sm text-muted-foreground">
-              {actorProfile.followingCount.toLocaleString()} accounts
-            </p>
+            {typeof actorProfile.followingCount === 'number' && (
+              <p className="text-sm text-muted-foreground">
+                {actorProfile.followingCount.toLocaleString()} accounts
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -501,6 +501,33 @@ describe('getProfileData', () => {
       })
     })
 
+    it('preserves null followersCount and followingCount when collections are private or inaccessible', async () => {
+      ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
+        followersCount: null,
+        followingCount: null,
+        statusesCount: 100
+      })
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).toMatchObject({
+        followersCount: null,
+        followingCount: null,
+        statusesCount: 0
+      })
+      expect(mockDatabase.setActorCounters).toHaveBeenCalledWith({
+        actorId: mockPerson.id,
+        followersCount: null,
+        followingCount: null,
+        statusCount: null
+      })
+    })
+
     it('creates newly discovered remote actor in database when persistedActor does not exist', async () => {
       ;(mockDatabase.getActorFromUsername as jest.Mock).mockResolvedValue(null)
       // No row under person.id yet — the create branch.

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -29,8 +29,8 @@ type ProfileData = {
     prevPageUrl: string | null
   }
   attachments: Attachment[]
-  followingCount: number
-  followersCount: number
+  followingCount: number | null
+  followersCount: number | null
   isInternalAccount: boolean
   hasFitnessData: boolean
   isPixelfed?: boolean
@@ -306,8 +306,8 @@ export const getProfileData = async (
         : actorPostsResponse.statuses.flatMap((status) =>
             status.type === StatusType.enum.Note ? status.attachments : []
           ),
-    followingCount: collectionCounts.followingCount ?? 0,
-    followersCount: collectionCounts.followersCount ?? 0,
+    followingCount: collectionCounts.followingCount,
+    followersCount: collectionCounts.followersCount,
     isInternalAccount: false,
     hasFitnessData: false,
     isPixelfed: await isPixelfedActor(person)

--- a/app/(timeline)/[actor]/page.follow-counts.test.tsx
+++ b/app/(timeline)/[actor]/page.follow-counts.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { getProfileData } from './getProfileData'
+import Page from './page'
+
+const mockDatabase = {
+  getFeaturedTags: vi.fn().mockResolvedValue([])
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  }),
+  getBaseURL: () => 'https://llun.social'
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('./getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('./ActorTimelines', () => ({
+  ActorTimelines: () => <div data-testid="actor-timelines" />
+}))
+
+vi.mock('./ProfileHeaderImage', () => ({
+  ProfileHeaderImage: () => <div data-testid="header-image" />
+}))
+
+vi.mock('./ProfileRelationshipActions', () => ({
+  ProfileRelationshipActions: () => <div data-testid="relationship-actions" />
+}))
+
+vi.mock('@/lib/services/mastodon/getMastodonFeaturedTag', () => ({
+  getMastodonFeaturedTag: vi.fn().mockResolvedValue([])
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+
+describe('[actor] page follow counts display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'user@llun.social' }
+    } as never)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+  })
+
+  it('renders both Following and Followers links when counts are numbers', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: 100,
+      followingCount: 15,
+      followersCount: 30,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('Following')).toBeInTheDocument()
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('Followers')).toBeInTheDocument()
+  })
+
+  it('omits Following when followingCount is null but shows Followers', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: 100,
+      followingCount: null,
+      followersCount: 30,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+    expect(screen.queryByText('Following')).not.toBeInTheDocument()
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('Followers')).toBeInTheDocument()
+  })
+
+  it('omits Followers when followersCount is null but shows Following', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: 100,
+      followingCount: 15,
+      followersCount: null,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('Following')).toBeInTheDocument()
+    expect(screen.queryByText('Followers')).not.toBeInTheDocument()
+  })
+
+  it('omits both Following and Followers when both counts are null', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: 100,
+      followingCount: null,
+      followersCount: null,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+    expect(screen.queryByText('Following')).not.toBeInTheDocument()
+    expect(screen.queryByText('Followers')).not.toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -238,22 +238,26 @@ const Page: FC<Props> = async ({ params }) => {
               <span className="font-semibold">{statusesCount}</span>{' '}
               <span className="text-muted-foreground">Posts</span>
             </div>
-            <Link
-              href={`/@${person.preferredUsername}@${actorDomain}/following`}
-              prefetch={false}
-              className="hover:underline"
-            >
-              <span className="font-semibold">{followingCount}</span>{' '}
-              <span className="text-muted-foreground">Following</span>
-            </Link>
-            <Link
-              href={`/@${person.preferredUsername}@${actorDomain}/followers`}
-              prefetch={false}
-              className="hover:underline"
-            >
-              <span className="font-semibold">{followersCount}</span>{' '}
-              <span className="text-muted-foreground">Followers</span>
-            </Link>
+            {followingCount !== null && (
+              <Link
+                href={`/@${person.preferredUsername}@${actorDomain}/following`}
+                prefetch={false}
+                className="hover:underline"
+              >
+                <span className="font-semibold">{followingCount}</span>{' '}
+                <span className="text-muted-foreground">Following</span>
+              </Link>
+            )}
+            {followersCount !== null && (
+              <Link
+                href={`/@${person.preferredUsername}@${actorDomain}/followers`}
+                prefetch={false}
+                className="hover:underline"
+              >
+                <span className="font-semibold">{followersCount}</span>{' '}
+                <span className="text-muted-foreground">Followers</span>
+              </Link>
+            )}
           </div>
 
           <FeaturedTagsBlock tags={featuredTags} />

--- a/lib/activities/getActorCollectionCounts.test.ts
+++ b/lib/activities/getActorCollectionCounts.test.ts
@@ -89,4 +89,152 @@ describe('getActorCollectionCounts', () => {
       statusesCount: null
     })
   })
+
+  it('keeps followers and following null when Misskey actor sets them to private', async () => {
+    const misskeyActorId = 'https://misskey.test/users/7rkrarq81i'
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      const url = new URL(req.url)
+      if (url.pathname === '/users/7rkrarq81i') {
+        return {
+          status: 200,
+          body: JSON.stringify(MockActivityPubPerson({ id: misskeyActorId }))
+        }
+      }
+      if (url.pathname === '/.well-known/nodeinfo') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: 'https://misskey.test/nodeinfo/2.0'
+              }
+            ]
+          })
+        }
+      }
+      if (url.pathname === '/nodeinfo/2.0') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: { name: 'misskey', version: '2025.4.1' }
+          })
+        }
+      }
+      if (url.pathname === '/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: '7rkrarq81i',
+            followersCount: 0,
+            followingCount: 0,
+            notesCount: 500,
+            followersVisibility: 'private',
+            followingVisibility: 'private'
+          })
+        }
+      }
+      if (url.pathname === '/users/7rkrarq81i/outbox') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: req.url,
+            type: 'OrderedCollection',
+            totalItems: 500
+          })
+        }
+      }
+      if (
+        url.pathname === '/users/7rkrarq81i/followers' ||
+        url.pathname === '/users/7rkrarq81i/following'
+      ) {
+        return { status: 403, body: '' }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const person = (await getActorPerson({ actorId: misskeyActorId })) as Actor
+
+    await expect(getActorCollectionCounts({ person })).resolves.toEqual({
+      followersCount: null,
+      followingCount: null,
+      statusesCount: 500
+    })
+  })
+
+  it('populates public followersCount for Misskey actor when public in users/show', async () => {
+    const misskeyActorId = 'https://misskey.test/users/publicuser'
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      const url = new URL(req.url)
+      if (url.pathname === '/users/publicuser') {
+        return {
+          status: 200,
+          body: JSON.stringify(MockActivityPubPerson({ id: misskeyActorId }))
+        }
+      }
+      if (url.pathname === '/.well-known/nodeinfo') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: 'https://misskey.test/nodeinfo/2.0'
+              }
+            ]
+          })
+        }
+      }
+      if (url.pathname === '/nodeinfo/2.0') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: { name: 'misskey', version: '2025.4.1' }
+          })
+        }
+      }
+      if (url.pathname === '/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: 'publicuser',
+            followersCount: 888,
+            followingCount: 0,
+            notesCount: 100,
+            followersVisibility: 'public',
+            followingVisibility: 'private'
+          })
+        }
+      }
+      if (url.pathname === '/users/publicuser/outbox') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: req.url,
+            type: 'OrderedCollection',
+            totalItems: 100
+          })
+        }
+      }
+      if (
+        url.pathname === '/users/publicuser/followers' ||
+        url.pathname === '/users/publicuser/following'
+      ) {
+        return { status: 404, body: '' }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const person = (await getActorPerson({ actorId: misskeyActorId })) as Actor
+
+    await expect(getActorCollectionCounts({ person })).resolves.toEqual({
+      followersCount: 888,
+      followingCount: null,
+      statusesCount: 100
+    })
+  })
 })

--- a/lib/activities/getActorCollectionCounts.ts
+++ b/lib/activities/getActorCollectionCounts.ts
@@ -1,4 +1,6 @@
 import { fetchCollectionRoot } from '@/lib/activities/getActorCollections'
+import { getMisskeyCollectionCounts } from '@/lib/activities/getMisskeyCollectionCounts'
+import { isMisskeyActor } from '@/lib/services/federation/serverSoftware'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
@@ -58,10 +60,25 @@ export const getActorCollectionCounts = async ({
   person,
   signingActor
 }: Params): Promise<ActorCollectionCounts> => {
-  const [followersCount, followingCount, statusesCount] = await Promise.all([
+  let [followersCount, followingCount, statusesCount] = await Promise.all([
     getCollectionTotalItems(person, 'followers', signingActor),
     getCollectionTotalItems(person, 'following', signingActor),
     getCollectionTotalItems(person, 'outbox', signingActor)
   ])
+
+  if (followersCount === null || followingCount === null) {
+    if (await isMisskeyActor(person)) {
+      const misskeyCounts = await getMisskeyCollectionCounts({
+        person,
+        currentCounts: { followersCount, followingCount, statusesCount }
+      })
+      followersCount = misskeyCounts.followersCount
+      followingCount = misskeyCounts.followingCount
+      if (statusesCount === null) {
+        statusesCount = misskeyCounts.statusesCount
+      }
+    }
+  }
+
   return { followersCount, followingCount, statusesCount }
 }

--- a/lib/activities/getMisskeyCollectionCounts.test.ts
+++ b/lib/activities/getMisskeyCollectionCounts.test.ts
@@ -1,0 +1,195 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { Actor } from '@/lib/types/activitypub'
+
+import { getMisskeyCollectionCounts } from './getMisskeyCollectionCounts'
+
+enableFetchMocks()
+
+describe('getMisskeyCollectionCounts', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('keeps followersCount and followingCount null when visibility is private', async () => {
+    const person = MockActivityPubPerson({
+      id: 'https://misskey.example/users/7rkrarq81i'
+    }) as Actor
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://misskey.example/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: '7rkrarq81i',
+            username: person.preferredUsername,
+            followersCount: 0,
+            followingCount: 0,
+            notesCount: 1500,
+            followersVisibility: 'private',
+            followingVisibility: 'private'
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const result = await getMisskeyCollectionCounts({
+      person,
+      currentCounts: {
+        followersCount: null,
+        followingCount: null,
+        statusesCount: 1500
+      }
+    })
+
+    expect(result).toEqual({
+      followersCount: null,
+      followingCount: null,
+      statusesCount: 1500
+    })
+  })
+
+  it('populates public followersCount while keeping followingCount null when following is private', async () => {
+    const person = MockActivityPubPerson({
+      id: 'https://misskey.example/users/7rkrarq81i'
+    }) as Actor
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://misskey.example/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: '7rkrarq81i',
+            username: person.preferredUsername,
+            followersCount: 250,
+            followingCount: 0,
+            notesCount: 50,
+            followersVisibility: 'public',
+            followingVisibility: 'private'
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const result = await getMisskeyCollectionCounts({
+      person,
+      currentCounts: {
+        followersCount: null,
+        followingCount: null,
+        statusesCount: 50
+      }
+    })
+
+    expect(result).toEqual({
+      followersCount: 250,
+      followingCount: null,
+      statusesCount: 50
+    })
+  })
+
+  it('populates public followingCount while keeping followersCount null when followers is private', async () => {
+    const person = MockActivityPubPerson({
+      id: 'https://misskey.example/users/7rkrarq81i'
+    }) as Actor
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://misskey.example/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: '7rkrarq81i',
+            username: person.preferredUsername,
+            followersCount: 0,
+            followingCount: 120,
+            notesCount: 80,
+            followersVisibility: 'private',
+            followingVisibility: 'public'
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const result = await getMisskeyCollectionCounts({
+      person,
+      currentCounts: {
+        followersCount: null,
+        followingCount: null,
+        statusesCount: 80
+      }
+    })
+
+    expect(result).toEqual({
+      followersCount: null,
+      followingCount: 120,
+      statusesCount: 80
+    })
+  })
+
+  it('populates both followers and following counts when both are public', async () => {
+    const person = MockActivityPubPerson({
+      id: 'https://misskey.example/users/7rkrarq81i'
+    }) as Actor
+
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://misskey.example/api/users/show') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: '7rkrarq81i',
+            username: person.preferredUsername,
+            followersCount: 1000,
+            followingCount: 200,
+            notesCount: 500,
+            followersVisibility: 'public',
+            followingVisibility: 'public'
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const result = await getMisskeyCollectionCounts({
+      person,
+      currentCounts: {
+        followersCount: null,
+        followingCount: null,
+        statusesCount: null
+      }
+    })
+
+    expect(result).toEqual({
+      followersCount: 1000,
+      followingCount: 200,
+      statusesCount: 500
+    })
+  })
+
+  it('returns current counts when request fails', async () => {
+    const person = MockActivityPubPerson({
+      id: 'https://misskey.example/users/7rkrarq81i'
+    }) as Actor
+
+    fetchMock.mockResponse(async () => {
+      return { status: 500, body: 'Server Error' }
+    })
+
+    const result = await getMisskeyCollectionCounts({
+      person,
+      currentCounts: {
+        followersCount: null,
+        followingCount: 42,
+        statusesCount: 10
+      }
+    })
+
+    expect(result).toEqual({
+      followersCount: null,
+      followingCount: 42,
+      statusesCount: 10
+    })
+  })
+})

--- a/lib/activities/getMisskeyCollectionCounts.ts
+++ b/lib/activities/getMisskeyCollectionCounts.ts
@@ -1,0 +1,93 @@
+import { ActorCollectionCounts } from '@/lib/activities/getActorCollectionCounts'
+import { Actor } from '@/lib/types/activitypub'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
+
+interface MisskeyUserShowResponse {
+  id?: string
+  followersCount?: number
+  followingCount?: number
+  notesCount?: number
+  followersVisibility?: string
+  followingVisibility?: string
+}
+
+interface Params {
+  person: Actor
+  currentCounts: ActorCollectionCounts
+}
+
+export const getMisskeyCollectionCounts = async ({
+  person,
+  currentCounts
+}: Params): Promise<ActorCollectionCounts> => {
+  let followersCount = currentCounts.followersCount
+  let followingCount = currentCounts.followingCount
+  let statusesCount = currentCounts.statusesCount
+
+  try {
+    const actorUrl = new URL(person.id)
+    const match = actorUrl.pathname.match(/^\/users\/([^/]+)/)
+    const userId = match ? match[1] : undefined
+
+    const bodyPayload = userId
+      ? { userId }
+      : { username: person.preferredUsername }
+
+    const response = await request({
+      url: `https://${actorUrl.host}/api/users/show`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, */*;q=0.8'
+      },
+      body: JSON.stringify(bodyPayload)
+    })
+
+    if (response.statusCode !== 200 || !response.body) {
+      return { followersCount, followingCount, statusesCount }
+    }
+
+    const data = JSON.parse(response.body) as MisskeyUserShowResponse
+
+    if (data.followersVisibility === 'private') {
+      followersCount = null
+    } else if (
+      followersCount === null &&
+      typeof data.followersCount === 'number' &&
+      Number.isFinite(data.followersCount) &&
+      data.followersCount >= 0
+    ) {
+      followersCount = Math.floor(data.followersCount)
+    }
+
+    if (data.followingVisibility === 'private') {
+      followingCount = null
+    } else if (
+      followingCount === null &&
+      typeof data.followingCount === 'number' &&
+      Number.isFinite(data.followingCount) &&
+      data.followingCount >= 0
+    ) {
+      followingCount = Math.floor(data.followingCount)
+    }
+
+    if (
+      statusesCount === null &&
+      typeof data.notesCount === 'number' &&
+      Number.isFinite(data.notesCount) &&
+      data.notesCount >= 0
+    ) {
+      statusesCount = Math.floor(data.notesCount)
+    }
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to fetch Misskey user collection counts',
+      actorId: person.id,
+      err: toLoggableError(error)
+    })
+  }
+
+  return { followersCount, followingCount, statusesCount }
+}

--- a/lib/components/profile/profile.test.tsx
+++ b/lib/components/profile/profile.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { Profile } from './profile'
+
+describe('Profile component', () => {
+  it('renders all counts when provided as numbers', () => {
+    render(
+      <Profile
+        name="Test User"
+        username="test"
+        domain="example.com"
+        url="https://example.com/@test"
+        totalPosts={10}
+        followingCount={20}
+        followersCount={30}
+        createdAt={1700000000000}
+      />
+    )
+
+    expect(screen.getByText('10 Posts')).toBeInTheDocument()
+    expect(screen.getByText('20 Following')).toBeInTheDocument()
+    expect(screen.getByText('30 Followers')).toBeInTheDocument()
+  })
+
+  it('omits Following when followingCount is null', () => {
+    render(
+      <Profile
+        name="Test User"
+        username="test"
+        domain="example.com"
+        url="https://example.com/@test"
+        totalPosts={10}
+        followingCount={null}
+        followersCount={30}
+        createdAt={1700000000000}
+      />
+    )
+
+    expect(screen.getByText('10 Posts')).toBeInTheDocument()
+    expect(screen.queryByText(/Following/)).not.toBeInTheDocument()
+    expect(screen.getByText('30 Followers')).toBeInTheDocument()
+  })
+
+  it('omits Followers when followersCount is null', () => {
+    render(
+      <Profile
+        name="Test User"
+        username="test"
+        domain="example.com"
+        url="https://example.com/@test"
+        totalPosts={10}
+        followingCount={20}
+        followersCount={null}
+        createdAt={1700000000000}
+      />
+    )
+
+    expect(screen.getByText('10 Posts')).toBeInTheDocument()
+    expect(screen.getByText('20 Following')).toBeInTheDocument()
+    expect(screen.queryByText(/Followers/)).not.toBeInTheDocument()
+  })
+
+  it('omits both when both are null', () => {
+    render(
+      <Profile
+        name="Test User"
+        username="test"
+        domain="example.com"
+        url="https://example.com/@test"
+        totalPosts={10}
+        followingCount={null}
+        followersCount={null}
+        createdAt={1700000000000}
+      />
+    )
+
+    expect(screen.getByText('10 Posts')).toBeInTheDocument()
+    expect(screen.queryByText(/Following/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Followers/)).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/profile/profile.tsx
+++ b/lib/components/profile/profile.tsx
@@ -11,8 +11,8 @@ interface Props {
   domain: string
   url: string
   totalPosts?: number
-  followingCount?: number
-  followersCount?: number
+  followingCount?: number | null
+  followersCount?: number | null
   createdAt: number
 }
 
@@ -33,17 +33,25 @@ export const Profile: FC<Props> = ({
         @{username}
       </Link>
     </h4>
-    {totalPosts || followingCount || followersCount ? (
+    {typeof totalPosts === 'number' ||
+    typeof followingCount === 'number' ||
+    typeof followersCount === 'number' ? (
       <p>
-        <span className="inline-block whitespace-nowrap">
-          {totalPosts} Posts
-        </span>
-        <span className="inline-block ml-2 whitespace-nowrap">
-          {followingCount} Following
-        </span>
-        <span className="inline-block ml-2 whitespace-nowrap">
-          {followersCount} Followers
-        </span>
+        {typeof totalPosts === 'number' && (
+          <span className="inline-block whitespace-nowrap">
+            {totalPosts} Posts
+          </span>
+        )}
+        {typeof followingCount === 'number' && (
+          <span className="inline-block ml-2 whitespace-nowrap">
+            {followingCount} Following
+          </span>
+        )}
+        {typeof followersCount === 'number' && (
+          <span className="inline-block ml-2 whitespace-nowrap">
+            {followersCount} Followers
+          </span>
+        )}
       </p>
     ) : null}
     {Number.isInteger(createdAt) ? (

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -10,6 +10,8 @@ import {
   clearServerSoftwareCache,
   getServerSoftware,
   getServerSoftwareCacheSizeForTests,
+  isMisskeyActor,
+  isMisskeyDomain,
   isPixelfedActor,
   isPixelfedDomain
 } from './serverSoftware'
@@ -273,5 +275,108 @@ describe('serverSoftware', () => {
     }
 
     expect(getServerSoftwareCacheSizeForTests()).toBe(MAX_CACHED_DOMAINS)
+  })
+
+  it('detects Misskey and fork instances via NodeInfo', async () => {
+    const domain = 'misskey.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${domain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${domain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'Misskey',
+              version: '2025.4.1'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isMisskeyDomain(domain)).toBe(true)
+    const person = MockActivityPubPerson({
+      id: `https://${domain}/users/7rkrarq81i`
+    }) as Actor
+    expect(await isMisskeyActor(person)).toBe(true)
+  })
+
+  it('detects Sharkey and Firefish as Misskey family', async () => {
+    const sharkeyDomain = 'sharkey.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${sharkeyDomain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${sharkeyDomain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${sharkeyDomain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'sharkey',
+              version: '2024.1.0'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isMisskeyDomain(sharkeyDomain)).toBe(true)
+  })
+
+  it('returns false for non-Misskey software in isMisskeyDomain', async () => {
+    const mastodonDomain = 'mastodon.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${mastodonDomain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${mastodonDomain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${mastodonDomain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'mastodon',
+              version: '4.3.0'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isMisskeyDomain(mastodonDomain)).toBe(false)
   })
 })

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -162,3 +162,25 @@ export const isPixelfedActor = async (person: Actor): Promise<boolean> => {
     return false
   }
 }
+
+const MISSKEY_FAMILY_SOFTWARE = new Set([
+  'misskey',
+  'sharkey',
+  'firefish',
+  'iceshrimp',
+  'calckey'
+])
+
+export const isMisskeyDomain = async (domain: string): Promise<boolean> => {
+  const software = await getServerSoftware(domain)
+  return software ? MISSKEY_FAMILY_SOFTWARE.has(software) : false
+}
+
+export const isMisskeyActor = async (person: Actor): Promise<boolean> => {
+  try {
+    const actorUrl = new URL(person.id)
+    return isMisskeyDomain(actorUrl.host)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Fixes an issue where remote actors with private or inaccessible follower/following collections (such as Misskey users who set `followersVisibility: "private"` or `followingVisibility: "private"`) were displayed with misleading `0 Following` and `0 Followers` counts on their profile header.

### Key Changes:
1. **Misskey Family Detection (`lib/services/federation/serverSoftware.ts`)**:
   - Added detection for Misskey and fork families (`misskey`, `sharkey`, `firefish`, `iceshrimp`, `calckey`) via NodeInfo probing (`isMisskeyDomain`, `isMisskeyActor`).
2. **Misskey Visibility & Count Resolution (`lib/activities/getMisskeyCollectionCounts.ts`)**:
   - For Misskey actors whose collections 403 or fail to return counts, queries `/api/users/show` to evaluate `followersVisibility` and `followingVisibility` independently.
   - If visibility is `'private'`, the count remains `null` (hidden).
   - If visibility is public, the public count from the Misskey API is used.
3. **Independent UI Hiding (`app/(timeline)/[actor]/getProfileData.ts`, `page.tsx`)**:
   - Updated `ProfileData` to permit `null` for `followingCount` and `followersCount`.
   - Prevented coercing `null` to `0` in `getProfileData`.
   - On the profile page, `Following` and `Followers` links/counts are evaluated independently: if either is `null`, only that metric is hidden. If both are `null`, both are hidden and only post count is displayed.
   - Updated `followers/page.tsx`, `following/page.tsx`, and `lib/components/profile/profile.tsx` to handle `null` counts gracefully.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
