### PR TITLE
feat: support PeerTube remote profiles and video-only media grid

### DIFF
--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -24,6 +24,7 @@ interface Props {
   initialAttachments: Attachment[]
   statuses?: Status[]
   isPixelfed?: boolean
+  isMediaOnly?: boolean
   className?: string
 }
 
@@ -32,8 +33,10 @@ export const ActorMediaGallery: FC<Props> = ({
   initialAttachments,
   statuses,
   isPixelfed = false,
+  isMediaOnly = false,
   className
 }) => {
+  const isMediaStream = isPixelfed || isMediaOnly
   const [modalIndex, setModalIndex] = useState<number | null>(null)
   const [attachments, setAttachments] =
     useState<Attachment[]>(initialAttachments)
@@ -42,7 +45,7 @@ export const ActorMediaGallery: FC<Props> = ({
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (isPixelfed && statuses && statuses.length > 0) {
+    if (isMediaStream && statuses && statuses.length > 0) {
       const derived = statuses.flatMap((s) =>
         s.type === StatusType.enum.Note ? s.attachments : []
       )
@@ -52,7 +55,7 @@ export const ActorMediaGallery: FC<Props> = ({
     } else if (initialAttachments.length > 0) {
       setAttachments(initialAttachments)
     }
-  }, [isPixelfed, statuses, initialAttachments])
+  }, [isMediaStream, statuses, initialAttachments])
 
   const statusMap = useMemo(() => {
     const map = new Map<string, StatusNote>()
@@ -205,7 +208,7 @@ export const ActorMediaGallery: FC<Props> = ({
         </div>
       )}
 
-      {!isPixelfed && hasMore && (
+      {!isMediaStream && hasMore && (
         <div className="mt-4 text-center">
           <Button
             variant="outline"

--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -7,7 +7,7 @@ import { getActorMedia } from '@/lib/client'
 import { MediasModal } from '@/lib/components/medias-modal/medias-modal'
 import { Media } from '@/lib/components/posts/media'
 import { Button } from '@/lib/components/ui/button'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, isVisualAttachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
@@ -46,9 +46,9 @@ export const ActorMediaGallery: FC<Props> = ({
 
   useEffect(() => {
     if (isMediaStream && statuses && statuses.length > 0) {
-      const derived = statuses.flatMap((s) =>
-        s.type === StatusType.enum.Note ? s.attachments : []
-      )
+      const derived = statuses
+        .flatMap((s) => (s.type === StatusType.enum.Note ? s.attachments : []))
+        .filter(isVisualAttachment)
       if (derived.length > 0) {
         setAttachments(derived)
       }

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -112,7 +112,7 @@ vi.mock('@/lib/components/posts/posts', () => ({
 }))
 
 vi.mock('./ActorMediaGallery', () => ({
-  ActorMediaGallery: () => null
+  ActorMediaGallery: () => <div data-testid="mock-media-gallery" />
 }))
 
 vi.mock('@/lib/components/ui/tabs', () => ({
@@ -801,6 +801,78 @@ describe('ActorTimelines', () => {
       await waitFor(() => {
         expect(mockGetActorStatuses).toHaveBeenCalledWith({
           actorId: 'https://pixelfed.social/users/dansup',
+          pageUrl: nextPageUrl
+        })
+      })
+    })
+
+    it('renders media gallery directly and skips tabs when isMediaOnly is true', () => {
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://framatube.org/accounts/framasoft"
+          statuses={[]}
+          attachments={[
+            {
+              id: 'att-1',
+              statusId: 'status-1',
+              actorId: 'https://framatube.org/accounts/framasoft',
+              mediaType: 'video/mp4',
+              url: 'https://framatube.org/video.mp4',
+              name: 'Test Video',
+              createdAt: FIXED_CURRENT_TIME,
+              updatedAt: FIXED_CURRENT_TIME
+            }
+          ]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isMediaOnly={true}
+          statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+        />
+      )
+
+      expect(
+        screen.queryByRole('button', { name: 'Posts' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Replies' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByTestId('mock-media-gallery')).toBeInTheDocument()
+    })
+
+    it('enables load more when isMediaOnly is true', async () => {
+      const mockGetActorStatuses = vi.mocked(getActorStatuses)
+      const nextPageUrl = 'https://framatube.org/api/page2'
+      const newStatus = createStatus('https://framatube.org/videos/watch/2')
+
+      mockGetActorStatuses.mockResolvedValueOnce({
+        statuses: [newStatus],
+        statusesCount: 1,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://framatube.org/accounts/framasoft"
+          statuses={[]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isMediaOnly={true}
+          statusPagination={{ nextPageUrl, prevPageUrl: null }}
+        />
+      )
+
+      const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+      expect(loadMoreButton).toBeInTheDocument()
+
+      fireEvent.click(loadMoreButton)
+
+      await waitFor(() => {
+        expect(mockGetActorStatuses).toHaveBeenCalledWith({
+          actorId: 'https://framatube.org/accounts/framasoft',
           pageUrl: nextPageUrl
         })
       })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -53,6 +53,7 @@ interface Props {
   isMediaUploadEnabled?: boolean
   isPixelfed?: boolean
   isInternalAccount?: boolean
+  isMediaOnly?: boolean
 }
 
 const LOAD_MORE_PAGE_LIMIT = 5
@@ -131,8 +132,10 @@ export const ActorTimelines: FC<Props> = ({
   hasFitnessData = false,
   isMediaUploadEnabled,
   isPixelfed = false,
-  isInternalAccount = true
+  isInternalAccount = true,
+  isMediaOnly = false
 }) => {
+  const isMediaView = isPixelfed || isMediaOnly
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,
@@ -179,7 +182,7 @@ export const ActorTimelines: FC<Props> = ({
   }, [showRepliesTab, hasMedia, showFitnessTab])
 
   const [activeTab, setActiveTab] = useState<ProfileTab>(
-    isPixelfed ? 'media' : 'posts'
+    isMediaView ? 'media' : 'posts'
   )
 
   const effectiveActiveTab = useMemo(() => {
@@ -208,7 +211,7 @@ export const ActorTimelines: FC<Props> = ({
   // also paginates via this outbox cursor.
   const canLoadMore =
     Boolean(currentStatusPagination.nextPageUrl) &&
-    (isPixelfed
+    (isMediaView
       ? activeTab === 'media'
       : effectiveActiveTab === 'posts' ||
         (showRepliesTab && effectiveActiveTab === 'replies') ||
@@ -402,7 +405,7 @@ export const ActorTimelines: FC<Props> = ({
       <EmptyState>{emptyMessage}</EmptyState>
     )
 
-  if (isPixelfed) {
+  if (isMediaView) {
     return (
       <div className="space-y-4">
         {attachments.length > 0 ||
@@ -413,7 +416,8 @@ export const ActorTimelines: FC<Props> = ({
             actorId={actorId}
             initialAttachments={attachments}
             statuses={currentStatuses}
-            isPixelfed={true}
+            isPixelfed={isPixelfed}
+            isMediaOnly={isMediaOnly}
           />
         ) : (
           <EmptyState>No media yet</EmptyState>

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -199,6 +199,19 @@ describe('getProfileData', () => {
       })
     })
 
+    it('returns isMediaOnly as false for internal local accounts', async () => {
+      const result = await getProfileData(
+        mockDatabase,
+        '@localuser@example.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.isInternalAccount).toBe(true)
+      expect(result?.isMediaOnly).toBe(false)
+    })
+
     it('should return hasFitnessData as false when actor has no fitness data', async () => {
       ;(mockDatabase.getActorHasFitnessData as jest.Mock).mockResolvedValue(
         false
@@ -788,6 +801,74 @@ describe('getProfileData', () => {
       expect(result).not.toBeNull()
       expect(result?.isMediaOnly).toBe(true)
       expect(result?.attachments).toEqual([mockAttachment])
+    })
+
+    it('filters out non-visual attachments in fallback attachments', async () => {
+      vi.mocked(isPeerTubeActor).mockResolvedValueOnce(true)
+      const mockVideoAttachment: Attachment = {
+        id: 'att-video-1',
+        actorId: mockPerson.id,
+        statusId: 'status-video-1',
+        type: 'Document',
+        mediaType: 'video/mp4',
+        url: 'https://peertube.example/video.mp4',
+        name: 'PeerTube Video',
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+      const mockAudioAttachment: Attachment = {
+        id: 'att-audio-1',
+        actorId: mockPerson.id,
+        statusId: 'status-video-1',
+        type: 'Document',
+        mediaType: 'audio/mp3',
+        url: 'https://peertube.example/audio.mp3',
+        name: 'Audio Track',
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+      vi.mocked(getActorPosts).mockResolvedValueOnce({
+        statuses: [
+          {
+            id: 'status-video-1',
+            url: 'https://peertube.example/videos/watch/1',
+            actorId: mockPerson.id,
+            actor: null,
+            type: StatusType.enum.Note,
+            text: 'Video description',
+            to: [],
+            cc: [],
+            edits: [],
+            reply: '',
+            replies: [],
+            totalReplies: 0,
+            actorAnnounceStatusId: null,
+            isActorLiked: false,
+            isActorBookmarked: false,
+            totalLikes: 10,
+            totalShares: 3,
+            attachments: [mockVideoAttachment, mockAudioAttachment],
+            tags: [],
+            createdAt: 1000,
+            updatedAt: 1000,
+            isLocalActor: false
+          }
+        ],
+        statusesCount: 1,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+      vi.mocked(mockDatabase.getAttachmentsForActor).mockResolvedValueOnce([])
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.attachments).toEqual([mockVideoAttachment])
     })
 
     it('should return null for anonymous user without calling remote APIs', async () => {

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -7,6 +7,7 @@ import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import {
   getServerSoftwareInfo,
+  isPeerTubeActor,
   isPixelfedActor
 } from '@/lib/services/federation/serverSoftware'
 import { Actor } from '@/lib/types/activitypub'
@@ -27,6 +28,7 @@ vi.mock('@/lib/services/federation/domainPolicy')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/services/federation/serverSoftware', () => ({
   isPixelfedActor: vi.fn().mockResolvedValue(false),
+  isPeerTubeActor: vi.fn().mockResolvedValue(false),
   getServerSoftwareInfo: vi.fn().mockResolvedValue(null)
 }))
 vi.mock('@/lib/utils/getPersonFromActor')
@@ -726,6 +728,65 @@ describe('getProfileData', () => {
 
       expect(result).not.toBeNull()
       expect(result?.isPixelfed).toBe(true)
+      expect(result?.isMediaOnly).toBe(true)
+      expect(result?.attachments).toEqual([mockAttachment])
+    })
+
+    it('returns isMediaOnly as true when isPeerTubeActor is true', async () => {
+      vi.mocked(isPeerTubeActor).mockResolvedValueOnce(true)
+      const mockAttachment: Attachment = {
+        id: 'att-video-1',
+        actorId: mockPerson.id,
+        statusId: 'status-video-1',
+        type: 'Document',
+        mediaType: 'video/mp4',
+        url: 'https://peertube.example/video.mp4',
+        name: 'PeerTube Video',
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+      vi.mocked(getActorPosts).mockResolvedValueOnce({
+        statuses: [
+          {
+            id: 'status-video-1',
+            url: 'https://peertube.example/videos/watch/1',
+            actorId: mockPerson.id,
+            actor: null,
+            type: StatusType.enum.Note,
+            text: 'Video description',
+            to: [],
+            cc: [],
+            edits: [],
+            reply: '',
+            replies: [],
+            totalReplies: 0,
+            actorAnnounceStatusId: null,
+            isActorLiked: false,
+            isActorBookmarked: false,
+            totalLikes: 10,
+            totalShares: 3,
+            attachments: [mockAttachment],
+            tags: [],
+            createdAt: 1000,
+            updatedAt: 1000,
+            isLocalActor: false
+          }
+        ],
+        statusesCount: 1,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+      vi.mocked(mockDatabase.getAttachmentsForActor).mockResolvedValueOnce([])
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.isMediaOnly).toBe(true)
       expect(result?.attachments).toEqual([mockAttachment])
     })
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -10,6 +10,7 @@ import { getFederationSigningActorSafe } from '@/lib/services/federation/getFede
 import {
   ServerSoftware,
   getServerSoftwareInfo,
+  isPeerTubeActor,
   isPixelfedActor
 } from '@/lib/services/federation/serverSoftware'
 import {
@@ -40,6 +41,7 @@ type ProfileData = {
   hasFitnessData: boolean
   isPixelfed?: boolean
   serverSoftware?: ServerSoftware | null
+  isMediaOnly?: boolean
 }
 
 type ProfileDataOptions = {
@@ -147,6 +149,17 @@ export const getProfileData = async (
       )
     ).filter((status): status is Status => status !== null)
 
+    const isMediaOnly =
+      statuses.length > 0 &&
+      statuses.every(
+        (status) =>
+          status.type === StatusType.enum.Note &&
+          status.attachments.length > 0 &&
+          status.attachments.every((attachment) =>
+            attachment.mediaType.startsWith('video/')
+          )
+      )
+
     return {
       person: getPersonFromActor(persistedActor),
       statuses,
@@ -164,7 +177,8 @@ export const getProfileData = async (
       serverSoftware: {
         name: 'activities.next',
         version: VERSION
-      }
+      },
+      isMediaOnly
     }
   }
 
@@ -312,6 +326,23 @@ export const getProfileData = async (
     })
   }
 
+  const isPixelfed =
+    serverSoftware?.name === 'pixelfed' || (await isPixelfedActor(person))
+  const isPeerTube =
+    serverSoftware?.name === 'peertube' || (await isPeerTubeActor(person))
+  const isMediaOnly =
+    Boolean(isPixelfed) ||
+    isPeerTube ||
+    (actorPostsResponse.statuses.length > 0 &&
+      actorPostsResponse.statuses.every(
+        (status) =>
+          status.type === StatusType.enum.Note &&
+          status.attachments.length > 0 &&
+          status.attachments.every((attachment) =>
+            attachment.mediaType.startsWith('video/')
+          )
+      ))
+
   return {
     ...actorPostsResponse,
     person,
@@ -330,8 +361,8 @@ export const getProfileData = async (
     followersCount: collectionCounts.followersCount,
     isInternalAccount: false,
     hasFitnessData: false,
-    isPixelfed:
-      serverSoftware?.name === 'pixelfed' || (await isPixelfedActor(person)),
+    isPixelfed,
+    isMediaOnly,
     serverSoftware
   }
 }

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -19,7 +19,7 @@ import {
 } from '@/lib/services/statusAccess'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, isVisualAttachment } from '@/lib/types/domain/attachment'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { logger } from '@/lib/utils/logger'
@@ -149,17 +149,6 @@ export const getProfileData = async (
       )
     ).filter((status): status is Status => status !== null)
 
-    const isMediaOnly =
-      statuses.length > 0 &&
-      statuses.every(
-        (status) =>
-          status.type === StatusType.enum.Note &&
-          status.attachments.length > 0 &&
-          status.attachments.every((attachment) =>
-            attachment.mediaType.startsWith('video/')
-          )
-      )
-
     return {
       person: getPersonFromActor(persistedActor),
       statuses,
@@ -178,7 +167,7 @@ export const getProfileData = async (
         name: 'activities.next',
         version: VERSION
       },
-      isMediaOnly
+      isMediaOnly: false
     }
   }
 
@@ -330,18 +319,7 @@ export const getProfileData = async (
     serverSoftware?.name === 'pixelfed' || (await isPixelfedActor(person))
   const isPeerTube =
     serverSoftware?.name === 'peertube' || (await isPeerTubeActor(person))
-  const isMediaOnly =
-    Boolean(isPixelfed) ||
-    isPeerTube ||
-    (actorPostsResponse.statuses.length > 0 &&
-      actorPostsResponse.statuses.every(
-        (status) =>
-          status.type === StatusType.enum.Note &&
-          status.attachments.length > 0 &&
-          status.attachments.every((attachment) =>
-            attachment.mediaType.startsWith('video/')
-          )
-      ))
+  const isMediaOnly = Boolean(isPixelfed) || isPeerTube
 
   return {
     ...actorPostsResponse,
@@ -354,9 +332,11 @@ export const getProfileData = async (
     attachments:
       attachments.length > 0
         ? attachments
-        : actorPostsResponse.statuses.flatMap((status) =>
-            status.type === StatusType.enum.Note ? status.attachments : []
-          ),
+        : actorPostsResponse.statuses
+            .flatMap((status) =>
+              status.type === StatusType.enum.Note ? status.attachments : []
+            )
+            .filter(isVisualAttachment),
     followingCount: collectionCounts.followingCount,
     followersCount: collectionCounts.followersCount,
     isInternalAccount: false,

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -18,6 +18,7 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { cn } from '@/lib/utils'
+import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { formatServerSoftware } from '@/lib/utils/formatServerSoftware'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
@@ -145,6 +146,7 @@ const Page: FC<Props> = async ({ params }) => {
     hasFitnessData,
     isPixelfed,
     isInternalAccount,
+    isMediaOnly,
     serverSoftware
   } = actorProfile
 
@@ -177,30 +179,32 @@ const Page: FC<Props> = async ({ params }) => {
 
   const getHeaderImage = () => {
     if (!person.image) return null
-    if (typeof person.image === 'string') return null
-    if (Array.isArray(person.image)) return null
-    if (person.image.type !== 'Image') return null
-    return {
-      url: person.image.url,
-      mediaType: person.image.mediaType ?? null
+    const imageItem = Array.isArray(person.image)
+      ? person.image.find(
+          (item) =>
+            item &&
+            typeof item === 'object' &&
+            'url' in item &&
+            typeof item.url === 'string'
+        )
+      : person.image
+    if (
+      !imageItem ||
+      imageItem.type !== 'Image' ||
+      typeof imageItem.url !== 'string'
+    ) {
+      return null
     }
-  }
-
-  const getIconImage = () => {
-    if (!person.icon) return null
-    if (typeof person.icon === 'string') return null
-    if (Array.isArray(person.icon)) return null
-    if (person.icon.type !== 'Image') return null
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const image = person.icon as any
-    if (typeof image.url !== 'string') return null
-    return image.url
+    return {
+      url: imageItem.url,
+      mediaType: imageItem.mediaType ?? null
+    }
   }
 
   const headerImage = getHeaderImage()
   const headerImageUrl = headerImage?.url ?? null
   const headerImageMediaType = headerImage?.mediaType ?? null
-  const iconImageUrl = getIconImage()
+  const iconImageUrl = getActorImageUrl(person.icon) ?? null
   const rawUrl = person.url ? getUrl(person.url) : null
   const profileUrl =
     (rawUrl && /^https?:\/\//i.test(rawUrl) ? rawUrl : null) ||
@@ -327,6 +331,7 @@ const Page: FC<Props> = async ({ params }) => {
         currentActor={currentActor ? getActorProfile(currentActor) : undefined}
         isCurrentUser={isCurrentUser}
         isPixelfed={isLoggedIn && Boolean(isPixelfed)}
+        isMediaOnly={isLoggedIn && Boolean(isMediaOnly)}
         hasFitnessData={hasFitnessData}
         isMediaUploadEnabled={Boolean(mediaStorage)}
         isInternalAccount={isInternalAccount}

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -1205,6 +1205,134 @@ describe('getActorPosts', () => {
 
     const response = await getActorPosts({ database, person })
     expect(response.statuses).toHaveLength(0)
->>>>>>> fba3895d6 (feat: support PeerTube remote profiles and video-only media grid)
+  })
+
+  it('rejects string-referenced objects whose URL is cross-origin relative to person.id', async () => {
+    const actorId = 'https://framatube.org/accounts/framasoft'
+    const crossOriginUrl = 'https://other-instance.example/videos/watch/abc'
+    const outboxPageUrl = `${actorId}/outbox?page=true`
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: outboxPageUrl
+          })
+        }
+      }
+      if (req.url === outboxPageUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: outboxPageUrl,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                id: 'https://framatube.org/videos/watch/abc/activity',
+                type: 'Create',
+                actor: actorId,
+                to: [ACTIVITY_STREAM_PUBLIC],
+                object: crossOriginUrl
+              }
+            ]
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    expect(response.statuses).toHaveLength(0)
+  })
+
+  it('rejects local database status when status actorId does not match person.id', async () => {
+    const actorId = 'https://framatube.org/accounts/framasoft'
+    const otherActorId = 'https://framatube.org/accounts/otheruser'
+    const statusId = 'https://framatube.org/videos/watch/123'
+    const outboxPageUrl = `${actorId}/outbox?page=true`
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    // Status exists in database but belongs to otherActorId
+    vi.spyOn(database, 'getStatus').mockResolvedValueOnce({
+      id: statusId,
+      url: statusId,
+      actorId: otherActorId,
+      actor: null,
+      type: StatusType.enum.Note,
+      text: 'Private other status',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      reply: '',
+      replies: [],
+      totalReplies: 0,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      isActorBookmarked: false,
+      totalLikes: 0,
+      totalShares: 0,
+      attachments: [],
+      tags: [],
+      createdAt: 1000,
+      updatedAt: 1000,
+      isLocalActor: false
+    })
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: outboxPageUrl
+          })
+        }
+      }
+      if (req.url === outboxPageUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: outboxPageUrl,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                id: `${statusId}/activity`,
+                type: 'Create',
+                actor: actorId,
+                to: [ACTIVITY_STREAM_PUBLIC],
+                object: statusId
+              }
+            ]
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    expect(response.statuses).toHaveLength(0)
   })
 })

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -1039,4 +1039,172 @@ describe('getActorPosts', () => {
     expect(response.statuses).toHaveLength(1)
     expect(response.statuses[0].id).toBe(statusId)
   })
+
+  it('resolves string-referenced PeerTube Video objects from outbox', async () => {
+    const actorId = 'https://framatube.org/accounts/framasoft'
+    const videoUrl = 'https://framatube.org/videos/watch/abc'
+    const outboxPageUrl = `${actorId}/outbox?page=true`
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: outboxPageUrl
+          })
+        }
+      }
+      if (req.url === outboxPageUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: outboxPageUrl,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                id: 'https://framatube.org/videos/watch/abc/activity',
+                type: 'Create',
+                actor: actorId,
+                to: [ACTIVITY_STREAM_PUBLIC],
+                object: videoUrl
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === videoUrl) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/activity+json' },
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: videoUrl,
+            type: 'Video',
+            name: 'Framasoft Video',
+            attributedTo: actorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            content: '<p>A great video</p>',
+            published: '2026-01-01T00:00:00Z',
+            url: [
+              {
+                type: 'Link',
+                mediaType: 'text/html',
+                href: videoUrl
+              },
+              {
+                type: 'Link',
+                mediaType: 'video/mp4',
+                href: 'https://framatube.org/static/webseed/abc.mp4'
+              }
+            ],
+            icon: [
+              {
+                type: 'Image',
+                url: 'https://framatube.org/static/thumbnails/abc.jpg'
+              }
+            ]
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response.statusesCount).toBe(1)
+    expect(response.statuses).toHaveLength(1)
+    const status = response.statuses[0]
+    expect(status.type).toBe(StatusType.enum.Note)
+    expect(status.text).toContain('Framasoft Video')
+    expect(status.attachments).toHaveLength(1)
+    expect(status.attachments[0].mediaType).toBe('video/mp4')
+    expect(status.attachments[0].url).toBe(
+      'https://framatube.org/static/webseed/abc.mp4'
+    )
+    expect(status.attachments[0].thumbnailUrl).toBe(
+      'https://framatube.org/static/thumbnails/abc.jpg'
+    )
+  })
+
+  it('rejects cross-origin string-referenced objects in outbox', async () => {
+    const actorId = 'https://framatube.org/accounts/framasoft'
+    const videoUrl = 'https://framatube.org/videos/watch/abc'
+    const evilNoteId = 'https://evil.example/videos/watch/abc'
+    const outboxPageUrl = `${actorId}/outbox?page=true`
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: outboxPageUrl
+          })
+        }
+      }
+      if (req.url === outboxPageUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: outboxPageUrl,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                '@context': 'https://www.w3.org/ns/activitystreams',
+                id: 'https://framatube.org/videos/watch/abc/activity',
+                type: 'Create',
+                actor: actorId,
+                to: [ACTIVITY_STREAM_PUBLIC],
+                object: videoUrl
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === videoUrl) {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/activity+json' },
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: evilNoteId,
+            type: 'Video',
+            attributedTo: actorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            published: '2026-01-01T00:00:00Z',
+            url: 'https://framatube.org/video.mp4'
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    expect(response.statuses).toHaveLength(0)
+>>>>>>> fba3895d6 (feat: support PeerTube remote profiles and video-only media grid)
+  })
 })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -188,12 +188,19 @@ export const getActorPosts: GetActorPostsFunction = async ({
 
           let rawObject: unknown = activity.object
           if (typeof rawObject === 'string') {
+            if (!isSameActivityPubOrigin(person.id, rawObject)) {
+              return null
+            }
+
             const localStatus = await database.getStatus({
               statusId: rawObject
             })
             if (localStatus && localStatus.type !== StatusType.enum.Announce) {
-              if (actor) localStatus.actor = actor
-              return localStatus
+              if (localStatus.actorId === person.id) {
+                if (actor) localStatus.actor = actor
+                return localStatus
+              }
+              return null
             }
             const fetchedNote = await getNote({
               statusId: rawObject,
@@ -216,6 +223,13 @@ export const getActorPosts: GetActorPostsFunction = async ({
 
           const status = getStatusFromNote(noteResult.data)
           if (!status) return null
+
+          if (
+            status.actorId !== person.id &&
+            !isSameActivityPubOrigin(person.id, status.actorId)
+          ) {
+            return null
+          }
 
           if (actor) status.actor = actor
           return status

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -1,5 +1,6 @@
 import { getNote } from '@/lib/activities'
 import { compactActivityPub } from '@/lib/activities/jsonld'
+import { BaseNote, BaseNoteSchema } from '@/lib/activities/note'
 import { Database } from '@/lib/database/types'
 import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
 import { detectLanguageFromHtml } from '@/lib/services/language-detection'
@@ -9,7 +10,6 @@ import {
   AnnounceAction,
   CreateAction
 } from '@/lib/types/activitypub/activities'
-import { Note } from '@/lib/types/activitypub/objects'
 import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
 import {
   Status,
@@ -18,6 +18,7 @@ import {
   fromNote
 } from '@/lib/types/domain/status'
 import {
+  isSameActivityPubOrigin,
   normalizeActivityPubAnnounce,
   normalizeActivityPubContent
 } from '@/lib/utils/activitypub'
@@ -46,10 +47,7 @@ type GetActorPostsFunction = (params: {
   prevPageUrl: string | null
 }>
 
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : String(error)
-
-const getStatusFromNote = (note: Note) => {
+const getStatusFromNote = (note: BaseNote) => {
   try {
     const status = fromNote(note)
     // Ephemeral status (not persisted), so content-detected language is
@@ -58,7 +56,10 @@ const getStatusFromNote = (note: Note) => {
       detectLanguageFromHtml(status.text)?.language ?? null
     return status
   } catch (error) {
-    logger.error(`[getActorPosts] ${getErrorMessage(error)}`)
+    logger.error({
+      message: 'Fail to convert note to status',
+      err: toLoggableError(error)
+    })
     return null
   }
 }
@@ -155,9 +156,11 @@ export const getActorPosts: GetActorPostsFunction = async ({
                 statusId: announce.object,
                 signingActor
               })
-              if (!note) return null
+              if (!note || !isSameActivityPubOrigin(announce.object, note.id)) {
+                return null
+              }
 
-              const noteResult = Note.safeParse(
+              const noteResult = BaseNoteSchema.safeParse(
                 normalizeActivityPubContent(note)
               )
               if (!noteResult.success) return null
@@ -181,15 +184,34 @@ export const getActorPosts: GetActorPostsFunction = async ({
           // Unsupported activity
           if (activity.type !== CreateAction) return null
           // Unsupported Object
-          if (!activity.object || typeof activity.object === 'string')
-            return null
-          const obj = activity.object as {
-            type?: string
-            [key: string]: unknown
-          }
-          if (obj.type !== 'Note') return null
+          if (!activity.object) return null
 
-          const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
+          let rawObject: unknown = activity.object
+          if (typeof rawObject === 'string') {
+            const localStatus = await database.getStatus({
+              statusId: rawObject
+            })
+            if (localStatus && localStatus.type !== StatusType.enum.Announce) {
+              if (actor) localStatus.actor = actor
+              return localStatus
+            }
+            const fetchedNote = await getNote({
+              statusId: rawObject,
+              signingActor
+            })
+            if (
+              !fetchedNote ||
+              !isSameActivityPubOrigin(rawObject, fetchedNote.id)
+            ) {
+              return null
+            }
+            rawObject = fetchedNote
+          }
+
+          if (!rawObject || typeof rawObject !== 'object') return null
+          const noteResult = BaseNoteSchema.safeParse(
+            normalizeActivityPubContent(rawObject as Record<string, unknown>)
+          )
           if (!noteResult.success) return null
 
           const status = getStatusFromNote(noteResult.data)

--- a/lib/activities/getRemoteStatus.ts
+++ b/lib/activities/getRemoteStatus.ts
@@ -1,7 +1,7 @@
 import { getNote } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { BaseNote, BaseNoteSchema } from '@/lib/activities/note'
 import { detectLanguageFromHtml } from '@/lib/services/language-detection'
-import { Note } from '@/lib/types/activitypub/objects'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { StatusNote, fromNote } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
@@ -11,6 +11,7 @@ import {
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 type GetRemoteStatusParams = {
   statusId: string
@@ -24,13 +25,10 @@ const publicStreams = [
   'as:Public'
 ]
 
-const hasPublicAudience = (value: Note['to'] | Note['cc']) => {
+const hasPublicAudience = (value: BaseNote['to'] | BaseNote['cc']) => {
   const items = Array.isArray(value) ? value : [value]
   return items.some((item) => publicStreams.includes(item))
 }
-
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : String(error)
 
 export const getRemoteStatus = async ({
   statusId,
@@ -40,15 +38,23 @@ export const getRemoteStatus = async ({
   try {
     remoteNote = await getNote({ statusId, signingActor })
   } catch (error) {
-    logger.error(`[getRemoteStatus] ${getErrorMessage(error)}`)
+    logger.error({
+      message: 'Failed to fetch remote note',
+      err: toLoggableError(error)
+    })
     return null
   }
   if (!remoteNote) return null
 
   // getNote already canonicalises the fetched note via JSON-LD compaction.
-  const noteResult = Note.safeParse(normalizeActivityPubContent(remoteNote))
+  const noteResult = BaseNoteSchema.safeParse(
+    normalizeActivityPubContent(remoteNote)
+  )
   if (!noteResult.success) {
-    logger.error(`[getRemoteStatus] ${noteResult.error.message}`)
+    logger.error({
+      message: 'Failed to parse remote note',
+      err: toLoggableError(noteResult.error)
+    })
     return null
   }
 
@@ -61,7 +67,10 @@ export const getRemoteStatus = async ({
   try {
     status = fromNote(note)
   } catch (error) {
-    logger.error(`[getRemoteStatus] ${getErrorMessage(error)}`)
+    logger.error({
+      message: 'Failed to convert note to status',
+      err: toLoggableError(error)
+    })
     return null
   }
   // Ephemeral status (not persisted), so content-detected language is
@@ -73,7 +82,10 @@ export const getRemoteStatus = async ({
     actorId: status.actorId,
     signingActor
   }).catch((error: unknown) => {
-    logger.error(`[getRemoteStatus.actor] ${getErrorMessage(error)}`)
+    logger.error({
+      message: 'Failed to get actor person',
+      err: toLoggableError(error)
+    })
     return null
   })
   status.actor = actorPerson ? getActorProfileFromPerson(actorPerson) : null

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -285,6 +285,8 @@ describe('note entity utilities', () => {
       expect(result[0].url).toEqual(
         'https://framatube.org/static/webseed/abc-1080.mp4'
       )
+      expect(result[0].width).toEqual(1920)
+      expect(result[0].height).toEqual(1080)
       expect(result[0].thumbnailUrl).toEqual(
         'https://framatube.org/static/thumbnails/abc.jpg'
       )
@@ -415,14 +417,28 @@ describe('note entity utilities', () => {
       expect(getContent(video)).toEqual('<p><strong>My Cool Video</strong></p>')
     })
 
-    it('does not duplicate title if Video content already contains name', () => {
+    it('escapes HTML in Video name', () => {
+      const video = {
+        type: 'Video',
+        name: 'Tom & Jerry <Live>',
+        content: '<p>Episode 1</p>'
+      } as unknown as BaseNote
+
+      expect(getContent(video)).toEqual(
+        '<p><strong>Tom &amp; Jerry &lt;Live&gt;</strong></p>\n<p>Episode 1</p>'
+      )
+    })
+
+    it('does not duplicate title if Video content already starts with formatted title', () => {
       const video = {
         type: 'Video',
         name: 'My Cool Video',
-        content: '<p>My Cool Video is awesome</p>'
+        content: '<p><strong>My Cool Video</strong></p>\n<p>Description</p>'
       } as unknown as BaseNote
 
-      expect(getContent(video)).toEqual('<p>My Cool Video is awesome</p>')
+      expect(getContent(video)).toEqual(
+        '<p><strong>My Cool Video</strong></p>\n<p>Description</p>'
+      )
     })
   })
 

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -242,6 +242,53 @@ describe('note entity utilities', () => {
 
       expect(result[0].mediaType).toEqual('video/mp4')
     })
+
+    it('extracts video stream and thumbnail for PeerTube Video object', () => {
+      const peertubeVideo = {
+        type: 'Video',
+        id: 'https://framatube.org/videos/watch/abc',
+        name: 'PeerTube Video Title',
+        url: [
+          {
+            type: 'Link',
+            mediaType: 'text/html',
+            href: 'https://framatube.org/videos/watch/abc'
+          },
+          {
+            type: 'Link',
+            mediaType: 'application/x-mpegURL',
+            href: 'https://framatube.org/static/streaming-playlists/hls/abc/master.m3u8'
+          },
+          {
+            type: 'Link',
+            mediaType: 'video/mp4',
+            href: 'https://framatube.org/static/webseed/abc-1080.mp4',
+            height: 1080,
+            width: 1920
+          }
+        ],
+        icon: [
+          {
+            type: 'Image',
+            mediaType: 'image/jpeg',
+            url: 'https://framatube.org/static/thumbnails/abc.jpg',
+            width: 1920,
+            height: 1080
+          }
+        ]
+      } as unknown as BaseNote
+
+      const result = getAttachments(peertubeVideo)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].mediaType).toEqual('video/mp4')
+      expect(result[0].url).toEqual(
+        'https://framatube.org/static/webseed/abc-1080.mp4'
+      )
+      expect(result[0].thumbnailUrl).toEqual(
+        'https://framatube.org/static/thumbnails/abc.jpg'
+      )
+    })
   })
 
   describe('getTags', () => {
@@ -345,6 +392,37 @@ describe('note entity utilities', () => {
       } as unknown as BaseNote
 
       expect(getContent(note)).toEqual('')
+    })
+
+    it('prepends Video name to content when object is a Video', () => {
+      const video = {
+        type: 'Video',
+        name: 'My Cool Video',
+        content: '<p>Description of the video</p>'
+      } as unknown as BaseNote
+
+      expect(getContent(video)).toEqual(
+        '<p><strong>My Cool Video</strong></p>\n<p>Description of the video</p>'
+      )
+    })
+
+    it('returns Video name in paragraph when Video has no content', () => {
+      const video = {
+        type: 'Video',
+        name: 'My Cool Video'
+      } as unknown as BaseNote
+
+      expect(getContent(video)).toEqual('<p><strong>My Cool Video</strong></p>')
+    })
+
+    it('does not duplicate title if Video content already contains name', () => {
+      const video = {
+        type: 'Video',
+        name: 'My Cool Video',
+        content: '<p>My Cool Video is awesome</p>'
+      } as unknown as BaseNote
+
+      expect(getContent(video)).toEqual('<p>My Cool Video is awesome</p>')
     })
   })
 

--- a/lib/activities/note.ts
+++ b/lib/activities/note.ts
@@ -13,6 +13,7 @@ import {
   type Tag,
   VideoContent
 } from '@/lib/types/activitypub'
+import { escapeHtml } from '@/lib/utils/text/escapeHtml'
 
 export type BaseNote =
   Note | ImageContent | PageContent | ArticleContent | VideoContent | Question
@@ -79,6 +80,8 @@ export const getAttachments = (object: BaseNote): Document[] => {
     const unsafeObject = object as any
     let url: string | undefined
     let mediaType: string | undefined
+    let width: number | undefined
+    let height: number | undefined
 
     if (object.type === 'Video' && Array.isArray(unsafeObject.url)) {
       let mediaItem = unsafeObject.url.find(
@@ -88,7 +91,15 @@ export const getAttachments = (object: BaseNote): Document[] => {
           'mediaType' in item &&
           typeof (item as { mediaType?: unknown }).mediaType === 'string' &&
           (item as { mediaType: string }).mediaType.startsWith('video/')
-      ) as { href?: string; url?: string; mediaType?: string } | undefined
+      ) as
+        | {
+            href?: string
+            url?: string
+            mediaType?: string
+            width?: number
+            height?: number
+          }
+        | undefined
 
       if (!mediaItem) {
         mediaItem = unsafeObject.url.find(
@@ -98,12 +109,25 @@ export const getAttachments = (object: BaseNote): Document[] => {
             'mediaType' in item &&
             (item as { mediaType?: unknown }).mediaType ===
               'application/x-mpegURL'
-        ) as { href?: string; url?: string; mediaType?: string } | undefined
+        ) as
+          | {
+              href?: string
+              url?: string
+              mediaType?: string
+              width?: number
+              height?: number
+            }
+          | undefined
       }
 
       if (mediaItem) {
         url = mediaItem.href || mediaItem.url
-        mediaType = mediaItem.mediaType
+        mediaType =
+          mediaItem.mediaType === 'application/x-mpegURL'
+            ? 'video/mp4'
+            : mediaItem.mediaType
+        width = mediaItem.width
+        height = mediaItem.height
       } else {
         const videoFileItem = unsafeObject.url.find(
           (item: unknown) =>
@@ -112,10 +136,12 @@ export const getAttachments = (object: BaseNote): Document[] => {
             'href' in item &&
             typeof (item as { href?: unknown }).href === 'string' &&
             /\.(mp4|webm|m3u8)(?:[?#]|$)/i.test((item as { href: string }).href)
-        ) as { href?: string } | undefined
+        ) as { href?: string; width?: number; height?: number } | undefined
         if (videoFileItem) {
           url = videoFileItem.href
           mediaType = 'video/mp4'
+          width = videoFileItem.width
+          height = videoFileItem.height
         }
       }
     }
@@ -148,8 +174,8 @@ export const getAttachments = (object: BaseNote): Document[] => {
           mediaType || (object.type === 'Image' ? 'image/jpeg' : 'video/mp4'),
         url,
         name: unsafeObject.name,
-        width: unsafeObject.width,
-        height: unsafeObject.height,
+        width: unsafeObject.width ?? width,
+        height: unsafeObject.height ?? height,
         blurhash: unsafeObject.blurhash,
         focalPoint: unsafeObject.focalPoint,
         ...(thumbnailUrl ? { thumbnailUrl } : {})
@@ -198,11 +224,10 @@ export const getContent = (object: BaseNote) => {
     typeof object.name === 'string' &&
     object.name.trim()
   ) {
-    const title = object.name.trim()
-    if (!content.includes(title)) {
-      return content
-        ? `<p><strong>${title}</strong></p>\n${content}`
-        : `<p><strong>${title}</strong></p>`
+    const title = escapeHtml(object.name.trim())
+    const titleHeader = `<p><strong>${title}</strong></p>`
+    if (!content.startsWith(titleHeader)) {
+      return content ? `${titleHeader}\n${content}` : titleHeader
     }
   }
 

--- a/lib/activities/note.ts
+++ b/lib/activities/note.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 import { normalizeLanguageCode } from '@/lib/services/translation/types'
 import {
   ArticleContent,
@@ -14,6 +16,15 @@ import {
 
 export type BaseNote =
   Note | ImageContent | PageContent | ArticleContent | VideoContent | Question
+
+export const BaseNoteSchema = z.union([
+  Note,
+  ImageContent,
+  PageContent,
+  ArticleContent,
+  VideoContent,
+  Question
+])
 
 type UrlValue = string | { href?: string } | (string | { href?: string })[]
 
@@ -66,19 +77,82 @@ export const getAttachments = (object: BaseNote): Document[] => {
   if (['Image', 'Video'].includes(object.type)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const unsafeObject = object as any
-    const url = getUrl(unsafeObject.url)
+    let url: string | undefined
+    let mediaType: string | undefined
+
+    if (object.type === 'Video' && Array.isArray(unsafeObject.url)) {
+      let mediaItem = unsafeObject.url.find(
+        (item: unknown) =>
+          item &&
+          typeof item === 'object' &&
+          'mediaType' in item &&
+          typeof (item as { mediaType?: unknown }).mediaType === 'string' &&
+          (item as { mediaType: string }).mediaType.startsWith('video/')
+      ) as { href?: string; url?: string; mediaType?: string } | undefined
+
+      if (!mediaItem) {
+        mediaItem = unsafeObject.url.find(
+          (item: unknown) =>
+            item &&
+            typeof item === 'object' &&
+            'mediaType' in item &&
+            (item as { mediaType?: unknown }).mediaType ===
+              'application/x-mpegURL'
+        ) as { href?: string; url?: string; mediaType?: string } | undefined
+      }
+
+      if (mediaItem) {
+        url = mediaItem.href || mediaItem.url
+        mediaType = mediaItem.mediaType
+      } else {
+        const videoFileItem = unsafeObject.url.find(
+          (item: unknown) =>
+            item &&
+            typeof item === 'object' &&
+            'href' in item &&
+            typeof (item as { href?: unknown }).href === 'string' &&
+            /\.(mp4|webm|m3u8)(?:[?#]|$)/i.test((item as { href: string }).href)
+        ) as { href?: string } | undefined
+        if (videoFileItem) {
+          url = videoFileItem.href
+          mediaType = 'video/mp4'
+        }
+      }
+    }
+
+    if (!url) {
+      url = getUrl(unsafeObject.url)
+      mediaType =
+        unsafeObject.mediaType ||
+        (object.type === 'Image' ? 'image/jpeg' : 'video/mp4')
+    }
+
+    let thumbnailUrl: string | undefined
+    if (unsafeObject.icon) {
+      if (Array.isArray(unsafeObject.icon)) {
+        thumbnailUrl = unsafeObject.icon.find(
+          (item: { url?: unknown }) => typeof item?.url === 'string'
+        )?.url
+      } else if (
+        typeof unsafeObject.icon === 'object' &&
+        typeof unsafeObject.icon.url === 'string'
+      ) {
+        thumbnailUrl = unsafeObject.icon.url
+      }
+    }
+
     if (url) {
       attachments.push({
         type: 'Document',
         mediaType:
-          unsafeObject.mediaType ||
-          (object.type === 'Image' ? 'image/jpeg' : 'video/mp4'),
+          mediaType || (object.type === 'Image' ? 'image/jpeg' : 'video/mp4'),
         url,
         name: unsafeObject.name,
         width: unsafeObject.width,
         height: unsafeObject.height,
         blurhash: unsafeObject.blurhash,
-        focalPoint: unsafeObject.focalPoint
+        focalPoint: unsafeObject.focalPoint,
+        ...(thumbnailUrl ? { thumbnailUrl } : {})
       })
     }
   }
@@ -98,27 +172,41 @@ export const getTags = (object: BaseNote): KnownTag[] => {
 }
 
 export const getContent = (object: BaseNote) => {
+  let content = ''
   if (object.content) {
     // Wordpress uses array in contentMap instead of locale map.
     // This is a temporary fixed to support it.
     if (Array.isArray(object.content)) {
-      return object.content[0]
+      content = object.content[0]
+    } else {
+      content = object.content
     }
-    return object.content
-  }
-
-  if (object.contentMap) {
+  } else if (object.contentMap) {
     if (Array.isArray(object.contentMap)) {
-      return object.contentMap[0]
+      content = object.contentMap[0]
+    } else {
+      const keys = Object.keys(object.contentMap)
+      if (keys.length > 0) {
+        content = object.contentMap[keys[0]]
+      }
     }
-
-    const keys = Object.keys(object.contentMap)
-    if (keys.length === 0) return ''
-
-    const key = Object.keys(object.contentMap)[0]
-    return object.contentMap[key]
   }
-  return ''
+
+  if (
+    object.type === 'Video' &&
+    'name' in object &&
+    typeof object.name === 'string' &&
+    object.name.trim()
+  ) {
+    const title = object.name.trim()
+    if (!content.includes(title)) {
+      return content
+        ? `<p><strong>${title}</strong></p>\n${content}`
+        : `<p><strong>${title}</strong></p>`
+    }
+  }
+
+  return content
 }
 
 const firstLocaleKey = (

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -13,6 +13,8 @@ import {
   getServerSoftwareInfo,
   isMisskeyActor,
   isMisskeyDomain,
+  isPeerTubeActor,
+  isPeerTubeDomain,
   isPixelfedActor,
   isPixelfedDomain
 } from './serverSoftware'
@@ -79,6 +81,48 @@ describe('serverSoftware', () => {
       id: `https://${domain}/users/dansup`
     }) as Actor
     expect(await isPixelfedActor(person)).toBe(true)
+  })
+
+  it('detects PeerTube instances via NodeInfo', async () => {
+    const domain = 'peertube.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${domain}/nodeinfo/2.0.json`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${domain}/nodeinfo/2.0.json`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'peertube',
+              version: '8.2.4'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const software = await getServerSoftware(domain)
+    expect(software).toBe('peertube')
+
+    const isPeerTube = await isPeerTubeDomain(domain)
+    expect(isPeerTube).toBe(true)
+
+    const person = MockActivityPubPerson({
+      id: `https://${domain}/accounts/framasoft`
+    }) as Actor
+    expect(await isPeerTubeActor(person)).toBe(true)
   })
 
   it('returns false for Mastodon or other non-Pixelfed instances', async () => {

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -197,6 +197,20 @@ export const isPixelfedActor = async (person: Actor): Promise<boolean> => {
   }
 }
 
+export const isPeerTubeDomain = async (domain: string): Promise<boolean> => {
+  const software = await getServerSoftware(domain)
+  return software === 'peertube'
+}
+
+export const isPeerTubeActor = async (person: Actor): Promise<boolean> => {
+  try {
+    const actorUrl = new URL(person.id)
+    return isPeerTubeDomain(actorUrl.host)
+  } catch {
+    return false
+  }
+}
+
 const MISSKEY_FAMILY_SOFTWARE = new Set([
   'misskey',
   'sharkey',

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -23,7 +23,8 @@ export const Document = z.object({
   width: z.number().optional(),
   height: z.number().optional(),
   name: z.string().optional().nullable(),
-  focalPoint: z.tuple([z.number(), z.number()]).optional()
+  focalPoint: z.tuple([z.number(), z.number()]).optional(),
+  thumbnailUrl: z.string().optional()
 })
 
 export type Document = z.infer<typeof Document>
@@ -258,10 +259,18 @@ export type ArticleContent = z.infer<typeof ArticleContent>
 export const VideoContent = BaseContent.extend({
   type: z.literal('Video'),
   name: z.string().nullish(),
+  url: z
+    .union([
+      z.string(),
+      z.looseObject({}),
+      z.union([z.string(), z.looseObject({})]).array()
+    ])
+    .nullish(),
   mediaType: z.string().nullish(),
   width: z.number().nullish(),
   height: z.number().nullish(),
-  blurhash: z.string().nullish()
+  blurhash: z.string().nullish(),
+  icon: z.union([Image, Image.array()]).nullish()
 })
 export type VideoContent = z.infer<typeof VideoContent>
 

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import { AnnounceStatus } from '@/lib/activities/announceStatus'
 import {
+  BaseNote,
+  getAttachments,
   getContent,
   getLanguage,
   getReply,
@@ -15,7 +17,6 @@ import {
 } from '@/lib/activities/quoteNoteFields'
 import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import type { Announce as ActivityPubAnnounce } from '@/lib/types/activitypub/activities'
-import { Document } from '@/lib/types/activitypub/objects'
 import {
   ENTITY_TYPE_QUESTION,
   Note,
@@ -294,7 +295,7 @@ const getActorIdFromAttributedTo = (
 // or array of Link objects (some ActivityPub implementations like Mastodon return arrays)
 // Note: The TypeScript schema types url as string | null | undefined, but some
 // implementations like Mastodon/ruby.social actually send arrays
-const getUrlFromNote = (note: Note): string => {
+const getUrlFromNote = (note: BaseNote): string => {
   const noteUrl = note.url as unknown
   if (typeof noteUrl === 'string') {
     return noteUrl
@@ -321,11 +322,9 @@ const getUrlFromNote = (note: Note): string => {
   return note.id
 }
 
-export const fromNote = (note: Note): StatusNote => {
+export const fromNote = (note: BaseNote): StatusNote => {
   const currentTime = Date.now()
-  const attachments = (
-    Array.isArray(note.attachment) ? note.attachment : [note.attachment]
-  ).filter((item): item is Document => item?.type === 'Document')
+  const attachments = getAttachments(note)
 
   const actorId = getActorIdFromAttributedTo(note.attributedTo)
 
@@ -371,6 +370,10 @@ export const fromNote = (note: Note): StatusNote => {
       mediaType: attachment.mediaType,
       url: attachment.url,
       name: attachment.name ?? '',
+      thumbnailUrl: attachment.thumbnailUrl ?? null,
+      width: attachment.width,
+      height: attachment.height,
+      blurhash: attachment.blurhash,
 
       createdAt: currentTime,
       updatedAt: currentTime

--- a/lib/utils/activitypub.ts
+++ b/lib/utils/activitypub.ts
@@ -155,12 +155,16 @@ export const normalizeActivityPubAnnounce = (data: unknown) => {
 
 export const normalizeActivityPubContent = (data: unknown) => {
   if (!isRecord(data)) return data
+  const type = normalizeActivityPubType(data.type) ?? data.type
   return {
     ...data,
-    type: normalizeActivityPubType(data.type) ?? data.type,
+    type,
     attributedTo: extractActivityPubId(data.attributedTo) ?? data.attributedTo,
     inReplyTo: extractActivityPubId(data.inReplyTo) ?? data.inReplyTo,
-    url: extractActivityPubId(data.url) ?? data.url,
+    url:
+      type === 'Video'
+        ? data.url
+        : (extractActivityPubId(data.url) ?? data.url),
     to: normalizeActivityPubRecipients(data.to) ?? data.to,
     cc: normalizeActivityPubRecipients(data.cc) ?? data.cc
   }


### PR DESCRIPTION
## Summary

Support remote user profiles from PeerTube instances (e.g. `https://llun.social/@framasoft@framatube.org`):
1. **Avatar & Banner Resolution**: PeerTube actor profiles deliver `icon` and `image` as arrays of `Image` objects at multiple resolutions. `app/(timeline)/[actor]/page.tsx` was discarding arrays by returning `null`. Resolved via `getActorImageUrl(person.icon)` and responsive banner fallback.
2. **Outbox Video Resolution**: PeerTube outbox emits `Create` activities where `activity.object` is a URL string (rather than an inline object) referencing objects of type `Video` (rather than `Note`). Updated `getActorPosts.ts` to resolve string URLs securely (enforcing `isSameActivityPubOrigin(rawObject, fetchedNote.id)`), extended `BaseNoteSchema` to support `Video`, and converted video attachments (`video/mp4` / `video/*`) with poster thumbnails (`thumbnailUrl`). In `normalizeActivityPubContent`, preserved `data.url` link arrays for `type === 'Video'`.
3. **Video-Only Media Grid Layout**: When a remote profile is a PeerTube actor or contains only video posts (similar to Pixelfed for photos), render the 3-column media grid (`ActorMediaGallery`) directly without the microblog tab bar (Posts, Replies, Media, Fitness), supporting video modal playback and outbox pagination.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: No doc updates required (no new env vars or scripts)
- [x] If migrations changed: No migrations added or changed
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
