### PR TITLE
fix: preserve custom emoji shortcodes in mastodon status content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1405,9 +1405,10 @@ null }` remains the precise "this retirement never happened" — it reopens the
   false. Attaching it unconditionally does not delay the fetch — it loses it.
 - **Extraction runs the WHOLE `processStatusTextContent` and walks its output.**
   Not a rearrangement of its parts — the same function the rendered post, the
-  notifications and the Mastodon API all use, in full, for local and remote
-  statuses alike. That is the only way to know what the reader sees, and
-  every time this ran a subset of the pipeline something got through:
+  notifications and (with emoji replacement disabled per the client spec) the
+  Mastodon API all use, for local and remote statuses alike. That is the only way
+  to know what the reader sees, and every time this ran a subset of the pipeline
+  something got through:
   walking marked's tokens missed hidden ancestors and entity-only link text;
   sanitizing but skipping the emoji step MEASURED TEXT THE RENDERER THEN
   DELETED (`sanitizeTrustedStatusText` serves emoji images over https only and

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -896,9 +896,17 @@ describe('getMastodonStatus', () => {
 
     const mastodonStatus = await getMastodonStatus(database, statusWithTags)
 
-    expect(mastodonStatus?.content).toContain(
-      '<img class="emoji" src="https://test.host/emoji.png" alt=":emoji:" />'
-    )
+    expect(mastodonStatus?.content).toBe('<p>Status with :emoji:</p>')
+    expect(mastodonStatus?.content).not.toContain('<img')
+    expect(mastodonStatus?.emojis).toEqual([
+      {
+        shortcode: 'emoji',
+        url: 'https://test.host/emoji.png',
+        static_url: 'https://test.host/emoji.png',
+        visible_in_picker: true,
+        category: null
+      }
+    ])
   })
 
   it('returns content with HTML formatting', async () => {

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -661,7 +661,10 @@ export const getMastodonStatus = async (
     | { state: string; quoted_status: Mastodon.Status | null }
     | { state: string; quoted_status_id: string | null }
     | undefined
-  let statusContent = processStatusText(host, status)
+  // In the Mastodon client API specification, `content` keeps custom emoji as
+  // literal `:shortcode:` tokens within the HTML; clients (e.g. Ivory, Elk)
+  // use `status.emojis` to render them natively and strip <img> tags in posts.
+  let statusContent = processStatusText(host, status, { convertEmojis: false })
   const edge = status.quote
   if (edge) {
     // Resolve the viewer-relative state and the readable quoted status once, then

--- a/lib/services/mastodon/getMastodonStatusEdits.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.ts
@@ -71,11 +71,15 @@ export const getMastodonStatusEdits = async (
     // extended fields; fall back to the status's current values for those.
     const sensitive = revision.sensitive ?? status.sensitive ?? false
     const pollOptions = revision.pollOptions ?? currentPollOptions
-    const rawContent = processStatusText(host, {
-      ...status,
-      text: revision.text,
-      summary: revision.summary
-    } as Status)
+    const rawContent = processStatusText(
+      host,
+      {
+        ...status,
+        text: revision.text,
+        summary: revision.summary
+      } as Status,
+      { convertEmojis: false }
+    )
     const fallbackUrl =
       status.quote?.quotedStatusUrl || status.quote?.quotedStatusId
     return {

--- a/lib/utils/text/processStatusText.test.ts
+++ b/lib/utils/text/processStatusText.test.ts
@@ -135,6 +135,36 @@ describe('processStatusText', () => {
       )
     })
 
+    it('preserves emoji shortcodes when convertEmojis is false', async () => {
+      const statusWithEmoji = await database.createNote({
+        id: `${ACTOR1_ID}/statuses/emoji-preserve-test`,
+        url: `${ACTOR1_ID}/statuses/emoji-preserve-test`,
+        actorId: ACTOR1_ID,
+        text: 'Status with :emoji:',
+        to: [],
+        cc: []
+      })
+
+      await database.createTag({
+        statusId: statusWithEmoji.id,
+        type: 'emoji',
+        name: ':emoji:',
+        value: 'https://test.host/emoji.png'
+      })
+
+      const statusWithTags = (await database.getStatus({
+        statusId: statusWithEmoji.id,
+        withReplies: false
+      })) as Status
+
+      const result = processStatusText(mockHost, statusWithTags, {
+        convertEmojis: false
+      })
+
+      expect(result).toBe('<p>Status with :emoji:</p>')
+      expect(result).not.toContain('<img')
+    })
+
     it('sanitizes custom emoji image URLs after emoji injection', async () => {
       const statusWithEmoji = await database.createNote({
         id: `${ACTOR1_ID}/statuses/emoji-xss-test`,

--- a/lib/utils/text/processStatusText.ts
+++ b/lib/utils/text/processStatusText.ts
@@ -33,27 +33,41 @@ export const getActualStatus = (status: Status) => {
  * raw text + tag list (e.g. the postbox preview) can reuse the exact same
  * pipeline instead of introducing a second rendering path.
  */
+export interface ProcessStatusTextOptions {
+  convertEmojis?: boolean
+}
+
 export const processStatusTextContent = (
   host: string,
   text: string,
   tags: Tag[],
-  isLocalActor: boolean
-) =>
-  _.chain(text)
+  isLocalActor: boolean,
+  options?: ProcessStatusTextOptions
+) => {
+  const convertEmojis = options?.convertEmojis ?? true
+  return _.chain(text)
     .thru(isLocalActor ? convertMarkdownText(host) : _.identity)
     .thru(sanitizeText)
-    .thru(_.curryRight(convertEmojisToImages)(tags))
-    .thru(sanitizeTrustedStatusText)
+    .thru(
+      convertEmojis ? _.curryRight(convertEmojisToImages)(tags) : _.identity
+    )
+    .thru(convertEmojis ? sanitizeTrustedStatusText : _.identity)
     .thru(_.trim)
     .value()
+}
 
-export const processStatusText = (host: string, status: Status) => {
+export const processStatusText = (
+  host: string,
+  status: Status,
+  options?: ProcessStatusTextOptions
+) => {
   const actualStatus = getActualStatus(status)
 
   return processStatusTextContent(
     host,
     actualStatus.text,
     actualStatus.tags,
-    actualStatus.isLocalActor
+    actualStatus.isLocalActor,
+    options
   )
 }


### PR DESCRIPTION
## Summary

Fixes an issue where custom emojis do not render in third-party Mastodon clients like Ivory.

### Root Cause
In the Mastodon Client API specification ([`Status` entity](https://docs.joinmastodon.org/entities/Status/)), status `content` is HTML-formatted text where custom emojis are kept as `:shortcode:` tokens (e.g. `<p>:blobcat: Hello</p>`), while metadata is provided in the `emojis` array (`[{ shortcode: 'blobcat', url: '...' }]`). Third-party native clients like Ivory parse status `content`, strip HTML `<img>` tags (since `<img>` is not permitted in post bodies), and search for `:shortcode:` tokens matching `emojis` to insert native custom emoji views inline.

Previously, `getMastodonStatus` (and `getMastodonStatusEdits`) called `processStatusText(host, status)` without options, which ran `convertEmojisToImages(actualStatus.tags)`. This replaced `:shortcode:` tokens with `<img class="emoji" src="..." alt=":shortcode:"></img>` inside `content`. When Ivory parsed the status, it stripped all `<img>` tags, removing the custom emojis and leaving no shortcode tokens for Ivory to match against `status.emojis`.

### Changes
1. Added `options?: ProcessStatusTextOptions` (`{ convertEmojis?: boolean }`, default `true`) to `processStatusTextContent` and `processStatusText` in `lib/utils/text/processStatusText.ts`.
2. Passed `{ convertEmojis: false }` to `processStatusText` in `lib/services/mastodon/getMastodonStatus.ts` and `lib/services/mastodon/getMastodonStatusEdits.ts`.
3. Preserved default `convertEmojis: true` for web UI components and link preview extraction.
4. Updated test in `lib/services/mastodon/getMastodonStatus.test.ts` to assert that status `content` preserves `:emoji:` and does not inject `<img>` tags, and added unit test in `lib/utils/text/processStatusText.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)