### PR TITLE
Bump version to v1.158.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.1",
+  "version": "1.158.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.1`
- Base main SHA: `4fcd5647e2d370a4cfd4b5b400d4723bda6fa6c9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
