### PR TITLE
feat: order DLQ messages descending, add drop all and selective actions

### DIFF
--- a/app/(timeline)/admin/queues/AdminQueuesList.test.tsx
+++ b/app/(timeline)/admin/queues/AdminQueuesList.test.tsx
@@ -1,12 +1,14 @@
 /**
  * @vitest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  deleteSelectedDeadLetterJobs,
   discardDeadLetterJob,
-  retryDeadLetterJob
+  retryDeadLetterJob,
+  retrySelectedDeadLetterJobs
 } from '@/app/(timeline)/admin/queues/actions'
 import { DeadLetterJob } from '@/lib/types/database/operations'
 
@@ -14,7 +16,9 @@ import { AdminQueuesList } from './AdminQueuesList'
 
 vi.mock('@/app/(timeline)/admin/queues/actions', () => ({
   retryDeadLetterJob: vi.fn().mockResolvedValue({ success: true }),
-  discardDeadLetterJob: vi.fn().mockResolvedValue({ success: true })
+  discardDeadLetterJob: vi.fn().mockResolvedValue({ success: true }),
+  retrySelectedDeadLetterJobs: vi.fn().mockResolvedValue({ success: true }),
+  deleteSelectedDeadLetterJobs: vi.fn().mockResolvedValue({ success: true })
 }))
 
 const sampleJob: DeadLetterJob = {
@@ -66,7 +70,9 @@ describe('AdminQueuesList', () => {
     render(<AdminQueuesList jobs={[sampleJob]} />)
 
     const retryBtn = screen.getByRole('button', { name: /retry/i })
-    fireEvent.click(retryBtn)
+    await act(async () => {
+      fireEvent.click(retryBtn)
+    })
     await vi.waitFor(() => {
       expect(retryDeadLetterJob).toHaveBeenCalledWith('job-123')
     })
@@ -76,9 +82,67 @@ describe('AdminQueuesList', () => {
     render(<AdminQueuesList jobs={[sampleJob]} />)
 
     const discardBtn = screen.getByRole('button', { name: /discard/i })
-    fireEvent.click(discardBtn)
+    await act(async () => {
+      fireEvent.click(discardBtn)
+    })
     await vi.waitFor(() => {
       expect(discardDeadLetterJob).toHaveBeenCalledWith('job-123')
+    })
+  })
+
+  it('selects all jobs and triggers selective retry', async () => {
+    const job2 = { ...sampleJob, id: 'job-456', jobName: 'job2' }
+    render(<AdminQueuesList jobs={[sampleJob, job2]} />)
+
+    const selectAllCheckbox = screen.getByRole('checkbox', {
+      name: /select all jobs/i
+    })
+    await act(async () => {
+      fireEvent.click(selectAllCheckbox)
+    })
+
+    expect(screen.getByText('2 of 2 selected')).toBeDefined()
+
+    const retrySelectedBtn = screen.getByRole('button', {
+      name: /retry selected \(2\)/i
+    })
+    await act(async () => {
+      fireEvent.click(retrySelectedBtn)
+    })
+
+    await vi.waitFor(() => {
+      expect(retrySelectedDeadLetterJobs).toHaveBeenCalledWith([
+        'job-123',
+        'job-456'
+      ])
+    })
+  })
+
+  it('selects single job and triggers selective delete with confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    render(<AdminQueuesList jobs={[sampleJob]} />)
+
+    const jobCheckbox = screen.getByRole('checkbox', {
+      name: /select job syncProfile/i
+    })
+    await act(async () => {
+      fireEvent.click(jobCheckbox)
+    })
+
+    expect(screen.getByText('1 of 1 selected')).toBeDefined()
+
+    const deleteSelectedBtn = screen.getByRole('button', {
+      name: /delete selected \(1\)/i
+    })
+    await act(async () => {
+      fireEvent.click(deleteSelectedBtn)
+    })
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to delete 1 selected job?'
+    )
+    await vi.waitFor(() => {
+      expect(deleteSelectedDeadLetterJobs).toHaveBeenCalledWith(['job-123'])
     })
   })
 })

--- a/app/(timeline)/admin/queues/AdminQueuesList.tsx
+++ b/app/(timeline)/admin/queues/AdminQueuesList.tsx
@@ -124,6 +124,7 @@ export const AdminQueuesList: FC<Props> = ({ jobs }) => {
           <Checkbox
             checked={allSelected}
             onChange={toggleSelectAll}
+            disabled={isPending}
             aria-label="Select all jobs"
           />
           <span className="font-medium text-muted-foreground">
@@ -183,7 +184,8 @@ export const AdminQueuesList: FC<Props> = ({ jobs }) => {
                 <Checkbox
                   checked={selectedIds.has(job.id)}
                   onChange={() => toggleSelect(job.id)}
-                  aria-label={`Select job ${job.jobName}`}
+                  disabled={isPending}
+                  aria-label={`Select job ${job.jobName} (${job.id})`}
                   className="mt-1 shrink-0"
                 />
                 <div className="min-w-0 space-y-1">

--- a/app/(timeline)/admin/queues/AdminQueuesList.tsx
+++ b/app/(timeline)/admin/queues/AdminQueuesList.tsx
@@ -6,16 +6,20 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
-  RotateCw
+  RotateCw,
+  Trash2
 } from 'lucide-react'
 import { FC, useState, useTransition } from 'react'
 
 import {
+  deleteSelectedDeadLetterJobs,
   discardDeadLetterJob,
-  retryDeadLetterJob
+  retryDeadLetterJob,
+  retrySelectedDeadLetterJobs
 } from '@/app/(timeline)/admin/queues/actions'
 import { Badge } from '@/lib/components/ui/badge'
 import { Button } from '@/lib/components/ui/button'
+import { Checkbox } from '@/lib/components/ui/checkbox'
 import { DeadLetterJob } from '@/lib/types/database/operations'
 
 interface Props {
@@ -26,8 +30,56 @@ export const AdminQueuesList: FC<Props> = ({ jobs }) => {
   const [expandedJobIds, setExpandedJobIds] = useState<Record<string, boolean>>(
     {}
   )
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [copiedKey, setCopiedKey] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+
+  const allSelected =
+    jobs.length > 0 && jobs.every((job) => selectedIds.has(job.id))
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(jobs.map((job) => job.id)))
+    }
+  }
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const handleRetrySelected = () => {
+    const ids = Array.from(selectedIds)
+    if (ids.length === 0) return
+    startTransition(async () => {
+      await retrySelectedDeadLetterJobs(ids)
+      setSelectedIds(new Set())
+    })
+  }
+
+  const handleDeleteSelected = () => {
+    const ids = Array.from(selectedIds)
+    if (ids.length === 0) return
+    if (
+      !confirm(
+        `Are you sure you want to delete ${ids.length} selected job${ids.length === 1 ? '' : 's'}?`
+      )
+    )
+      return
+    startTransition(async () => {
+      await deleteSelectedDeadLetterJobs(ids)
+      setSelectedIds(new Set())
+    })
+  }
 
   const toggleExpand = (id: string) => {
     setExpandedJobIds((prev) => ({ ...prev, [id]: !prev[id] }))
@@ -67,6 +119,55 @@ export const AdminQueuesList: FC<Props> = ({ jobs }) => {
 
   return (
     <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-background/50 px-3 py-2 text-xs">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={allSelected}
+            onChange={toggleSelectAll}
+            aria-label="Select all jobs"
+          />
+          <span className="font-medium text-muted-foreground">
+            {selectedIds.size > 0
+              ? `${selectedIds.size} of ${jobs.length} selected`
+              : 'Select all'}
+          </span>
+        </div>
+
+        {selectedIds.size > 0 && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isPending}
+              onClick={handleRetrySelected}
+              className="gap-1 text-xs"
+            >
+              <RotateCw className="h-3 w-3" />
+              Retry selected ({selectedIds.size})
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isPending}
+              onClick={handleDeleteSelected}
+              className="gap-1 text-xs text-destructive hover:bg-destructive/10"
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete selected ({selectedIds.size})
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={isPending}
+              onClick={() => setSelectedIds(new Set())}
+              className="text-xs text-muted-foreground"
+            >
+              Clear
+            </Button>
+          </div>
+        )}
+      </div>
+
       {jobs.map((job) => {
         const isExpanded = !!expandedJobIds[job.id]
         const formattedPayload = JSON.stringify(job.payload, null, 2)
@@ -78,32 +179,40 @@ export const AdminQueuesList: FC<Props> = ({ jobs }) => {
             className="rounded-xl border bg-background/80 p-4 shadow-sm transition-colors"
           >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="min-w-0 space-y-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-semibold text-sm sm:text-base">
-                    {job.jobName}
-                  </span>
-                  <Badge
-                    tone={
-                      job.status === 'failed'
-                        ? 'destructive'
-                        : job.status === 'retried'
-                          ? 'success'
-                          : 'gray'
-                    }
-                  >
-                    {job.status}
-                  </Badge>
-                  <span className="text-xs text-muted-foreground">
-                    Attempts: {job.attempts}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {dateString}
-                  </span>
+              <div className="flex items-start gap-3 min-w-0">
+                <Checkbox
+                  checked={selectedIds.has(job.id)}
+                  onChange={() => toggleSelect(job.id)}
+                  aria-label={`Select job ${job.jobName}`}
+                  className="mt-1 shrink-0"
+                />
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-semibold text-sm sm:text-base">
+                      {job.jobName}
+                    </span>
+                    <Badge
+                      tone={
+                        job.status === 'failed'
+                          ? 'destructive'
+                          : job.status === 'retried'
+                            ? 'success'
+                            : 'gray'
+                      }
+                    >
+                      {job.status}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      Attempts: {job.attempts}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {dateString}
+                    </span>
+                  </div>
+                  <p className="truncate text-sm text-destructive font-mono">
+                    {job.errorMessage}
+                  </p>
                 </div>
-                <p className="truncate text-sm text-destructive font-mono">
-                  {job.errorMessage}
-                </p>
               </div>
 
               <div className="flex shrink-0 items-center gap-2">

--- a/app/(timeline)/admin/queues/AdminQueuesToolbar.test.tsx
+++ b/app/(timeline)/admin/queues/AdminQueuesToolbar.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearDiscardedJobs,
+  dropAllDeadLetterJobs,
+  retryAllDeadLetterJobs
+} from '@/app/(timeline)/admin/queues/actions'
+
+import { AdminQueuesToolbar } from './AdminQueuesToolbar'
+
+vi.mock('@/app/(timeline)/admin/queues/actions', () => ({
+  retryAllDeadLetterJobs: vi.fn().mockResolvedValue({ success: true }),
+  clearDiscardedJobs: vi.fn().mockResolvedValue({ success: true }),
+  dropAllDeadLetterJobs: vi.fn().mockResolvedValue({ success: true })
+}))
+
+describe('AdminQueuesToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  it('renders nothing when all counts are 0', () => {
+    const { container } = render(
+      <AdminQueuesToolbar allCount={0} failedCount={0} discardedCount={0} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders retry all button when failedCount > 0 and calls action', async () => {
+    render(
+      <AdminQueuesToolbar allCount={3} failedCount={3} discardedCount={0} />
+    )
+
+    const retryBtn = screen.getByRole('button', {
+      name: /retry all failed \(3\)/i
+    })
+    expect(retryBtn).toBeDefined()
+
+    await act(async () => {
+      fireEvent.click(retryBtn)
+    })
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to retry all failed jobs?'
+    )
+    expect(retryAllDeadLetterJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders clear discarded button when discardedCount > 0 and calls action', async () => {
+    render(
+      <AdminQueuesToolbar allCount={2} failedCount={0} discardedCount={2} />
+    )
+
+    const clearBtn = screen.getByRole('button', {
+      name: /clear discarded \(2\)/i
+    })
+    expect(clearBtn).toBeDefined()
+
+    await act(async () => {
+      fireEvent.click(clearBtn)
+    })
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to permanently delete all discarded jobs?'
+    )
+    expect(clearDiscardedJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders drop all messages button when allCount > 0 and calls action', async () => {
+    render(
+      <AdminQueuesToolbar allCount={5} failedCount={3} discardedCount={2} />
+    )
+
+    const dropBtn = screen.getByRole('button', {
+      name: /drop all messages \(5\)/i
+    })
+    expect(dropBtn).toBeDefined()
+
+    await act(async () => {
+      fireEvent.click(dropBtn)
+    })
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to permanently drop all messages in the dead letter queue?'
+    )
+    expect(dropAllDeadLetterJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invoke dropAllDeadLetterJobs when confirmation is cancelled', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(
+      <AdminQueuesToolbar allCount={5} failedCount={3} discardedCount={2} />
+    )
+
+    const dropBtn = screen.getByRole('button', {
+      name: /drop all messages \(5\)/i
+    })
+    await act(async () => {
+      fireEvent.click(dropBtn)
+    })
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(dropAllDeadLetterJobs).not.toHaveBeenCalled()
+  })
+})

--- a/app/(timeline)/admin/queues/AdminQueuesToolbar.tsx
+++ b/app/(timeline)/admin/queues/AdminQueuesToolbar.tsx
@@ -5,16 +5,19 @@ import { FC, useTransition } from 'react'
 
 import {
   clearDiscardedJobs,
+  dropAllDeadLetterJobs,
   retryAllDeadLetterJobs
 } from '@/app/(timeline)/admin/queues/actions'
 import { Button } from '@/lib/components/ui/button'
 
 interface Props {
+  allCount?: number
   failedCount: number
   discardedCount: number
 }
 
 export const AdminQueuesToolbar: FC<Props> = ({
+  allCount = 0,
   failedCount,
   discardedCount
 }) => {
@@ -39,7 +42,19 @@ export const AdminQueuesToolbar: FC<Props> = ({
     })
   }
 
-  if (failedCount === 0 && discardedCount === 0) {
+  const handleDropAll = () => {
+    if (
+      !confirm(
+        'Are you sure you want to permanently drop all messages in the dead letter queue?'
+      )
+    )
+      return
+    startTransition(async () => {
+      await dropAllDeadLetterJobs()
+    })
+  }
+
+  if (failedCount === 0 && discardedCount === 0 && allCount === 0) {
     return null
   }
 
@@ -67,6 +82,18 @@ export const AdminQueuesToolbar: FC<Props> = ({
         >
           <Trash2 className="h-3.5 w-3.5" />
           Clear discarded ({discardedCount})
+        </Button>
+      )}
+      {allCount > 0 && (
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={handleDropAll}
+          className="gap-1.5 text-xs text-destructive hover:bg-destructive/10"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          Drop all messages ({allCount})
         </Button>
       )}
     </div>

--- a/app/(timeline)/admin/queues/actions.test.ts
+++ b/app/(timeline)/admin/queues/actions.test.ts
@@ -5,16 +5,21 @@ import { DeadLetterJob } from '@/lib/types/database/operations'
 
 import {
   clearDiscardedJobs,
+  deleteSelectedDeadLetterJobs,
   discardDeadLetterJob,
+  dropAllDeadLetterJobs,
   retryAllDeadLetterJobs,
-  retryDeadLetterJob
+  retryDeadLetterJob,
+  retrySelectedDeadLetterJobs
 } from './actions'
 
 const mockDatabase = {
   getDeadLetterJobById: vi.fn(),
   updateDeadLetterJobStatus: vi.fn(),
   getDeadLetterJobs: vi.fn(),
-  deleteDeadLetterJobsByStatus: vi.fn()
+  deleteDeadLetterJobsByStatus: vi.fn(),
+  deleteAllDeadLetterJobs: vi.fn(),
+  deleteDeadLetterJobs: vi.fn()
 }
 
 const mockQueue = {
@@ -136,6 +141,57 @@ describe('Admin Queues Actions', () => {
       expect(mockDatabase.deleteDeadLetterJobsByStatus).toHaveBeenCalledWith(
         'discarded'
       )
+    })
+  })
+
+  describe('dropAllDeadLetterJobs', () => {
+    it('drops all dead letter jobs', async () => {
+      mockDatabase.deleteAllDeadLetterJobs.mockResolvedValue(10)
+
+      const res = await dropAllDeadLetterJobs()
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(10)
+      expect(mockDatabase.deleteAllDeadLetterJobs).toHaveBeenCalled()
+    })
+  })
+
+  describe('retrySelectedDeadLetterJobs', () => {
+    it('retries selected dead letter jobs in batch', async () => {
+      mockDatabase.getDeadLetterJobById.mockResolvedValue(sampleJob)
+      mockQueue.publish.mockResolvedValue(undefined)
+      mockDatabase.updateDeadLetterJobStatus.mockResolvedValue({})
+
+      const res = await retrySelectedDeadLetterJobs(['j1', 'j2'])
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(2)
+      expect(mockQueue.publish).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns error if no ids provided', async () => {
+      const res = await retrySelectedDeadLetterJobs([])
+      expect(res.success).toBe(false)
+      expect(res.error).toBe('No jobs selected')
+    })
+  })
+
+  describe('deleteSelectedDeadLetterJobs', () => {
+    it('deletes selected dead letter jobs', async () => {
+      mockDatabase.deleteDeadLetterJobs.mockResolvedValue(3)
+
+      const res = await deleteSelectedDeadLetterJobs(['j1', 'j2', 'j3'])
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(3)
+      expect(mockDatabase.deleteDeadLetterJobs).toHaveBeenCalledWith([
+        'j1',
+        'j2',
+        'j3'
+      ])
+    })
+
+    it('returns error if no ids provided', async () => {
+      const res = await deleteSelectedDeadLetterJobs([])
+      expect(res.success).toBe(false)
+      expect(res.error).toBe('No jobs selected')
     })
   })
 })

--- a/app/(timeline)/admin/queues/actions.test.ts
+++ b/app/(timeline)/admin/queues/actions.test.ts
@@ -171,6 +171,10 @@ describe('Admin Queues Actions', () => {
       const res = await retrySelectedDeadLetterJobs([])
       expect(res.success).toBe(false)
       expect(res.error).toBe('No jobs selected')
+
+      const resInvalid = await retrySelectedDeadLetterJobs(null as any)
+      expect(resInvalid.success).toBe(false)
+      expect(resInvalid.error).toBe('No jobs selected')
     })
   })
 
@@ -192,6 +196,12 @@ describe('Admin Queues Actions', () => {
       const res = await deleteSelectedDeadLetterJobs([])
       expect(res.success).toBe(false)
       expect(res.error).toBe('No jobs selected')
+
+      const resInvalid = await deleteSelectedDeadLetterJobs(
+        'not-an-array' as any
+      )
+      expect(resInvalid.success).toBe(false)
+      expect(resInvalid.error).toBe('No jobs selected')
     })
   })
 })

--- a/app/(timeline)/admin/queues/actions.ts
+++ b/app/(timeline)/admin/queues/actions.ts
@@ -61,3 +61,31 @@ export async function clearDiscardedJobs() {
   revalidatePath(ADMIN_QUEUES_PATH)
   return result
 }
+
+export async function dropAllDeadLetterJobs() {
+  await verifyAdmin()
+  const provider = getDLQProvider()
+  const result = await provider.dropAll()
+  revalidatePath(ADMIN_QUEUES_PATH)
+  return result
+}
+
+export async function retrySelectedDeadLetterJobs(ids: string[]) {
+  await verifyAdmin()
+  if (!ids || ids.length === 0)
+    return { success: false, error: 'No jobs selected' }
+  const provider = getDLQProvider()
+  const result = await provider.retryJobs(ids)
+  revalidatePath(ADMIN_QUEUES_PATH)
+  return result
+}
+
+export async function deleteSelectedDeadLetterJobs(ids: string[]) {
+  await verifyAdmin()
+  if (!ids || ids.length === 0)
+    return { success: false, error: 'No jobs selected' }
+  const provider = getDLQProvider()
+  const result = await provider.deleteJobs(ids)
+  revalidatePath(ADMIN_QUEUES_PATH)
+  return result
+}

--- a/app/(timeline)/admin/queues/actions.ts
+++ b/app/(timeline)/admin/queues/actions.ts
@@ -72,7 +72,7 @@ export async function dropAllDeadLetterJobs() {
 
 export async function retrySelectedDeadLetterJobs(ids: string[]) {
   await verifyAdmin()
-  if (!ids || ids.length === 0)
+  if (!Array.isArray(ids) || ids.length === 0)
     return { success: false, error: 'No jobs selected' }
   const provider = getDLQProvider()
   const result = await provider.retryJobs(ids)
@@ -82,7 +82,7 @@ export async function retrySelectedDeadLetterJobs(ids: string[]) {
 
 export async function deleteSelectedDeadLetterJobs(ids: string[]) {
   await verifyAdmin()
-  if (!ids || ids.length === 0)
+  if (!Array.isArray(ids) || ids.length === 0)
     return { success: false, error: 'No jobs selected' }
   const provider = getDLQProvider()
   const result = await provider.deleteJobs(ids)

--- a/app/(timeline)/admin/queues/page.test.tsx
+++ b/app/(timeline)/admin/queues/page.test.tsx
@@ -23,7 +23,8 @@ const mockDLQProvider = {
   retryJob: vi.fn(),
   discardJob: vi.fn(),
   retryAll: vi.fn(),
-  clearDiscarded: vi.fn()
+  clearDiscarded: vi.fn(),
+  dropAll: vi.fn()
 }
 
 vi.mock('@/lib/database', () => ({
@@ -75,6 +76,7 @@ describe('/admin/queues page', () => {
     expect(markup).toContain('failed')
     expect(markup).toContain('Attempts: 5')
     expect(markup).toContain('Retry all failed')
+    expect(markup).toContain('Drop all messages')
     expect(markup).toContain('Cloud Tasks (Database DLQ)')
   })
 

--- a/app/(timeline)/admin/queues/page.tsx
+++ b/app/(timeline)/admin/queues/page.tsx
@@ -134,6 +134,7 @@ const Page = async ({ searchParams }: Props) => {
         </div>
 
         <AdminQueuesToolbar
+          allCount={counts.all}
           failedCount={counts.failed}
           discardedCount={counts.discarded}
         />

--- a/app/(timeline)/admin/queues/page.tsx
+++ b/app/(timeline)/admin/queues/page.tsx
@@ -140,7 +140,7 @@ const Page = async ({ searchParams }: Props) => {
         />
       </div>
 
-      <AdminQueuesList jobs={jobs} />
+      <AdminQueuesList key={`${activeStatus ?? 'all'}-${page}`} jobs={jobs} />
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between border-t pt-4">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,7 +232,7 @@ Long-running operations (sending activities to remote servers, processing file u
 
 #### Queues & Dead Letter Queue (DLQ) Management
 
-Instance administrators can inspect terminally failed tasks, view formatted payloads and error stack traces, re-dispatch jobs, or purge discarded records via the Admin UI at `/admin/queues`. The admin interface is queue-backend agnostic and seamlessly adapts to the active provider:
+Instance administrators can inspect terminally failed tasks, view formatted payloads and error stack traces, re-dispatch jobs, drop all messages, or purge discarded records via the Admin UI at `/admin/queues`. Messages are sorted by failure time in descending order (most recent terminal failures first). The admin interface is queue-backend agnostic and seamlessly adapts to the active provider:
 
 - **Google Cloud Tasks (`ACTIVITIES_QUEUE_TYPE=cloudtasks`)**:
   - Webhook endpoint: `/api/v1/queue/cloudtasks`.

--- a/lib/database/sql/deadLetterJob.ts
+++ b/lib/database/sql/deadLetterJob.ts
@@ -85,6 +85,7 @@ export const DeadLetterJobSQLDatabaseMixin = (
 
     const rows = await query
       .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
       .limit(limit)
       .offset(offset)
 
@@ -132,7 +133,16 @@ export const DeadLetterJobSQLDatabaseMixin = (
     return count > 0
   },
 
+  async deleteDeadLetterJobs(ids: string[]) {
+    if (ids.length === 0) return 0
+    return await database('dead_letter_jobs').whereIn('id', ids).delete()
+  },
+
   async deleteDeadLetterJobsByStatus(status: DeadLetterJobStatus) {
     return await database('dead_letter_jobs').where({ status }).delete()
+  },
+
+  async deleteAllDeadLetterJobs() {
+    return await database('dead_letter_jobs').delete()
   }
 })

--- a/lib/database/sql/deadLetterJobs.test.ts
+++ b/lib/database/sql/deadLetterJobs.test.ts
@@ -112,6 +112,36 @@ describe('DeadLetterJobSQLDatabaseMixin', () => {
     })
   })
 
+  it('retrieves jobs ordered descending by created_at (last fail first)', async () => {
+    await withFreshDatabase(async (database) => {
+      // Insert with slight delay or different timestamps
+      const j1 = await database.createDeadLetterJob({
+        jobName: 'first-fail',
+        payload: samplePayload,
+        errorMessage: 'err1'
+      })
+      // Small pause to guarantee different timestamp if stored in seconds/ms
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      const j2 = await database.createDeadLetterJob({
+        jobName: 'second-fail',
+        payload: samplePayload,
+        errorMessage: 'err2'
+      })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      const j3 = await database.createDeadLetterJob({
+        jobName: 'third-fail',
+        payload: samplePayload,
+        errorMessage: 'err3'
+      })
+
+      const jobs = await database.getDeadLetterJobs()
+      expect(jobs).toHaveLength(3)
+      expect(jobs[0].id).toBe(j3.id)
+      expect(jobs[1].id).toBe(j2.id)
+      expect(jobs[2].id).toBe(j1.id)
+    })
+  })
+
   it('counts dead letter jobs correctly', async () => {
     await withFreshDatabase(async (database) => {
       await database.createDeadLetterJob({
@@ -218,6 +248,64 @@ describe('DeadLetterJobSQLDatabaseMixin', () => {
       const remaining = await database.getDeadLetterJobs()
       expect(remaining).toHaveLength(1)
       expect(remaining[0].status).toBe('failed')
+    })
+  })
+
+  it('deletes all dead letter jobs with deleteAllDeadLetterJobs', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.createDeadLetterJob({
+        jobName: 'j1',
+        payload: samplePayload,
+        errorMessage: 'err1',
+        status: 'discarded'
+      })
+      await database.createDeadLetterJob({
+        jobName: 'j2',
+        payload: samplePayload,
+        errorMessage: 'err2',
+        status: 'failed'
+      })
+      await database.createDeadLetterJob({
+        jobName: 'j3',
+        payload: samplePayload,
+        errorMessage: 'err3',
+        status: 'retried'
+      })
+
+      const deletedCount = await database.deleteAllDeadLetterJobs()
+      expect(deletedCount).toBe(3)
+
+      const remaining = await database.getDeadLetterJobs()
+      expect(remaining).toHaveLength(0)
+    })
+  })
+
+  it('deletes selected dead letter jobs with deleteDeadLetterJobs', async () => {
+    await withFreshDatabase(async (database) => {
+      const j1 = await database.createDeadLetterJob({
+        jobName: 'j1',
+        payload: samplePayload,
+        errorMessage: 'err1'
+      })
+      const j2 = await database.createDeadLetterJob({
+        jobName: 'j2',
+        payload: samplePayload,
+        errorMessage: 'err2'
+      })
+      const j3 = await database.createDeadLetterJob({
+        jobName: 'j3',
+        payload: samplePayload,
+        errorMessage: 'err3'
+      })
+
+      const deletedCount = await database.deleteDeadLetterJobs([j1.id, j3.id])
+      expect(deletedCount).toBe(2)
+
+      const remaining = await database.getDeadLetterJobs()
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0].id).toBe(j2.id)
+
+      expect(await database.deleteDeadLetterJobs([])).toBe(0)
     })
   })
 })

--- a/lib/services/queue/dlq/database.ts
+++ b/lib/services/queue/dlq/database.ts
@@ -120,4 +120,41 @@ export class DatabaseDLQProvider implements DLQProvider {
     const count = await database.deleteDeadLetterJobsByStatus('discarded')
     return { success: true, count }
   }
+
+  async dropAll(): Promise<DLQActionResult> {
+    const database = this.getDatabase()
+    const count = await database.deleteAllDeadLetterJobs()
+    return { success: true, count }
+  }
+
+  async retryJobs(ids: string[]): Promise<DLQActionResult> {
+    const database = this.getDatabase()
+    const queue = getQueue()
+    let retriedCount = 0
+
+    for (const id of ids) {
+      const job = await database.getDeadLetterJobById(id)
+      if (!job) continue
+
+      try {
+        await queue.publish(job.payload)
+        await database.updateDeadLetterJobStatus(id, 'retried')
+        retriedCount++
+      } catch (error) {
+        logger.error({
+          err: error,
+          jobId: id,
+          message: 'Failed to retry dead letter job'
+        })
+      }
+    }
+
+    return { success: true, count: retriedCount }
+  }
+
+  async deleteJobs(ids: string[]): Promise<DLQActionResult> {
+    const database = this.getDatabase()
+    const count = await database.deleteDeadLetterJobs(ids)
+    return { success: true, count }
+  }
 }

--- a/lib/services/queue/dlq/index.test.ts
+++ b/lib/services/queue/dlq/index.test.ts
@@ -138,6 +138,39 @@ describe('DLQ Providers', () => {
       expect(mockRetry).toHaveBeenCalledWith({ all: true })
     })
 
+    it('orders messages by createdAt descending (last fail first)', async () => {
+      const provider = new QStashDLQProvider(qstashConfig)
+
+      mockListMessages.mockResolvedValue({
+        messages: [
+          {
+            dlqId: 'dlq_old',
+            messageId: 'msg_1',
+            body: JSON.stringify({ id: 'm1', name: 'firstJob' }),
+            createdAt: 1000
+          },
+          {
+            dlqId: 'dlq_newest',
+            messageId: 'msg_2',
+            body: JSON.stringify({ id: 'm2', name: 'latestJob' }),
+            createdAt: 3000
+          },
+          {
+            dlqId: 'dlq_middle',
+            messageId: 'msg_3',
+            body: JSON.stringify({ id: 'm3', name: 'middleJob' }),
+            createdAt: 2000
+          }
+        ]
+      })
+
+      const res = await provider.getJobs()
+      expect(res.jobs).toHaveLength(3)
+      expect(res.jobs[0].id).toBe('dlq_newest')
+      expect(res.jobs[1].id).toBe('dlq_middle')
+      expect(res.jobs[2].id).toBe('dlq_old')
+    })
+
     it('calls clear all', async () => {
       const provider = new QStashDLQProvider(qstashConfig)
       mockDelete.mockResolvedValue({ deleted: 5 })
@@ -146,6 +179,38 @@ describe('DLQ Providers', () => {
       expect(res.success).toBe(true)
       expect(res.count).toBe(5)
       expect(mockDelete).toHaveBeenCalledWith({ all: true })
+    })
+
+    it('calls drop all', async () => {
+      const provider = new QStashDLQProvider(qstashConfig)
+      mockDelete.mockResolvedValue({ deleted: 8 })
+
+      const res = await provider.dropAll()
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(8)
+      expect(mockDelete).toHaveBeenCalledWith({ all: true })
+    })
+
+    it('calls retryJobs with array of dlqIds', async () => {
+      const provider = new QStashDLQProvider(qstashConfig)
+      mockRetry.mockResolvedValue({
+        responses: [{ messageId: 'm1' }, { messageId: 'm2' }]
+      })
+
+      const res = await provider.retryJobs(['dlq_1', 'dlq_2'])
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(2)
+      expect(mockRetry).toHaveBeenCalledWith({ dlqIds: ['dlq_1', 'dlq_2'] })
+    })
+
+    it('calls deleteJobs with array of dlqIds', async () => {
+      const provider = new QStashDLQProvider(qstashConfig)
+      mockDelete.mockResolvedValue({ deleted: 2 })
+
+      const res = await provider.deleteJobs(['dlq_1', 'dlq_2'])
+      expect(res.success).toBe(true)
+      expect(res.count).toBe(2)
+      expect(mockDelete).toHaveBeenCalledWith({ dlqIds: ['dlq_1', 'dlq_2'] })
     })
   })
 })

--- a/lib/services/queue/dlq/qstash.ts
+++ b/lib/services/queue/dlq/qstash.ts
@@ -70,6 +70,10 @@ export class QStashDLQProvider implements DLQProvider {
         }
       })
 
+      allFormatted.sort(
+        (a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id)
+      )
+
       const filteredJobs = isFailedOrAll ? allFormatted : []
       const pagedJobs = filteredJobs.slice(offset, offset + limit)
 
@@ -147,6 +151,55 @@ export class QStashDLQProvider implements DLQProvider {
         message: 'Failed to clear all QStash DLQ jobs'
       })
       return { success: false, error: 'Failed to clear jobs in QStash' }
+    }
+  }
+
+  async dropAll(): Promise<DLQActionResult> {
+    try {
+      const res = await this._client.dlq.delete({ all: true })
+      return { success: true, count: res.deleted ?? 0 }
+    } catch (error) {
+      logger.error({
+        err: error,
+        message: 'Failed to drop all QStash DLQ messages'
+      })
+      return { success: false, error: 'Failed to drop all messages in QStash' }
+    }
+  }
+
+  async retryJobs(ids: string[]): Promise<DLQActionResult> {
+    if (ids.length === 0) return { success: true, count: 0 }
+    try {
+      const res = await this._client.dlq.retry({ dlqIds: ids })
+      return { success: true, count: res.responses?.length ?? 0 }
+    } catch (error) {
+      logger.error({
+        err: error,
+        ids,
+        message: 'Failed to retry selected QStash DLQ jobs'
+      })
+      return {
+        success: false,
+        error: 'Failed to retry selected jobs in QStash'
+      }
+    }
+  }
+
+  async deleteJobs(ids: string[]): Promise<DLQActionResult> {
+    if (ids.length === 0) return { success: true, count: 0 }
+    try {
+      const res = await this._client.dlq.delete({ dlqIds: ids })
+      return { success: true, count: res.deleted ?? 0 }
+    } catch (error) {
+      logger.error({
+        err: error,
+        ids,
+        message: 'Failed to delete selected QStash DLQ jobs'
+      })
+      return {
+        success: false,
+        error: 'Failed to delete selected jobs in QStash'
+      }
     }
   }
 }

--- a/lib/services/queue/dlq/types.ts
+++ b/lib/services/queue/dlq/types.ts
@@ -35,4 +35,7 @@ export interface DLQProvider {
   discardJob(id: string): Promise<DLQActionResult>
   retryAll(): Promise<DLQActionResult>
   clearDiscarded(): Promise<DLQActionResult>
+  dropAll(): Promise<DLQActionResult>
+  retryJobs(ids: string[]): Promise<DLQActionResult>
+  deleteJobs(ids: string[]): Promise<DLQActionResult>
 }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -4268,5 +4268,7 @@ export interface DeadLetterJobDatabase {
     status: DeadLetterJobStatus
   ): Promise<DeadLetterJob | null>
   deleteDeadLetterJob(id: string): Promise<boolean>
+  deleteDeadLetterJobs(ids: string[]): Promise<number>
   deleteDeadLetterJobsByStatus(status: DeadLetterJobStatus): Promise<number>
+  deleteAllDeadLetterJobs(): Promise<number>
 }


### PR DESCRIPTION
## Summary

Enhances the Dead Letter Queue (DLQ) admin interface (`/admin/queues`) and underlying DLQ providers:
- **Descending Order**: DLQ messages are now displayed with the most recent failure first.
  - In `lib/database/sql/deadLetterJob.ts`, added `.orderBy('created_at', 'desc').orderBy('id', 'desc')`.
  - In `lib/services/queue/dlq/qstash.ts`, added sorting by `createdAt` descending with fallback to `id` descending.
- **Drop All Messages**: Added a "Drop all messages ({count})" action button to `AdminQueuesToolbar` with confirmation dialog, which permanently purges all DLQ messages.
  - Implemented `deleteAllDeadLetterJobs()` on `DeadLetterJobDatabase` (SQL) and `dropAll()` on `DLQProvider` (both SQL database and QStash backends).
- **Selective Delete & Retry**: Added selection checkboxes on each job card and a top "Select all" control bar in `AdminQueuesList`.
  - When jobs are selected, a selective action bar displays the selection count, a "Retry selected ({count})" action, a "Delete selected ({count})" action with confirmation dialog, and a "Clear" button.
  - Implemented `deleteDeadLetterJobs(ids)` on `DeadLetterJobDatabase` (SQL), and `retryJobs(ids)` / `deleteJobs(ids)` on `DLQProvider` (both SQL and QStash backends).
  - Added server actions `dropAllDeadLetterJobs`, `retrySelectedDeadLetterJobs`, and `deleteSelectedDeadLetterJobs` in `app/(timeline)/admin/queues/actions.ts`.
- **Documentation**: Updated `docs/architecture.md` (DLQ Management section).
- **Tests**: Added comprehensive unit and component tests for SQL methods, DLQ providers, server actions, `AdminQueuesToolbar`, `AdminQueuesList`, and `admin/queues/page`.

## Screenshots

Verified on local dev server in Chromium browser:
- **Descending Order & Drop All Button**: DLQ messages listed chronologically descending (newest failure first), with "Drop all messages (3)" in the toolbar.
- **Selective Actions Bar**: Individual checkboxes and "Select all" bar allow selecting jobs; shows "2 of 3 selected" with "Retry selected (2)", "Delete selected (2)", and "Clear" buttons.
- **Post-Action State & Empty State**: Deleting selected items leaves unselected items and updates counters; dropping all messages updates UI to empty state "No dead-lettered jobs found."

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)