### PR TITLE
feat: enhance federated profile rendering, counter formatting, and media handling

### DIFF
--- a/app/(timeline)/[actor]/ActorMediaGallery.tsx
+++ b/app/(timeline)/[actor]/ActorMediaGallery.tsx
@@ -36,7 +36,7 @@ export const ActorMediaGallery: FC<Props> = ({
   isMediaOnly = false,
   className
 }) => {
-  const isMediaStream = isPixelfed || isMediaOnly
+  const isMediaGrid = isPixelfed || isMediaOnly
   const [modalIndex, setModalIndex] = useState<number | null>(null)
   const [attachments, setAttachments] =
     useState<Attachment[]>(initialAttachments)
@@ -45,7 +45,7 @@ export const ActorMediaGallery: FC<Props> = ({
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (isMediaStream && statuses && statuses.length > 0) {
+    if (isMediaGrid && statuses && statuses.length > 0) {
       const derived = statuses
         .flatMap((s) => (s.type === StatusType.enum.Note ? s.attachments : []))
         .filter(isVisualAttachment)
@@ -55,7 +55,7 @@ export const ActorMediaGallery: FC<Props> = ({
     } else if (initialAttachments.length > 0) {
       setAttachments(initialAttachments)
     }
-  }, [isMediaStream, statuses, initialAttachments])
+  }, [isMediaGrid, statuses, initialAttachments])
 
   const statusMap = useMemo(() => {
     const map = new Map<string, StatusNote>()
@@ -109,8 +109,7 @@ export const ActorMediaGallery: FC<Props> = ({
             const attachmentCount = parentStatus?.attachments.length ?? 1
             const isVideo =
               attachment.mediaType.startsWith('video') ||
-              attachment.url.endsWith('.mp4') ||
-              attachment.url.endsWith('.webm')
+              /\.(mp4|webm|m3u8)(?:[?#]|$)/i.test(attachment.url)
 
             return (
               <button
@@ -125,7 +124,16 @@ export const ActorMediaGallery: FC<Props> = ({
                 }
               >
                 <Media
-                  attachment={attachment}
+                  attachment={
+                    attachment.thumbnailUrl
+                      ? {
+                          ...attachment,
+                          mediaType: 'image/jpeg',
+                          url: attachment.thumbnailUrl
+                        }
+                      : attachment
+                  }
+                  loading="lazy"
                   className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
                 />
 
@@ -208,7 +216,7 @@ export const ActorMediaGallery: FC<Props> = ({
         </div>
       )}
 
-      {!isMediaStream && hasMore && (
+      {!isMediaGrid && hasMore && (
         <div className="mt-4 text-center">
           <Button
             variant="outline"

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -421,6 +421,46 @@ describe('ActorTimelines', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('stops trying and removes load more when an empty feed yields no statuses', async () => {
+    const nextPageUrl =
+      'https://remote.example/users/actor/outbox?page=true&max_id=1'
+
+    getActorStatusesMock.mockResolvedValue({
+      statuses: [],
+      statusesCount: 0,
+      nextPageUrl:
+        'https://remote.example/users/actor/outbox?page=true&max_id=2',
+      prevPageUrl: 'https://remote.example/users/actor/outbox?page=true'
+    })
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        statusPagination={{
+          nextPageUrl,
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+    expect(loadMoreButton).toBeInTheDocument()
+
+    fireEvent.click(loadMoreButton)
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('button', { name: 'Loading...' })
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Load more' })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
     // Regression test for React hydration mismatch (error #418): the relative
     // timestamps in Posts must derive from the server-provided currentTime prop
@@ -840,7 +880,7 @@ describe('ActorTimelines', () => {
       expect(screen.getByTestId('mock-media-gallery')).toBeInTheDocument()
     })
 
-    it('enables load more when isMediaOnly is true', async () => {
+    it('enables load more when isMediaOnly or isMediaService is true', async () => {
       const mockGetActorStatuses = vi.mocked(getActorStatuses)
       const nextPageUrl = 'https://framatube.org/api/page2'
       const newStatus = createStatus('https://framatube.org/videos/watch/2')
@@ -860,7 +900,7 @@ describe('ActorTimelines', () => {
           attachments={[]}
           currentTime={FIXED_CURRENT_TIME}
           currentActor={currentActorProfile}
-          isMediaOnly={true}
+          isMediaService={true}
           statusPagination={{ nextPageUrl, prevPageUrl: null }}
         />
       )
@@ -875,6 +915,47 @@ describe('ActorTimelines', () => {
           actorId: 'https://framatube.org/accounts/framasoft',
           pageUrl: nextPageUrl
         })
+      })
+    })
+
+    it('displays error message when load more fails and allows retrying', async () => {
+      const mockGetActorStatuses = vi.mocked(getActorStatuses)
+      const nextPageUrl = 'https://framatube.org/api/page2'
+
+      mockGetActorStatuses.mockRejectedValueOnce(new Error('Network failure'))
+
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://framatube.org/accounts/framasoft"
+          statuses={[createStatus('https://framatube.org/videos/watch/1')]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={currentActorProfile}
+          isMediaService={true}
+          statusPagination={{ nextPageUrl, prevPageUrl: null }}
+        />
+      )
+
+      const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+      fireEvent.click(loadMoreButton)
+
+      const errorAlert = await screen.findByRole('alert')
+      expect(errorAlert).toHaveTextContent(
+        'Failed to load more posts. Please try again.'
+      )
+
+      mockGetActorStatuses.mockResolvedValueOnce({
+        statuses: [createStatus('https://framatube.org/videos/watch/2')],
+        statusesCount: 2,
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+
+      fireEvent.click(loadMoreButton)
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
       })
     })
   })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/components/ui/tabs'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, isVisualAttachment } from '@/lib/types/domain/attachment'
 import {
   Status,
   StatusNote,
@@ -52,6 +52,7 @@ interface Props {
   hasFitnessData?: boolean
   isMediaUploadEnabled?: boolean
   isPixelfed?: boolean
+  isMediaService?: boolean
   isInternalAccount?: boolean
   isMediaOnly?: boolean
 }
@@ -132,10 +133,11 @@ export const ActorTimelines: FC<Props> = ({
   hasFitnessData = false,
   isMediaUploadEnabled,
   isPixelfed = false,
+  isMediaService = false,
   isInternalAccount = true,
-  isMediaOnly = false
+  isMediaOnly: isMediaOnlyProp = false
 }) => {
-  const isMediaView = isPixelfed || isMediaOnly
+  const isMediaOnly = Boolean(isPixelfed || isMediaService || isMediaOnlyProp)
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,
@@ -144,6 +146,8 @@ export const ActorTimelines: FC<Props> = ({
   const [isLoadingMoreStatuses, setLoadingMoreStatuses] =
     useState<boolean>(false)
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const [requireManualLoadMore, setRequireManualLoadMore] =
+    useState<boolean>(false)
   const loadMoreRef = useRef<HTMLDivElement>(null)
   const isLoadingRef = useRef<boolean>(false)
 
@@ -152,9 +156,11 @@ export const ActorTimelines: FC<Props> = ({
   const showRepliesTab = Boolean(isInternalAccount)
 
   const mediaAttachments = useMemo(() => {
-    const statusAttachments = currentStatuses.flatMap((status) =>
-      status.type === StatusType.enum.Note ? status.attachments : []
-    )
+    const statusAttachments = currentStatuses
+      .flatMap((status) =>
+        status.type === StatusType.enum.Note ? status.attachments : []
+      )
+      .filter(isVisualAttachment)
     if (attachments.length === 0) {
       return statusAttachments
     }
@@ -166,6 +172,12 @@ export const ActorTimelines: FC<Props> = ({
   }, [attachments, currentStatuses])
 
   const hasMedia = mediaAttachments.length > 0
+
+  const hasLoadedMedia =
+    attachments.length > 0 ||
+    currentStatuses.some(
+      (s) => s.type === StatusType.enum.Note && s.attachments.length > 0
+    )
 
   const availableTabs = useMemo(() => {
     const tabs: ProfileTab[] = ['posts']
@@ -182,15 +194,15 @@ export const ActorTimelines: FC<Props> = ({
   }, [showRepliesTab, hasMedia, showFitnessTab])
 
   const [activeTab, setActiveTab] = useState<ProfileTab>(
-    isMediaView ? 'media' : 'posts'
+    isMediaOnly ? 'media' : 'posts'
   )
 
   const effectiveActiveTab = useMemo(() => {
     if (availableTabs.includes(activeTab)) {
       return activeTab
     }
-    return availableTabs[0] ?? 'posts'
-  }, [activeTab, availableTabs])
+    return 'posts'
+  }, [availableTabs, activeTab])
 
   const postStatuses = useMemo(
     () => currentStatuses.filter((status) => !isReply(status)),
@@ -207,11 +219,11 @@ export const ActorTimelines: FC<Props> = ({
 
   // The outbox cursor feeds the post/reply/fitness feeds (all derived from the
   // loaded status list), so the standalone load more control is offered on
-  // those tabs. For Pixelfed profiles, the media grid is the status feed, so it
+  // those tabs. For media-only profiles, the media grid is the status feed, so it
   // also paginates via this outbox cursor.
   const canLoadMore =
     Boolean(currentStatusPagination.nextPageUrl) &&
-    (isMediaView
+    (isMediaOnly
       ? activeTab === 'media'
       : effectiveActiveTab === 'posts' ||
         (showRepliesTab && effectiveActiveTab === 'replies') ||
@@ -337,8 +349,22 @@ export const ActorTimelines: FC<Props> = ({
         }
       }
 
+      const isCompletelyEmpty =
+        nextStatuses.length === 0 &&
+        currentStatuses.length === 0 &&
+        mediaAttachments.length === 0
+
+      if (
+        nextStatuses.length === 0 &&
+        (currentStatuses.length > 0 || mediaAttachments.length > 0)
+      ) {
+        setRequireManualLoadMore(true)
+      } else {
+        setRequireManualLoadMore(false)
+      }
+
       setCurrentStatusPagination({
-        nextPageUrl: pageUrl,
+        nextPageUrl: isCompletelyEmpty ? null : pageUrl,
         prevPageUrl
       })
       if (nextStatuses.length > 0) {
@@ -355,13 +381,24 @@ export const ActorTimelines: FC<Props> = ({
   }, [
     actorId,
     currentStatusPagination.nextPageUrl,
-    currentStatusPagination.prevPageUrl
+    currentStatusPagination.prevPageUrl,
+    currentStatuses.length,
+    mediaAttachments.length
   ])
+
+  const handleManualLoadMore = useCallback(() => {
+    setRequireManualLoadMore(false)
+    loadMoreStatuses()
+  }, [loadMoreStatuses])
 
   useEffect(() => {
     const loadMoreElement = loadMoreRef.current
     if (!loadMoreElement) return
     if (typeof IntersectionObserver === 'undefined') return
+    if (loadMoreError) return
+    if (requireManualLoadMore) return
+    // Don't auto-trigger infinite scroll on an empty feed — let the user click "Load more"
+    if (currentStatuses.length === 0 && mediaAttachments.length === 0) return
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -381,7 +418,14 @@ export const ActorTimelines: FC<Props> = ({
     return () => {
       observer.disconnect()
     }
-  }, [loadMoreStatuses, canLoadMore])
+  }, [
+    loadMoreStatuses,
+    canLoadMore,
+    loadMoreError,
+    requireManualLoadMore,
+    currentStatuses.length,
+    mediaAttachments.length
+  ])
 
   const renderFeed = (feedStatuses: Status[], emptyMessage: string) =>
     feedStatuses.length > 0 ? (
@@ -405,13 +449,10 @@ export const ActorTimelines: FC<Props> = ({
       <EmptyState>{emptyMessage}</EmptyState>
     )
 
-  if (isMediaView) {
+  if (isMediaOnly) {
     return (
       <div className="space-y-4">
-        {attachments.length > 0 ||
-        currentStatuses.some(
-          (s) => s.type === StatusType.enum.Note && s.attachments.length > 0
-        ) ? (
+        {hasLoadedMedia ? (
           <ActorMediaGallery
             actorId={actorId}
             initialAttachments={attachments}
@@ -433,7 +474,7 @@ export const ActorTimelines: FC<Props> = ({
             <Button
               variant="outline"
               disabled={isLoadingMoreStatuses}
-              onClick={loadMoreStatuses}
+              onClick={handleManualLoadMore}
             >
               {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
             </Button>
@@ -458,7 +499,7 @@ export const ActorTimelines: FC<Props> = ({
             <Button
               variant="outline"
               disabled={isLoadingMoreStatuses}
-              onClick={loadMoreStatuses}
+              onClick={handleManualLoadMore}
             >
               {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
             </Button>
@@ -544,7 +585,7 @@ export const ActorTimelines: FC<Props> = ({
           <Button
             variant="outline"
             disabled={isLoadingMoreStatuses}
-            onClick={loadMoreStatuses}
+            onClick={handleManualLoadMore}
           >
             {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
           </Button>

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -209,6 +209,8 @@ describe('getProfileData', () => {
 
       expect(result).not.toBeNull()
       expect(result?.isInternalAccount).toBe(true)
+      expect(result?.isMediaService).toBe(false)
+      expect(result?.isPeerTube).toBe(false)
       expect(result?.isMediaOnly).toBe(false)
     })
 
@@ -741,6 +743,7 @@ describe('getProfileData', () => {
 
       expect(result).not.toBeNull()
       expect(result?.isPixelfed).toBe(true)
+      expect(result?.isMediaService).toBe(true)
       expect(result?.isMediaOnly).toBe(true)
       expect(result?.attachments).toEqual([mockAttachment])
     })
@@ -799,6 +802,8 @@ describe('getProfileData', () => {
       )
 
       expect(result).not.toBeNull()
+      expect(result?.isPeerTube).toBe(true)
+      expect(result?.isMediaService).toBe(true)
       expect(result?.isMediaOnly).toBe(true)
       expect(result?.attachments).toEqual([mockAttachment])
     })

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -40,6 +40,8 @@ type ProfileData = {
   isInternalAccount: boolean
   hasFitnessData: boolean
   isPixelfed?: boolean
+  isPeerTube?: boolean
+  isMediaService?: boolean
   serverSoftware?: ServerSoftware | null
   isMediaOnly?: boolean
 }
@@ -163,6 +165,8 @@ export const getProfileData = async (
       isInternalAccount: true,
       hasFitnessData,
       isPixelfed: false,
+      isPeerTube: false,
+      isMediaService: false,
       serverSoftware: {
         name: 'activities.next',
         version: VERSION
@@ -293,7 +297,11 @@ export const getProfileData = async (
     ])
 
   const resolvedStatusesCount =
-    collectionCounts.statusesCount ?? actorPostsResponse.statusesCount ?? null
+    collectionCounts.statusesCount ??
+    actorPostsResponse.statusesCount ??
+    (actorPostsResponse.statuses.length > 0
+      ? actorPostsResponse.statuses.length
+      : null)
 
   // Persist the freshly-fetched collection sizes for known actors so the
   // Mastodon API (which reads the counter rows) serves the same counts this
@@ -319,7 +327,8 @@ export const getProfileData = async (
     serverSoftware?.name === 'pixelfed' || (await isPixelfedActor(person))
   const isPeerTube =
     serverSoftware?.name === 'peertube' || (await isPeerTubeActor(person))
-  const isMediaOnly = Boolean(isPixelfed) || isPeerTube
+  const isMediaService = isPixelfed || isPeerTube
+  const isMediaOnly = isMediaService
 
   return {
     ...actorPostsResponse,
@@ -342,6 +351,8 @@ export const getProfileData = async (
     isInternalAccount: false,
     hasFitnessData: false,
     isPixelfed,
+    isPeerTube,
+    isMediaService,
     isMediaOnly,
     serverSoftware
   }

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -18,7 +18,6 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { cn } from '@/lib/utils'
-import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { formatServerSoftware } from '@/lib/utils/formatServerSoftware'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
@@ -31,6 +30,12 @@ import { getNonLocalActorRedirectTarget } from './resolveActorRedirect'
 
 interface Props {
   params: Promise<{ actor: string }>
+}
+
+const numberFormatter = new Intl.NumberFormat('en-US')
+const formatNumber = (count: number): string => {
+  if (typeof count !== 'number' || Number.isNaN(count)) return '0'
+  return numberFormatter.format(Math.max(0, count))
 }
 
 const getInitials = (name: string, fallback: string) => {
@@ -145,6 +150,7 @@ const Page: FC<Props> = async ({ params }) => {
     followersCount,
     hasFitnessData,
     isPixelfed,
+    isMediaService,
     isInternalAccount,
     isMediaOnly,
     serverSoftware
@@ -179,32 +185,58 @@ const Page: FC<Props> = async ({ params }) => {
 
   const getHeaderImage = () => {
     if (!person.image) return null
-    const imageItem = Array.isArray(person.image)
-      ? person.image.find(
-          (item) =>
-            item &&
-            typeof item === 'object' &&
-            'url' in item &&
-            typeof item.url === 'string'
-        )
-      : person.image
-    if (
-      !imageItem ||
-      imageItem.type !== 'Image' ||
-      typeof imageItem.url !== 'string'
-    ) {
-      return null
+    if (typeof person.image === 'string') {
+      return { url: person.image, mediaType: null }
     }
-    return {
-      url: imageItem.url,
-      mediaType: imageItem.mediaType ?? null
+    const imgObj = Array.isArray(person.image) ? person.image[0] : person.image
+    if (!imgObj) return null
+    if (typeof imgObj === 'string') {
+      return { url: imgObj, mediaType: null }
     }
+    if (typeof imgObj === 'object') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const image = imgObj as any
+      const url =
+        typeof image.url === 'string'
+          ? image.url
+          : typeof image.href === 'string'
+            ? image.href
+            : null
+      if (url) {
+        return {
+          url,
+          mediaType:
+            typeof image.mediaType === 'string' ? image.mediaType : null
+        }
+      }
+    }
+    return null
+  }
+
+  const getIconImage = () => {
+    if (!person.icon) return null
+    if (typeof person.icon === 'string') return person.icon
+    const iconObj = Array.isArray(person.icon) ? person.icon[0] : person.icon
+    if (!iconObj) return null
+    if (typeof iconObj === 'string') return iconObj
+    if (typeof iconObj === 'object') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const image = iconObj as any
+      const url =
+        typeof image.url === 'string'
+          ? image.url
+          : typeof image.href === 'string'
+            ? image.href
+            : null
+      if (url) return url
+    }
+    return null
   }
 
   const headerImage = getHeaderImage()
   const headerImageUrl = headerImage?.url ?? null
   const headerImageMediaType = headerImage?.mediaType ?? null
-  const iconImageUrl = getActorImageUrl(person.icon) ?? null
+  const iconImageUrl = getIconImage()
   const rawUrl = person.url ? getUrl(person.url) : null
   const profileUrl =
     (rawUrl && /^https?:\/\//i.test(rawUrl) ? rawUrl : null) ||
@@ -273,7 +305,9 @@ const Page: FC<Props> = async ({ params }) => {
             <div className="mt-5 flex flex-wrap gap-6 text-sm">
               {statusesCount !== null && (
                 <div>
-                  <span className="font-semibold">{statusesCount}</span>{' '}
+                  <span className="font-semibold">
+                    {formatNumber(statusesCount)}
+                  </span>{' '}
                   <span className="text-muted-foreground">Posts</span>
                 </div>
               )}
@@ -283,7 +317,9 @@ const Page: FC<Props> = async ({ params }) => {
                   prefetch={false}
                   className="hover:underline"
                 >
-                  <span className="font-semibold">{followingCount}</span>{' '}
+                  <span className="font-semibold">
+                    {formatNumber(followingCount)}
+                  </span>{' '}
                   <span className="text-muted-foreground">Following</span>
                 </Link>
               )}
@@ -293,7 +329,9 @@ const Page: FC<Props> = async ({ params }) => {
                   prefetch={false}
                   className="hover:underline"
                 >
-                  <span className="font-semibold">{followersCount}</span>{' '}
+                  <span className="font-semibold">
+                    {formatNumber(followersCount)}
+                  </span>{' '}
                   <span className="text-muted-foreground">Followers</span>
                 </Link>
               )}
@@ -331,8 +369,9 @@ const Page: FC<Props> = async ({ params }) => {
         postLineLimit={actorSettings?.postLineLimit}
         currentActor={currentActor ? getActorProfile(currentActor) : undefined}
         isCurrentUser={isCurrentUser}
-        isPixelfed={isLoggedIn && Boolean(isPixelfed)}
-        isMediaOnly={isLoggedIn && Boolean(isMediaOnly)}
+        isPixelfed={Boolean(isPixelfed)}
+        isMediaService={Boolean(isMediaService ?? isMediaOnly)}
+        isMediaOnly={Boolean(isMediaOnly ?? isMediaService)}
         hasFitnessData={hasFitnessData}
         isMediaUploadEnabled={Boolean(mediaStorage)}
         isInternalAccount={isInternalAccount}

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -1335,4 +1335,95 @@ describe('getActorPosts', () => {
     const response = await getActorPosts({ database, person })
     expect(response.statuses).toHaveLength(0)
   })
+
+  it('fetches and resolves Create activity where object is a string URI (PeerTube pattern)', async () => {
+    const actorId = 'https://framatube.org/accounts/peertube'
+    const videoUri = 'https://framatube.org/videos/watch/abc-123'
+    const person = MockActivityPubPerson({
+      id: actorId,
+      preferredUsername: 'peertube',
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: `${actorId}/outbox?page=1`
+          })
+        }
+      }
+
+      if (req.url === `${actorId}/outbox?page=1`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${actorId}/outbox?page=1`,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                id: `${actorId}/outbox/activity/1`,
+                type: 'Create',
+                actor: actorId,
+                published: new Date().toISOString(),
+                object: videoUri
+              }
+            ]
+          })
+        }
+      }
+
+      if (req.url === videoUri) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: videoUri,
+            type: 'Video',
+            attributedTo: actorId,
+            to: ['https://www.w3.org/ns/activitystreams#Public'],
+            cc: [],
+            published: new Date().toISOString(),
+            content: 'Watch my video',
+            mediaType: 'text/markdown',
+            url: [
+              {
+                type: 'Link',
+                mediaType: 'video/mp4',
+                href: 'https://framatube.org/video.mp4',
+                width: 1920,
+                height: 1080
+              }
+            ],
+            icon: [
+              {
+                type: 'Image',
+                url: 'https://framatube.org/thumb.jpg'
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    expect(response.statuses).toHaveLength(1)
+    expect(response.statuses[0].id).toBe(videoUri)
+    expect(response.statuses[0].attachments).toHaveLength(1)
+    expect(response.statuses[0].attachments[0].url).toBe(
+      'https://framatube.org/video.mp4'
+    )
+    expect(response.statuses[0].attachments[0].thumbnailUrl).toBe(
+      'https://framatube.org/thumb.jpg'
+    )
+  })
 })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -1,3 +1,5 @@
+import { Span } from '@opentelemetry/api'
+
 import { getNote } from '@/lib/activities'
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { BaseNote, BaseNoteSchema } from '@/lib/activities/note'
@@ -51,7 +53,7 @@ type GetActorPostsFunction = (params: {
   prevPageUrl: string | null
 }>
 
-const getStatusFromNote = (note: BaseNote) => {
+const getStatusFromNote = (note: BaseNote, span?: Span) => {
   try {
     const status = fromNote(note)
     // Ephemeral status (not persisted), so content-detected language is
@@ -60,10 +62,7 @@ const getStatusFromNote = (note: BaseNote) => {
       detectLanguageFromHtml(status.text)?.language ?? null
     return status
   } catch (error) {
-    logger.error({
-      message: 'Failed to build status from note',
-      err: toLoggableError(error)
-    })
+    span?.recordException(toLoggableError(error))
     return null
   }
 }
@@ -80,7 +79,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
     {
       actorId: person.id
     },
-    async () => {
+    async (span) => {
       const actor = await database.getActorFromId({ id: person.id })
       const actorProfileCache = new Map<string, Promise<ActorProfile | null>>()
       const getActorProfile = (actorId: string) => {
@@ -183,7 +182,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
                 )
                 if (!noteResult.success) return null
 
-                originalStatus = getStatusFromNote(noteResult.data)
+                originalStatus = getStatusFromNote(noteResult.data, span)
                 if (!originalStatus) return null
               }
 
@@ -242,7 +241,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
             )
             if (!noteResult.success) return null
 
-            const status = getStatusFromNote(noteResult.data)
+            const status = getStatusFromNote(noteResult.data, span)
             if (!status) return null
 
             if (
@@ -255,10 +254,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
             if (actor) status.actor = actor
             return status
           } catch (error) {
-            logger.warn({
-              message: 'Failed to parse outbox activity item',
-              err: toLoggableError(error)
-            })
+            span.recordException(toLoggableError(error))
             return null
           }
         })
@@ -281,6 +277,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
               return pixelfedResult
             }
           } catch (err) {
+            span.recordException(toLoggableError(err))
             logger.warn({
               message:
                 'Failed to fetch Pixelfed posts via API, falling back to Atom feed',

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -26,6 +26,10 @@ import {
   getActorProfileFromPerson,
   isOpaqueActorUsername
 } from '@/lib/utils/activitypubActor'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
@@ -57,7 +61,7 @@ const getStatusFromNote = (note: BaseNote) => {
     return status
   } catch (error) {
     logger.error({
-      message: 'Fail to convert note to status',
+      message: 'Failed to build status from note',
       err: toLoggableError(error)
     })
     return null
@@ -124,115 +128,139 @@ export const getActorPosts: GetActorPostsFunction = async ({
         }
       }
 
-      const items = value.page?.orderedItems ?? []
+      const rawItems = value.page?.orderedItems
+      const items = Array.isArray(rawItems) ? rawItems : []
       const statuses = await Promise.all(
         items.map(async (item) => {
-          // This should be impossible for status api
-          if (typeof item === 'string') return null
+          try {
+            // This should be impossible for status api
+            if (typeof item === 'string') return null
 
-          // Canonicalise the activity (and any embedded object) via JSON-LD
-          // compaction before validating, so dialect variations in `type`,
-          // recipients and id references collapse to a predictable shape.
-          const activity = await compactActivityPub(item)
+            // Canonicalise the activity (and any embedded object) via JSON-LD
+            // compaction before validating, so dialect variations in `type`,
+            // recipients and id references collapse to a predictable shape.
+            const activity = await compactActivityPub(item)
 
-          if (activity.type === AnnounceAction) {
-            const announceResult = Announce.safeParse(
-              normalizeActivityPubAnnounce(activity)
-            )
-            if (!announceResult.success) return null
+            if (activity.type === AnnounceAction) {
+              const announceResult = Announce.safeParse(
+                normalizeActivityPubAnnounce(activity)
+              )
+              if (!announceResult.success) return null
 
-            const announce = announceResult.data
-            const localStatus = await database.getStatus({
-              statusId: announce.object
-            })
-
-            let originalStatus =
-              localStatus?.type !== StatusType.enum.Announce
-                ? localStatus
-                : null
-
-            if (!originalStatus) {
-              const note = await getNote({
-                statusId: announce.object,
-                signingActor
+              const announce = announceResult.data
+              const localStatus = await database.getStatus({
+                statusId: announce.object
               })
-              if (!note || !isSameActivityPubOrigin(announce.object, note.id)) {
+
+              let originalStatus =
+                localStatus?.type !== StatusType.enum.Announce
+                  ? localStatus
+                  : null
+
+              if (originalStatus) {
+                const isPublic =
+                  originalStatus.to.includes(ACTIVITY_STREAM_PUBLIC) ||
+                  originalStatus.cc.includes(ACTIVITY_STREAM_PUBLIC) ||
+                  originalStatus.to.includes(ACTIVITY_STREAM_PUBLIC_COMPACT) ||
+                  originalStatus.cc.includes(ACTIVITY_STREAM_PUBLIC_COMPACT)
+                if (!isPublic) return null
+              }
+
+              if (!originalStatus) {
+                const note = await getNote({
+                  statusId: announce.object,
+                  signingActor
+                })
+                if (
+                  !note ||
+                  !isSameActivityPubOrigin(announce.object, note.id)
+                ) {
+                  return null
+                }
+
+                const noteResult = BaseNoteSchema.safeParse(
+                  normalizeActivityPubContent(note)
+                )
+                if (!noteResult.success) return null
+
+                originalStatus = getStatusFromNote(noteResult.data)
+                if (!originalStatus) return null
+              }
+
+              const originalStatusWithActor = {
+                ...originalStatus,
+                actor: await getActorProfile(originalStatus.actorId)
+              }
+              const announceStatus = fromAnnounce(
+                announce,
+                originalStatusWithActor
+              )
+              if (actor) announceStatus.actor = actor
+              return announceStatus
+            }
+
+            // Unsupported activity
+            if (activity.type !== CreateAction) return null
+            // Unsupported Object
+            if (!activity.object) return null
+
+            let rawObject: unknown = activity.object
+            if (typeof rawObject === 'string') {
+              if (!isSameActivityPubOrigin(person.id, rawObject)) {
                 return null
               }
 
-              const noteResult = BaseNoteSchema.safeParse(
-                normalizeActivityPubContent(note)
-              )
-              if (!noteResult.success) return null
-
-              originalStatus = getStatusFromNote(noteResult.data)
-              if (!originalStatus) return null
-            }
-
-            const originalStatusWithActor = {
-              ...originalStatus,
-              actor: await getActorProfile(originalStatus.actorId)
-            }
-            const announceStatus = fromAnnounce(
-              announce,
-              originalStatusWithActor
-            )
-            if (actor) announceStatus.actor = actor
-            return announceStatus
-          }
-
-          // Unsupported activity
-          if (activity.type !== CreateAction) return null
-          // Unsupported Object
-          if (!activity.object) return null
-
-          let rawObject: unknown = activity.object
-          if (typeof rawObject === 'string') {
-            if (!isSameActivityPubOrigin(person.id, rawObject)) {
-              return null
-            }
-
-            const localStatus = await database.getStatus({
-              statusId: rawObject
-            })
-            if (localStatus && localStatus.type !== StatusType.enum.Announce) {
-              if (localStatus.actorId === person.id) {
-                if (actor) localStatus.actor = actor
-                return localStatus
+              const localStatus = await database.getStatus({
+                statusId: rawObject
+              })
+              if (
+                localStatus &&
+                localStatus.type !== StatusType.enum.Announce
+              ) {
+                if (localStatus.actorId === person.id) {
+                  if (actor) localStatus.actor = actor
+                  return localStatus
+                }
+                return null
               }
-              return null
+              const fetchedNote = await getNote({
+                statusId: rawObject,
+                signingActor
+              })
+              if (
+                !fetchedNote ||
+                !isSameActivityPubOrigin(rawObject, fetchedNote.id)
+              ) {
+                return null
+              }
+              rawObject = fetchedNote
             }
-            const fetchedNote = await getNote({
-              statusId: rawObject,
-              signingActor
-            })
+
+            if (!rawObject || typeof rawObject !== 'object') return null
+            const noteResult = BaseNoteSchema.safeParse(
+              normalizeActivityPubContent(rawObject as Record<string, unknown>)
+            )
+            if (!noteResult.success) return null
+
+            const status = getStatusFromNote(noteResult.data)
+            if (!status) return null
+
             if (
-              !fetchedNote ||
-              !isSameActivityPubOrigin(rawObject, fetchedNote.id)
+              status.actorId !== person.id &&
+              !isSameActivityPubOrigin(person.id, status.actorId)
             ) {
               return null
             }
-            rawObject = fetchedNote
-          }
 
-          if (!rawObject || typeof rawObject !== 'object') return null
-          const noteResult = BaseNoteSchema.safeParse(
-            normalizeActivityPubContent(rawObject as Record<string, unknown>)
-          )
-          if (!noteResult.success) return null
-
-          const status = getStatusFromNote(noteResult.data)
-          if (!status) return null
-
-          if (
-            status.actorId !== person.id &&
-            !isSameActivityPubOrigin(person.id, status.actorId)
-          ) {
+            if (actor) status.actor = actor
+            return status
+          } catch (error) {
+            logger.warn({
+              message: 'Failed to parse outbox activity item',
+              err: toLoggableError(error)
+            })
             return null
           }
-
-          if (actor) status.actor = actor
-          return status
         })
       )
 

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -243,26 +243,21 @@ describe('note entity utilities', () => {
       expect(result[0].mediaType).toEqual('video/mp4')
     })
 
-    it('extracts video stream and thumbnail for PeerTube Video object', () => {
+    it('extracts playable video stream and icon thumbnail from PeerTube Video object', () => {
       const peertubeVideo = {
         type: 'Video',
-        id: 'https://framatube.org/videos/watch/abc',
-        name: 'PeerTube Video Title',
+        id: 'https://framatube.org/videos/watch/123',
+        mediaType: 'text/markdown',
         url: [
           {
             type: 'Link',
             mediaType: 'text/html',
-            href: 'https://framatube.org/videos/watch/abc'
-          },
-          {
-            type: 'Link',
-            mediaType: 'application/x-mpegURL',
-            href: 'https://framatube.org/static/streaming-playlists/hls/abc/master.m3u8'
+            href: 'https://framatube.org/videos/watch/123'
           },
           {
             type: 'Link',
             mediaType: 'video/mp4',
-            href: 'https://framatube.org/static/webseed/abc-1080.mp4',
+            href: 'https://framatube.org/static/webseed/123.mp4',
             height: 1080,
             width: 1920
           }
@@ -270,8 +265,7 @@ describe('note entity utilities', () => {
         icon: [
           {
             type: 'Image',
-            mediaType: 'image/jpeg',
-            url: 'https://framatube.org/static/thumbnails/abc.jpg',
+            url: 'https://framatube.org/lazy-static/video-thumbnails/123.jpg',
             width: 1920,
             height: 1080
           }
@@ -281,15 +275,110 @@ describe('note entity utilities', () => {
       const result = getAttachments(peertubeVideo)
 
       expect(result).toHaveLength(1)
-      expect(result[0].mediaType).toEqual('video/mp4')
-      expect(result[0].url).toEqual(
-        'https://framatube.org/static/webseed/abc-1080.mp4'
-      )
-      expect(result[0].width).toEqual(1920)
-      expect(result[0].height).toEqual(1080)
-      expect(result[0].thumbnailUrl).toEqual(
-        'https://framatube.org/static/thumbnails/abc.jpg'
-      )
+      expect(result[0]).toMatchObject({
+        type: 'Document',
+        mediaType: 'video/mp4',
+        url: 'https://framatube.org/static/webseed/123.mp4',
+        thumbnailUrl:
+          'https://framatube.org/lazy-static/video-thumbnails/123.jpg',
+        width: 1920,
+        height: 1080
+      })
+    })
+
+    it('does not extract attachment if video url array only contains html watch pages', () => {
+      const videoWithoutStreams = {
+        type: 'Video',
+        id: 'https://peertube.example/videos/watch/123',
+        url: [
+          {
+            type: 'Link',
+            mediaType: 'text/html',
+            href: 'https://peertube.example/videos/watch/123'
+          }
+        ]
+      } as unknown as BaseNote
+
+      const result = getAttachments(videoWithoutStreams)
+      expect(result).toHaveLength(0)
+    })
+
+    it('resolves nested link icon for Video thumbnail', () => {
+      const videoWithNestedIcon = {
+        type: 'Video',
+        id: 'https://example.com/video/1',
+        url: 'https://example.com/stream.m3u8',
+        icon: {
+          type: 'Link',
+          href: 'https://example.com/thumb.jpg'
+        }
+      } as unknown as BaseNote
+
+      const result = getAttachments(videoWithNestedIcon)
+      expect(result).toHaveLength(1)
+      expect(result[0].thumbnailUrl).toBe('https://example.com/thumb.jpg')
+    })
+
+    it('prioritizes direct MP4 stream over HLS playlist in video url array', () => {
+      const video = {
+        type: 'Video',
+        id: 'https://peertube.example/videos/1',
+        url: [
+          {
+            type: 'Link',
+            mediaType: 'application/x-mpegURL',
+            href: 'https://peertube.example/master.m3u8'
+          },
+          {
+            type: 'Link',
+            mediaType: 'video/mp4',
+            href: 'https://peertube.example/video.mp4',
+            width: 1920,
+            height: 1080
+          }
+        ]
+      } as unknown as BaseNote
+
+      const result = getAttachments(video)
+      expect(result).toHaveLength(1)
+      expect(result[0].url).toBe('https://peertube.example/video.mp4')
+      expect(result[0].mediaType).toBe('video/mp4')
+    })
+
+    it('extracts direct video stream from string URLs in url array', () => {
+      const video = {
+        type: 'Video',
+        id: 'https://example.com/video/1',
+        url: ['https://example.com/video.mp4']
+      } as unknown as BaseNote
+
+      const result = getAttachments(video)
+      expect(result).toHaveLength(1)
+      expect(result[0].url).toBe('https://example.com/video.mp4')
+    })
+
+    it('tolerates non-string mediaType or href without throwing TypeError', () => {
+      const malformedVideo = {
+        type: 'Video',
+        id: 'https://example.com/video/1',
+        url: [
+          {
+            type: 'Link',
+            mediaType: 12345,
+            href: null
+          },
+          {
+            type: 'Link',
+            mediaType: 'video/mp4',
+            href: 'https://example.com/good.mp4'
+          }
+        ]
+      } as unknown as BaseNote
+
+      expect(() => getAttachments(malformedVideo)).not.toThrow()
+      const result = getAttachments(malformedVideo)
+      expect(result).toHaveLength(1)
+      expect(result[0].url).toBe('https://example.com/good.mp4')
     })
   })
 

--- a/lib/activities/note.ts
+++ b/lib/activities/note.ts
@@ -27,16 +27,28 @@ export const BaseNoteSchema = z.union([
   Question
 ])
 
-type UrlValue = string | { href?: string } | (string | { href?: string })[]
+type UrlValue =
+  | string
+  | { href?: unknown; [key: string]: unknown }
+  | (string | { href?: unknown; [key: string]: unknown })[]
+  | null
+  | undefined
 
 export const getUrl = (url: UrlValue): string | undefined => {
+  if (!url) return undefined
   if (Array.isArray(url)) {
     const first = url[0]
     if (typeof first === 'string') return first
-    return first?.href
+    if (first && typeof first === 'object' && typeof first.href === 'string') {
+      return first.href
+    }
+    return undefined
   }
   if (typeof url === 'string') return url
-  return url?.href
+  if (typeof url === 'object' && typeof url.href === 'string') {
+    return url.href
+  }
+  return undefined
 }
 
 type ReplyValue = string | { id?: string } | null | undefined
@@ -61,6 +73,24 @@ export const getQuoteTargetId = (object: BaseNote): string | null => {
   return object.quoteUrl || object.quoteUri || object._misskey_quote || null
 }
 
+const resolveIconUrl = (icon: unknown): string | null => {
+  if (!icon) return null
+  if (typeof icon === 'string') return icon
+  if (typeof icon === 'object') {
+    const rec = icon as { url?: unknown; href?: unknown }
+    if (typeof rec.url === 'string') return rec.url
+    if (
+      typeof rec.url === 'object' &&
+      rec.url !== null &&
+      typeof (rec.url as { href?: unknown }).href === 'string'
+    ) {
+      return (rec.url as { href: string }).href
+    }
+    if (typeof rec.href === 'string') return rec.href
+  }
+  return null
+}
+
 const isDocument = (attachment: Attachment): attachment is Document =>
   Document.safeParse(attachment).success
 
@@ -78,107 +108,105 @@ export const getAttachments = (object: BaseNote): Document[] => {
   if (['Image', 'Video'].includes(object.type)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const unsafeObject = object as any
-    let url: string | undefined
-    let mediaType: string | undefined
-    let width: number | undefined
-    let height: number | undefined
+    let url = getUrl(unsafeObject.url)
+    let mediaType =
+      unsafeObject.mediaType ||
+      (object.type === 'Image' ? 'image/jpeg' : 'video/mp4')
+    let width = unsafeObject.width
+    let height = unsafeObject.height
+    let thumbnailUrl: string | null = null
 
-    if (object.type === 'Video' && Array.isArray(unsafeObject.url)) {
-      let mediaItem = unsafeObject.url.find(
-        (item: unknown) =>
-          item &&
-          typeof item === 'object' &&
-          'mediaType' in item &&
-          typeof (item as { mediaType?: unknown }).mediaType === 'string' &&
-          (item as { mediaType: string }).mediaType.startsWith('video/')
-      ) as
-        | {
-            href?: string
-            url?: string
-            mediaType?: string
-            width?: number
-            height?: number
+    if (object.type === 'Video') {
+      if (Array.isArray(unsafeObject.url)) {
+        type VideoLink = {
+          mediaType?: string
+          href?: string
+          width?: number
+          height?: number
+        }
+
+        const parseVideoLink = (u: unknown): VideoLink | null => {
+          if (typeof u === 'string') {
+            return { href: u }
           }
-        | undefined
-
-      if (!mediaItem) {
-        mediaItem = unsafeObject.url.find(
-          (item: unknown) =>
-            item &&
-            typeof item === 'object' &&
-            'mediaType' in item &&
-            (item as { mediaType?: unknown }).mediaType ===
-              'application/x-mpegURL'
-        ) as
-          | {
-              href?: string
-              url?: string
-              mediaType?: string
-              width?: number
-              height?: number
+          if (typeof u === 'object' && u !== null) {
+            const rawHref = (u as { href?: unknown }).href
+            const rawMediaType = (u as { mediaType?: unknown }).mediaType
+            const rawWidth = (u as { width?: unknown }).width
+            const rawHeight = (u as { height?: unknown }).height
+            return {
+              href: typeof rawHref === 'string' ? rawHref : undefined,
+              mediaType:
+                typeof rawMediaType === 'string' ? rawMediaType : undefined,
+              width: typeof rawWidth === 'number' ? rawWidth : undefined,
+              height: typeof rawHeight === 'number' ? rawHeight : undefined
             }
-          | undefined
+          }
+          return null
+        }
+
+        const isDirectVideo = (link: VideoLink) => {
+          const mt = (link.mediaType || '').toLowerCase()
+          const href = (link.href || '').toLowerCase()
+          return (
+            mt.startsWith('video/') || /\.(mp4|webm|ogv)(?:[?#]|$)/i.test(href)
+          )
+        }
+
+        const isHlsVideo = (link: VideoLink) => {
+          const mt = (link.mediaType || '').toLowerCase()
+          const href = (link.href || '').toLowerCase()
+          return mt.includes('mpegurl') || /\.m3u8(?:[?#]|$)/i.test(href)
+        }
+
+        const parsedLinks = (unsafeObject.url as unknown[])
+          .map(parseVideoLink)
+          .filter((link): link is VideoLink => Boolean(link && link.href))
+
+        const directLink = parsedLinks.find(isDirectVideo)
+        const hlsLink = parsedLinks.find(isHlsVideo)
+        const videoLink = directLink ?? hlsLink
+
+        if (videoLink && videoLink.href) {
+          url = videoLink.href
+          if (videoLink.mediaType) {
+            mediaType = videoLink.mediaType
+          }
+          if (typeof videoLink.width === 'number') width = videoLink.width
+          if (typeof videoLink.height === 'number') height = videoLink.height
+        } else {
+          url = undefined
+        }
       }
 
-      if (mediaItem) {
-        url = mediaItem.href || mediaItem.url
-        mediaType =
-          mediaItem.mediaType === 'application/x-mpegURL'
-            ? 'video/mp4'
-            : mediaItem.mediaType
-        width = mediaItem.width
-        height = mediaItem.height
-      } else {
-        const videoFileItem = unsafeObject.url.find(
-          (item: unknown) =>
-            item &&
-            typeof item === 'object' &&
-            'href' in item &&
-            typeof (item as { href?: unknown }).href === 'string' &&
-            /\.(mp4|webm|m3u8)(?:[?#]|$)/i.test((item as { href: string }).href)
-        ) as { href?: string; width?: number; height?: number } | undefined
-        if (videoFileItem) {
-          url = videoFileItem.href
-          mediaType = 'video/mp4'
-          width = videoFileItem.width
-          height = videoFileItem.height
+      // PeerTube video objects have mediaType: 'text/markdown' for the description.
+      // If mediaType is not a video type, default to 'video/mp4'.
+      if (!mediaType || !mediaType.startsWith('video/')) {
+        mediaType = 'video/mp4'
+      }
+
+      if (unsafeObject.icon) {
+        if (Array.isArray(unsafeObject.icon)) {
+          thumbnailUrl = resolveIconUrl(unsafeObject.icon[0])
+        } else {
+          thumbnailUrl = resolveIconUrl(unsafeObject.icon)
         }
       }
     }
 
-    if (!url) {
-      url = getUrl(unsafeObject.url)
-      mediaType =
-        unsafeObject.mediaType ||
-        (object.type === 'Image' ? 'image/jpeg' : 'video/mp4')
-    }
-
-    let thumbnailUrl: string | undefined
-    if (unsafeObject.icon) {
-      if (Array.isArray(unsafeObject.icon)) {
-        thumbnailUrl = unsafeObject.icon.find(
-          (item: { url?: unknown }) => typeof item?.url === 'string'
-        )?.url
-      } else if (
-        typeof unsafeObject.icon === 'object' &&
-        typeof unsafeObject.icon.url === 'string'
-      ) {
-        thumbnailUrl = unsafeObject.icon.url
-      }
-    }
-
-    if (url) {
+    if (url && !attachments.some((a) => a.url === url)) {
       attachments.push({
         type: 'Document',
-        mediaType:
-          mediaType || (object.type === 'Image' ? 'image/jpeg' : 'video/mp4'),
+        mediaType,
         url,
+        ...(thumbnailUrl ? { thumbnailUrl } : {}),
         name: unsafeObject.name,
-        width: unsafeObject.width ?? width,
-        height: unsafeObject.height ?? height,
+        width: typeof width === 'number' ? width : undefined,
+        height: typeof height === 'number' ? height : undefined,
         blurhash: unsafeObject.blurhash,
-        focalPoint: unsafeObject.focalPoint,
-        ...(thumbnailUrl ? { thumbnailUrl } : {})
+        ...(unsafeObject.focalPoint
+          ? { focalPoint: unsafeObject.focalPoint }
+          : {})
       })
     }
   }

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -12,7 +12,8 @@ import {
   getQuoteTargetId,
   getReply,
   getSummary,
-  getTags
+  getTags,
+  getUrl
 } from '@/lib/activities/note'
 import { NOTE_ACTIVITY_CONTEXT } from '@/lib/activities/noteContext'
 import {
@@ -122,7 +123,7 @@ export const createNoteJob = createJobHandle(
       recordActorIfNeeded({ actorId, database }),
       database.createNoteWithResult({
         id: note.id,
-        url: typeof note.url === 'string' ? note.url : note.id,
+        url: getUrl(note.url) || note.id,
 
         actorId,
 

--- a/lib/jobs/fetchRemoteStatusJob.ts
+++ b/lib/jobs/fetchRemoteStatusJob.ts
@@ -4,6 +4,7 @@ import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { getNote } from '@/lib/activities'
 import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
 import { compactActivityPub } from '@/lib/activities/jsonld'
+import { BaseNoteSchema, getUrl } from '@/lib/activities/note'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
@@ -90,7 +91,7 @@ const fetchRemoteStatus = async (
   try {
     await database.createNote({
       id: sanitizedNote.id,
-      url: sanitizedNote.url || sanitizedNote.id,
+      url: getUrl(sanitizedNote.url) || sanitizedNote.id,
       actorId: sanitizedNote.attributedTo,
       text: Array.isArray(sanitizedNote.content)
         ? sanitizedNote.content.join('')
@@ -219,7 +220,7 @@ export const fetchRemoteStatusJob = createJobHandle(
           ...forValidation
         } = doc
 
-        const noteResult = Note.safeParse(
+        const noteResult = BaseNoteSchema.safeParse(
           normalizeActivityPubContent(forValidation)
         )
         if (!noteResult.success) return null
@@ -258,7 +259,7 @@ export const fetchRemoteStatusJob = createJobHandle(
         try {
           await database.createNote({
             id: sanitizedReply.id,
-            url: sanitizedReply.url || sanitizedReply.id,
+            url: getUrl(sanitizedReply.url) || sanitizedReply.id,
             actorId: sanitizedReply.attributedTo,
             text: Array.isArray(sanitizedReply.content)
               ? sanitizedReply.content.join('')

--- a/lib/services/federation/serverSoftware.test.ts
+++ b/lib/services/federation/serverSoftware.test.ts
@@ -11,6 +11,8 @@ import {
   getServerSoftware,
   getServerSoftwareCacheSizeForTests,
   getServerSoftwareInfo,
+  isMediaOnlyActor,
+  isMediaOnlyDomain,
   isMisskeyActor,
   isMisskeyDomain,
   isPeerTubeActor,
@@ -471,5 +473,115 @@ describe('serverSoftware', () => {
     })
 
     expect(await isMisskeyDomain(mastodonDomain)).toBe(false)
+  })
+
+  it('detects PeerTube instances correctly with isPeerTubeDomain and isPeerTubeActor', async () => {
+    const peertubeDomain = 'framatube.org'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${peertubeDomain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${peertubeDomain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${peertubeDomain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'peertube',
+              version: '6.0.0'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isPeerTubeDomain(peertubeDomain)).toBe(true)
+    const person = MockActivityPubPerson({
+      id: `https://${peertubeDomain}/accounts/framasoft`
+    }) as Actor
+    expect(await isPeerTubeActor(person)).toBe(true)
+    expect(await isMediaOnlyDomain(peertubeDomain)).toBe(true)
+    expect(await isMediaOnlyActor(person)).toBe(true)
+  })
+
+  it('detects Pixelfed instances as media-only with isMediaOnlyDomain and isMediaOnlyActor', async () => {
+    const pixelfedDomain = 'pixelfed.social'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${pixelfedDomain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${pixelfedDomain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${pixelfedDomain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'pixelfed',
+              version: '0.12.9'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isMediaOnlyDomain(pixelfedDomain)).toBe(true)
+    const person = MockActivityPubPerson({
+      id: `https://${pixelfedDomain}/users/gargron`
+    }) as Actor
+    expect(await isMediaOnlyActor(person)).toBe(true)
+  })
+
+  it('returns false for general microblogging platforms in isMediaOnlyDomain', async () => {
+    const mastodonDomain = 'mastodon.social'
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `https://${mastodonDomain}/.well-known/nodeinfo`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            links: [
+              {
+                rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+                href: `https://${mastodonDomain}/nodeinfo/2.0`
+              }
+            ]
+          })
+        }
+      }
+      if (req.url === `https://${mastodonDomain}/nodeinfo/2.0`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            software: {
+              name: 'mastodon',
+              version: '4.3.0'
+            }
+          })
+        }
+      }
+      return { status: 404, body: 'Not Found' }
+    })
+
+    expect(await isPeerTubeDomain(mastodonDomain)).toBe(false)
+    expect(await isMediaOnlyDomain(mastodonDomain)).toBe(false)
   })
 })

--- a/lib/services/federation/serverSoftware.ts
+++ b/lib/services/federation/serverSoftware.ts
@@ -63,7 +63,8 @@ const isSameHostNodeInfoLink = (
 ): boolean => {
   if (typeof link?.href !== 'string') return false
   try {
-    return new URL(link.href).host.toLowerCase() === expectedHost
+    const resolved = new URL(link.href, `https://${expectedHost}`)
+    return resolved.host.toLowerCase() === expectedHost
   } catch {
     return false
   }
@@ -228,6 +229,22 @@ export const isMisskeyActor = async (person: Actor): Promise<boolean> => {
   try {
     const actorUrl = new URL(person.id)
     return isMisskeyDomain(actorUrl.host)
+  } catch {
+    return false
+  }
+}
+
+const MEDIA_ONLY_SOFTWARE = new Set(['pixelfed', 'peertube'])
+
+export const isMediaOnlyDomain = async (domain: string): Promise<boolean> => {
+  const software = await getServerSoftware(domain)
+  return software ? MEDIA_ONLY_SOFTWARE.has(software) : false
+}
+
+export const isMediaOnlyActor = async (person: Actor): Promise<boolean> => {
+  try {
+    const actorUrl = new URL(person.id)
+    return isMediaOnlyDomain(actorUrl.host)
   } catch {
     return false
   }

--- a/lib/types/activitypub/collections.test.ts
+++ b/lib/types/activitypub/collections.test.ts
@@ -1,4 +1,7 @@
-import { CollectionSummary } from '@/lib/types/activitypub/collections'
+import {
+  CollectionSummary,
+  CollectionWithFirstPage
+} from '@/lib/types/activitypub/collections'
 
 describe('ActivityPub collections', () => {
   it('accepts OrderedCollection summaries from Mastodon-compatible servers', () => {
@@ -7,6 +10,20 @@ describe('ActivityPub collections', () => {
         id: 'https://remote.test/users/alice/followers',
         type: 'OrderedCollection',
         totalItems: 12
+      }).success
+    ).toBe(true)
+  })
+
+  it('accepts CollectionWithFirstPage where next is omitted (e.g. single-page replies)', () => {
+    expect(
+      CollectionWithFirstPage.safeParse({
+        id: 'https://remote.test/posts/1/replies',
+        type: 'Collection',
+        first: {
+          type: 'CollectionPage',
+          partOf: 'https://remote.test/posts/1/replies',
+          items: []
+        }
       }).success
     ).toBe(true)
   })

--- a/lib/types/activitypub/collections.ts
+++ b/lib/types/activitypub/collections.ts
@@ -9,8 +9,8 @@ export const CollectionWithFirstPage = z.object({
   type: CollectionType,
   first: z.object({
     type: CollectionPageType,
-    next: z.string(),
-    partOf: z.string(),
+    next: z.string().optional(),
+    partOf: z.string().optional(),
     items: z.union([z.any(), z.array(z.any())])
   })
 })

--- a/lib/types/activitypub/objects.test.ts
+++ b/lib/types/activitypub/objects.test.ts
@@ -1,4 +1,9 @@
-import { Note, Question } from '@/lib/types/activitypub/objects'
+import {
+  ImageContent,
+  Note,
+  Question,
+  VideoContent
+} from '@/lib/types/activitypub/objects'
 
 describe('Note quote fields', () => {
   const base = {
@@ -74,4 +79,91 @@ describe('Question', () => {
       }
     }
   )
+})
+
+describe('BaseContent variations', () => {
+  const base = {
+    id: 'https://remote.example/notes/1',
+    type: 'Note' as const,
+    attributedTo: 'https://remote.example/users/alice',
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [],
+    content: 'test content',
+    published: '2026-01-01T00:00:00Z'
+  }
+
+  it('accepts string URLs for replies, likes, and shares (NodeBB, PeerTube dialects)', () => {
+    const result = Note.safeParse({
+      ...base,
+      replies: 'https://community.nodebb.org/comments/post/123/replies',
+      likes: 'https://peertube.example/videos/watch/123/likes',
+      shares: 'https://peertube.example/videos/watch/123/announces'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts array or link object for url', () => {
+    const result = Note.safeParse({
+      ...base,
+      url: [
+        { type: 'Link', href: 'https://example.com/post/1' },
+        {
+          type: 'Link',
+          mediaType: 'video/mp4',
+          href: 'https://example.com/video.mp4'
+        }
+      ]
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('VideoContent and ImageContent schemas', () => {
+  it('preserves icon and focalPoint on VideoContent', () => {
+    const parsed = VideoContent.safeParse({
+      id: 'https://example.com/videos/1',
+      type: 'Video',
+      attributedTo: 'https://example.com/users/alice',
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      published: '2026-01-01T00:00:00Z',
+      url: 'https://example.com/video.mp4',
+      mediaType: 'video/mp4',
+      width: 1920,
+      height: 1080,
+      focalPoint: [0.5, -0.5],
+      icon: {
+        type: 'Image',
+        url: 'https://example.com/thumb.jpg'
+      }
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.focalPoint).toEqual([0.5, -0.5])
+      expect(parsed.data.icon).toEqual({
+        type: 'Image',
+        url: 'https://example.com/thumb.jpg'
+      })
+    }
+  })
+
+  it('preserves focalPoint on ImageContent', () => {
+    const parsed = ImageContent.safeParse({
+      id: 'https://example.com/images/1',
+      type: 'Image',
+      attributedTo: 'https://example.com/users/alice',
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      published: '2026-01-01T00:00:00Z',
+      url: 'https://example.com/photo.jpg',
+      mediaType: 'image/jpeg',
+      focalPoint: [0.2, 0.8]
+    })
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.focalPoint).toEqual([0.2, 0.8])
+    }
+  })
 })

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -19,12 +19,12 @@ export const Document = z.object({
   type: z.literal('Document'),
   mediaType: z.string(),
   url: z.string(),
+  thumbnailUrl: z.string().optional().nullable(),
   blurhash: z.string().optional(),
   width: z.number().optional(),
   height: z.number().optional(),
   name: z.string().optional().nullable(),
-  focalPoint: z.tuple([z.number(), z.number()]).optional(),
-  thumbnailUrl: z.string().optional()
+  focalPoint: z.tuple([z.number(), z.number()]).optional()
 })
 
 export type Document = z.infer<typeof Document>
@@ -92,7 +92,14 @@ export type Attachment = z.infer<typeof Attachment>
 
 export const BaseContent = z.object({
   id: z.string(),
-  url: z.string().describe('Note URL. This is optional for Pleloma').nullish(),
+  url: z
+    .union([
+      z.string(),
+      z.array(z.union([z.string(), z.looseObject({})])),
+      z.looseObject({})
+    ])
+    .describe('Note URL. This is optional for Pleroma')
+    .nullish(),
   attributedTo: z.string().describe('Note publisher'),
 
   to: z.union([z.string(), z.string().array()]),
@@ -123,9 +130,9 @@ export const BaseContent = z.object({
         .array()
     ])
     .nullish(),
-  replies: Collection.nullish(),
-  likes: Collection.nullish(),
-  shares: Collection.nullish(),
+  replies: z.union([z.string(), Collection, z.looseObject({})]).nullish(),
+  likes: z.union([z.string(), Collection, z.looseObject({})]).nullish(),
+  shares: z.union([z.string(), Collection, z.looseObject({})]).nullish(),
 
   attachment: z.union([Attachment, Attachment.array()]).nullish(),
   tag: z.union([Tag, Tag.array()]).nullish(),
@@ -227,7 +234,8 @@ export const ImageContent = BaseContent.extend({
   mediaType: z.string().nullish(),
   width: z.number().nullish(),
   height: z.number().nullish(),
-  blurhash: z.string().nullish()
+  blurhash: z.string().nullish(),
+  focalPoint: z.array(z.number()).nullish()
 })
 export type ImageContent = z.infer<typeof ImageContent>
 
@@ -259,18 +267,18 @@ export type ArticleContent = z.infer<typeof ArticleContent>
 export const VideoContent = BaseContent.extend({
   type: z.literal('Video'),
   name: z.string().nullish(),
-  url: z
-    .union([
-      z.string(),
-      z.looseObject({}),
-      z.union([z.string(), z.looseObject({})]).array()
-    ])
-    .nullish(),
   mediaType: z.string().nullish(),
   width: z.number().nullish(),
   height: z.number().nullish(),
   blurhash: z.string().nullish(),
-  icon: z.union([Image, Image.array()]).nullish()
+  focalPoint: z.array(z.number()).nullish(),
+  icon: z
+    .union([
+      z.string(),
+      z.looseObject({}),
+      z.array(z.union([z.string(), z.looseObject({})]))
+    ])
+    .nullish()
 })
 export type VideoContent = z.infer<typeof VideoContent>
 

--- a/lib/types/domain/attachment.test.ts
+++ b/lib/types/domain/attachment.test.ts
@@ -319,9 +319,27 @@ describe('attachment', () => {
         description: 'returns false for an unknown media type',
         mediaType: '',
         expected: false
+      },
+      {
+        description:
+          'returns true for video stream URL with application/octet-stream',
+        mediaType: 'application/octet-stream',
+        url: 'https://example.com/stream.m3u8?token=xyz',
+        expected: true
+      },
+      {
+        description: 'returns true for attachment with thumbnailUrl',
+        mediaType: 'application/octet-stream',
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        expected: true
       }
-    ])('$description', ({ mediaType, expected }) => {
-      const result = isVisualAttachment({ ...baseAttachment, mediaType })
+    ])('$description', ({ mediaType, url, thumbnailUrl, expected }) => {
+      const result = isVisualAttachment({
+        ...baseAttachment,
+        mediaType,
+        url: url ?? 'https://example.com/media/file.bin',
+        thumbnailUrl: thumbnailUrl ?? null
+      })
 
       expect(result).toBe(expected)
     })

--- a/lib/types/domain/attachment.ts
+++ b/lib/types/domain/attachment.ts
@@ -98,9 +98,16 @@ const hasFitnessExtension = (value: string) => {
  * frame, and a fitness file or a PDF has nothing to render at all, so both are
  * kept out of the picture layouts and handled separately by their surface.
  */
-export const isVisualAttachment = (attachment: Pick<Attachment, 'mediaType'>) =>
+export const isVisualAttachment = (
+  attachment: Pick<Attachment, 'mediaType'> & {
+    url?: string
+    thumbnailUrl?: string | null
+  }
+) =>
   attachment.mediaType.startsWith('image') ||
-  attachment.mediaType.startsWith('video')
+  attachment.mediaType.startsWith('video') ||
+  Boolean(attachment.thumbnailUrl) ||
+  Boolean(attachment.url && /\.(mp4|webm|m3u8)(?:[?#]|$)/i.test(attachment.url))
 
 /** Media that plays but has no frame — an `<audio controls>` element. */
 export const isAudibleAttachment = (

--- a/lib/types/domain/status.test.ts
+++ b/lib/types/domain/status.test.ts
@@ -169,6 +169,50 @@ describe('Status', () => {
       expect(status.detectedLanguage).toBeNull()
     })
 
+    it('creates StatusNote from PeerTube Video object with video stream and thumbnail', () => {
+      const peertubeVideo = {
+        type: 'Video',
+        id: 'https://framatube.org/videos/watch/123',
+        attributedTo: ACTOR1_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        published: '2026-01-01T00:00:00Z',
+        content: 'Watch this video',
+        mediaType: 'text/markdown',
+        url: [
+          {
+            type: 'Link',
+            mediaType: 'text/html',
+            href: 'https://framatube.org/videos/watch/123'
+          },
+          {
+            type: 'Link',
+            mediaType: 'video/mp4',
+            href: 'https://framatube.org/static/webseed/123.mp4',
+            width: 1920,
+            height: 1080
+          }
+        ],
+        icon: [
+          {
+            type: 'Image',
+            url: 'https://framatube.org/lazy-static/video-thumbnails/123.jpg'
+          }
+        ]
+      }
+      const status = fromNote(peertubeVideo as unknown as BaseNote)
+      expect(status.type).toBe(StatusType.enum.Note)
+      expect(status.attachments).toHaveLength(1)
+      expect(status.attachments[0]).toMatchObject({
+        mediaType: 'video/mp4',
+        url: 'https://framatube.org/static/webseed/123.mp4',
+        thumbnailUrl:
+          'https://framatube.org/lazy-static/video-thumbnails/123.jpg',
+        width: 1920,
+        height: 1080
+      })
+    })
+
     it('handles inReplyTo as an object with id property', () => {
       const note = MockMastodonActivityPubNote({
         content: 'Hello',

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -369,11 +369,11 @@ export const fromNote = (note: BaseNote): StatusNote => {
       type: 'Document',
       mediaType: attachment.mediaType,
       url: attachment.url,
-      name: attachment.name ?? '',
+      width: attachment.width ?? undefined,
+      height: attachment.height ?? undefined,
+      blurhash: attachment.blurhash ?? null,
       thumbnailUrl: attachment.thumbnailUrl ?? null,
-      width: attachment.width,
-      height: attachment.height,
-      blurhash: attachment.blurhash,
+      name: attachment.name ?? '',
 
       createdAt: currentTime,
       updatedAt: currentTime
@@ -386,7 +386,12 @@ export const fromNote = (note: BaseNote): StatusNote => {
     isLocalActor: false,
     totalLikes: 0,
 
-    createdAt: new Date(note.published).getTime(),
+    createdAt: (() => {
+      const publishedTime = note.published
+        ? new Date(note.published).getTime()
+        : currentTime
+      return Number.isNaN(publishedTime) ? currentTime : publishedTime
+    })(),
     updatedAt: currentTime
   })
 }
@@ -416,7 +421,12 @@ export const fromAnnounce = (
 
     isLocalActor: false,
 
-    createdAt: new Date(announce.published).getTime(),
+    createdAt: (() => {
+      const publishedTime = announce.published
+        ? new Date(announce.published).getTime()
+        : currentTime
+      return Number.isNaN(publishedTime) ? currentTime : publishedTime
+    })(),
     updatedAt: currentTime
   })
 }

--- a/lib/utils/activitypub.ts
+++ b/lib/utils/activitypub.ts
@@ -155,16 +155,37 @@ export const normalizeActivityPubAnnounce = (data: unknown) => {
 
 export const normalizeActivityPubContent = (data: unknown) => {
   if (!isRecord(data)) return data
-  const type = normalizeActivityPubType(data.type) ?? data.type
+  const isVideoOrComplexUrl =
+    Array.isArray(data.url) &&
+    (data.type === 'Video' ||
+      data.url.some((u) => {
+        if (typeof u === 'string') {
+          return /\.(mp4|m3u8|webm|ogv)(?:[?#]|$)/i.test(u)
+        }
+        if (typeof u === 'object' && u !== null) {
+          const rawMt =
+            (u as { mediaType?: unknown }).mediaType ||
+            (u as { mimeType?: unknown }).mimeType
+          const mt = typeof rawMt === 'string' ? rawMt.toLowerCase() : ''
+          const rawHref = (u as { href?: unknown }).href
+          const href = typeof rawHref === 'string' ? rawHref.toLowerCase() : ''
+          return (
+            mt.startsWith('video/') ||
+            mt.includes('mpegurl') ||
+            /\.(mp4|m3u8|webm|ogv)(?:[?#]|$)/i.test(href)
+          )
+        }
+        return false
+      }))
+
   return {
     ...data,
-    type,
+    type: normalizeActivityPubType(data.type) ?? data.type,
     attributedTo: extractActivityPubId(data.attributedTo) ?? data.attributedTo,
     inReplyTo: extractActivityPubId(data.inReplyTo) ?? data.inReplyTo,
-    url:
-      type === 'Video'
-        ? data.url
-        : (extractActivityPubId(data.url) ?? data.url),
+    url: isVideoOrComplexUrl
+      ? data.url
+      : (extractActivityPubId(data.url) ?? data.url),
     to: normalizeActivityPubRecipients(data.to) ?? data.to,
     cc: normalizeActivityPubRecipients(data.cc) ?? data.cc
   }

--- a/lib/utils/formatServerSoftware.test.ts
+++ b/lib/utils/formatServerSoftware.test.ts
@@ -22,6 +22,21 @@ describe('formatServerSoftware', () => {
     expect(
       formatServerSoftware({ name: 'activities-next', version: '1.158.3' })
     ).toBe('activities.next/1.158.3')
+    expect(formatServerSoftware({ name: 'nodebb', version: '3.6.0' })).toBe(
+      'NodeBB/3.6.0'
+    )
+    expect(formatServerSoftware({ name: 'owncast', version: '0.1.3' })).toBe(
+      'Owncast/0.1.3'
+    )
+    expect(formatServerSoftware({ name: 'writefreely', version: null })).toBe(
+      'WriteFreely'
+    )
+    expect(formatServerSoftware({ name: 'funkwhale', version: null })).toBe(
+      'Funkwhale'
+    )
+    expect(formatServerSoftware({ name: 'castopod', version: null })).toBe(
+      'Castopod'
+    )
   })
 
   it('omits version slash when version is null or empty', () => {

--- a/lib/utils/formatServerSoftware.ts
+++ b/lib/utils/formatServerSoftware.ts
@@ -20,7 +20,15 @@ const KNOWN_SOFTWARE_NAMES: Record<string, string> = {
   diaspora: 'Diaspora',
   threads: 'Threads',
   'micro.blog': 'Micro.blog',
-  microdotblog: 'Micro.blog'
+  microdotblog: 'Micro.blog',
+  nodebb: 'NodeBB',
+  owncast: 'Owncast',
+  writefreely: 'WriteFreely',
+  funkwhale: 'Funkwhale',
+  castopod: 'Castopod',
+  ghost: 'Ghost',
+  mbin: 'Mbin',
+  kbin: 'Kbin'
 }
 
 export const formatServerSoftware = (software: ServerSoftware): string => {


### PR DESCRIPTION
## Summary

Audited federated profile rendering across 21 platform variants (Mastodon, Misskey, Sharkey, Pleroma, Akkoma, GoToSocial, Threads, Friendica, Hubzilla, Lemmy, Mbin/Kbin, NodeBB, Pixelfed, PeerTube, Owncast, WordPress, Ghost, WriteFreely, BookWyrm, Castopod, Funkwhale) and fixed key rendering gaps:

1. **Profile Counter Formatting**: Formatted statuses, followers, and following counters with `Intl.NumberFormat('en-US')` so counts with thousands or more (e.g. `107,010`) display thousand separators cleanly.
2. **Media-Only Platforms (Pixelfed & PeerTube)**:
   - Added PeerTube and media-only platform detection in `serverSoftware.ts`.
   - Render media-only platforms in a dedicated media gallery view without microblog post/replies tabs or redundant DB-only load controls.
3. **PeerTube Video Parsing & Remote Note Resolution**:
   - In `getActorPosts.ts`, resolved `Create` activities whose `object` is a string URI (standard in PeerTube outbox items) via `getNote`.
   - Added `BaseNoteSchema` to recognize `Video`, `Article`, `Page`, etc.
   - Extracted playable video streams (`.mp4`, `.m3u8`, `.webm`) and poster thumbnails from `icon` arrays.
   - In `normalizeActivityPubContent`, preserved `url` arrays for video and typed media links instead of flattening to the first HTML link.
4. **Infinite Loading Loop on Empty Feeds**:
   - In `ActorTimelines.tsx`, ensured `IntersectionObserver` does not auto-fire at the top of an empty feed.
   - If an empty feed walks the outbox and finds no renderable statuses, `nextPageUrl` is cleared to `null` to permanently dismiss the loading button and prevent repeated requests.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)