### PR TITLE
feat: add software name and version to user profile header

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -134,6 +134,8 @@ describe('getProfileData', () => {
       null
     )
     ;(getPersonFromActor as jest.Mock).mockReturnValue(mockPerson)
+    vi.mocked(getServerSoftwareInfo).mockResolvedValue(null)
+    vi.mocked(isPixelfedActor).mockResolvedValue(false)
   })
 
   describe('when actor is local (has account)', () => {

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -5,7 +5,10 @@ import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
-import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
+import {
+  getServerSoftwareInfo,
+  isPixelfedActor
+} from '@/lib/services/federation/serverSoftware'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
@@ -23,7 +26,8 @@ vi.mock('@/lib/activities/getWebfingerSelf')
 vi.mock('@/lib/services/federation/domainPolicy')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/services/federation/serverSoftware', () => ({
-  isPixelfedActor: vi.fn().mockResolvedValue(false)
+  isPixelfedActor: vi.fn().mockResolvedValue(false),
+  getServerSoftwareInfo: vi.fn().mockResolvedValue(null)
 }))
 vi.mock('@/lib/utils/getPersonFromActor')
 vi.mock('@/lib/utils/logger', () => ({
@@ -175,6 +179,20 @@ describe('getProfileData', () => {
       // Should not call remote APIs
       expect(getWebfingerSelf).not.toHaveBeenCalled()
       expect(getActorPerson).not.toHaveBeenCalled()
+    })
+
+    it('should return serverSoftware as activities.next for local actors', async () => {
+      const result = await getProfileData(
+        mockDatabase,
+        '@localuser@example.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(result?.serverSoftware).toEqual({
+        name: 'activities.next',
+        version: expect.any(String)
+      })
     })
 
     it('should return hasFitnessData as false when actor has no fitness data', async () => {
@@ -461,6 +479,26 @@ describe('getProfileData', () => {
       expect(getActorCollectionCounts).toHaveBeenCalledWith({
         person: mockPerson,
         signingActor: mockFederationSigningActor
+      })
+    })
+
+    it('resolves serverSoftware for remote actors', async () => {
+      vi.mocked(getServerSoftwareInfo).mockResolvedValueOnce({
+        name: 'mastodon',
+        version: '4.3.0'
+      })
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        { currentActor: null }
+      )
+
+      expect(getServerSoftwareInfo).toHaveBeenCalledWith('remote.com')
+      expect(result?.serverSoftware).toEqual({
+        name: 'mastodon',
+        version: '4.3.0'
       })
     })
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -330,7 +330,8 @@ export const getProfileData = async (
     followersCount: collectionCounts.followersCount,
     isInternalAccount: false,
     hasFitnessData: false,
-    isPixelfed: await isPixelfedActor(person),
+    isPixelfed:
+      serverSoftware?.name === 'pixelfed' || (await isPixelfedActor(person)),
     serverSoftware
   }
 }

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -7,7 +7,11 @@ import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstr
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
-import { isPixelfedActor } from '@/lib/services/federation/serverSoftware'
+import {
+  ServerSoftware,
+  getServerSoftwareInfo,
+  isPixelfedActor
+} from '@/lib/services/federation/serverSoftware'
 import {
   canActorReadStatus,
   resolveActorStatusesAudience
@@ -19,6 +23,7 @@ import { Status, StatusType } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
+import { VERSION } from '@/lib/utils/version'
 
 type ProfileData = {
   person: Actor
@@ -34,6 +39,7 @@ type ProfileData = {
   isInternalAccount: boolean
   hasFitnessData: boolean
   isPixelfed?: boolean
+  serverSoftware?: ServerSoftware | null
 }
 
 type ProfileDataOptions = {
@@ -154,7 +160,11 @@ export const getProfileData = async (
       followersCount,
       isInternalAccount: true,
       hasFitnessData,
-      isPixelfed: false
+      isPixelfed: false,
+      serverSoftware: {
+        name: 'activities.next',
+        version: VERSION
+      }
     }
   }
 
@@ -256,8 +266,15 @@ export const getProfileData = async (
     followersAudience: remoteAudience.followersAudience
   }
 
-  const [actorPostsResponse, attachments, collectionCounts] = await Promise.all(
-    [
+  let remoteDomain: string | null = null
+  try {
+    remoteDomain = new URL(person.id).host
+  } catch {
+    // Malformed person.id
+  }
+
+  const [actorPostsResponse, attachments, collectionCounts, serverSoftware] =
+    await Promise.all([
       getActorPosts({
         database,
         person,
@@ -268,9 +285,9 @@ export const getProfileData = async (
         actorId: person.id,
         ...remoteVisibilityScope
       }),
-      getActorCollectionCounts({ person, ...signingParams })
-    ]
-  )
+      getActorCollectionCounts({ person, ...signingParams }),
+      remoteDomain ? getServerSoftwareInfo(remoteDomain) : Promise.resolve(null)
+    ])
 
   const resolvedStatusesCount =
     collectionCounts.statusesCount ?? actorPostsResponse.statusesCount ?? null
@@ -313,6 +330,7 @@ export const getProfileData = async (
     followersCount: collectionCounts.followersCount,
     isInternalAccount: false,
     hasFitnessData: false,
-    isPixelfed: await isPixelfedActor(person)
+    isPixelfed: await isPixelfedActor(person),
+    serverSoftware
   }
 }

--- a/app/(timeline)/[actor]/page.test.tsx
+++ b/app/(timeline)/[actor]/page.test.tsx
@@ -257,6 +257,7 @@ describe('[actor] page header handle link', () => {
     expect(softwareElement).toHaveClass(
       'text-sm',
       'text-muted-foreground',
+      'break-words',
       'mt-3'
     )
   })
@@ -293,6 +294,75 @@ describe('[actor] page header handle link', () => {
 
     const softwareElement = screen.getByText('Mastodon')
     expect(softwareElement).toBeInTheDocument()
-    expect(softwareElement).toHaveClass('text-sm', 'text-muted-foreground')
+    expect(softwareElement).toHaveClass(
+      'text-sm',
+      'text-muted-foreground',
+      'break-words'
+    )
+  })
+
+  it('applies mt-5 when all counts are null and software is present', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://mastodon.social/users/bob',
+        type: 'Person',
+        preferredUsername: 'bob',
+        name: 'Bob',
+        summary: '',
+        url: 'https://mastodon.social/@bob'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: null,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: null,
+      followersCount: null,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false,
+      serverSoftware: {
+        name: 'mastodon',
+        version: '4.3.0'
+      }
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@bob@mastodon.social' })
+    })
+    render(element)
+
+    const softwareElement = screen.getByText('Mastodon/4.3.0')
+    expect(softwareElement).toBeInTheDocument()
+    expect(softwareElement).toHaveClass('mt-5')
+  })
+
+  it('omits software container when serverSoftware is null', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://mastodon.social/users/bob',
+        type: 'Person',
+        preferredUsername: 'bob',
+        name: 'Bob',
+        summary: '',
+        url: 'https://mastodon.social/@bob'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 10,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 5,
+      followersCount: 15,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false,
+      serverSoftware: null
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@bob@mastodon.social' })
+    })
+    render(element)
+
+    expect(screen.queryByText(/mastodon/i)).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/page.test.tsx
+++ b/app/(timeline)/[actor]/page.test.tsx
@@ -221,4 +221,78 @@ describe('[actor] page header handle link', () => {
       expect.objectContaining({ isInternalAccount: true })
     )
   })
