### PR TITLE
feat: add link to handle in profile header

### DIFF
--- a/app/(timeline)/[actor]/page.test.tsx
+++ b/app/(timeline)/[actor]/page.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { Actor } from '@/lib/types/activitypub'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { getProfileData } from './getProfileData'
+import Page from './page'
+
+const mockDatabase = {
+  getFeaturedTags: vi.fn().mockResolvedValue([]),
+  getActorSettings: vi.fn().mockResolvedValue(undefined)
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  }),
+  getBaseURL: () => 'https://llun.social'
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('./getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('./ActorTimelines', () => ({
+  ActorTimelines: () => <div data-testid="actor-timelines" />
+}))
+
+vi.mock('./ProfileHeaderImage', () => ({
+  ProfileHeaderImage: () => <div data-testid="header-image" />
+}))
+
+vi.mock('./ProfileRelationshipActions', () => ({
+  ProfileRelationshipActions: () => <div data-testid="relationship-actions" />
+}))
+
+vi.mock('@/lib/services/mastodon/getMastodonFeaturedTag', () => ({
+  getMastodonFeaturedTag: vi.fn()
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+
+describe('[actor] page header handle link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { email: 'viewer@llun.social' }
+    } as never)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+  })
+
+  it('renders handle as a link opening in a new tab for a remote user with string url', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://pouet.chapril.org/users/clairenony',
+        type: 'Person',
+        preferredUsername: 'clairenony',
+        name: 'Claire Nony',
+        summary: 'Hello world',
+        url: 'https://pouet.chapril.org/@clairenony'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 5,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 10,
+      followersCount: 20,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' })
+    })
+    render(element)
+
+    const link = screen.getByRole('link', { name: '@clairenony' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute(
+      'href',
+      'https://pouet.chapril.org/@clairenony'
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link).toHaveAttribute('title', 'Open profile page')
+  })
+
+  it('renders handle link for remote user with object url', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://mastodon.social/users/bob',
+        type: 'Person',
+        preferredUsername: 'bob',
+        name: 'Bob',
+        summary: '',
+        url: { type: 'Link', href: 'https://mastodon.social/@bob' }
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 1,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 2,
+      followersCount: 3,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@bob@mastodon.social' })
+    })
+    render(element)
+
+    const link = screen.getByRole('link', { name: '@bob' })
+    expect(link).toHaveAttribute('href', 'https://mastodon.social/@bob')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('falls back to person.id when person.url is missing', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://remote.example/users/alice',
+        type: 'Person',
+        preferredUsername: 'alice',
+        name: 'Alice',
+        summary: ''
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 0,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 0,
+      followersCount: 0,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@alice@remote.example' })
+    })
+    render(element)
+
+    const link = screen.getByRole('link', { name: '@alice' })
+    expect(link).toHaveAttribute('href', 'https://remote.example/users/alice')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders handle as a link opening in a new tab for a local user', async () => {
+    mockIsLocalFederationDomain.mockResolvedValue(true)
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/localuser',
+        type: 'Person',
+        preferredUsername: 'localuser',
+        name: 'Local User',
+        summary: 'Local bio',
+        url: 'https://llun.social/@localuser'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 12,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 3,
+      followersCount: 4,
+      isInternalAccount: true,
+      hasFitnessData: false,
+      isPixelfed: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@localuser@llun.social' })
+    })
+    render(element)
+
+    const link = screen.getByRole('link', { name: '@localuser' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://llun.social/@localuser')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -1,9 +1,11 @@
+import { ExternalLink } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
 import { getActorEmojiTags } from '@/lib/actions/utils'
+import { getUrl } from '@/lib/activities/note'
 import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Bio } from '@/lib/components/bio/Bio'
 import { FeaturedTagsBlock } from '@/lib/components/profile/FeaturedTagsBlock'
@@ -196,6 +198,11 @@ const Page: FC<Props> = async ({ params }) => {
   const headerImageUrl = headerImage?.url ?? null
   const headerImageMediaType = headerImage?.mediaType ?? null
   const iconImageUrl = getIconImage()
+  const rawUrl = person.url ? getUrl(person.url) : null
+  const profileUrl =
+    (rawUrl && /^https?:\/\//i.test(rawUrl) ? rawUrl : null) ||
+    (/^https?:\/\//i.test(person.id) ? person.id : null) ||
+    `https://${actorDomain}/@${actorUsername}`
 
   return (
     <div className={cn('space-y-6', isLoggedIn && 'pt-6 sm:pt-8')}>
@@ -221,7 +228,16 @@ const Page: FC<Props> = async ({ params }) => {
                 />
               </h1>
               <p className="truncate text-muted-foreground">
-                @{person.preferredUsername}
+                <a
+                  href={profileUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:underline hover:text-foreground"
+                  title="Open profile page"
+                >
+                  <span>@{person.preferredUsername}</span>
+                  <ExternalLink className="size-3.5" />
+                </a>
               </p>
             </div>
             {isCurrentUser ? (


### PR DESCRIPTION
## Summary

Links the handle (`@{person.preferredUsername}`) in the profile header card to the user's profile page for all users (both local and remote), opening in a new page/tab (`target="_blank"`, `rel="noopener noreferrer"`) with an `ExternalLink` icon.

### Key Changes
- In `app/(timeline)/[actor]/page.tsx`:
  - Resolved `profileUrl` using `getUrl(person.url)` (from `@/lib/activities/note`), falling back to `person.id` and `https://${actorDomain}/@${actorUsername}`.
  - Wrapped `@{person.preferredUsername}` in an anchor linking to `profileUrl` with `target="_blank"`, `rel="noopener noreferrer"`, `title="Open profile page"`, and an `ExternalLink` icon.
- Added unit tests in `app/(timeline)/[actor]/page.test.tsx` covering local and remote user handle links, string vs object `person.url`, and fallback to `person.id`.

## Verification

### Automated Tests
- `yarn run prettier --write .` (passed)
- `yarn lint` (passed with 0 errors)
- `yarn typecheck` (passed with 0 errors)
- `yarn build` (passed with 0 errors)
- `yarn test` (all 942 test files passed, 12,679 tests)

### Local Manual / Browser Testing
- Verified locally in a headless browser with Playwright against a local SQLite instance with mock users.
- Confirmed that clicking/hovering the handle opens the target profile URL in a new tab with proper security attributes (`rel="noopener noreferrer"`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: No doc updates required
- [x] If migrations changed: No migrations added/changed
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description
