### PR TITLE
feat: restore border on Pixelfed profile and reduce media grid padding

### DIFF
--- a/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.test.tsx
@@ -262,4 +262,55 @@ describe('ActorMediaGallery', () => {
     ).toBeInTheDocument()
     expect(screen.queryByText('Load more')).not.toBeInTheDocument()
   })
+
+  it('renders the gallery grid inside a framed card with reduced padding for both standard and Pixelfed profiles', () => {
+    const attachment = buildAttachment({
+      id: 'photo-1',
+      name: 'Sample image'
+    })
+
+    const { container: standardContainer } = render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[attachment]}
+        isPixelfed={false}
+      />
+    )
+
+    const standardFrame = standardContainer.querySelector(
+      '.rounded-xl.border.bg-card.p-1.shadow-sm'
+    )
+    expect(standardFrame).toBeInTheDocument()
+    expect(standardFrame).toHaveClass('sm:p-2')
+
+    const { container: pixelfedContainer } = render(
+      <ActorMediaGallery
+        actorId="https://pixelfed.example/users/user"
+        initialAttachments={[attachment]}
+        isPixelfed={true}
+      />
+    )
+
+    const pixelfedFrame = pixelfedContainer.querySelector(
+      '.rounded-xl.border.bg-card.p-1.shadow-sm'
+    )
+    expect(pixelfedFrame).toBeInTheDocument()
+    expect(pixelfedFrame).toHaveClass('sm:p-2')
+  })
+
+  it('merges custom className onto the framed card container', () => {
+    const attachment = buildAttachment({ id: 'photo-1' })
+    const { container } = render(
+      <ActorMediaGallery
+        actorId="https://activities.local/users/llun"
+        initialAttachments={[attachment]}
+        className="custom-test-class"
+      />
+    )
+
+    const frame = container.querySelector(
+      '.rounded-xl.border.bg-card.p-1.shadow-sm'
+    )
+    expect(frame).toHaveClass('custom-test-class')
+  })
 })