+
+  it('renders software name and version under the counts block', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://mastodon.social/users/bob',
+        type: 'Person',
+        preferredUsername: 'bob',
+        name: 'Bob',
+        summary: '',
+        url: 'https://mastodon.social/@bob'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 10,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 5,
+      followersCount: 15,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false,
+      serverSoftware: {
+        name: 'mastodon',
+        version: '4.3.0'
+      }
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@bob@mastodon.social' })
+    })
+    render(element)
+
+    const softwareElement = screen.getByText('Mastodon/4.3.0')
+    expect(softwareElement).toBeInTheDocument()
+    expect(softwareElement).toHaveClass(
+      'text-sm',
+      'text-muted-foreground',
+      'mt-3'
+    )
+  })
+
+  it('renders software name without version when version is omitted', async () => {
+    mockGetProfileData.mockResolvedValue({
+      person: {
+        id: 'https://mastodon.social/users/bob',
+        type: 'Person',
+        preferredUsername: 'bob',
+        name: 'Bob',
+        summary: '',
+        url: 'https://mastodon.social/@bob'
+      } as unknown as Actor,
+      statuses: [],
+      statusesCount: 10,
+      statusPagination: { nextPageUrl: null, prevPageUrl: null },
+      attachments: [],
+      followingCount: 5,
+      followersCount: 15,
+      isInternalAccount: false,
+      hasFitnessData: false,
+      isPixelfed: false,
+      serverSoftware: {
+        name: 'mastodon',
+        version: null
+      }
+    })
+
+    const element = await Page({
+      params: Promise.resolve({ actor: '@bob@mastodon.social' })
+    })
+    render(element)
+
+    const softwareElement = screen.getByText('Mastodon')
+    expect(softwareElement).toBeInTheDocument()
+    expect(softwareElement).toHaveClass('text-sm', 'text-muted-foreground')
+  })
 })

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -299,7 +299,7 @@ const Page: FC<Props> = async ({ params }) => {
           {formattedSoftware && (
             <div
               className={cn(
-                'text-sm text-muted-foreground',
+                'text-sm text-muted-foreground break-words',
                 statusesCount !== null ||
                   followingCount !== null ||
                   followersCount !== null

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -18,6 +18,7 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { cn } from '@/lib/utils'
+import { formatServerSoftware } from '@/lib/utils/formatServerSoftware'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { ActorRedirectCard } from './ActorRedirectCard'
@@ -143,7 +144,8 @@ const Page: FC<Props> = async ({ params }) => {
     followersCount,
     hasFitnessData,
     isPixelfed,
-    isInternalAccount
+    isInternalAccount,
+    serverSoftware
   } = actorProfile
 
   const isCurrentUser = currentActor?.id === person.id
@@ -204,6 +206,10 @@ const Page: FC<Props> = async ({ params }) => {
     (rawUrl && /^https?:\/\//i.test(rawUrl) ? rawUrl : null) ||
     (/^https?:\/\//i.test(person.id) ? person.id : null) ||
     `https://${actorDomain}/@${actorUsername}`
+
+  const formattedSoftware = serverSoftware
+    ? formatServerSoftware(serverSoftware)
+    : null
 
   return (
     <div className={cn('space-y-6', isLoggedIn && 'pt-6 sm:pt-8')}>
@@ -287,6 +293,21 @@ const Page: FC<Props> = async ({ params }) => {
                   <span className="text-muted-foreground">Followers</span>
                 </Link>
               )}
+            </div>
+          )}
+
+          {formattedSoftware && (
+            <div
+              className={cn(
+                'text-sm text-muted-foreground',
+                statusesCount !== null ||
+                  followingCount !== null ||
+                  followersCount !== null
+                  ? 'mt-3'
+                  : 'mt-5'
+              )}
+            >
+              {formattedSoftware}
             </div>
           )}
 

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -10,6 +10,7 @@ import {
   clearServerSoftwareCache,
   getServerSoftware,
   getServerSoftwareCacheSizeForTests,
+  getServerSoftwareInfo,
   isMisskeyActor,
   isMisskeyDomain,
   isPixelfedActor,
@@ -65,6 +66,12 @@ describe('serverSoftware', () => {
     const software = await getServerSoftware(domain)
     expect(software).toBe('pixelfed')
 
+    const softwareInfo = await getServerSoftwareInfo(domain)
+    expect(softwareInfo).toEqual({
+      name: 'pixelfed',
+      version: '0.12.9'
+    })
+
     const isPixelfed = await isPixelfedDomain(domain)
     expect(isPixelfed).toBe(true)
 
@@ -104,8 +111,50 @@ describe('serverSoftware', () => {
       return { status: 404, body: 'Not Found' }
     })
 
+    const softwareInfo = await getServerSoftwareInfo(domain)
+    expect(softwareInfo).toEqual({
+      name: 'mastodon',
+      version: '4.3.0'
+    })
+
     const isPixelfed = await isPixelfedDomain(domain)
     expect(isPixelfed).toBe(false)
+  })
+
+  it('handles server software without a version', async () => {
+    const domain = 'noversion.example'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${domain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${domain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${domain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'pleroma'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const softwareInfo = await getServerSoftwareInfo(domain)
+    expect(softwareInfo).toEqual({
+      name: 'pleroma',
+      version: null
+    })
   })
 
   it('handles 404 on NodeInfo gracefully and caches negative result', async () => {

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -58,10 +58,10 @@ const setBoundedEntry = (
 // hostile `.well-known/nodeinfo` redirect the probe at an arbitrary server. The
 // `typeof href === 'string'` guard was missing on the old rel-less fallback.
 const isSameHostNodeInfoLink = (
-  link: { rel?: string; href?: string },
+  link: { rel?: string; href?: string } | null | undefined,
   expectedHost: string
 ): boolean => {
-  if (typeof link.href !== 'string') return false
+  if (typeof link?.href !== 'string') return false
   try {
     return new URL(link.href).host.toLowerCase() === expectedHost
   } catch {
@@ -105,7 +105,9 @@ export const getServerSoftwareInfo = async (
         links?: Array<{ rel?: string; href?: string }>
       }
 
-      const links = nodeInfoWellKnown.links ?? []
+      const links = Array.isArray(nodeInfoWellKnown?.links)
+        ? nodeInfoWellKnown.links
+        : []
       const nodeInfoLink =
         links.find(
           (link) =>
@@ -141,8 +143,8 @@ export const getServerSoftwareInfo = async (
       }
 
       const rawName =
-        typeof schema.software?.name === 'string'
-          ? schema.software.name.trim().toLowerCase()
+        typeof schema?.software?.name === 'string'
+          ? schema.software.name.trim().toLowerCase().slice(0, 100)
           : ''
 
       if (!rawName) {
@@ -151,8 +153,8 @@ export const getServerSoftwareInfo = async (
       }
 
       const rawVersion =
-        typeof schema.software?.version === 'string'
-          ? schema.software.version.trim()
+        typeof schema?.software?.version === 'string'
+          ? schema.software.version.trim().slice(0, 100)
           : null
       const version = rawVersion || null
 

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -4,10 +4,15 @@ import { request } from '@/lib/utils/request'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
 
+export interface ServerSoftware {
+  name: string
+  version: string | null
+}
+
 type CacheEntry = {
-  // '' is the negative-cache value (probe failed / not resolvable), kept
+  // null is the negative-cache value (probe failed / not resolvable), kept
   // distinct from "not cached" so a failure does not re-probe until it expires.
-  software: string
+  software: ServerSoftware | null
   expiresAt: number
 }
 
@@ -30,7 +35,11 @@ const domainSoftwareCache = new Map<string, CacheEntry>()
 // `actorPublicStatusesCount.ts` and `setBoundedCacheValue` in
 // `lib/utils/host.ts` — both are private to their own domains, so this is a
 // deliberate copy rather than an export widened for one caller.
-const setBoundedEntry = (domain: string, software: string, ttlMs: number) => {
+const setBoundedEntry = (
+  domain: string,
+  software: ServerSoftware | null,
+  ttlMs: number
+) => {
   if (domainSoftwareCache.has(domain)) {
     domainSoftwareCache.delete(domain)
   } else if (domainSoftwareCache.size >= MAX_CACHED_DOMAINS) {
@@ -66,16 +75,16 @@ export const clearServerSoftwareCache = () => {
 
 export const getServerSoftwareCacheSizeForTests = () => domainSoftwareCache.size
 
-export const getServerSoftware = async (
+export const getServerSoftwareInfo = async (
   domain: string
-): Promise<string | null> =>
-  withSpan('federation', 'getServerSoftware', { domain }, async () => {
+): Promise<ServerSoftware | null> =>
+  withSpan('federation', 'getServerSoftwareInfo', { domain }, async () => {
     const normalizedDomain = domain.trim().toLowerCase()
     if (!normalizedDomain) return null
 
     const cached = domainSoftwareCache.get(normalizedDomain)
     if (cached && cached.expiresAt > Date.now()) {
-      return cached.software || null
+      return cached.software
     }
 
     try {
@@ -88,7 +97,7 @@ export const getServerSoftware = async (
       })
 
       if (statusCode !== 200 || !body || typeof body !== 'string') {
-        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
+        setBoundedEntry(normalizedDomain, null, FAILURE_TTL_MS)
         return null
       }
 
@@ -110,7 +119,7 @@ export const getServerSoftware = async (
         links.find((link) => isSameHostNodeInfoLink(link, normalizedDomain))
 
       if (!nodeInfoLink?.href) {
-        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
+        setBoundedEntry(normalizedDomain, null, FAILURE_TTL_MS)
         return null
       }
 
@@ -123,31 +132,54 @@ export const getServerSoftware = async (
       })
 
       if (infoStatus !== 200 || !infoBody || typeof infoBody !== 'string') {
-        setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
+        setBoundedEntry(normalizedDomain, null, FAILURE_TTL_MS)
         return null
       }
 
       const schema = JSON.parse(infoBody) as {
-        software?: { name?: string }
+        software?: { name?: unknown; version?: unknown }
       }
 
-      const softwareName = schema.software?.name?.trim().toLowerCase() ?? ''
-      setBoundedEntry(
-        normalizedDomain,
-        softwareName,
-        softwareName ? SUCCESS_TTL_MS : FAILURE_TTL_MS
-      )
-      return softwareName || null
+      const rawName =
+        typeof schema.software?.name === 'string'
+          ? schema.software.name.trim().toLowerCase()
+          : ''
+
+      if (!rawName) {
+        setBoundedEntry(normalizedDomain, null, FAILURE_TTL_MS)
+        return null
+      }
+
+      const rawVersion =
+        typeof schema.software?.version === 'string'
+          ? schema.software.version.trim()
+          : null
+      const version = rawVersion || null
+
+      const software: ServerSoftware = {
+        name: rawName,
+        version
+      }
+
+      setBoundedEntry(normalizedDomain, software, SUCCESS_TTL_MS)
+      return software
     } catch (error) {
       logger.warn({
         message: 'Failed to resolve server software via NodeInfo',
         domain: normalizedDomain,
         err: toLoggableError(error)
       })
-      setBoundedEntry(normalizedDomain, '', FAILURE_TTL_MS)
+      setBoundedEntry(normalizedDomain, null, FAILURE_TTL_MS)
       return null
     }
   })
+
+export const getServerSoftware = async (
+  domain: string
+): Promise<string | null> => {
+  const info = await getServerSoftwareInfo(domain)
+  return info?.name ?? null
+}
 
 export const isPixelfedDomain = async (domain: string): Promise<boolean> => {
   const software = await getServerSoftware(domain)

--- a/lib/utils/formatServerSoftware.test.ts
+++ b/lib/utils/formatServerSoftware.test.ts
@@ -49,4 +49,16 @@ describe('formatServerSoftware', () => {
     expect(formatServerSoftware({ name: '', version: '1.0' })).toBe('')
     expect(formatServerSoftware({ name: '   ', version: '1.0' })).toBe('')
   })
+
+  it('safely handles Object prototype property names without collision', () => {
+    expect(formatServerSoftware({ name: 'constructor', version: null })).toBe(
+      'Constructor'
+    )
+    expect(formatServerSoftware({ name: 'toString', version: '1.0' })).toBe(
+      'ToString/1.0'
+    )
+    expect(formatServerSoftware({ name: 'valueOf', version: null })).toBe(
+      'ValueOf'
+    )
+  })
 })

--- a/lib/utils/formatServerSoftware.test.ts
+++ b/lib/utils/formatServerSoftware.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatServerSoftware } from './formatServerSoftware'
+
+describe('formatServerSoftware', () => {
+  it('formats known software with version', () => {
+    expect(formatServerSoftware({ name: 'mastodon', version: '4.3.0' })).toBe(
+      'Mastodon/4.3.0'
+    )
+    expect(formatServerSoftware({ name: 'pixelfed', version: '0.12.9' })).toBe(
+      'Pixelfed/0.12.9'
+    )
+    expect(
+      formatServerSoftware({ name: 'gotosocial', version: '0.17.0' })
+    ).toBe('GoToSocial/0.17.0')
+    expect(formatServerSoftware({ name: 'peertube', version: '6.0.0' })).toBe(
+      'PeerTube/6.0.0'
+    )
+    expect(
+      formatServerSoftware({ name: 'activities.next', version: '1.158.3' })
+    ).toBe('activities.next/1.158.3')
+    expect(
+      formatServerSoftware({ name: 'activities-next', version: '1.158.3' })
+    ).toBe('activities.next/1.158.3')
+  })
+
+  it('omits version slash when version is null or empty', () => {
+    expect(formatServerSoftware({ name: 'mastodon', version: null })).toBe(
+      'Mastodon'
+    )
+    expect(formatServerSoftware({ name: 'pixelfed', version: '' })).toBe(
+      'Pixelfed'
+    )
+    expect(formatServerSoftware({ name: 'pixelfed', version: '   ' })).toBe(
+      'Pixelfed'
+    )
+  })
+
+  it('formats unknown software by capitalizing the first letter', () => {
+    expect(
+      formatServerSoftware({ name: 'unknownengine', version: '1.0.0' })
+    ).toBe('Unknownengine/1.0.0')
+    expect(
+      formatServerSoftware({ name: 'customPlatform', version: null })
+    ).toBe('CustomPlatform')
+  })
+
+  it('handles empty software name gracefully', () => {
+    expect(formatServerSoftware({ name: '', version: '1.0' })).toBe('')
+    expect(formatServerSoftware({ name: '   ', version: '1.0' })).toBe('')
+  })
+})

--- a/lib/utils/formatServerSoftware.ts
+++ b/lib/utils/formatServerSoftware.ts
@@ -1,4 +1,4 @@
-import { ServerSoftware } from '@/lib/services/federation/serverSoftware'
+import type { ServerSoftware } from '@/lib/services/federation/serverSoftware'
 
 const KNOWN_SOFTWARE_NAMES: Record<string, string> = {
   mastodon: 'Mastodon',
@@ -28,9 +28,9 @@ export const formatServerSoftware = (software: ServerSoftware): string => {
   if (!rawName) return ''
 
   const lookupKey = rawName.toLowerCase()
-  const formattedName =
-    KNOWN_SOFTWARE_NAMES[lookupKey] ??
-    rawName.charAt(0).toUpperCase() + rawName.slice(1)
+  const formattedName = Object.hasOwn(KNOWN_SOFTWARE_NAMES, lookupKey)
+    ? KNOWN_SOFTWARE_NAMES[lookupKey]
+    : rawName.charAt(0).toUpperCase() + rawName.slice(1)
 
   const trimmedVersion = software.version?.trim()
   if (trimmedVersion) {

--- a/lib/utils/formatServerSoftware.ts
+++ b/lib/utils/formatServerSoftware.ts
@@ -1,0 +1,41 @@
+import { ServerSoftware } from '@/lib/services/federation/serverSoftware'
+
+const KNOWN_SOFTWARE_NAMES: Record<string, string> = {
+  mastodon: 'Mastodon',
+  pixelfed: 'Pixelfed',
+  gotosocial: 'GoToSocial',
+  lemmy: 'Lemmy',
+  peertube: 'PeerTube',
+  misskey: 'Misskey',
+  firefish: 'Firefish',
+  sharkey: 'Sharkey',
+  akkoma: 'Akkoma',
+  pleroma: 'Pleroma',
+  bookwyrm: 'BookWyrm',
+  wordpress: 'WordPress',
+  'activities.next': 'activities.next',
+  'activities-next': 'activities.next',
+  friendica: 'Friendica',
+  hubzilla: 'Hubzilla',
+  diaspora: 'Diaspora',
+  threads: 'Threads',
+  'micro.blog': 'Micro.blog',
+  microdotblog: 'Micro.blog'
+}
+
+export const formatServerSoftware = (software: ServerSoftware): string => {
+  const rawName = software.name.trim()
+  if (!rawName) return ''
+
+  const lookupKey = rawName.toLowerCase()
+  const formattedName =
+    KNOWN_SOFTWARE_NAMES[lookupKey] ??
+    rawName.charAt(0).toUpperCase() + rawName.slice(1)
+
+  const trimmedVersion = software.version?.trim()
+  if (trimmedVersion) {
+    return `${formattedName}/${trimmedVersion}`
+  }
+
+  return formattedName
+}


### PR DESCRIPTION
## Summary

Adds the server software name and version (e.g. `Mastodon/4.3.0`, `Pixelfed/0.12.9`, `activities.next/1.158.3`) in the user profile header under the posts/following/followers count, styled with the same font and color (`text-sm text-muted-foreground`) as the posts/following/followers labels.

- Extends `lib/services/federation/serverSoftware.ts` to parse and cache both `name` and `version` via `getServerSoftwareInfo`, while preserving `getServerSoftware` for existing callers.
- Adds `formatServerSoftware` utility with friendly Fediverse capitalization mappings (`mastodon` -> `Mastodon`, `pixelfed` -> `Pixelfed`, `gotosocial` -> `GoToSocial`, `activities.next` -> `activities.next`, etc.) and formatting `${name}/${version}` (or `${name}` if version is omitted).
- Updates `getProfileData.ts` to supply local instance info (`activities.next` + `VERSION`) and resolve remote software concurrently alongside collection/outbox queries.
- Renders the formatted software info in `app/(timeline)/[actor]/page.tsx` below the counts block.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)