### PR TITLE
Bump version to v1.156.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.156.1",
+  "version": "1.156.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.156.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.156.1`
- Base main SHA: `23a19d76bd1c08f92bc1d1e9fbf928c7f1e62963`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
