### PR TITLE
Bump version to v1.158.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.2",
+  "version": "1.158.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.2`
- Base main SHA: `a98e07aae3259be428a766bce1057b3fd5f32a1c`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
