### PR TITLE
minor: add support for custom emoji in user display names

### DIFF
--- a/app/(nosidebar)/auth/select-actor/ActorSelectionList.tsx
+++ b/app/(nosidebar)/auth/select-actor/ActorSelectionList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import { switchActor } from '@/lib/client'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 
 interface ActorInfo {
@@ -12,6 +13,7 @@ interface ActorInfo {
   domain: string
   name?: string | null
   iconUrl?: string | null
+  tags?: { type: string; name: string; value: string }[] | null
 }
 
 interface ActorSelectionListProps {
@@ -61,7 +63,10 @@ export function ActorSelectionList({ actors }: ActorSelectionListProps) {
           </Avatar>
           <div className="flex-1 overflow-hidden text-left">
             <p className="text-base font-medium truncate">
-              {actor.name || actor.username}
+              <ActorDisplayName
+                name={actor.name || actor.username}
+                tags={actor.tags}
+              />
             </p>
             <p className="text-sm text-muted-foreground truncate">
               {getHandle(actor)}

--- a/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
+++ b/app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { FC } from 'react'
 
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
@@ -14,8 +15,9 @@ import {
 } from '@/lib/components/ui/card'
 import { ActorProfile } from '@/lib/types/domain/actor'
 
-const getInitials = (name: string, fallback: string) =>
-  (name || fallback)
+const getInitials = (name: string, fallback: string) => {
+  const cleanName = name.replaceAll(/:[^\s:]{1,64}:/g, '').trim()
+  return (cleanName || fallback)
     .trim()
     .split(/\s+/)
     .map((part) => Array.from(part)[0])
@@ -23,11 +25,12 @@ const getInitials = (name: string, fallback: string) =>
     .slice(0, 2)
     .join('')
     .toUpperCase()
+}
 
 interface AuthorizeInteractionCardProps {
   actor: Pick<
     ActorProfile,
-    'id' | 'username' | 'domain' | 'name' | 'iconUrl' | 'type'
+    'id' | 'username' | 'domain' | 'name' | 'iconUrl' | 'type' | 'tags'
   >
   isSelf: boolean
 }
@@ -63,7 +66,9 @@ export const AuthorizeInteractionCard: FC<AuthorizeInteractionCardProps> = ({
         </Avatar>
         <div className="text-center">
           {actor.name ? (
-            <p className="text-lg font-semibold">{actor.name}</p>
+            <p className="text-lg font-semibold">
+              <ActorDisplayName name={actor.name} tags={actor.tags} />
+            </p>
           ) : null}
           <p className="text-muted-foreground">{handle}</p>
         </div>

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { FC, useState } from 'react'
 
 import { switchActor } from '@/lib/client'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import {
@@ -313,7 +314,10 @@ export const AuthorizeCard: FC<Props> = ({
                     </Avatar>
                     <div className="flex-1 overflow-hidden">
                       <p className="text-sm font-medium truncate">
-                        {selectedActor?.name || selectedActor?.username}
+                        <ActorDisplayName
+                          name={selectedActor?.name || selectedActor?.username}
+                          tags={selectedActor?.tags}
+                        />
                       </p>
                       <p className="text-xs text-muted-foreground truncate">
                         {selectedActor && getHandle(selectedActor)}
@@ -338,7 +342,10 @@ export const AuthorizeCard: FC<Props> = ({
                       </Avatar>
                       <div className="flex-1 overflow-hidden">
                         <p className="text-sm font-medium truncate">
-                          {actor.name || actor.username}
+                          <ActorDisplayName
+                            name={actor.name || actor.username}
+                            tags={actor.tags}
+                          />
                         </p>
                         <p className="text-xs text-muted-foreground truncate">
                           {getHandle(actor)}

--- a/app/(timeline)/[actor]/FollowList.tsx
+++ b/app/(timeline)/[actor]/FollowList.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -38,9 +39,11 @@ export const FollowList: FC<Props> = ({
     <div className="divide-y">
       {users.map((user) => {
         const displayName = user.name || user.username
-        const initials = displayName
-          .split(' ')
+        const cleanName = displayName.replaceAll(/:[^\s:]{1,64}:/g, '').trim()
+        const initials = (cleanName || displayName)
+          .split(/\s+/)
           .map((n) => n[0])
+          .filter(Boolean)
           .join('')
           .toUpperCase()
         const summary = htmlToPlainText(user.summary)
@@ -60,7 +63,7 @@ export const FollowList: FC<Props> = ({
                 prefetch={false}
                 className="block truncate font-semibold hover:underline"
               >
-                {displayName}
+                <ActorDisplayName name={displayName} tags={user.tags} />
               </Link>
               <div className="truncate text-sm text-muted-foreground">
                 @{user.username}@{user.domain}

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
+import { getActorEmojiTags } from '@/lib/actions/utils'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Bio } from '@/lib/components/bio/Bio'
 import { FeaturedTagsBlock } from '@/lib/components/profile/FeaturedTagsBlock'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
@@ -27,8 +29,9 @@ interface Props {
   params: Promise<{ actor: string }>
 }
 
-const getInitials = (name: string, fallback: string) =>
-  (name || fallback)
+const getInitials = (name: string, fallback: string) => {
+  const cleanName = name.replaceAll(/:[^\s:]{1,64}:/g, '').trim()
+  return (cleanName || fallback)
     .trim()
     .split(/\s+/)
     .map((part) => Array.from(part)[0])
@@ -36,6 +39,7 @@ const getInitials = (name: string, fallback: string) =>
     .slice(0, 2)
     .join('')
     .toUpperCase()
+}
 
 export const generateMetadata = async ({
   params
@@ -211,7 +215,10 @@ const Page: FC<Props> = async ({ params }) => {
           <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
             <div className="min-w-0">
               <h1 className="text-2xl font-semibold break-words">
-                {person.name}
+                <ActorDisplayName
+                  name={person.name}
+                  tags={getActorEmojiTags(person)}
+                />
               </h1>
               <p className="truncate text-muted-foreground">
                 @{person.preferredUsername}

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -10,6 +10,7 @@ import {
   type NotificationWithAccount,
   hasStatusActor
 } from '@/app/(timeline)/notifications/types'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
 import type { Mastodon } from '@/lib/types/activitypub'
 import type { Status } from '@/lib/types/domain/status'
@@ -133,7 +134,10 @@ export const NotificationItem = ({
             prefetch={false}
             className="font-semibold text-foreground hover:underline"
           >
-            {getGroupedName(name, notification.groupedCount)}
+            <ActorDisplayName
+              name={getGroupedName(name, notification.groupedCount)}
+              emojis={acc.emojis}
+            />
           </Link>{' '}
           {cfg.verb}
         </span>

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Account blocks** — Block or unblock remote accounts and list blocked accounts
 - ✅ **Domain blocks** — Block or unblock an entire remote domain and list your blocked domains via `/api/v1/domain_blocks`; blocking hides that domain's posts (and boosts) from your timelines, is reflected in `domain_blocking` on relationships, and severs follows in both directions
 - ✅ **Follow requests** — Review, authorize, and reject follow requests
-- ✅ **Custom emoji** — Instance-defined custom emoji with a sticker/emoji picker in the post box
+- ✅ **Custom emoji** — Instance-defined custom emoji with a sticker/emoji picker in the post box, and custom emoji shortcode (`:shortcode:`) support in user display names across the web UI, Mastodon API, and ActivityPub federation
 - ✅ **Featured hashtags** — Feature hashtags on your profile and manage them from settings
 - ✅ **Status translation** — Translate posts into your language via DeepL, LibreTranslate, or an OpenAI-compatible backend
 - ✅ **Public & logged-out pages** — Logged-out landing page plus publicly viewable profile and status pages, with design-system error pages (404/500)

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -3,7 +3,11 @@ import knex from 'knex'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 
-import { BlockedFederationDomainError, recordActorIfNeeded } from './utils'
+import {
+  BlockedFederationDomainError,
+  getPersistableProfile,
+  recordActorIfNeeded
+} from './utils'
 
 const mockGetActorPerson = vi.fn()
 const mockGetActorCollectionCounts = vi.fn()
@@ -305,5 +309,76 @@ describe('recordActorIfNeeded', () => {
     } finally {
       await database.destroy()
     }
+  })
+
+  describe('getPersistableProfile', () => {
+    it('extracts custom emoji tags from person.tag', () => {
+      const person = {
+        id: 'https://remote.test/users/alice',
+        type: 'Person' as const,
+        preferredUsername: 'alice',
+        name: 'Alice :blobcat:',
+        inbox: 'https://remote.test/users/alice/inbox',
+        publicKey: {
+          id: 'https://remote.test/users/alice#main-key',
+          owner: 'https://remote.test/users/alice',
+          publicKeyPem: 'KEY'
+        },
+        tag: [
+          {
+            type: 'Emoji' as const,
+            name: ':blobcat:',
+            icon: {
+              type: 'Image' as const,
+              url: 'https://remote.test/emojis/blobcat.png'
+            },
+            updated: '2023-01-01T00:00:00Z'
+          }
+        ]
+      }
+      const profile = getPersistableProfile(person as never)
+      expect(profile.tags).toEqual([
+        {
+          type: 'emoji',
+          name: ':blobcat:',
+          value: 'https://remote.test/emojis/blobcat.png'
+        }
+      ])
+    })
+
+    it('handles single object person.tag or absent tag', () => {
+      const personWithSingleTag = {
+        id: 'https://remote.test/users/alice',
+        type: 'Person' as const,
+        preferredUsername: 'alice',
+        inbox: 'https://remote.test/users/alice/inbox',
+        tag: {
+          type: 'Emoji' as const,
+          name: ':blobcat:',
+          icon: {
+            type: 'Image' as const,
+            url: 'https://remote.test/emojis/blobcat.png'
+          },
+          updated: '2023-01-01T00:00:00Z'
+        }
+      }
+      expect(getPersistableProfile(personWithSingleTag as never).tags).toEqual([
+        {
+          type: 'emoji',
+          name: ':blobcat:',
+          value: 'https://remote.test/emojis/blobcat.png'
+        }
+      ])
+
+      const personWithoutTag = {
+        id: 'https://remote.test/users/bob',
+        type: 'Person' as const,
+        preferredUsername: 'bob',
+        inbox: 'https://remote.test/users/bob/inbox'
+      }
+      expect(
+        getPersistableProfile(personWithoutTag as never).tags
+      ).toBeUndefined()
+    })
   })
 })

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -62,6 +62,37 @@ const syncActorCollectionCounts = async (
   }
 }
 
+export const getActorEmojiTags = (
+  person: ActivityPubActor
+): { type: 'emoji'; name: string; value: string }[] => {
+  if (!person.tag) return []
+  const rawTags = Array.isArray(person.tag) ? person.tag : [person.tag]
+  return rawTags.flatMap((tag) => {
+    if (
+      typeof tag === 'object' &&
+      tag !== null &&
+      'type' in tag &&
+      tag.type === 'Emoji' &&
+      'name' in tag &&
+      typeof tag.name === 'string' &&
+      'icon' in tag &&
+      typeof tag.icon === 'object' &&
+      tag.icon !== null &&
+      'url' in tag.icon &&
+      typeof tag.icon.url === 'string'
+    ) {
+      return [
+        {
+          type: 'emoji' as const,
+          name: tag.name,
+          value: tag.icon.url
+        }
+      ]
+    }
+    return []
+  })
+}
+
 // The remote profile data persisted whenever a remote actor is recorded or
 // refreshed (recordActorIfNeeded here, plus the web profile page), so
 // Mastodon clients see the actor's real display name, bio, images, metadata
@@ -69,6 +100,7 @@ const syncActorCollectionCounts = async (
 export const getPersistableProfile = (person: ActivityPubActor) => {
   const iconUrl = getActorImageUrl(person.icon)
   const headerImageUrl = getActorImageUrl(person.image)
+  const tags = getActorEmojiTags(person)
   return {
     type: person.type,
     ...(person.name ? { name: person.name } : {}),
@@ -81,7 +113,8 @@ export const getPersistableProfile = (person: ActivityPubActor) => {
     followersUrl: person.followers ?? '',
     inboxUrl: person.inbox,
     sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-    publicKey: person.publicKey?.publicKeyPem || ''
+    publicKey: person.publicKey?.publicKeyPem || '',
+    ...(tags.length > 0 ? { tags } : {})
   }
 }
 

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import { switchActor } from '@/lib/client'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import {
   DropdownMenu,
@@ -23,6 +24,7 @@ export interface ActorInfo {
   domain: string
   name?: string | null
   iconUrl?: string | null
+  tags?: { type: string; name: string; value: string }[] | null
   deletionStatus?: string | null
   deletionScheduledAt?: number | null
 }
@@ -106,7 +108,9 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
 
   const identity = (
     <div className="flex-1 overflow-hidden">
-      <p className="text-sm font-medium truncate">{displayName}</p>
+      <p className="text-sm font-medium truncate">
+        <ActorDisplayName name={displayName} tags={currentActor.tags} />
+      </p>
       <p className="text-xs text-muted-foreground truncate">
         {getHandle(currentActor)}
       </p>
@@ -183,7 +187,10 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
                   className={`flex-1 overflow-hidden ${reducedOpacity ? 'opacity-60' : ''}`}
                 >
                   <p className="text-sm font-medium truncate">
-                    {actor.name || actor.username}
+                    <ActorDisplayName
+                      name={actor.name || actor.username}
+                      tags={actor.tags}
+                    />
                   </p>
                   <p className="text-xs text-muted-foreground truncate">
                     {isPendingDeletion ? (

--- a/lib/components/actors/ActorDisplayName.test.tsx
+++ b/lib/components/actors/ActorDisplayName.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+
+import { ActorDisplayName } from './ActorDisplayName'
+
+describe('ActorDisplayName', () => {
+  it('renders null when name is not provided', () => {
+    const { container } = render(<ActorDisplayName name={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders plain text when no tags or emojis are provided', () => {
+    render(<ActorDisplayName name="Alice" />)
+    expect(screen.getByText('Alice')).toBeDefined()
+  })
+
+  it('renders plain text when tags do not match any shortcode in name', () => {
+    render(
+      <ActorDisplayName
+        name="Alice"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      />
+    )
+    expect(screen.getByText('Alice')).toBeDefined()
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('renders custom emoji image when tag matches shortcode in name', () => {
+    render(
+      <ActorDisplayName
+        name="Alice :blobcat:"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      />
+    )
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeDefined()
+    expect(img.getAttribute('src')).toBe('https://example.com/blobcat.png')
+    expect(img.getAttribute('title')).toBe(':blobcat:')
+    expect(screen.getByText(/Alice/)).toBeDefined()
+  })
+
+  it('supports emojis prop from Mastodon accounts', () => {
+    render(
+      <ActorDisplayName
+        name=":partyblob: Bob"
+        emojis={[
+          {
+            shortcode: 'partyblob',
+            url: 'https://example.com/partyblob.png'
+          }
+        ]}
+      />
+    )
+    const img = screen.getByRole('img', { name: ':partyblob:' })
+    expect(img).toBeDefined()
+    expect(img.getAttribute('src')).toBe('https://example.com/partyblob.png')
+    expect(screen.getByText(/Bob/)).toBeDefined()
+  })
+
+  it('renders multiple custom emojis in name while leaving unknown shortcodes as text', () => {
+    render(
+      <ActorDisplayName
+        name=":blobcat: Alice and :partyblob: Bob :unknown:"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          },
+          {
+            type: 'emoji',
+            name: ':partyblob:',
+            value: 'https://example.com/partyblob.png'
+          }
+        ]}
+      />
+    )
+    const imgs = screen.getAllByRole('img')
+    expect(imgs).toHaveLength(2)
+    expect(imgs[0].getAttribute('src')).toBe('https://example.com/blobcat.png')
+    expect(imgs[1].getAttribute('src')).toBe(
+      'https://example.com/partyblob.png'
+    )
+    expect(screen.getByText(/:unknown:/)).toBeDefined()
+  })
+
+  it('applies custom className when provided', () => {
+    const { container } = render(
+      <ActorDisplayName
+        name="Alice :blobcat:"
+        className="custom-title-class"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      />
+    )
+    expect(container.querySelector('.custom-title-class')).not.toBeNull()
+  })
+})

--- a/lib/components/actors/ActorDisplayName.tsx
+++ b/lib/components/actors/ActorDisplayName.tsx
@@ -1,0 +1,94 @@
+import { FC, ReactNode } from 'react'
+
+import { ActorEmojiTag } from '@/lib/types/domain/actor'
+import { Tag } from '@/lib/types/domain/tag'
+import { cn } from '@/lib/utils'
+import { toEmojiShortcodeToken } from '@/lib/utils/text/getEmojiTags'
+
+const SHORTCODE_CAPTURE_REGEX = /(:[^\s:]{1,64}:)/g
+
+export interface MastodonAccountCustomEmoji {
+  shortcode: string
+  url: string
+  static_url?: string
+}
+
+export interface ActorDisplayNameProps {
+  name?: string | null
+  tags?:
+    | (
+        | Pick<Tag, 'type' | 'name' | 'value'>
+        | ActorEmojiTag
+        | { type: string; name: string; value: string }
+      )[]
+    | null
+  emojis?: MastodonAccountCustomEmoji[] | null
+  className?: string
+  emojiClassName?: string
+}
+
+export const ActorDisplayName: FC<ActorDisplayNameProps> = ({
+  name,
+  tags,
+  emojis,
+  className,
+  emojiClassName
+}) => {
+  if (!name) return null
+
+  const urlByShortcode = new Map<string, string>()
+
+  for (const tag of tags ?? []) {
+    if (tag.type !== 'emoji') continue
+    const token = toEmojiShortcodeToken(tag.name)
+    if (!token) continue
+    if (!urlByShortcode.has(token)) {
+      urlByShortcode.set(token, tag.value)
+    }
+  }
+
+  for (const emoji of emojis ?? []) {
+    const token = toEmojiShortcodeToken(emoji.shortcode)
+    if (!token) continue
+    if (!urlByShortcode.has(token)) {
+      urlByShortcode.set(token, emoji.url)
+    }
+  }
+
+  if (urlByShortcode.size === 0) {
+    return className ? <span className={className}>{name}</span> : <>{name}</>
+  }
+
+  const parts = name.split(SHORTCODE_CAPTURE_REGEX)
+  let hasEmoji = false
+
+  const content: ReactNode[] = parts.map((part, index) => {
+    const url = urlByShortcode.get(part)
+    if (url) {
+      hasEmoji = true
+      return (
+        <img
+          key={index}
+          src={url}
+          alt={part}
+          title={part}
+          className={cn(
+            'inline h-[1.2em] w-[1.2em] align-[-0.2em] object-contain',
+            emojiClassName
+          )}
+        />
+      )
+    }
+    return part
+  })
+
+  if (!hasEmoji) {
+    return className ? <span className={className}>{name}</span> : <>{name}</>
+  }
+
+  return className ? (
+    <span className={className}>{content}</span>
+  ) : (
+    <>{content}</>
+  )
+}

--- a/lib/components/actors/index.ts
+++ b/lib/components/actors/index.ts
@@ -1,0 +1,5 @@
+export { ActorDisplayName } from './ActorDisplayName'
+export type {
+  ActorDisplayNameProps,
+  MastodonAccountCustomEmoji
+} from './ActorDisplayName'

--- a/lib/components/posts/actor.test.tsx
+++ b/lib/components/posts/actor.test.tsx
@@ -241,6 +241,14 @@ describe('ActorAvatar', () => {
       description: 'the actor id handle when there is no actor',
       props: { actorId: 'https://llun.test/users/test' },
       initials: 'T'
+    },
+    {
+      description: 'the actor name without leading emoji shortcode',
+      props: {
+        actor: { ...actor, name: ':blobcat: Alice' },
+        actorId: 'https://llun.test/users/test'
+      },
+      initials: 'A'
     }
   ])(
     'builds the fallback initials from $description',
@@ -250,4 +258,25 @@ describe('ActorAvatar', () => {
       expect(screen.getByText(initials)).toBeInTheDocument()
     }
   )
+
+  it('renders custom emoji image in ActorInfo when actor has emoji tags', () => {
+    render(
+      <ActorInfo
+        actor={{
+          ...actor,
+          name: 'Alice :blobcat:',
+          tags: [
+            {
+              type: 'emoji',
+              name: ':blobcat:',
+              value: 'https://llun.test/blobcat.png'
+            }
+          ]
+        }}
+      />
+    )
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://llun.test/blobcat.png')
+  })
 })

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { FC } from 'react'
 
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { getMentionDomainFromActorID } from '@/lib/types/domain/actor'
 import type { ActorProfile } from '@/lib/types/domain/actor'
@@ -21,14 +22,17 @@ type ActorIdParts = {
   href?: string
 }
 
-const getInitials = (value: string) =>
-  value
+const getInitials = (value: string) => {
+  const clean = value.replaceAll(/:[^\s:]{1,64}:/g, '').trim()
+  return (clean || value)
     .replace(/^@/, '')
-    .split(' ')
+    .split(/\s+/)
     .map((n) => n[0])
+    .filter(Boolean)
     .join('')
     .toUpperCase()
     .slice(0, 2)
+}
 
 const getDisplayUsername = (username: string) =>
   username.replace(/^@+/, '').split('@')[0]
@@ -252,10 +256,12 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
           prefetch={false}
           className="font-semibold hover:underline truncate"
         >
-          {name}
+          <ActorDisplayName name={name} tags={actor?.tags} />
         </Link>
       ) : (
-        <span className="font-semibold truncate">{name}</span>
+        <span className="font-semibold truncate">
+          <ActorDisplayName name={name} tags={actor?.tags} />
+        </span>
       )}
       <span className="text-muted-foreground truncate">{mutedHandle}</span>
     </div>

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -6,6 +6,7 @@ import { Activity, ExternalLink, Repeat2 } from 'lucide-react'
 import Link from 'next/link'
 import { FC } from 'react'
 
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { FitnessStatGrid } from '@/lib/components/fitness/FitnessStatGrid'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -121,10 +122,10 @@ export const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
             className="font-medium text-foreground hover:underline"
             onClick={(e) => e.stopPropagation()}
           >
-            {actorName}
+            <ActorDisplayName name={actorName} tags={status.actor?.tags} />
           </Link>
         ) : (
-          actorName
+          <ActorDisplayName name={actorName} tags={status.actor?.tags} />
         )}
       </span>
     </div>

--- a/lib/components/settings/ActorsSection.tsx
+++ b/lib/components/settings/ActorsSection.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 
 import { switchActor } from '@/lib/client'
 import { ActorInfo, AddActorDialog } from '@/lib/components/actor-switcher'
+import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import {
@@ -154,7 +155,10 @@ export function ActorsSection({
               <div className="flex-1 overflow-hidden">
                 <div className="flex items-center gap-1.5">
                   <p className="text-sm font-medium truncate">
-                    {selectedActor?.name || selectedActor?.username}
+                    <ActorDisplayName
+                      name={selectedActor?.name || selectedActor?.username}
+                      tags={selectedActor?.tags}
+                    />
                   </p>
                   {selectedActorId === currentActor.id && (
                     <span className="text-xs text-muted-foreground shrink-0">
@@ -207,7 +211,10 @@ export function ActorsSection({
                     className={`flex-1 overflow-hidden ${reducedOpacity ? 'opacity-60' : ''}`}
                   >
                     <p className="text-sm font-medium truncate">
-                      {actor.name || actor.username}
+                      <ActorDisplayName
+                        name={actor.name || actor.username}
+                        tags={actor.tags}
+                      />
                     </p>
                     <p className="text-xs text-muted-foreground truncate">
                       {isPendingDeletion ? (

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -802,6 +802,74 @@ describe('ActorDatabase', () => {
         expect(actor?.source.attribution_domains).toEqual(['blog.example.com'])
       })
 
+      it('serializes custom emojis from actor settings tags', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `emoji-actor-${suffix}`
+        const actorId = `https://${TEST_DOMAIN}/users/${username}`
+        await createSigningAccount(database, username)
+        await database.updateActor({
+          actorId,
+          tags: [
+            {
+              type: 'emoji',
+              name: ':blobcat:',
+              value: 'https://example.com/emojis/blobcat.png'
+            }
+          ]
+        })
+
+        const actor = await database.getMastodonActorFromId({ id: actorId })
+        expect(actor?.emojis).toEqual([
+          {
+            shortcode: 'blobcat',
+            url: 'https://example.com/emojis/blobcat.png',
+            static_url: 'https://example.com/emojis/blobcat.png',
+            visible_in_picker: true,
+            category: null
+          }
+        ])
+      })
+
+      it('automatically resolves local custom emoji when display name is updated', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `autoresolve-${suffix}`
+        const actorId = `https://${TEST_DOMAIN}/users/${username}`
+        await createSigningAccount(database, username)
+
+        await database.createCustomEmoji({
+          shortcode: 'partyblob',
+          url: 'https://example.com/partyblob.png',
+          staticUrl: 'https://example.com/partyblob.png'
+        })
+
+        await database.updateActor({
+          actorId,
+          name: 'Alice :partyblob:'
+        })
+
+        const actor = await database.getActorFromId({ id: actorId })
+        expect(actor?.tags).toEqual([
+          {
+            type: 'emoji',
+            name: ':partyblob:',
+            value: 'https://example.com/partyblob.png'
+          }
+        ])
+
+        const mastodonActor = await database.getMastodonActorFromId({
+          id: actorId
+        })
+        expect(mastodonActor?.emojis).toEqual([
+          {
+            shortcode: 'partyblob',
+            url: 'https://example.com/partyblob.png',
+            static_url: 'https://example.com/partyblob.png',
+            visible_in_picker: true,
+            category: null
+          }
+        ])
+      })
+
       it('serializes suspended actors with suspended: true and silenced actors with limited: true', async () => {
         await withFreshDatabase(async (database) => {
           const suffix = crypto.randomUUID().slice(0, 8)

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -85,6 +85,10 @@ import {
   toPublicIdLookupKey
 } from '@/lib/utils/publicId'
 import { generateKeyPair } from '@/lib/utils/signature'
+import {
+  getEmojiTags,
+  toEmojiShortcodeToken
+} from '@/lib/utils/text/getEmojiTags'
 
 export interface SQLActorDatabase extends ActorDatabase {
   getActor: (
@@ -120,6 +124,48 @@ const getActorCounterSummary = async (
   }
 }
 
+const getConfiguredActorDomain = () => {
+  const host = getConfig().host
+  return host.includes('://') ? new URL(host).host : host
+}
+
+const resolveLocalEmojiTags = async (
+  database: Knex,
+  text: string
+): Promise<{ type: 'emoji'; name: string; value: string }[]> => {
+  if (!text) return []
+  const rows = await database('customEmojis')
+    .select('shortcode', 'url')
+    .where('disabled', false)
+  const tags = getEmojiTags(text, rows)
+  return tags.map((tag) => ({
+    type: 'emoji' as const,
+    name: tag.name,
+    value: tag.value
+  }))
+}
+
+const getAccountEmojisFromTags = (
+  tags?: { type: string; name: string; value: string }[]
+): Mastodon.CustomEmoji[] => {
+  if (!tags) return []
+  return tags
+    .filter((tag) => tag.type === 'emoji')
+    .flatMap((tag) => {
+      const token = toEmojiShortcodeToken(tag.name)
+      if (!token) return []
+      return [
+        {
+          shortcode: token.slice(1, -1),
+          url: tag.value,
+          static_url: tag.value,
+          visible_in_picker: true,
+          category: null
+        }
+      ]
+    })
+}
+
 const insertActorWithSearchIndex = async (
   database: Knex,
   {
@@ -133,6 +179,7 @@ const insertActorWithSearchIndex = async (
     headerImageUrl,
     manuallyApprovesFollowers,
     fields,
+    tags,
     followersUrl,
     inboxUrl,
     sharedInboxUrl,
@@ -142,6 +189,18 @@ const insertActorWithSearchIndex = async (
   }: CreateActorParams
 ) => {
   const currentTime = new Date()
+  let resolvedTags = tags
+  if (resolvedTags === undefined && (name || summary)) {
+    const isLocal =
+      domain.toLowerCase() === getConfiguredActorDomain().toLowerCase()
+    if (isLocal) {
+      resolvedTags = await resolveLocalEmojiTags(
+        database,
+        `${name ?? ''} ${summary ?? ''}`
+      )
+    }
+  }
+
   const settings: ActorSettings = {
     iconUrl,
     headerImageUrl,
@@ -151,7 +210,8 @@ const insertActorWithSearchIndex = async (
     ...(manuallyApprovesFollowers !== undefined
       ? { manuallyApprovesFollowers }
       : null),
-    ...(fields !== undefined ? { fields } : null)
+    ...(fields !== undefined ? { fields } : null),
+    ...(resolvedTags && resolvedTags.length > 0 ? { tags: resolvedTags } : null)
   }
   const actor = {
     id: actorId,
@@ -178,11 +238,6 @@ const insertActorWithSearchIndex = async (
 }
 
 const getStatusUrlHash = (url: string): string => getHashFromString(url)
-
-const getConfiguredActorDomain = () => {
-  const host = getConfig().host
-  return host.includes('://') ? new URL(host).host : host
-}
 
 const getFederationSigningActorSettings = (
   actorId: string,
@@ -311,7 +366,7 @@ const getMastodonAccountFromSQLActor = ({
     header_description: settings.headerDescription ?? '',
 
     fields: profileFields,
-    emojis: [],
+    emojis: getAccountEmojisFromTags(settings.tags),
 
     // Moderation flags: emitted only when set, matching Mastodon's Account
     // entity (extra "only when suspended/silenced" attributes).
@@ -776,6 +831,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         ? { headerImageUrl: settings.headerImageUrl }
         : null),
       manuallyApprovesFollowers: settings.manuallyApprovesFollowers ?? true,
+      ...(settings.tags ? { tags: settings.tags } : null),
       // Booleans use !== undefined so a persisted `false` survives the
       // row-to-domain round-trip (a truthy spread would drop it).
       ...(settings.readingExpandMedia !== undefined
@@ -921,6 +977,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     headerImageUrl,
     manuallyApprovesFollowers,
     fields,
+    tags,
     bot,
     discoverable,
     indexable,
@@ -959,6 +1016,26 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       .first()
     if (!persistedActor) return null
 
+    let resolvedTags = tags
+    if (
+      resolvedTags === undefined &&
+      (name !== undefined || summary !== undefined)
+    ) {
+      const isLocal =
+        persistedActor.domain.toLowerCase() ===
+        getConfiguredActorDomain().toLowerCase()
+      if (isLocal) {
+        const targetName =
+          name !== undefined ? name : (persistedActor.name ?? '')
+        const targetSummary =
+          summary !== undefined ? summary : (persistedActor.summary ?? '')
+        resolvedTags = await resolveLocalEmojiTags(
+          database,
+          `${targetName} ${targetSummary}`
+        )
+      }
+    }
+
     const persistedSettings = getCompatibleJSON(persistedActor.settings)
     // The explicit settings changes requested by this call (undefined fields
     // mean "no change"). Kept as a standalone object so the
@@ -971,6 +1048,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         ? { manuallyApprovesFollowers }
         : null),
       ...(fields !== undefined ? { fields } : null),
+      ...(resolvedTags !== undefined ? { tags: resolvedTags } : null),
       ...(bot !== undefined ? { bot } : null),
       ...(discoverable !== undefined ? { discoverable } : null),
       ...(indexable !== undefined ? { indexable } : null),

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -74,6 +74,7 @@ export type CreateActorParams = {
   manuallyApprovesFollowers?: boolean
   // Mastodon profile metadata fields (name/value pairs).
   fields?: { name: string; value: string }[]
+  tags?: { type: 'emoji'; name: string; value: string }[]
 
   inboxUrl: string
   sharedInboxUrl: string
@@ -135,6 +136,7 @@ export type UpdateActorParams = {
   manuallyApprovesFollowers?: boolean
   // Mastodon profile metadata fields (name/value pairs).
   fields?: { name: string; value: string }[]
+  tags?: { type: 'emoji'; name: string; value: string }[]
   // Mastodon `bot`/`discoverable` flags and `source.*` posting defaults.
   bot?: boolean
   discoverable?: boolean

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -15,6 +15,8 @@ export interface ActorSettings {
   // Profile metadata fields (Mastodon update_credentials `fields_attributes`).
   // Stored as plain name/value pairs; URL verification is not performed.
   fields?: { name: string; value: string }[]
+  // Custom emoji tags in display name/bio.
+  tags?: { type: 'emoji'; name: string; value: string }[]
   // Mastodon `bot`/`discoverable` flags. `bot` marks an automated account;
   // `discoverable` opts into discovery features (profile directory). When unset
   // the builder falls back to a sensible default for the actor type.

--- a/lib/types/domain/actor.test.ts
+++ b/lib/types/domain/actor.test.ts
@@ -2,6 +2,7 @@ import omit from 'lodash/omit'
 
 import { MockActor } from '@/lib/stub/actor'
 import {
+  ActorProfile,
   getActorProfile,
   getActorURL,
   getMention,
@@ -64,6 +65,38 @@ describe('Actor', () => {
       expect(getMentionFromActorID('https://chat.llun.me/me', true)).toEqual(
         '@me@chat.llun.me'
       )
+    })
+  })
+
+  describe('ActorProfile with emoji tags', () => {
+    it('parses actor profile with emoji tags', () => {
+      const profile = ActorProfile.parse({
+        id: 'https://chat.llun.dev/users/me',
+        username: 'me',
+        domain: 'chat.llun.dev',
+        followersUrl: 'https://chat.llun.dev/users/me/followers',
+        inboxUrl: 'https://chat.llun.dev/users/me/inbox',
+        sharedInboxUrl: 'https://chat.llun.dev/inbox',
+        followingCount: 0,
+        followersCount: 0,
+        statusCount: 0,
+        lastStatusAt: 0,
+        createdAt: Date.now(),
+        tags: [
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/emojis/blobcat.png'
+          }
+        ]
+      })
+      expect(profile.tags).toEqual([
+        {
+          type: 'emoji',
+          name: ':blobcat:',
+          value: 'https://example.com/emojis/blobcat.png'
+        }
+      ])
     })
   })
 })

--- a/lib/types/domain/actor.ts
+++ b/lib/types/domain/actor.ts
@@ -14,6 +14,13 @@ export const ACTOR_TYPES = [
 export const ActorType = z.enum(ACTOR_TYPES)
 export type ActorType = z.infer<typeof ActorType>
 
+export const ActorEmojiTag = z.object({
+  type: z.literal('emoji'),
+  name: z.string(),
+  value: z.string()
+})
+export type ActorEmojiTag = z.infer<typeof ActorEmojiTag>
+
 export const ActorProfile = z.object({
   id: z.string(),
   publicId: z.string().nullable().optional(),
@@ -25,6 +32,7 @@ export const ActorProfile = z.object({
   iconUrl: z.string().optional(),
   headerImageUrl: z.string().optional(),
   manuallyApprovesFollowers: z.boolean().optional(),
+  tags: ActorEmojiTag.array().optional(),
 
   followersUrl: z.string(),
   inboxUrl: z.string(),

--- a/lib/utils/getPersonFromActor.test.ts
+++ b/lib/utils/getPersonFromActor.test.ts
@@ -34,4 +34,36 @@ describe('getPersonFromActor', () => {
       }
     })
   })
+
+  it('serializes custom emoji tags and includes toot:Emoji in @context', () => {
+    const actor = MockActor({})
+    const actorWithTags = {
+      ...actor,
+      name: 'Alice :blobcat:',
+      tags: [
+        {
+          type: 'emoji' as const,
+          name: ':blobcat:',
+          value: 'https://chat.llun.dev/emojis/blobcat.png'
+        }
+      ]
+    }
+    const person = getPersonFromActor(actorWithTags)
+    expect(person['@context']).toContainEqual({
+      toot: 'http://joinmastodon.org/ns#',
+      Emoji: 'toot:Emoji'
+    })
+    expect(person.tag).toEqual([
+      {
+        type: 'Emoji',
+        id: 'https://chat.llun.dev/emojis/blobcat.png',
+        name: ':blobcat:',
+        updated: expect.toBeString(),
+        icon: {
+          type: 'Image',
+          url: 'https://chat.llun.dev/emojis/blobcat.png'
+        }
+      }
+    ])
+  })
 })

--- a/lib/utils/getPersonFromActor.ts
+++ b/lib/utils/getPersonFromActor.ts
@@ -8,10 +8,11 @@ import {
 } from '@/lib/utils/activitypubId'
 import { FEP_7AA9_CONTEXT_URL } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { toEmojiShortcodeToken } from '@/lib/utils/text/getEmojiTags'
 
 export const getPersonFromActor = (
   actor: Actor
-): ActivityPubActor & { '@context': string[] } => {
+): ActivityPubActor & { '@context': (string | Record<string, unknown>)[] } => {
   const actorType = actor.type ?? 'Person'
   const profileUrl =
     actorType === 'Service'
@@ -35,6 +36,22 @@ export const getPersonFromActor = (
         }
       }
     : null
+
+  const emojiTags = (actor.tags ?? [])
+    .filter((tag) => tag.type === 'emoji')
+    .map((tag) => {
+      const token = toEmojiShortcodeToken(tag.name)
+      return {
+        type: 'Emoji' as const,
+        id: tag.value,
+        name: token ?? tag.name,
+        updated: getISOTimeUTC(actor.updatedAt),
+        icon: {
+          type: 'Image' as const,
+          url: tag.value
+        }
+      }
+    })
 
   const person = ActivityPubActor.parse({
     id: actor.id,
@@ -60,7 +77,8 @@ export const getPersonFromActor = (
       sharedInbox: actor.sharedInboxUrl
     },
     ...icon,
-    ...headerImage
+    ...headerImage,
+    ...(emojiTags.length > 0 ? { tag: emojiTags } : null)
   })
 
   return {
@@ -69,7 +87,10 @@ export const getPersonFromActor = (
     '@context': [
       'https://www.w3.org/ns/activitystreams',
       'https://w3id.org/security/v1',
-      FEP_7AA9_CONTEXT_URL
+      FEP_7AA9_CONTEXT_URL,
+      ...(emojiTags.length > 0
+        ? [{ toot: 'http://joinmastodon.org/ns#', Emoji: 'toot:Emoji' }]
+        : [])
     ],
     ...person
   }

--- a/lib/utils/text/convertEmojisToImages.ts
+++ b/lib/utils/text/convertEmojisToImages.ts
@@ -66,7 +66,10 @@ const HTML_TAG_SPLIT_REGEX = /(<[^>]*>)/
  * A rejected tag renders as nothing: the literal `:shortcode:` stays in the
  * text, which is what a reader on a server lacking that emoji sees anyway.
  */
-export const convertEmojisToImages = (text: string, tags: Tag[]) => {
+export const convertEmojisToImages = (
+  text: string,
+  tags: Pick<Tag, 'type' | 'name' | 'value'>[]
+) => {
   const urlByShortcode = new Map<string, string>()
   for (const tag of tags) {
     if (tag.type !== 'emoji') continue


### PR DESCRIPTION
## Summary

Adds end-to-end support for custom emoji shortcodes (`:shortcode:`) in user display names across the database layer, Mastodon API serializer, ActivityPub inbound/outbound federation, and the web UI.

## Context & Motivation

Users and federated accounts frequently include custom emoji shortcodes (e.g. `:blobcat:`, `:partyblob:`) in their profile display names. Previously, these shortcodes were treated as plain strings or caused display glitches:
- Remote actors federating in with `Emoji` tags had their tags dropped during actor ingest.
- Local actors updating their profile names did not resolve shortcodes against the local `customEmojis` table.
- Mastodon client serializers (`getMastodonAccountFromSQLActor`) returned empty `emojis: []` on account entities, preventing third-party clients (Elk, Ivory, Mona, Phanpy) from rendering custom emojis in profile names.
- Outbound ActivityPub Person documents did not include `tag` entries for emojis or Mastodon's `toot:Emoji` `@context` extension.
- UI components rendered raw `:shortcode:` text strings, and avatar initials fallbacks naively included colon characters (e.g. producing `:` as an initial from `:blobcat: Alice`).

## Changes

### 1. Types & Domain Layer
- **`lib/types/domain/actor.ts`**: Added `ActorEmojiTag` schema (`{ type: 'emoji', name: string, value: string }`) and optional `tags` array on `ActorProfile`.
- **`lib/types/database/rows.ts`**: Added `tags?: { type: 'emoji'; name: string; value: string }[]` to `ActorSettings`. Stored in existing `actors.settings` JSON without requiring database migrations.
- **`lib/types/database/operations.ts`**: Added `tags` to `CreateActorParams` and `UpdateActorParams`.

### 2. Remote Actor Ingestion (ActivityPub Inbound)
- **`lib/actions/utils.ts`**:
  - Added `getActorEmojiTags(person)` to extract `Emoji` tags from `person.tag` (handling both array and single object shapes).
  - Updated `getPersistableProfile` to extract and store emoji tags in `settings.tags`.

### 3. Local Actor Tag Resolution & Mastodon API Serializer
- **`lib/database/sql/actor.ts`**:
  - Implemented `resolveLocalEmojiTags`: on local actor creation or update, matches shortcode tokens in `name` and `summary` against enabled rows in `customEmojis`.
  - Implemented `getAccountEmojisFromTags`: serializes stored emoji tags into Mastodon `Account.emojis` (`{ shortcode, url, static_url, visible_in_picker: true, category: null }`).
  - Updated `getActor` to map `settings.tags` to `actor.tags`.
  - Updated `getMastodonAccountFromSQLActor` to emit `emojis` from `settings.tags`.

### 4. Outbound ActivityPub Federation
- **`lib/utils/getPersonFromActor.ts`**:
  - Serializes `actor.tags` as ActivityPub `Emoji` objects into `person.tag`.
  - Injects `{ toot: 'http://joinmastodon.org/ns#', Emoji: 'toot:Emoji' }` into `@context` when emoji tags are present.

### 5. Web UI Rendering
- **`lib/components/actors/ActorDisplayName.tsx`**: New component that safely parses display name strings with `SHORTCODE_CAPTURE_REGEX` (`/(:[^\s:]{1,64}:)/g`), replacing matching shortcodes with inline `<img>` tags while preserving surrounding text.
- **Initials Fallback**: Updated avatar initials calculation across UI components to strip `:shortcode:` tokens prior to initial extraction.
- **Component Integrations**:
  - `lib/components/posts/actor.tsx`: `ActorInfo` and `getInitials`
  - `lib/components/posts/post.tsx`: `BoostStatus`
  - `app/(timeline)/[actor]/page.tsx`: Profile header `<h1>` and `getInitials`
  - `app/(timeline)/[actor]/FollowList.tsx`: User list names and initials
  - `app/(timeline)/notifications/NotificationItem.tsx`: Notification actor name
  - `lib/components/actor-switcher/ActorSwitcher.tsx`: Current identity and switcher list
  - `lib/components/settings/ActorsSection.tsx`: Settings default actor selection
  - `app/(nosidebar)/auth/select-actor/ActorSelectionList.tsx`: Sign-in actor selection list
  - `app/(nosidebar)/authorize_interaction/AuthorizeInteractionCard.tsx`: Remote interaction card
  - `app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx`: OAuth authorization card

### 6. Documentation
- Updated `docs/features.md` to document custom emoji display name support.

## Verification

### Automated Tests
- `lib/types/domain/actor.test.ts`
- `lib/actions/utils.test.ts`
- `lib/database/sql/actor.test.ts` (all 85 tests passing)
- `lib/utils/getPersonFromActor.test.ts`
- `lib/components/actors/ActorDisplayName.test.tsx` (new test suite)
- `lib/components/posts/actor.test.tsx` (including emoji initial stripping & rendering)
- `app/(timeline)/[actor]/FollowList.test.tsx`
- `app/(timeline)/notifications/NotificationItem.test.tsx`
- `lib/components/actor-switcher/ActorSwitcher.test.tsx`
- `lib/components/settings/ActorsSection.test.tsx`
- `lib/components/posts/post.test.tsx`
- `app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx`
- `lib/clientModuleBoundary.test.ts`

### Quality Gates
1. `yarn run prettier --write .` (Passed)
2. `yarn lint` (Passed, 0 errors)
3. `yarn typecheck` (Passed, 0 errors)
4. `yarn build` (Passed, production build succeeded)
5. `yarn test` (Passed, 942 test files, 12,690 tests passed)
