### PR TITLE
Bump version to v1.157.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.156.3",
+  "version": "1.157.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.157.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.156.3`
- Base main SHA: `05dc5f274b40aefdd0158c0adee1559c434b2020`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
