### PR TITLE
fix: hide posts count when unknown on remote profiles and omit empty stats row

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -398,12 +398,12 @@ describe('getProfileData', () => {
       ;(getActorPerson as jest.Mock).mockResolvedValue(mockPerson)
       ;(getActorPosts as jest.Mock).mockResolvedValue({
         statuses: mockStatuses,
-        statusesCount: 0
+        statusesCount: null
       })
       ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
         followersCount: 20,
         followingCount: 10,
-        statusesCount: 0
+        statusesCount: null
       })
       ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(
         mockFederationSigningActor
@@ -518,13 +518,13 @@ describe('getProfileData', () => {
       expect(result).toMatchObject({
         followersCount: null,
         followingCount: null,
-        statusesCount: 0
+        statusesCount: 100
       })
       expect(mockDatabase.setActorCounters).toHaveBeenCalledWith({
         actorId: mockPerson.id,
         followersCount: null,
         followingCount: null,
-        statusCount: null
+        statusCount: 100
       })
     })
 
@@ -559,7 +559,7 @@ describe('getProfileData', () => {
         actorId: mockPerson.id,
         followersCount: 100,
         followingCount: 50,
-        statusCount: null
+        statusCount: 10
       })
     })
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -23,7 +23,7 @@ import { toLoggableError } from '@/lib/utils/toLoggableError'
 type ProfileData = {
   person: Actor
   statuses: Status[]
-  statusesCount: number
+  statusesCount: number | null
   statusPagination: {
     nextPageUrl: string | null
     prevPageUrl: string | null
@@ -272,18 +272,24 @@ export const getProfileData = async (
     ]
   )
 
+  const resolvedStatusesCount =
+    collectionCounts.statusesCount ??
+    (actorPostsResponse.statusesCount !== null &&
+    actorPostsResponse.statusesCount !== undefined
+      ? actorPostsResponse.statusesCount
+      : null)
+
   // Persist the freshly-fetched collection sizes for known actors so the
   // Mastodon API (which reads the counter rows) serves the same counts this
   // page displays. getActorCollectionCounts distinguishes a fetch failure
-  // (null, preserves the stored counter) from a real zero. getActorPosts
-  // reports 0 for both, so only positive status counts are trusted here.
+  // (null, preserves the stored counter) from a real zero.
   // Best-effort — the page renders from the live values either way.
   try {
     await database.setActorCounters({
       actorId: person.id,
       followersCount: collectionCounts.followersCount,
       followingCount: collectionCounts.followingCount,
-      statusCount: actorPostsResponse.statusesCount || null
+      statusCount: resolvedStatusesCount
     })
   } catch (error) {
     logger.warn({
@@ -296,6 +302,7 @@ export const getProfileData = async (
   return {
     ...actorPostsResponse,
     person,
+    statusesCount: resolvedStatusesCount,
     statusPagination: {
       nextPageUrl: actorPostsResponse.nextPageUrl ?? null,
       prevPageUrl: actorPostsResponse.prevPageUrl ?? null

--- a/app/(timeline)/[actor]/page.follow-counts.test.tsx
+++ b/app/(timeline)/[actor]/page.follow-counts.test.tsx
@@ -193,4 +193,86 @@ describe('[actor] page follow counts display', () => {
     expect(screen.queryByText('Following')).not.toBeInTheDocument()
     expect(screen.queryByText('Followers')).not.toBeInTheDocument()
   })
+
+  it('omits Posts when statusesCount is null but shows Following and Followers', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://blob.cat/users/critical',
+        preferredUsername: 'critical',
+        summary: ''
+      } as never,
+      statusesCount: null,
+      followingCount: 424,
+      followersCount: 524,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: false,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@critical@blob.cat' })
+    })
+    render(element)
+
+    expect(screen.queryByText('Posts')).not.toBeInTheDocument()
+    expect(screen.getByText('424')).toBeInTheDocument()
+    expect(screen.getByText('Following')).toBeInTheDocument()
+    expect(screen.getByText('524')).toBeInTheDocument()
+    expect(screen.getByText('Followers')).toBeInTheDocument()
+  })
+
+  it('renders 0 Posts when statusesCount is 0', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: 0,
+      followingCount: 5,
+      followersCount: 10,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: true,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+  })
+
+  it('omits the entire counts row when all counts are null', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://llun.social/users/testuser',
+        preferredUsername: 'testuser',
+        summary: ''
+      } as never,
+      statusesCount: null,
+      followingCount: null,
+      followersCount: null,
+      statuses: [],
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      isInternalAccount: false,
+      hasFitnessData: false
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@testuser@llun.social' })
+    })
+    render(element)
+
+    expect(screen.queryByText('Posts')).not.toBeInTheDocument()
+    expect(screen.queryByText('Following')).not.toBeInTheDocument()
+    expect(screen.queryByText('Followers')).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -256,32 +256,38 @@ const Page: FC<Props> = async ({ params }) => {
 
           <Bio summary={person.summary} tags={getActorEmojiTags(person)} />
 
-          <div className="mt-5 flex flex-wrap gap-6 text-sm">
-            <div>
-              <span className="font-semibold">{statusesCount}</span>{' '}
-              <span className="text-muted-foreground">Posts</span>
+          {(statusesCount !== null ||
+            followingCount !== null ||
+            followersCount !== null) && (
+            <div className="mt-5 flex flex-wrap gap-6 text-sm">
+              {statusesCount !== null && (
+                <div>
+                  <span className="font-semibold">{statusesCount}</span>{' '}
+                  <span className="text-muted-foreground">Posts</span>
+                </div>
+              )}
+              {followingCount !== null && (
+                <Link
+                  href={`/@${person.preferredUsername}@${actorDomain}/following`}
+                  prefetch={false}
+                  className="hover:underline"
+                >
+                  <span className="font-semibold">{followingCount}</span>{' '}
+                  <span className="text-muted-foreground">Following</span>
+                </Link>
+              )}
+              {followersCount !== null && (
+                <Link
+                  href={`/@${person.preferredUsername}@${actorDomain}/followers`}
+                  prefetch={false}
+                  className="hover:underline"
+                >
+                  <span className="font-semibold">{followersCount}</span>{' '}
+                  <span className="text-muted-foreground">Followers</span>
+                </Link>
+              )}
             </div>
-            {followingCount !== null && (
-              <Link
-                href={`/@${person.preferredUsername}@${actorDomain}/following`}
-                prefetch={false}
-                className="hover:underline"
-              >
-                <span className="font-semibold">{followingCount}</span>{' '}
-                <span className="text-muted-foreground">Following</span>
-              </Link>
-            )}
-            {followersCount !== null && (
-              <Link
-                href={`/@${person.preferredUsername}@${actorDomain}/followers`}
-                prefetch={false}
-                className="hover:underline"
-              >
-                <span className="font-semibold">{followersCount}</span>{' '}
-                <span className="text-muted-foreground">Followers</span>
-              </Link>
-            )}
-          </div>
+          )}
 
           <FeaturedTagsBlock tags={featuredTags} />
         </div>

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -121,13 +121,22 @@ export const getActorCollections = async ({
           ? pageUrl
           : firstPageUrl
 
+      const parseTotalItems = (val: unknown): number | null => {
+        if (typeof val !== 'number' || !Number.isFinite(val) || val < 0) {
+          return null
+        }
+        return Math.floor(val)
+      }
+
+      const collectionTotalItems = parseTotalItems(collection.totalItems)
+
       // Return totalItems even if page URL is not available
       // This is common for remote actors where Mastodon only provides totalItems
       // without exposing the actual list of followers/following
       if (!collectionPageUrl) {
         return {
           page: null,
-          totalItems: collection.totalItems ?? 0
+          totalItems: collectionTotalItems
         }
       }
 
@@ -152,12 +161,14 @@ export const getActorCollections = async ({
           // Return totalItems even if page fetch fails
           return {
             page: null,
-            totalItems: collection.totalItems ?? 0
+            totalItems: collectionTotalItems
           }
         }
+        const page = JSON.parse(response.body) as OrderedCollectionPage
+        const pageTotalItems = parseTotalItems(page.totalItems)
         return {
-          page: JSON.parse(response.body) as OrderedCollectionPage,
-          totalItems: collection.totalItems ?? 0
+          page,
+          totalItems: collectionTotalItems ?? pageTotalItems
         }
       } catch (error) {
         const nodeError = error as NodeJS.ErrnoException
@@ -166,7 +177,7 @@ export const getActorCollections = async ({
         // Return totalItems even on error
         return {
           page: null,
-          totalItems: collection.totalItems ?? 0
+          totalItems: collectionTotalItems
         }
       }
     }

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -981,4 +981,62 @@ describe('getActorPosts', () => {
     expect(response.nextPageUrl).toBeNull()
     expect(response.prevPageUrl).toBeNull()
   })
+
+  it('returns null statusesCount when remote outbox has no totalItems', async () => {
+    const actorId = 'https://blob.cat/users/critical'
+    const statusId = `${actorId}/statuses/1`
+    const person = MockActivityPubPerson({
+      id: actorId,
+      preferredUsername: 'critical',
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            first: `${actorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${actorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${actorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                id: `${statusId}/activity`,
+                type: 'Create',
+                actor: actorId,
+                published: new Date().toISOString(),
+                object: MockMastodonActivityPubNote({
+                  id: statusId,
+                  from: actorId,
+                  content: 'Test post content',
+                  withContext: true
+                })
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBeNull()
+    expect(response.statuses).toHaveLength(1)
+    expect(response.statuses[0].id).toBe(statusId)
+  })
 })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -40,7 +40,7 @@ type GetActorPostsFunction = (params: {
   signingActor?: DomainActor
   pageUrl?: string
 }) => Promise<{
-  statusesCount: number
+  statusesCount: number | null
   statuses: Status[]
   nextPageUrl: string | null
   prevPageUrl: string | null
@@ -116,7 +116,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
       })
       if (!value) {
         return {
-          statusesCount: 0,
+          statusesCount: null,
           statuses: [],
           nextPageUrl: null,
           prevPageUrl: null
@@ -236,7 +236,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
       }
 
       return {
-        statusesCount: value.totalItems ?? validStatuses.length,
+        statusesCount: value.totalItems,
         statuses: validStatuses,
         nextPageUrl: value.page?.next ?? null,
         prevPageUrl: value.page?.prev ?? null

--- a/lib/activities/orderedCollection.ts
+++ b/lib/activities/orderedCollection.ts
@@ -8,6 +8,7 @@ export interface ContextEntity {
 export interface OrderedCollectionPage extends ContextEntity {
   id?: string
   type: 'OrderedCollectionPage'
+  totalItems?: number
   orderedItems: (string | Record<string, unknown>)[]
   next?: string
   prev?: string

--- a/lib/services/mastodon/remoteFollowCollection.ts
+++ b/lib/services/mastodon/remoteFollowCollection.ts
@@ -377,7 +377,7 @@ const fetchRemoteFollowCollectionPage = async ({
           accounts,
           nextPageUrl: getPageUrl(collection.page.next, collectionUrl),
           prevPageUrl: getPageUrl(collection.page.prev, collectionUrl),
-          totalItems: collection.totalItems
+          totalItems: collection.totalItems ?? 0
         }
       }
     }


### PR DESCRIPTION
## Summary

When visiting `@critical@blob.cat` (or other remote profiles where the ActivityPub server, such as Akkoma/Pleroma, does not provide `totalItems` on `outbox` collections), the profile previously showed `0 Posts` even while the first page of posts rendered below.

- In `lib/activities/getActorCollections.ts`, parse finite non-negative numbers for `totalItems` and return `null` when omitted rather than defaulting to `0`. Also check `page.totalItems` if `collection.totalItems` is missing on the collection root.
- In `lib/activities/orderedCollection.ts`, add optional `totalItems?: number` to `OrderedCollectionPage`.
- In `lib/activities/getActorPosts.ts`, update `statusesCount` in `GetActorPostsFunction` to `number | null` and return `value.totalItems`.
- In `app/(timeline)/[actor]/getProfileData.ts`, update `statusesCount` to `number | null` and resolve via `collectionCounts.statusesCount ?? actorPostsResponse.statusesCount ?? null`.
- In `app/(timeline)/[actor]/page.tsx`, conditionally render the "Posts" count only when `statusesCount !== null`, and omit the entire stats row if all three counts (`statusesCount`, `followingCount`, `followersCount`) are `null`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)