--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -9,6 +9,7 @@ import { Media } from '@/lib/components/posts/media'
 import { Button } from '@/lib/components/ui/button'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 
 const compactNumberFormatter = new Intl.NumberFormat('en', {
   notation: 'compact',
@@ -23,13 +24,15 @@ interface Props {
   initialAttachments: Attachment[]
   statuses?: Status[]
   isPixelfed?: boolean
+  className?: string
 }
 
 export const ActorMediaGallery: FC<Props> = ({
   actorId,
   initialAttachments,
   statuses,
-  isPixelfed = false
+  isPixelfed = false,
+  className
 }) => {
   const [modalIndex, setModalIndex] = useState<number | null>(null)
   const [attachments, setAttachments] =
@@ -87,106 +90,113 @@ export const ActorMediaGallery: FC<Props> = ({
 
   return (
     <>
-      <div className="grid grid-cols-3 gap-1 sm:gap-2">
-        {attachments.map((attachment, index) => {
-          const parentStatus = statusMap.get(attachment.statusId)
-          const totalLikes = parentStatus?.totalLikes ?? 0
-          const totalShares = parentStatus?.totalShares ?? 0
-          const totalReplies =
-            parentStatus?.totalReplies ?? parentStatus?.replies.length ?? 0
-          const attachmentCount = parentStatus?.attachments.length ?? 1
-          const isVideo =
-            attachment.mediaType.startsWith('video') ||
-            attachment.url.endsWith('.mp4') ||
-            attachment.url.endsWith('.webm')
+      <div
+        className={cn(
+          'rounded-xl border bg-card p-1 shadow-sm sm:p-2',
+          className
+        )}
+      >
+        <div className="grid grid-cols-3 gap-1 sm:gap-2">
+          {attachments.map((attachment, index) => {
+            const parentStatus = statusMap.get(attachment.statusId)
+            const totalLikes = parentStatus?.totalLikes ?? 0
+            const totalShares = parentStatus?.totalShares ?? 0
+            const totalReplies =
+              parentStatus?.totalReplies ?? parentStatus?.replies.length ?? 0
+            const attachmentCount = parentStatus?.attachments.length ?? 1
+            const isVideo =
+              attachment.mediaType.startsWith('video') ||
+              attachment.url.endsWith('.mp4') ||
+              attachment.url.endsWith('.webm')
 
-          return (
-            <button
-              key={attachment.id}
-              type="button"
-              className="group relative aspect-square overflow-hidden bg-muted/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
-              onClick={() => setModalIndex(index)}
-              aria-label={
-                attachment.name
-                  ? `Open media: ${attachment.name}`
-                  : `Open media ${index + 1}`
-              }
-            >
-              <Media
-                attachment={attachment}
-                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
-              />
-
-              {/* Multiple attachments badge */}
-              {attachmentCount > 1 ? (
-                <span
-                  className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
-                  aria-label="Multiple items"
-                  data-testid="album-indicator"
-                >
-                  <Copy className="size-3.5 sm:size-4" aria-hidden="true" />
-                </span>
-              ) : isVideo ? (
-                <span
-                  className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
-                  aria-label="Video"
-                  data-testid="video-indicator"
-                >
-                  <Video className="size-3.5 sm:size-4" aria-hidden="true" />
-                </span>
-              ) : null}
-
-              {/* Alt text badge */}
-              {attachment.name?.trim() ? (
-                <span
-                  className="pointer-events-none absolute bottom-1.5 left-1.5 z-10 flex items-center rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-white shadow-sm backdrop-blur-xs"
-                  aria-hidden="true"
-                >
-                  ALT
-                </span>
-              ) : null}
-
-              {/* Engagement counts overlay on hover/focus */}
-              <div
-                className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
-                data-testid={`media-overlay-${attachment.id}`}
+            return (
+              <button
+                key={attachment.id}
+                type="button"
+                className="group relative aspect-square overflow-hidden bg-muted/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
+                onClick={() => setModalIndex(index)}
+                aria-label={
+                  attachment.name
+                    ? `Open media: ${attachment.name}`
+                    : `Open media ${index + 1}`
+                }
               >
-                <div className="flex flex-wrap items-center justify-center gap-3 px-2 text-white font-semibold text-sm sm:gap-4 sm:text-base">
+                <Media
+                  attachment={attachment}
+                  className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
+                />
+
+                {/* Multiple attachments badge */}
+                {attachmentCount > 1 ? (
                   <span
-                    className="flex items-center gap-1.5"
-                    title={`${totalLikes} favorites`}
+                    className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
+                    aria-label="Multiple items"
+                    data-testid="album-indicator"
                   >
-                    <Heart
-                      className="size-4 sm:size-5 fill-white text-white"
-                      aria-hidden="true"
-                    />
-                    <span>{formatCount(totalLikes)}</span>
+                    <Copy className="size-3.5 sm:size-4" aria-hidden="true" />
                   </span>
+                ) : isVideo ? (
                   <span
-                    className="flex items-center gap-1.5"
-                    title={`${totalReplies} comments`}
+                    className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center rounded bg-black/60 p-1 text-white shadow-sm backdrop-blur-xs"
+                    aria-label="Video"
+                    data-testid="video-indicator"
                   >
-                    <MessageCircle
-                      className="size-4 sm:size-5 fill-white text-white"
-                      aria-hidden="true"
-                    />
-                    <span>{formatCount(totalReplies)}</span>
+                    <Video className="size-3.5 sm:size-4" aria-hidden="true" />
                   </span>
+                ) : null}
+
+                {/* Alt text badge */}
+                {attachment.name?.trim() ? (
                   <span
-                    className="flex items-center gap-1.5"
-                    title={`${totalShares} reposts`}
+                    className="pointer-events-none absolute bottom-1.5 left-1.5 z-10 flex items-center rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-white shadow-sm backdrop-blur-xs"
+                    aria-hidden="true"
                   >
-                    <Repeat2
-                      className="size-4 sm:size-5 text-white"
-                      aria-hidden="true"
-                    />
-                    <span>{formatCount(totalShares)}</span>
+                    ALT
                   </span>
+                ) : null}
+
+                {/* Engagement counts overlay on hover/focus */}
+                <div
+                  className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                  data-testid={`media-overlay-${attachment.id}`}
+                >
+                  <div className="flex flex-wrap items-center justify-center gap-3 px-2 text-white font-semibold text-sm sm:gap-4 sm:text-base">
+                    <span
+                      className="flex items-center gap-1.5"
+                      title={`${totalLikes} favorites`}
+                    >
+                      <Heart
+                        className="size-4 sm:size-5 fill-white text-white"
+                        aria-hidden="true"
+                      />
+                      <span>{formatCount(totalLikes)}</span>
+                    </span>
+                    <span
+                      className="flex items-center gap-1.5"
+                      title={`${totalReplies} comments`}
+                    >
+                      <MessageCircle
+                        className="size-4 sm:size-5 fill-white text-white"
+                        aria-hidden="true"
+                      />
+                      <span>{formatCount(totalReplies)}</span>
+                    </span>
+                    <span
+                      className="flex items-center gap-1.5"
+                      title={`${totalShares} reposts`}
+                    >
+                      <Repeat2
+                        className="size-4 sm:size-5 text-white"
+                        aria-hidden="true"
+                      />
+                      <span>{formatCount(totalShares)}</span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </button>
-          )
-        })}
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       {error && (

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -431,14 +431,12 @@ export const ActorTimelines: FC<Props> = ({
 
         <TabsContent value="media" className="mt-0">
           {attachments.length > 0 ? (
-            <div className="rounded-xl border bg-card p-2 shadow-sm sm:p-4">
-              <ActorMediaGallery
-                actorId={actorId}
-                initialAttachments={attachments}
-                statuses={currentStatuses}
-                isPixelfed={false}
-              />
-            </div>
+            <ActorMediaGallery
+              actorId={actorId}
+              initialAttachments={attachments}
+              statuses={currentStatuses}
+              isPixelfed={false}
+            />
           ) : (
             <EmptyState>No media yet</EmptyState>
           )}


### PR DESCRIPTION
## Summary

Restores the framed card border (`rounded-xl border bg-card shadow-sm`) on Pixelfed profile timelines and tightens the interior padding between the media grid and the card border across both Pixelfed profiles and the standard profile Media tab:

- Encapsulated the card wrapper (`rounded-xl border bg-card p-1 shadow-sm sm:p-2`) inside `ActorMediaGallery.tsx` directly around the 3-column image grid.
- Reduced the interior padding from `p-2 sm:p-4` to `p-1 sm:p-2`, matching the grid item gap (`gap-1 sm:gap-2`) and reducing excess whitespace between the images and the card border.
- Removed the redundant outer card container from the Media tab in `ActorTimelines.tsx`.
- Preserved pagination ("Load more") and error states outside underneath the media grid card.
- Added unit tests in `ActorMediaGallery.test.tsx` covering both standard and Pixelfed profiles, as well as custom `className` merging.

## Screenshots

Verified in Chromium on local dev server across desktop (1280x900) and mobile (390x844) viewports:
- **Pixelfed Profile Timeline**: Framed border card is present with uniform `p-1 sm:p-2` padding around photos.
- **Standard Profile Media Tab**: Framed border card with uniform `p-1 sm:p-2` padding around photos.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
