### PR TITLE
fix: polish totalItems parser scope and statusesCount resolution

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -273,11 +273,7 @@ export const getProfileData = async (
   )
 
   const resolvedStatusesCount =
-    collectionCounts.statusesCount ??
-    (actorPostsResponse.statusesCount !== null &&
-    actorPostsResponse.statusesCount !== undefined
-      ? actorPostsResponse.statusesCount
-      : null)
+    collectionCounts.statusesCount ?? actorPostsResponse.statusesCount ?? null
 
   // Persist the freshly-fetched collection sizes for known actors so the
   // Mastodon API (which reads the counter rows) serves the same counts this

--- a/lib/activities/getActorCollectionCounts.ts
+++ b/lib/activities/getActorCollectionCounts.ts
@@ -1,4 +1,7 @@
-import { fetchCollectionRoot } from '@/lib/activities/getActorCollections'
+import {
+  fetchCollectionRoot,
+  parseTotalItems
+} from '@/lib/activities/getActorCollections'
 import { getMisskeyCollectionCounts } from '@/lib/activities/getMisskeyCollectionCounts'
 import { isMisskeyActor } from '@/lib/services/federation/serverSoftware'
 import { Actor } from '@/lib/types/activitypub'
@@ -32,15 +35,7 @@ const getCollectionTotalItems = async (
 
   try {
     const { collection } = await fetchCollectionRoot({ url, signingActor })
-    const totalItems = collection?.totalItems
-    if (
-      typeof totalItems !== 'number' ||
-      !Number.isFinite(totalItems) ||
-      totalItems < 0
-    ) {
-      return null
-    }
-    return Math.floor(totalItems)
+    return parseTotalItems(collection?.totalItems)
   } catch (error) {
     logger.warn({
       message: 'Failed to fetch actor collection total items',

--- a/lib/activities/getActorCollections.test.ts
+++ b/lib/activities/getActorCollections.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isCollectionPageUrl,
+  parseTotalItems
+} from '@/lib/activities/getActorCollections'
+
+describe('parseTotalItems', () => {
+  it('returns null for undefined, null, and non-number types', () => {
+    expect(parseTotalItems(undefined)).toBeNull()
+    expect(parseTotalItems(null)).toBeNull()
+    expect(parseTotalItems('10')).toBeNull()
+    expect(parseTotalItems({})).toBeNull()
+    expect(parseTotalItems([])).toBeNull()
+    expect(parseTotalItems(true)).toBeNull()
+  })
+
+  it('returns null for negative numbers and non-finite values', () => {
+    expect(parseTotalItems(-1)).toBeNull()
+    expect(parseTotalItems(-0.5)).toBeNull()
+    expect(parseTotalItems(Number.NaN)).toBeNull()
+    expect(parseTotalItems(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(parseTotalItems(Number.NEGATIVE_INFINITY)).toBeNull()
+  })
+
+  it('returns non-negative integers', () => {
+    expect(parseTotalItems(0)).toBe(0)
+    expect(parseTotalItems(42)).toBe(42)
+    expect(parseTotalItems(10.8)).toBe(10)
+  })
+})
+
+describe('isCollectionPageUrl', () => {
+  it('returns true when page url matches collection url exactly', () => {
+    expect(
+      isCollectionPageUrl(
+        'https://example.com/users/alice/followers',
+        'https://example.com/users/alice/followers'
+      )
+    ).toBe(true)
+  })
+
+  it('returns true when page url is subpath of collection url', () => {
+    expect(
+      isCollectionPageUrl(
+        'https://example.com/users/alice/followers/page/1',
+        'https://example.com/users/alice/followers'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when host or protocol does not match', () => {
+    expect(
+      isCollectionPageUrl(
+        'https://other.com/users/alice/followers',
+        'https://example.com/users/alice/followers'
+      )
+    ).toBe(false)
+  })
+})

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -66,6 +66,13 @@ export const fetchCollectionRoot = async ({
   }
 }
 
+export const parseTotalItems = (val: unknown): number | null => {
+  if (typeof val !== 'number' || !Number.isFinite(val) || val < 0) {
+    return null
+  }
+  return Math.floor(val)
+}
+
 export const getActorCollections = async ({
   person,
   field,
@@ -111,7 +118,9 @@ export const getActorCollections = async ({
             type: 'OrderedCollectionPage' as const,
             orderedItems: collection.orderedItems
           },
-          totalItems: collection.totalItems ?? collection.orderedItems.length
+          totalItems:
+            parseTotalItems(collection.totalItems) ??
+            collection.orderedItems.length
         }
       }
 
@@ -120,13 +129,6 @@ export const getActorCollections = async ({
         pageUrl && isCollectionPageUrl(pageUrl, person[field])
           ? pageUrl
           : firstPageUrl
-
-      const parseTotalItems = (val: unknown): number | null => {
-        if (typeof val !== 'number' || !Number.isFinite(val) || val < 0) {
-          return null
-        }
-        return Math.floor(val)
-      }
 
       const collectionTotalItems = parseTotalItems(collection.totalItems)
 


### PR DESCRIPTION
## Summary

Follow-up polish to #1763:
- Hoist `parseTotalItems` to module scope in `lib/activities/getActorCollections.ts` and export it so it can be reused across collection modules.
- Use `parseTotalItems` on the inline `orderedItems` branch in `lib/activities/getActorCollections.ts` and in `lib/activities/getActorCollectionCounts.ts` to deduplicate logic.
- Simplify status count coalescing in `app/(timeline)/[actor]/getProfileData.ts` to `collectionCounts.statusesCount ?? actorPostsResponse.statusesCount ?? null`.
- Add dedicated unit tests for `parseTotalItems` and `isCollectionPageUrl` in `lib/activities/getActorCollections.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)