### PR TITLE
Bump version to v1.158.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.3",
+  "version": "1.158.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.3`
- Base main SHA: `affbf5daacd6859d197fc18aa11def0c0d24d43c`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
