### PR TITLE
fix: conditionally omit replies and media tabs and hide single tab bar on actor profiles

### DIFF
--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -850,6 +850,29 @@ describe('ActorTimelines', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('includes the Media tab when attachments prop is empty but statuses contain media', () => {
+      const statusWithMedia = createStatus(
+        'https://remote.example/statuses/with-media',
+        { attachments: [sampleAttachment] }
+      )
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://mastodon.social/users/someone"
+          statuses={[statusWithMedia]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          isInternalAccount={false}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Posts' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Media' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Replies' })
+      ).not.toBeInTheDocument()
+    })
+
     it('does not show tabs when only one tab (Posts) is available', () => {
       const { container } = render(
         <ActorTimelines

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -13,6 +13,7 @@ import { ReactNode } from 'react'
 
 import { getActorStatuses } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
+import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusType } from '@/lib/types/domain/status'
 
 import { ActorTimelines } from './ActorTimelines'
@@ -198,6 +199,18 @@ const createFitnessStatus = (id: string): Status =>
 const currentActorProfile = {
   id: 'https://local.example/users/me'
 } as ActorProfile
+
+const sampleAttachment: Attachment = {
+  id: 'att-1',
+  actorId: 'https://mastodon.social/users/someone',
+  statusId: 'status-1',
+  type: 'Document',
+  mediaType: 'image/jpeg',
+  url: 'https://mastodon.social/media/1.jpg',
+  width: 200,
+  height: 200,
+  blurhash: null
+}
 
 const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
 
@@ -729,13 +742,13 @@ describe('ActorTimelines', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('renders standard Posts, Replies, and Media tabs when isPixelfed is false', () => {
+    it('renders standard Posts, Replies, and Media tabs when isPixelfed is false and media is present', () => {
       const { container } = render(
         <ActorTimelines
           host="localhost:3000"
           actorId="https://mastodon.social/users/someone"
           statuses={[]}
-          attachments={[]}
+          attachments={[sampleAttachment]}
           currentTime={FIXED_CURRENT_TIME}
           currentActor={currentActorProfile}
           isPixelfed={false}
@@ -791,6 +804,113 @@ describe('ActorTimelines', () => {
           pageUrl: nextPageUrl
         })
       })
+    })
+  })
+
+  describe('Profile tabs visibility', () => {
+    it('omits the Replies tab when isInternalAccount is false (external account)', () => {
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://mastodon.social/users/someone"
+          statuses={[
+            createStatus('https://mastodon.social/users/someone/statuses/1')
+          ]}
+          attachments={[sampleAttachment]}
+          currentTime={FIXED_CURRENT_TIME}
+          isInternalAccount={false}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Posts' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Replies' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Media' })).toBeInTheDocument()
+    })
+
+    it('omits the Media tab when there are no attachments or statuses with media', () => {
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://local.example/users/someone"
+          statuses={[createStatus('https://local.example/statuses/1')]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          isInternalAccount={true}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Posts' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Replies' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Media' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show tabs when only one tab (Posts) is available', () => {
+      const { container } = render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://mastodon.social/users/verge"
+          statuses={[createStatus('https://mastodon.social/statuses/1')]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          isInternalAccount={false}
+        />
+      )
+
+      expect(
+        screen.queryByRole('button', { name: 'Posts' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Replies' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Media' })
+      ).not.toBeInTheDocument()
+      expect(
+        container.querySelector('[data-active-tab]')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText('https://mastodon.social/statuses/1')
+      ).toBeInTheDocument()
+    })
+
+    it('renders load more control when only one tab is available and more pages exist', async () => {
+      const getActorStatusesMock = getActorStatuses as jest.Mock
+      getActorStatusesMock.mockResolvedValueOnce({
+        statuses: [createStatus('https://mastodon.social/statuses/2')],
+        statusesCount: 2,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+
+      const { container } = render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://mastodon.social/users/verge"
+          statuses={[createStatus('https://mastodon.social/statuses/1')]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          isInternalAccount={false}
+          statusPagination={{
+            nextPageUrl: 'https://mastodon.social/users/verge/outbox?page=2',
+            prevPageUrl: null
+          }}
+        />
+      )
+
+      expect(
+        container.querySelector('[data-active-tab]')
+      ).not.toBeInTheDocument()
+      const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+      expect(loadMoreButton).toBeInTheDocument()
+
+      fireEvent.click(loadMoreButton)
+      await screen.findByText('https://mastodon.social/statuses/2')
     })
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -148,15 +148,21 @@ export const ActorTimelines: FC<Props> = ({
   const showFitnessTab = Boolean(hasFitnessData)
   const showRepliesTab = Boolean(isInternalAccount)
 
-  const hasMedia = useMemo(
-    () =>
-      attachments.length > 0 ||
-      currentStatuses.some(
-        (status) =>
-          status.type === StatusType.enum.Note && status.attachments.length > 0
-      ),
-    [attachments, currentStatuses]
-  )
+  const mediaAttachments = useMemo(() => {
+    const statusAttachments = currentStatuses.flatMap((status) =>
+      status.type === StatusType.enum.Note ? status.attachments : []
+    )
+    if (attachments.length === 0) {
+      return statusAttachments
+    }
+    const seenIds = new Set(attachments.map((a) => a.id))
+    const newAttachments = statusAttachments.filter((a) => !seenIds.has(a.id))
+    return newAttachments.length > 0
+      ? [...attachments, ...newAttachments]
+      : attachments
+  }, [attachments, currentStatuses])
+
+  const hasMedia = mediaAttachments.length > 0
 
   const availableTabs = useMemo(() => {
     const tabs: ProfileTab[] = ['posts']
@@ -204,11 +210,9 @@ export const ActorTimelines: FC<Props> = ({
     Boolean(currentStatusPagination.nextPageUrl) &&
     (isPixelfed
       ? activeTab === 'media'
-      : availableTabs.length <= 1
-        ? availableTabs[0] === 'posts'
-        : effectiveActiveTab === 'posts' ||
-          (showRepliesTab && effectiveActiveTab === 'replies') ||
-          (showFitnessTab && effectiveActiveTab === 'fitness'))
+      : effectiveActiveTab === 'posts' ||
+        (showRepliesTab && effectiveActiveTab === 'replies') ||
+        (showFitnessTab && effectiveActiveTab === 'fitness'))
 
   const handleStatusCreated = useCallback(
     (status: Status) => {
@@ -436,34 +440,9 @@ export const ActorTimelines: FC<Props> = ({
   }
 
   if (availableTabs.length <= 1) {
-    const singleTab = availableTabs[0] ?? 'posts'
     return (
       <div className="space-y-4">
-        {singleTab === 'posts' && renderFeed(postStatuses, 'No posts yet')}
-        {singleTab === 'replies' && renderFeed(replyStatuses, 'No replies yet')}
-        {singleTab === 'media' && (
-          <ActorMediaGallery
-            actorId={actorId}
-            initialAttachments={attachments}
-            statuses={currentStatuses}
-            isPixelfed={false}
-          />
-        )}
-        {singleTab === 'fitness' && (
-          <div className="space-y-4">
-            {isCurrentUser && (
-              <div className="flex justify-end">
-                <Button variant="outline" asChild>
-                  <Link href="/fitness">
-                    <Activity className="size-4" aria-hidden="true" />
-                    Fitness dashboard
-                  </Link>
-                </Button>
-              </div>
-            )}
-            {renderFeed(fitnessStatuses, 'No fitness activities yet')}
-          </div>
-        )}
+        {renderFeed(postStatuses, 'No posts yet')}
 
         {canLoadMore && (
           <div ref={loadMoreRef} className="text-center">
@@ -527,7 +506,7 @@ export const ActorTimelines: FC<Props> = ({
           <TabsContent value="media" className="mt-0">
             <ActorMediaGallery
               actorId={actorId}
-              initialAttachments={attachments}
+              initialAttachments={mediaAttachments}
               statuses={currentStatuses}
               isPixelfed={false}
             />

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -52,6 +52,7 @@ interface Props {
   hasFitnessData?: boolean
   isMediaUploadEnabled?: boolean
   isPixelfed?: boolean
+  isInternalAccount?: boolean
 }
 
 const LOAD_MORE_PAGE_LIMIT = 5
@@ -129,11 +130,9 @@ export const ActorTimelines: FC<Props> = ({
   isCurrentUser = false,
   hasFitnessData = false,
   isMediaUploadEnabled,
-  isPixelfed = false
+  isPixelfed = false,
+  isInternalAccount = true
 }) => {
-  const [activeTab, setActiveTab] = useState<ProfileTab>(
-    isPixelfed ? 'media' : 'posts'
-  )
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,
@@ -147,6 +146,42 @@ export const ActorTimelines: FC<Props> = ({
 
   const showActions = Boolean(currentActor)
   const showFitnessTab = Boolean(hasFitnessData)
+  const showRepliesTab = Boolean(isInternalAccount)
+
+  const hasMedia = useMemo(
+    () =>
+      attachments.length > 0 ||
+      currentStatuses.some(
+        (status) =>
+          status.type === StatusType.enum.Note && status.attachments.length > 0
+      ),
+    [attachments, currentStatuses]
+  )
+
+  const availableTabs = useMemo(() => {
+    const tabs: ProfileTab[] = ['posts']
+    if (showRepliesTab) {
+      tabs.push('replies')
+    }
+    if (hasMedia) {
+      tabs.push('media')
+    }
+    if (showFitnessTab) {
+      tabs.push('fitness')
+    }
+    return tabs
+  }, [showRepliesTab, hasMedia, showFitnessTab])
+
+  const [activeTab, setActiveTab] = useState<ProfileTab>(
+    isPixelfed ? 'media' : 'posts'
+  )
+
+  const effectiveActiveTab = useMemo(() => {
+    if (availableTabs.includes(activeTab)) {
+      return activeTab
+    }
+    return availableTabs[0] ?? 'posts'
+  }, [activeTab, availableTabs])
 
   const postStatuses = useMemo(
     () => currentStatuses.filter((status) => !isReply(status)),
@@ -167,10 +202,13 @@ export const ActorTimelines: FC<Props> = ({
   // also paginates via this outbox cursor.
   const canLoadMore =
     Boolean(currentStatusPagination.nextPageUrl) &&
-    (activeTab === 'posts' ||
-      activeTab === 'replies' ||
-      activeTab === 'fitness' ||
-      (isPixelfed && activeTab === 'media'))
+    (isPixelfed
+      ? activeTab === 'media'
+      : availableTabs.length <= 1
+        ? availableTabs[0] === 'posts'
+        : effectiveActiveTab === 'posts' ||
+          (showRepliesTab && effectiveActiveTab === 'replies') ||
+          (showFitnessTab && effectiveActiveTab === 'fitness'))
 
   const handleStatusCreated = useCallback(
     (status: Status) => {
@@ -397,10 +435,60 @@ export const ActorTimelines: FC<Props> = ({
     )
   }
 
+  if (availableTabs.length <= 1) {
+    const singleTab = availableTabs[0] ?? 'posts'
+    return (
+      <div className="space-y-4">
+        {singleTab === 'posts' && renderFeed(postStatuses, 'No posts yet')}
+        {singleTab === 'replies' && renderFeed(replyStatuses, 'No replies yet')}
+        {singleTab === 'media' && (
+          <ActorMediaGallery
+            actorId={actorId}
+            initialAttachments={attachments}
+            statuses={currentStatuses}
+            isPixelfed={false}
+          />
+        )}
+        {singleTab === 'fitness' && (
+          <div className="space-y-4">
+            {isCurrentUser && (
+              <div className="flex justify-end">
+                <Button variant="outline" asChild>
+                  <Link href="/fitness">
+                    <Activity className="size-4" aria-hidden="true" />
+                    Fitness dashboard
+                  </Link>
+                </Button>
+              </div>
+            )}
+            {renderFeed(fitnessStatuses, 'No fitness activities yet')}
+          </div>
+        )}
+
+        {canLoadMore && (
+          <div ref={loadMoreRef} className="text-center">
+            {loadMoreError && (
+              <p className="mb-3 text-sm text-destructive" role="alert">
+                {loadMoreError}
+              </p>
+            )}
+            <Button
+              variant="outline"
+              disabled={isLoadingMoreStatuses}
+              onClick={loadMoreStatuses}
+            >
+              {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-4">
       <Tabs
-        value={activeTab}
+        value={effectiveActiveTab}
         onValueChange={(value) => setActiveTab(value as ProfileTab)}
         className="w-full gap-4"
       >
@@ -408,12 +496,16 @@ export const ActorTimelines: FC<Props> = ({
           <TabsTrigger value="posts" className="flex-1 sm:flex-none">
             Posts
           </TabsTrigger>
-          <TabsTrigger value="replies" className="flex-1 sm:flex-none">
-            Replies
-          </TabsTrigger>
-          <TabsTrigger value="media" className="flex-1 sm:flex-none">
-            Media
-          </TabsTrigger>
+          {showRepliesTab && (
+            <TabsTrigger value="replies" className="flex-1 sm:flex-none">
+              Replies
+            </TabsTrigger>
+          )}
+          {hasMedia && (
+            <TabsTrigger value="media" className="flex-1 sm:flex-none">
+              Media
+            </TabsTrigger>
+          )}
           {showFitnessTab && (
             <TabsTrigger value="fitness" className="flex-1 sm:flex-none">
               Fitness
@@ -425,22 +517,22 @@ export const ActorTimelines: FC<Props> = ({
           {renderFeed(postStatuses, 'No posts yet')}
         </TabsContent>
 
-        <TabsContent value="replies" className="mt-0">
-          {renderFeed(replyStatuses, 'No replies yet')}
-        </TabsContent>
+        {showRepliesTab && (
+          <TabsContent value="replies" className="mt-0">
+            {renderFeed(replyStatuses, 'No replies yet')}
+          </TabsContent>
+        )}
 
-        <TabsContent value="media" className="mt-0">
-          {attachments.length > 0 ? (
+        {hasMedia && (
+          <TabsContent value="media" className="mt-0">
             <ActorMediaGallery
               actorId={actorId}
               initialAttachments={attachments}
               statuses={currentStatuses}
               isPixelfed={false}
             />
-          ) : (
-            <EmptyState>No media yet</EmptyState>
-          )}
-        </TabsContent>
+          </TabsContent>
+        )}
 
         {showFitnessTab && (
           <TabsContent value="fitness" className="mt-0 space-y-4">

--- a/app/(timeline)/[actor]/page.test.tsx
+++ b/app/(timeline)/[actor]/page.test.tsx
@@ -49,8 +49,12 @@ vi.mock('./getProfileData', () => ({
   getProfileData: vi.fn()
 }))
 
+const mockActorTimelines = vi.fn()
 vi.mock('./ActorTimelines', () => ({
-  ActorTimelines: () => <div data-testid="actor-timelines" />
+  ActorTimelines: (props: unknown) => {
+    mockActorTimelines(props)
+    return <div data-testid="actor-timelines" />
+  }
 }))
 
 vi.mock('./ProfileHeaderImage', () => ({
@@ -115,6 +119,9 @@ describe('[actor] page header handle link', () => {
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     expect(link).toHaveAttribute('title', 'Open profile page')
+    expect(mockActorTimelines).toHaveBeenCalledWith(
+      expect.objectContaining({ isInternalAccount: false })
+    )
   })
 
   it('renders handle link for remote user with object url', async () => {
@@ -210,5 +217,8 @@ describe('[actor] page header handle link', () => {
     expect(link).toHaveAttribute('href', 'https://llun.social/@localuser')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(mockActorTimelines).toHaveBeenCalledWith(
+      expect.objectContaining({ isInternalAccount: true })
+    )
   })
 })

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -142,7 +142,8 @@ const Page: FC<Props> = async ({ params }) => {
     followingCount,
     followersCount,
     hasFitnessData,
-    isPixelfed
+    isPixelfed,
+    isInternalAccount
   } = actorProfile
 
   const isCurrentUser = currentActor?.id === person.id
@@ -307,6 +308,7 @@ const Page: FC<Props> = async ({ params }) => {
         isPixelfed={isLoggedIn && Boolean(isPixelfed)}
         hasFitnessData={hasFitnessData}
         isMediaUploadEnabled={Boolean(mediaStorage)}
+        isInternalAccount={isInternalAccount}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

Addresses issues with profile tabs when viewing external/remote accounts and accounts with limited media:
1. External federated accounts do not expose replies via ActivityPub outbox. Previously, the profile rendered a "Replies" tab which was permanently empty, triggering continuous load-more calls and resulting in an infinite loading spinner.
2. The "Media" tab was rendered even for accounts that had never posted any media attachments.
3. When only a single tab remained (e.g. only "Posts"), the tab header still rendered a redundant single tab trigger button.

### Changes
- In `app/(timeline)/[actor]/ActorTimelines.tsx`:
  - Added `isInternalAccount?: boolean` prop (default `true`).
  - Conditionally omitted Replies tab when `isInternalAccount` is false (`showRepliesTab = Boolean(isInternalAccount)`).
  - Dynamically calculated `hasMedia` based on `attachments.length > 0` and media attachments across statuses, omitting the Media tab when empty.
  - Dynamically constructed `availableTabs` list (`posts`, optional `replies`, optional `media`, optional `fitness`).
  - Added single-tab rendering: when `availableTabs.length <= 1`, the `<Tabs>` and `<TabsList>` containers are omitted entirely and the feed is rendered directly with pagination.
  - Added active tab fallback to `availableTabs[0]` if the active tab is not in `availableTabs`.
  - Updated `canLoadMore` to only trigger pagination for applicable active tabs.
- In `app/(timeline)/[actor]/page.tsx`:
  - Passed `isInternalAccount={isInternalAccount}` from `actorProfile` to `<ActorTimelines>`.
- In `app/(timeline)/[actor]/ActorTimelines.test.tsx` and `app/(timeline)/[actor]/page.test.tsx`:
  - Added comprehensive unit tests covering omitting the Replies tab for external accounts, omitting the Media tab when empty, omitting the tab bar when only 1 tab is available, and load-more behavior with a single tab.

## Screenshots

Verified in Chromium on local dev server across desktop (1280x900) and mobile (390x844) viewports:
- **Internal Account**: Shows "Posts", "Replies", and "Media" tabs.
- **External Account (No Media)**: Tab bar is omitted completely; feed is rendered directly with 1 available tab.
- **External Account (With Media)**: Tab bar shows "Posts" and "Media" tabs only; "Replies" tab is omitted.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)