### PR TITLE
feat: add info icon in front of software version in profile page

### DIFF
--- a/app/(timeline)/[actor]/page.test.tsx
+++ b/app/(timeline)/[actor]/page.test.tsx
@@ -254,12 +254,20 @@ describe('[actor] page header handle link', () => {
 
     const softwareElement = screen.getByText('Mastodon/4.3.0')
     expect(softwareElement).toBeInTheDocument()
-    expect(softwareElement).toHaveClass(
+    const container = softwareElement.closest('div')
+    expect(container).toHaveClass(
+      'flex',
+      'items-center',
+      'gap-1.5',
       'text-sm',
       'text-muted-foreground',
       'break-words',
       'mt-3'
     )
+    const icon = container?.querySelector('svg')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('lucide-info', 'size-3.5')
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
   })
 
   it('renders software name without version when version is omitted', async () => {
@@ -294,11 +302,18 @@ describe('[actor] page header handle link', () => {
 
     const softwareElement = screen.getByText('Mastodon')
     expect(softwareElement).toBeInTheDocument()
-    expect(softwareElement).toHaveClass(
+    const container = softwareElement.closest('div')
+    expect(container).toHaveClass(
+      'flex',
+      'items-center',
+      'gap-1.5',
       'text-sm',
       'text-muted-foreground',
       'break-words'
     )
+    const icon = container?.querySelector('svg')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('lucide-info', 'size-3.5')
   })
 
   it('applies mt-5 when all counts are null and software is present', async () => {
@@ -333,7 +348,7 @@ describe('[actor] page header handle link', () => {
 
     const softwareElement = screen.getByText('Mastodon/4.3.0')
     expect(softwareElement).toBeInTheDocument()
-    expect(softwareElement).toHaveClass('mt-5')
+    expect(softwareElement.closest('div')).toHaveClass('mt-5')
   })
 
   it('omits software container when serverSoftware is null', async () => {

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Info } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
@@ -303,7 +303,7 @@ const Page: FC<Props> = async ({ params }) => {
           {formattedSoftware && (
             <div
               className={cn(
-                'text-sm text-muted-foreground break-words',
+                'flex items-center gap-1.5 text-sm text-muted-foreground break-words',
                 statusesCount !== null ||
                   followingCount !== null ||
                   followersCount !== null
@@ -311,7 +311,8 @@ const Page: FC<Props> = async ({ params }) => {
                   : 'mt-5'
               )}
             >
-              {formattedSoftware}
+              <Info className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>{formattedSoftware}</span>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Adds an Info icon (`lucide-react`) in front of the server software name and version on the profile page header under the stats count block, aligning icon and text with `flex items-center gap-1.5`.

- Updates `app/(timeline)/[actor]/page.tsx` to render `<Info className="size-3.5 shrink-0" aria-hidden="true" />` in front of `{formattedSoftware}`.
- Updates `app/(timeline)/[actor]/page.test.tsx` to verify the container layout classes and ensure the Info icon is present with `aria-hidden="true"`.

## Screenshots

Verified in browser on local SQLite dev server (Chromium):
- Profile page displays `(i) activities.next/1.158.6` under the stats counts with proper alignment, spacing (`gap-1.5`), and color (`text-muted-foreground`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)