### PR TITLE
Bump version to v1.158.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.0",
+  "version": "1.158.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.0`
- Base main SHA: `f82cd216f9186d32c3d8ebc3aa87dcf5a8f10118`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
