### PR TITLE
Bump version to v1.158.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.157.1",
+  "version": "1.158.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.157.1`
- Base main SHA: `0707cc5d69f87054193c9b71c94486f9055094e9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
