### PR TITLE
Bump version to v1.157.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.157.0",
+  "version": "1.157.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.157.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.157.0`
- Base main SHA: `956d25eae79de934d2b1980cf0a302225a4174fb`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
