### PR TITLE
Bump version to v1.158.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.5",
+  "version": "1.158.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.5`
- Base main SHA: `2ad56e7ae7bd86ce2edd307a9759e58e132073ab`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
