### PR TITLE
minor: extend custom emoji support across statuses, alt text, polls, and profiles

### DIFF
--- a/app/(timeline)/[actor]/FollowList.tsx
+++ b/app/(timeline)/[actor]/FollowList.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 
-import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
+import {
+  ActorDisplayName,
+  CustomEmojiText
+} from '@/lib/components/actors/ActorDisplayName'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -70,7 +73,7 @@ export const FollowList: FC<Props> = ({
               </div>
               {summary ? (
                 <div className="mt-1 line-clamp-1 text-sm text-muted-foreground">
-                  {summary}
+                  <CustomEmojiText text={summary} tags={user.tags} />
                 </div>
               ) : null}
             </div>

--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -15,6 +15,7 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/domain/tag'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 import type { PublicMapProvider } from '@/lib/utils/mapProvider'
 
@@ -48,6 +49,7 @@ export const StatusBox: FC<Props> = ({
   const router = useRouter()
   const [modalMedias, setModalMedias] = useState<{
     medias: Attachment[]
+    tags?: Tag[]
     initialSelection: number
   } | null>(null)
   // Reply/quote/edit share the same inline composer used by every feed so the
@@ -74,11 +76,16 @@ export const StatusBox: FC<Props> = ({
           replies={replies}
           isMediaUploadEnabled={isMediaUploadEnabled}
           onShowAttachment={(allMedias, index) => {
-            setModalMedias({ medias: allMedias, initialSelection: index })
+            setModalMedias({
+              medias: allMedias,
+              tags: actualStatus.tags,
+              initialSelection: index
+            })
           }}
         />
         <MediasModal
           medias={modalMedias?.medias ?? null}
+          tags={modalMedias?.tags ?? null}
           initialSelection={modalMedias?.initialSelection ?? 0}
           onClosed={() => setModalMedias(null)}
         />
@@ -125,7 +132,11 @@ export const StatusBox: FC<Props> = ({
           }
           onOpenStatus={variant === 'comment' ? openStatus : undefined}
           onShowAttachment={(allMedias, index) => {
-            setModalMedias({ medias: allMedias, initialSelection: index })
+            setModalMedias({
+              medias: allMedias,
+              tags: actualStatus.tags,
+              initialSelection: index
+            })
           }}
         />
         {variant === 'detail' && currentActor && (
@@ -150,6 +161,7 @@ export const StatusBox: FC<Props> = ({
       </article>
       <MediasModal
         medias={modalMedias?.medias ?? null}
+        tags={modalMedias?.tags ?? null}
         initialSelection={modalMedias?.initialSelection ?? 0}
         onClosed={() => setModalMedias(null)}
       />

--- a/app/(timeline)/[actor]/[status]/StatusLikes.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusLikes.tsx
@@ -4,6 +4,7 @@ import { Heart } from 'lucide-react'
 import Link from 'next/link'
 import { FC, useEffect, useMemo, useState } from 'react'
 
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import {
@@ -120,7 +121,10 @@ export const StatusLikes: FC<Props> = ({
                   <AvatarFallback>{getInitials(account)}</AvatarFallback>
                 </Avatar>
                 <span className="max-w-40 truncate">
-                  {getDisplayName(account)}
+                  <CustomEmojiText
+                    text={getDisplayName(account)}
+                    emojis={account.emojis}
+                  />
                 </span>
               </Link>
             ))}
@@ -185,7 +189,10 @@ export const StatusLikes: FC<Props> = ({
                     </Avatar>
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium">
-                        {getDisplayName(account)}
+                        <CustomEmojiText
+                          text={getDisplayName(account)}
+                          emojis={account.emojis}
+                        />
                       </p>
                       <p className="truncate text-xs text-muted-foreground">
                         @{account.acct}

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -254,7 +254,7 @@ const Page: FC<Props> = async ({ params }) => {
             )}
           </div>
 
-          <Bio summary={person.summary} />
+          <Bio summary={person.summary} tags={getActorEmojiTags(person)} />
 
           <div className="mt-5 flex flex-wrap gap-6 text-sm">
             <div>

--- a/app/(timeline)/notifications/components/StatusNotification.tsx
+++ b/app/(timeline)/notifications/components/StatusNotification.tsx
@@ -6,6 +6,7 @@ import {
   getInitials
 } from '@/app/(timeline)/notifications/notificationConfig'
 import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
@@ -51,7 +52,7 @@ export const StatusNotification: FC<Props> = ({
           prefetch={false}
           className="truncate text-[13px] font-semibold hover:underline"
         >
-          {groupedName}
+          <CustomEmojiText text={groupedName} emojis={account.emojis} />
         </Link>
       </div>
       <div

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -15,6 +15,7 @@ import {
 import type { ReactNode } from 'react'
 
 import { SearchResult, SearchType, search as searchClient } from '@/lib/client'
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
 import { TrendingNowBlock } from '@/lib/components/trends/trending-now-block'
@@ -211,12 +212,14 @@ const AccountRow = ({
       </Avatar>
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
-          <p className="truncate text-sm font-medium">{label}</p>
+          <p className="truncate text-sm font-medium">
+            <CustomEmojiText text={label} emojis={account.emojis} />
+          </p>
           <p className="truncate text-xs text-muted-foreground">{handle}</p>
         </div>
         {note && (
           <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-            {note}
+            <CustomEmojiText text={note} emojis={account.emojis} />
           </p>
         )}
       </div>

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Account blocks** — Block or unblock remote accounts and list blocked accounts
 - ✅ **Domain blocks** — Block or unblock an entire remote domain and list your blocked domains via `/api/v1/domain_blocks`; blocking hides that domain's posts (and boosts) from your timelines, is reflected in `domain_blocking` on relationships, and severs follows in both directions
 - ✅ **Follow requests** — Review, authorize, and reject follow requests
-- ✅ **Custom emoji** — Instance-defined custom emoji with a sticker/emoji picker in the post box, and custom emoji shortcode (`:shortcode:`) support in user display names across the web UI, Mastodon API, and ActivityPub federation
+- ✅ **Custom emoji** — Instance-defined custom emoji with a sticker/emoji picker in the post box, and custom emoji shortcode (`:shortcode:`) support across user display names, profile bios, profile metadata fields, content warnings, poll choices, and media attachment descriptions in the web UI, composer preview, Mastodon API, and ActivityPub federation
 - ✅ **Featured hashtags** — Feature hashtags on your profile and manage them from settings
 - ✅ **Status translation** — Translate posts into your language via DeepL, LibreTranslate, or an OpenAI-compatible backend
 - ✅ **Public & logged-out pages** — Logged-out landing page plus publicly viewable profile and status pages, with design-system error pages (404/500)

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -170,10 +170,11 @@ export const persistEmojiTagsForStatus = async ({
 }: {
   database: Database
   statusId: string
-  text: string
+  text: string | string[]
 }): Promise<number> => {
+  const combinedText = Array.isArray(text) ? text.join(' ') : text
   const customEmojis = await database.getCustomEmojis()
-  const emojiTags = getEmojiTags(text, customEmojis)
+  const emojiTags = getEmojiTags(combinedText, customEmojis)
   await Promise.all(
     emojiTags.map((emojiTag) =>
       database.createTag({
@@ -553,7 +554,11 @@ export const createNoteFromUserInput = async ({
       })
     }
 
-    await persistEmojiTagsForStatus({ database, statusId, text })
+    await persistEmojiTagsForStatus({
+      database,
+      statusId,
+      text: [text, summary ?? '', ...attachments.map((a) => a.name || '')]
+    })
 
     const mediaIds = attachments
       .map((attachment) => attachment.id)

--- a/lib/actions/createNoteEmoji.test.ts
+++ b/lib/actions/createNoteEmoji.test.ts
@@ -3,6 +3,7 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { createPollFromUserInput } from '@/lib/actions/createPoll'
 import { updateNoteFromUserInput } from '@/lib/actions/updateNote'
+import { updatePollFromUserInput } from '@/lib/actions/updatePoll'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
@@ -197,5 +198,109 @@ describe('Custom emoji status federation', () => {
     expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toEqual([
       expect.objectContaining({ name: ':blobcat:' })
     ])
+  })
+
+  it('persists an emoji tag when shortcode appears in summary (content warning)', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'plain post body',
+      summary: 'spoiler with :blobcat:',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+  })
+
+  it('persists an emoji tag when shortcode appears in attachment alt text', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'image post',
+      attachments: [
+        {
+          type: 'upload',
+          id: 'media-emoji-1',
+          mediaType: 'image/png',
+          url: 'https://example.com/test.png',
+          width: 400,
+          height: 300,
+          name: 'alt with :blobcat:'
+        }
+      ],
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+  })
+
+  it('persists an emoji tag when shortcode appears in poll choices', async () => {
+    const status = await createPollFromUserInput({
+      currentActor: actor1,
+      text: 'poll question',
+      choices: ['option 1 :blobcat:', 'option 2'],
+      endAt: 4102444800000,
+      database
+    })
+    if (!status) throw new Error('Expected a poll status')
+
+    const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+  })
+
+  it('re-syncs emoji tags when summary or attachments are updated', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'plain text',
+      summary: 'plain summary',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const updated = await updateNoteFromUserInput({
+      statusId: status.id,
+      currentActor: actor1,
+      summary: 'warning with :blobcat:',
+      database,
+      publish: false
+    })
+
+    const tags = await database.getTags({ statusId: status.id })
+    const emojiTags = tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
+  })
+
+  it('re-syncs emoji tags when poll choices are updated', async () => {
+    const status = await createPollFromUserInput({
+      currentActor: actor1,
+      text: 'poll question',
+      choices: ['option 1', 'option 2'],
+      endAt: 4102444800000,
+      database
+    })
+    if (!status) throw new Error('Expected a poll status')
+
+    const updated = await updatePollFromUserInput({
+      statusId: status.id,
+      currentActor: actor1,
+      poll: {
+        options: ['new choice :blobcat:', 'option 2'],
+        expiresIn: 3600
+      },
+      database
+    })
+
+    const tags = await database.getTags({ statusId: status.id })
+    const emojiTags = tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
   })
 })

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -150,7 +150,11 @@ export const createPollFromUserInput = async ({
       )
     ])
 
-    await persistEmojiTagsForStatus({ database, statusId, text })
+    await persistEmojiTagsForStatus({
+      database,
+      statusId,
+      text: [text, summary ?? '', ...choices]
+    })
 
     const status = await database.getStatus({ statusId, withReplies: false })
     if (!status) {

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -79,18 +79,42 @@ export const updateNoteFromUserInput = async ({
       return null
     }
 
-    // Re-sync emoji tags when the text changes so newly added `:shortcode:`
-    // tokens federate and removed ones stop federating, then re-fetch so the
-    // returned status and the timeline cache reflect the re-synced tags (mirroring
-    // createNoteFromUserInput).
-    if (text !== undefined) {
+    // Re-sync emoji tags when the text, summary, or attachments change so newly
+    // added `:shortcode:` tokens federate and removed ones stop federating, then
+    // re-fetch so the returned status and the timeline cache reflect the
+    // re-synced tags (mirroring createNoteFromUserInput).
+    if (
+      text !== undefined ||
+      summary !== undefined ||
+      attachments !== undefined
+    ) {
       await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
-      await persistEmojiTagsForStatus({ database, statusId, text })
+      const noteAttachments =
+        updatedStatus.type === StatusType.enum.Note
+          ? updatedStatus.attachments
+          : []
+      const noteSummary =
+        updatedStatus.type === StatusType.enum.Note
+          ? (updatedStatus.summary ?? '')
+          : ''
+      const noteText =
+        updatedStatus.type === StatusType.enum.Note ? updatedStatus.text : ''
+      await persistEmojiTagsForStatus({
+        database,
+        statusId,
+        text: [
+          noteText,
+          noteSummary,
+          ...noteAttachments.map((a) => a.name || '')
+        ]
+      })
 
-      // Re-detect the content language alongside the edit; the previous
-      // detection (if any) is stale once the text changes — persistDetectedLanguage
-      // clears the old row when the new text no longer detects confidently.
-      await persistDetectedLanguage({ database, statusId, text })
+      if (text !== undefined) {
+        // Re-detect the content language alongside the edit; the previous
+        // detection (if any) is stale once the text changes — persistDetectedLanguage
+        // clears the old row when the new text no longer detects confidently.
+        await persistDetectedLanguage({ database, statusId, text })
+      }
 
       updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
     }

--- a/lib/actions/updatePoll.ts
+++ b/lib/actions/updatePoll.ts
@@ -88,12 +88,30 @@ export const updatePollFromUserInput = async ({
       return null
     }
 
-    // Mirror updateNoteFromUserInput: re-sync emoji tags and re-detect the
-    // content language when the text changes.
-    if (text !== undefined) {
+    // Mirror updateNoteFromUserInput: re-sync emoji tags when text, summary, or
+    // poll options change, and re-detect the content language when text changes.
+    if (
+      text !== undefined ||
+      summary !== undefined ||
+      poll?.options !== undefined
+    ) {
       await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
-      await persistEmojiTagsForStatus({ database, statusId, text })
-      await persistDetectedLanguage({ database, statusId, text })
+      const pollChoices =
+        updatedStatus.type === StatusType.enum.Poll ? updatedStatus.choices : []
+      const pollSummary =
+        updatedStatus.type === StatusType.enum.Poll
+          ? (updatedStatus.summary ?? '')
+          : ''
+      const pollText =
+        updatedStatus.type === StatusType.enum.Poll ? updatedStatus.text : ''
+      await persistEmojiTagsForStatus({
+        database,
+        statusId,
+        text: [pollText, pollSummary, ...pollChoices.map((c) => c.title)]
+      })
+      if (text !== undefined) {
+        await persistDetectedLanguage({ database, statusId, text })
+      }
       updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
     }
 

--- a/lib/components/actors/ActorDisplayName.test.tsx
+++ b/lib/components/actors/ActorDisplayName.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react'
 
-import { ActorDisplayName } from './ActorDisplayName'
+import { ActorDisplayName, CustomEmojiText } from './ActorDisplayName'
 
 describe('ActorDisplayName', () => {
   it('renders null when name is not provided', () => {
@@ -113,5 +113,24 @@ describe('ActorDisplayName', () => {
       />
     )
     expect(container.querySelector('.custom-title-class')).not.toBeNull()
+  })
+
+  it('supports text prop via CustomEmojiText export', () => {
+    render(
+      <CustomEmojiText
+        text="Content Warning :blobcat:"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      />
+    )
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeDefined()
+    expect(img.getAttribute('src')).toBe('https://example.com/blobcat.png')
+    expect(screen.getByText(/Content Warning/)).toBeDefined()
   })
 })

--- a/lib/components/actors/ActorDisplayName.tsx
+++ b/lib/components/actors/ActorDisplayName.tsx
@@ -13,7 +13,8 @@ export interface MastodonAccountCustomEmoji {
   static_url?: string
 }
 
-export interface ActorDisplayNameProps {
+export interface CustomEmojiTextProps {
+  text?: string | null
   name?: string | null
   tags?:
     | (
@@ -27,14 +28,18 @@ export interface ActorDisplayNameProps {
   emojiClassName?: string
 }
 
-export const ActorDisplayName: FC<ActorDisplayNameProps> = ({
+export type ActorDisplayNameProps = CustomEmojiTextProps
+
+export const CustomEmojiText: FC<CustomEmojiTextProps> = ({
+  text,
   name,
   tags,
   emojis,
   className,
   emojiClassName
 }) => {
-  if (!name) return null
+  const contentText = text ?? name
+  if (!contentText) return null
 
   const urlByShortcode = new Map<string, string>()
 
@@ -56,10 +61,14 @@ export const ActorDisplayName: FC<ActorDisplayNameProps> = ({
   }
 
   if (urlByShortcode.size === 0) {
-    return className ? <span className={className}>{name}</span> : <>{name}</>
+    return className ? (
+      <span className={className}>{contentText}</span>
+    ) : (
+      <>{contentText}</>
+    )
   }
 
-  const parts = name.split(SHORTCODE_CAPTURE_REGEX)
+  const parts = contentText.split(SHORTCODE_CAPTURE_REGEX)
   let hasEmoji = false
 
   const content: ReactNode[] = parts.map((part, index) => {
@@ -83,7 +92,11 @@ export const ActorDisplayName: FC<ActorDisplayNameProps> = ({
   })
 
   if (!hasEmoji) {
-    return className ? <span className={className}>{name}</span> : <>{name}</>
+    return className ? (
+      <span className={className}>{contentText}</span>
+    ) : (
+      <>{contentText}</>
+    )
   }
 
   return className ? (
@@ -92,3 +105,5 @@ export const ActorDisplayName: FC<ActorDisplayNameProps> = ({
     <>{content}</>
   )
 }
+
+export const ActorDisplayName = CustomEmojiText

--- a/lib/components/actors/index.ts
+++ b/lib/components/actors/index.ts
@@ -1,5 +1,6 @@
-export { ActorDisplayName } from './ActorDisplayName'
+export { ActorDisplayName, CustomEmojiText } from './ActorDisplayName'
 export type {
   ActorDisplayNameProps,
+  CustomEmojiTextProps,
   MastodonAccountCustomEmoji
 } from './ActorDisplayName'

--- a/lib/components/bio/Bio.test.tsx
+++ b/lib/components/bio/Bio.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+
+import { Bio } from './Bio'
+
+describe('Bio', () => {
+  it('renders plain text summary', () => {
+    render(<Bio summary="Hello world" />)
+    expect(screen.getByText('Hello world')).toBeDefined()
+  })
+
+  it('renders sanitized HTML links in summary', () => {
+    const { container } = render(
+      <Bio summary='<p>Visit <a href="https://example.com">website</a></p>' />
+    )
+    const link = container.querySelector('a')
+    expect(link).toBeDefined()
+    expect(link?.getAttribute('href')).toBe('https://example.com')
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.textContent).toBe('website')
+  })
+
+  it('converts custom emoji shortcodes to images using tags', () => {
+    const { container } = render(
+      <Bio
+        summary="<p>Hello :blobcat: world</p>"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img).toBeDefined()
+    expect(img?.getAttribute('src')).toBe('https://example.com/blobcat.png')
+    expect(img?.getAttribute('alt')).toBe(':blobcat:')
+    expect(img?.className).toContain('size-5 inline')
+  })
+
+  it('converts custom emoji shortcodes to images using emojis', () => {
+    const { container } = render(
+      <Bio
+        summary="<p>Hello :partyblob:</p>"
+        emojis={[
+          {
+            shortcode: 'partyblob',
+            url: 'https://example.com/partyblob.png'
+          }
+        ]}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img).toBeDefined()
+    expect(img?.getAttribute('src')).toBe('https://example.com/partyblob.png')
+    expect(img?.getAttribute('alt')).toBe(':partyblob:')
+    expect(img?.className).toContain('size-5 inline')
+  })
+})

--- a/lib/components/bio/Bio.tsx
+++ b/lib/components/bio/Bio.tsx
@@ -2,17 +2,54 @@
 
 import { FC, useMemo } from 'react'
 
+import { MastodonAccountCustomEmoji } from '@/lib/components/actors/ActorDisplayName'
+import { ActorEmojiTag } from '@/lib/types/domain/actor'
+import { Tag } from '@/lib/types/domain/tag'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
-import { sanitizeText } from '@/lib/utils/text/sanitizeText'
+import { convertEmojisToImages } from '@/lib/utils/text/convertEmojisToImages'
+import { toEmojiShortcodeToken } from '@/lib/utils/text/getEmojiTags'
+import {
+  sanitizeText,
+  sanitizeTrustedStatusText
+} from '@/lib/utils/text/sanitizeText'
 
 interface Props {
   summary?: string | null
+  tags?:
+    | (
+        | Pick<Tag, 'type' | 'name' | 'value'>
+        | ActorEmojiTag
+        | { type: string; name: string; value: string }
+      )[]
+    | null
+  emojis?: MastodonAccountCustomEmoji[] | null
 }
 
-export const Bio: FC<Props> = ({ summary }) => {
+export const Bio: FC<Props> = ({ summary, tags, emojis }) => {
+  const resolvedTags = useMemo(() => {
+    const list: Pick<Tag, 'type' | 'name' | 'value'>[] = []
+    for (const tag of tags ?? []) {
+      if (tag.type === 'emoji') {
+        list.push({ type: 'emoji', name: tag.name, value: tag.value })
+      }
+    }
+    for (const emoji of emojis ?? []) {
+      const token = toEmojiShortcodeToken(emoji.shortcode)
+      if (token) {
+        list.push({ type: 'emoji', name: token, value: emoji.url })
+      }
+    }
+    return list
+  }, [tags, emojis])
+
   const bio = useMemo(
-    () => cleanClassName(sanitizeText(summary || '')),
-    [summary]
+    () =>
+      cleanClassName(
+        sanitizeTrustedStatusText(
+          convertEmojisToImages(sanitizeText(summary || ''), resolvedTags)
+        )
+      ),
+    [summary, resolvedTags]
   )
   return (
     <div className="mt-4 text-sm leading-relaxed break-words [&_a]:text-sky-600 dark:[&_a]:text-sky-400 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-sky-700 dark:[&_a:hover]:text-sky-300 [&_p]:mb-4 last:[&_p]:mb-0">

--- a/lib/components/medias-modal/medias-modal.test.tsx
+++ b/lib/components/medias-modal/medias-modal.test.tsx
@@ -125,4 +125,29 @@ describe('MediasModal', () => {
     altElements[1].dispatchEvent(touchStartEvent)
     expect(stopPropagationSpy).toHaveBeenCalled()
   })
+
+  it('renders custom emoji images in alt text when matching tags are passed', () => {
+    const attachment = buildAttachment({
+      name: 'Image caption with :blobcat:'
+    })
+
+    render(
+      <MediasModal
+        medias={[attachment]}
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+        initialSelection={0}
+        onClosed={vi.fn()}
+      />
+    )
+
+    const imgs = screen.getAllByRole('img', { name: ':blobcat:' })
+    expect(imgs.length).toBeGreaterThanOrEqual(1)
+    expect(imgs[0]).toHaveAttribute('src', 'https://example.com/blobcat.png')
+  })
 })

--- a/lib/components/medias-modal/medias-modal.tsx
+++ b/lib/components/medias-modal/medias-modal.tsx
@@ -2,9 +2,12 @@ import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import { Media } from '@/lib/components/posts/media'
 import { Button } from '@/lib/components/ui/button'
+import { ActorEmojiTag } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
+import { Tag } from '@/lib/types/domain/tag'
 import { cn } from '@/lib/utils'
 
 const MIN_SWIPE_DISTANCE = 50 // Minimum distance in pixels for a swipe to be recognized
@@ -13,12 +16,20 @@ const INTERACTIVE_SWIPE_IGNORE_SELECTOR =
 
 interface Props {
   medias: Attachment[] | null
+  tags?:
+    | (
+        | Pick<Tag, 'type' | 'name' | 'value'>
+        | ActorEmojiTag
+        | { type: string; name: string; value: string }
+      )[]
+    | null
   initialSelection: number
   onClosed: () => void
 }
 
 export const MediasModal: FC<Props> = ({
   medias,
+  tags,
   initialSelection,
   onClosed
 }) => {
@@ -300,7 +311,10 @@ export const MediasModal: FC<Props> = ({
                         onTouchStart={(e) => e.stopPropagation()}
                         className="mt-2 max-h-24 max-w-2xl overflow-y-auto px-4 text-center text-sm leading-relaxed text-white/85 select-text"
                       >
-                        {medias[index].name.trim()}
+                        <CustomEmojiText
+                          text={medias[index].name.trim()}
+                          tags={tags}
+                        />
                       </p>
                     ) : null}
                   </div>

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -1050,6 +1050,43 @@ describe('PostBox markdown preview', () => {
     )
   })
 
+  it('renders custom emoji shortcodes in content warning preview', async () => {
+    ;(getCustomEmojis as jest.Mock).mockResolvedValueOnce([
+      {
+        shortcode: 'blobcat',
+        url: 'https://activities.local/emojis/blobcat.png',
+        static_url: 'https://activities.local/emojis/blobcat.png',
+        visible_in_picker: true,
+        category: null
+      }
+    ])
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        onDiscardReply={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add content warning' }))
+    const cwInput = screen.getByPlaceholderText('Write your warning here')
+    fireEvent.change(cwInput, { target: { value: 'CW :blobcat:' } })
+    const textarea = screen.getByPlaceholderText('What is on your mind?')
+    fireEvent.change(textarea, { target: { value: 'hidden secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle preview' }))
+
+    const image = await screen.findByAltText(':blobcat:')
+    expect(image).toHaveAttribute(
+      'src',
+      'https://activities.local/emojis/blobcat.png'
+    )
+    expect(screen.getAllByText('hidden secret')).toHaveLength(2)
+  })
+
   it('shows nothing to preview message when textarea is empty', async () => {
     render(
       <PostBox

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -28,6 +28,7 @@ import {
   uploadFitnessFile
 } from '@/lib/client'
 import { useInstanceLimits } from '@/lib/components/instance-limits'
+import { ContentWarning } from '@/lib/components/posts/content-warning'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import { Duration } from '@/lib/services/statuses/pollDurations'
@@ -391,8 +392,9 @@ export const PostBox: FC<Props> = ({
   // convertEmojisToImages pipeline the rendered Post uses. The synthetic ids are
   // preview-only and never persisted.
   const buildSyntheticEmojiTags = useCallback(
-    (value: string): Tag[] =>
-      getEmojiTags(value, customEmojis).map((emojiTag, index) => ({
+    (value: string | string[]): Tag[] => {
+      const textToScan = Array.isArray(value) ? value.join(' ') : value
+      return getEmojiTags(textToScan, customEmojis).map((emojiTag, index) => ({
         id: `preview-${index}`,
         statusId: 'preview',
         type: 'emoji' as const,
@@ -400,7 +402,8 @@ export const PostBox: FC<Props> = ({
         value: emojiTag.value,
         createdAt: 0,
         updatedAt: 0
-      })),
+      }))
+    },
     [customEmojis]
   )
 
@@ -1058,7 +1061,31 @@ export const PostBox: FC<Props> = ({
                 <div className="mb-2 flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   <Eye className="size-3" /> Preview
                 </div>
-                {text ? (
+                {postExtension.contentWarningVisible &&
+                postExtension.contentWarning ? (
+                  <ContentWarning
+                    summary={postExtension.contentWarning}
+                    tags={buildSyntheticEmojiTags([
+                      text,
+                      postExtension.contentWarning
+                    ])}
+                    defaultOpen
+                  >
+                    <div className="markdown-content max-w-none text-sm">
+                      {cleanClassName(
+                        processStatusTextContent(
+                          host,
+                          text,
+                          buildSyntheticEmojiTags([
+                            text,
+                            postExtension.contentWarning
+                          ]),
+                          true
+                        )
+                      )}
+                    </div>
+                  </ContentWarning>
+                ) : text ? (
                   <div className="markdown-content max-w-none text-sm">
                     {cleanClassName(
                       processStatusTextContent(

--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -1290,4 +1290,70 @@ describe('Attachments', () => {
 
     expect(parentOnClick).not.toHaveBeenCalled()
   })
+
+  it('renders custom emoji images in single-image alt text', () => {
+    const status = {
+      ...buildNoteStatus([
+        buildAttachment({
+          width: 800,
+          height: 600,
+          name: 'A photo with :blobcat: emoji'
+        })
+      ]),
+      tags: [
+        {
+          id: 'tag-1',
+          statusId: 'status-1',
+          type: 'emoji' as const,
+          name: ':blobcat:',
+          value: 'https://example.com/blobcat.png',
+          createdAt: 0,
+          updatedAt: 0
+        }
+      ]
+    }
+
+    render(<Attachments status={status} onMediaSelected={vi.fn()} />)
+
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://example.com/blobcat.png')
+    expect(screen.getByText(/A photo with/)).toBeInTheDocument()
+  })
+
+  it('renders custom emoji images in multi-image alt text drawer', () => {
+    const status = {
+      ...buildNoteStatus([
+        buildAttachment({
+          id: 'att-1',
+          width: 800,
+          height: 600,
+          name: 'First :blobcat:'
+        }),
+        buildAttachment({
+          id: 'att-2',
+          width: 800,
+          height: 600,
+          name: 'Second :blobcat:'
+        })
+      ]),
+      tags: [
+        {
+          id: 'tag-1',
+          statusId: 'status-1',
+          type: 'emoji' as const,
+          name: ':blobcat:',
+          value: 'https://example.com/blobcat.png',
+          createdAt: 0,
+          updatedAt: 0
+        }
+      ]
+    }
+
+    render(<Attachments status={status} onMediaSelected={vi.fn()} />)
+
+    const imgs = screen.getAllByRole('img', { name: ':blobcat:' })
+    expect(imgs.length).toBeGreaterThanOrEqual(1)
+    expect(imgs[0]).toHaveAttribute('src', 'https://example.com/blobcat.png')
+  })
 })

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
 import { CSSProperties, FC, MouseEvent, useId, useMemo, useState } from 'react'
 
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import {
   Attachment,
   isAudibleAttachment,
@@ -286,7 +287,7 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               onClick={(e) => e.stopPropagation()}
               className="mt-1.5 text-sm leading-relaxed text-muted-foreground break-words select-text"
             >
-              {altText}
+              <CustomEmojiText text={altText} tags={status.tags} />
             </p>
           ) : null}
         </div>
@@ -451,7 +452,9 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
                       <sup className="shrink-0 pt-0.5 text-xs font-semibold select-none">
                         {entry.indices.join(' ')}
                       </sup>
-                      <span className="break-words">{entry.text}</span>
+                      <span className="break-words">
+                        <CustomEmojiText text={entry.text} tags={status.tags} />
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/lib/components/posts/content-warning.test.tsx
+++ b/lib/components/posts/content-warning.test.tsx
@@ -39,4 +39,27 @@ describe('ContentWarning', () => {
 
     expect(screen.queryByText('Hidden details')).not.toBeInTheDocument()
   })
+
+  it('renders custom emoji images in summary when matching tags are provided', () => {
+    render(
+      <ContentWarning
+        summary="CW :blobcat: beware"
+        tags={[
+          {
+            type: 'emoji',
+            name: ':blobcat:',
+            value: 'https://example.com/blobcat.png'
+          }
+        ]}
+      >
+        <p>Hidden details</p>
+      </ContentWarning>
+    )
+
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://example.com/blobcat.png')
+    expect(screen.getByText(/CW/)).toBeInTheDocument()
+    expect(screen.getByText(/beware/)).toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/content-warning.tsx
+++ b/lib/components/posts/content-warning.tsx
@@ -3,13 +3,30 @@
 import { AlertTriangle } from 'lucide-react'
 import { FC, ReactNode, useId, useState } from 'react'
 
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
+import { ActorEmojiTag } from '@/lib/types/domain/actor'
+import { Tag } from '@/lib/types/domain/tag'
+
 interface Props {
   children: ReactNode
   summary: string
+  defaultOpen?: boolean
+  tags?:
+    | (
+        | Pick<Tag, 'type' | 'name' | 'value'>
+        | ActorEmojiTag
+        | { type: string; name: string; value: string }
+      )[]
+    | null
 }
 
-export const ContentWarning: FC<Props> = ({ children, summary }) => {
-  const [isExpanded, setIsExpanded] = useState(false)
+export const ContentWarning: FC<Props> = ({
+  children,
+  summary,
+  defaultOpen = false,
+  tags
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultOpen)
   const contentId = useId()
 
   return (
@@ -27,7 +44,9 @@ export const ContentWarning: FC<Props> = ({ children, summary }) => {
       >
         <div className="flex min-w-0 items-center gap-2">
           <AlertTriangle className="size-4 shrink-0 text-muted-foreground" />
-          <span className="break-words text-sm font-medium">{summary}</span>
+          <span className="break-words text-sm font-medium">
+            <CustomEmojiText text={summary} tags={tags} />
+          </span>
         </div>
         <span
           className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-input bg-secondary px-3 text-sm font-medium text-secondary-foreground shadow-xs"

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -203,4 +203,43 @@ describe('Poll', () => {
     expect(screen.getByText('0%')).toBeInTheDocument()
     expect(screen.getByText(/1 vote/)).toBeInTheDocument()
   })
+
+  it('renders custom emoji images in poll choices', () => {
+    const statusWithEmoji: StatusPoll = {
+      ...pollStatus,
+      tags: [
+        {
+          id: 'tag-1',
+          statusId: pollStatus.id,
+          type: 'emoji',
+          name: ':blobcat:',
+          value: 'https://example.com/blobcat.png',
+          createdAt: currentTime,
+          updatedAt: currentTime
+        }
+      ],
+      choices: [
+        {
+          statusId: pollStatus.id,
+          title: 'Option :blobcat:',
+          totalVotes: 0,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        }
+      ]
+    }
+
+    render(
+      <Poll
+        status={statusWithEmoji}
+        currentTime={currentTime}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    const img = screen.getByRole('img', { name: ':blobcat:' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://example.com/blobcat.png')
+    expect(screen.getByText(/Option/)).toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -5,6 +5,7 @@ import { Check } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 
 import { votePoll } from '@/lib/client'
+import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
@@ -182,7 +183,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
                     ))}
                 </span>
                 <span className="min-w-0 flex-1 truncate">
-                  {titleFor(index)}
+                  <CustomEmojiText text={titleFor(index)} tags={status.tags} />
                 </span>
               </label>
             )
@@ -212,7 +213,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
                     mine && 'font-semibold'
                   )}
                 >
-                  {titleFor(index)}
+                  <CustomEmojiText text={titleFor(index)} tags={status.tags} />
                   {mine && <span className="text-primary"> ✓</span>}
                 </span>
                 <span className="shrink-0 tabular-nums text-muted-foreground">

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -483,7 +483,9 @@ export const Post: FC<PostProps> = (props) => {
           </div>
 
           {summary ? (
-            <ContentWarning summary={summary}>{statusBody}</ContentWarning>
+            <ContentWarning summary={summary} tags={actualStatus.tags}>
+              {statusBody}
+            </ContentWarning>
           ) : (
             statusBody
           )}

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -8,6 +8,7 @@ import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/domain/tag'
 import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import { cn } from '@/lib/utils'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
@@ -79,6 +80,7 @@ export const Posts: FC<Props> = ({
   const router = useRouter()
   const [modalMedias, setModalMedias] = useState<{
     medias: Attachment[]
+    tags?: Tag[]
     initialSelection: number
   } | null>(null)
   // Reply/quote/edit share one inline composer owned here, so every surface
@@ -161,7 +163,11 @@ export const Posts: FC<Props> = ({
                 onReactionsChanged={onReactionsChanged}
                 onOpenStatus={openStatus}
                 onShowAttachment={(allMedias, index) => {
-                  setModalMedias({ medias: allMedias, initialSelection: index })
+                  setModalMedias({
+                    medias: allMedias,
+                    tags: actualStatus.tags,
+                    initialSelection: index
+                  })
                 }}
               />
               {activeComposer && currentActor ? (
@@ -183,6 +189,7 @@ export const Posts: FC<Props> = ({
       </section>
       <MediasModal
         medias={modalMedias?.medias ?? null}
+        tags={modalMedias?.tags ?? null}
         initialSelection={modalMedias?.initialSelection ?? 0}
         onClosed={() => setModalMedias(null)}
       />

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -870,6 +870,33 @@ describe('ActorDatabase', () => {
         ])
       })
 
+      it('automatically resolves local custom emoji when profile fields are updated', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `autoresolve-fields-${suffix}`
+        const actorId = `https://${TEST_DOMAIN}/users/${username}`
+        await createSigningAccount(database, username)
+
+        await database.createCustomEmoji({
+          shortcode: 'fieldblob',
+          url: 'https://example.com/fieldblob.png',
+          staticUrl: 'https://example.com/fieldblob.png'
+        })
+
+        await database.updateActor({
+          actorId,
+          fields: [{ name: 'Pronouns', value: ':fieldblob:' }]
+        })
+
+        const actor = await database.getActorFromId({ id: actorId })
+        expect(actor?.tags).toEqual([
+          {
+            type: 'emoji',
+            name: ':fieldblob:',
+            value: 'https://example.com/fieldblob.png'
+          }
+        ])
+      })
+
       it('serializes suspended actors with suspended: true and silenced actors with limited: true', async () => {
         await withFreshDatabase(async (database) => {
           const suffix = crypto.randomUUID().slice(0, 8)

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -190,13 +190,15 @@ const insertActorWithSearchIndex = async (
 ) => {
   const currentTime = new Date()
   let resolvedTags = tags
-  if (resolvedTags === undefined && (name || summary)) {
+  if (resolvedTags === undefined && (name || summary || fields)) {
     const isLocal =
       domain.toLowerCase() === getConfiguredActorDomain().toLowerCase()
     if (isLocal) {
+      const fieldsText =
+        fields?.map((f) => `${f.name} ${f.value}`).join(' ') ?? ''
       resolvedTags = await resolveLocalEmojiTags(
         database,
-        `${name ?? ''} ${summary ?? ''}`
+        `${name ?? ''} ${summary ?? ''} ${fieldsText}`.trim()
       )
     }
   }
@@ -1016,10 +1018,11 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       .first()
     if (!persistedActor) return null
 
+    const persistedSettings = getCompatibleJSON(persistedActor.settings)
     let resolvedTags = tags
     if (
       resolvedTags === undefined &&
-      (name !== undefined || summary !== undefined)
+      (name !== undefined || summary !== undefined || fields !== undefined)
     ) {
       const isLocal =
         persistedActor.domain.toLowerCase() ===
@@ -1029,14 +1032,17 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
           name !== undefined ? name : (persistedActor.name ?? '')
         const targetSummary =
           summary !== undefined ? summary : (persistedActor.summary ?? '')
+        const targetFields =
+          fields !== undefined ? fields : (persistedSettings.fields ?? [])
+        const fieldsText = targetFields
+          .map((f: { name: string; value: string }) => `${f.name} ${f.value}`)
+          .join(' ')
         resolvedTags = await resolveLocalEmojiTags(
           database,
-          `${targetName} ${targetSummary}`
+          `${targetName} ${targetSummary} ${fieldsText}`.trim()
         )
       }
     }
-
-    const persistedSettings = getCompatibleJSON(persistedActor.settings)
     // The explicit settings changes requested by this call (undefined fields
     // mean "no change"). Kept as a standalone object so the
     // appendNotificationAcceptedSenders path can re-apply them on top of the

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -816,7 +816,7 @@ export const getMastodonStatus = async (
         title: choice.title,
         votes_count: showTotals ? choice.totalVotes : null
       })),
-      emojis: [],
+      emojis,
       voted,
       own_votes: ownVotes
     })


### PR DESCRIPTION
## Summary

Extends custom emoji (`:shortcode:`) support to all relevant surfaces across the web UI, composer preview, Mastodon API, and ActivityPub federation, building on the initial profile display name custom emoji work (#1752).

Key changes:
- **Component & Text rendering:**
  - Exported `CustomEmojiText` from `lib/components/actors/ActorDisplayName.tsx` (aliasing `ActorDisplayName` with support for both `text` and `name` props).
  - Extended `ContentWarning` (`lib/components/posts/content-warning.tsx`) to accept `tags` and optional `defaultOpen` and render summary with `CustomEmojiText`.
  - Extended poll choice titles (`lib/components/posts/poll.tsx`) to render with `CustomEmojiText`.
  - Extended media attachment alt text in single image overlay and multi-image drawer (`lib/components/posts/attachments.tsx`), and in media modal lightbox (`lib/components/medias-modal/medias-modal.tsx`).
  - Extended profile bio (`Bio.tsx`) to accept `tags` and `emojis` and process custom emoji tokens through `convertEmojisToImages` with sanitization and size styling.
  - Extended follow list bio summaries (`FollowList.tsx`), search account rows (`SearchPageClient.tsx`), status likes lists (`StatusLikes.tsx`), and status notifications (`StatusNotification.tsx`).
- **Composer live preview:**
  - Updated `PostBox` (`lib/components/post-box/post-box.tsx`) to include content warning in synthetic emoji tags and render content warning preview with custom emojis.
- **Backend & Action pipelines:**
  - Updated `persistEmojiTagsForStatus` (`lib/actions/createNote.ts`) to scan `[text, summary, ...attachments]` on create and update of notes (`updateNote.ts`).
  - Updated `createPoll.ts` and `updatePoll.ts` to scan `[text, summary, ...choices]`.
  - Updated `insertActorWithSearchIndex` and `updateActor` (`lib/database/sql/actor.ts`) to scan profile metadata fields (`fields`) for custom emojis into `actor.settings.tags`.
  - Updated `getMastodonStatus.ts` to populate poll `emojis` from status emoji tags.
- **Documentation:**
  - Updated `docs/features.md` to reflect extended custom emoji coverage.

## Screenshots

<!-- Draft PR; UI verified with automated tests and component rendering -->

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)