### PR TITLE
fix: add RE: fallback link prefix when composing quote post in web timeline

### DIFF
--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -463,6 +463,128 @@ describe('PostBox edit media', () => {
     )
   })
 
+  it('keeps post button disabled when replying to own status with empty content', async () => {
+    const ownStatus = {
+      id: 'https://activities.local/users/llun/statuses/own-1',
+      url: 'https://activities.local/@llun/own-1',
+      actorId: profile.id,
+      actor: profile,
+      type: StatusType.enum.Note,
+      text: 'my own post',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        replyStatus={ownStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue('')
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    expect(postButton).toBeDisabled()
+  })
+
+  it('unwraps announced status when quoting a boost', async () => {
+    const originalStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    const announceStatus = {
+      id: 'https://activities.local/users/alice/statuses/2',
+      actorId: 'https://activities.local/users/alice',
+      type: StatusType.enum.Announce,
+      originalStatus,
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={announceStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue('RE: https://activities.local/@bob/1\n\n')
+  })
+
+  it('strips the RE: quote prefix and preserves commentary even when separated by a single newline', async () => {
+    const onDiscardQuote = vi.fn()
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={onDiscardQuote}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    fireEvent.change(textbox, {
+      target: {
+        value: 'RE: https://activities.local/@bob/1\nmy commentary'
+      }
+    })
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss quote' })
+    fireEvent.click(dismissButton)
+
+    expect(onDiscardQuote).toHaveBeenCalled()
+    expect(textbox).toHaveValue('my commentary')
+  })
+
   it('disables the poll toggle while composing a quote (mutually exclusive)', async () => {
     const quotedStatus = {
       id: 'https://activities.local/users/bob/statuses/1',

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -258,16 +258,209 @@ describe('PostBox edit media', () => {
     expect(screen.getByText('Quoting')).toBeInTheDocument()
 
     const textbox = screen.getByPlaceholderText('What is on your mind?')
-    fireEvent.change(textbox, { target: { value: 'my commentary' } })
+    expect(textbox).toHaveValue(
+      'RE: https://activities.local/users/bob/statuses/1\n\n'
+    )
     const postButton = screen.getByRole('button', { name: 'Post' })
     await waitFor(() => expect(postButton).toBeEnabled())
+
+    fireEvent.change(textbox, {
+      target: {
+        value:
+          'RE: https://activities.local/users/bob/statuses/1\n\nmy commentary'
+      }
+    })
     fireEvent.click(postButton)
 
     await waitFor(() => {
       expect(createNoteMock).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'my commentary', quotedStatus })
+        expect.objectContaining({
+          message:
+            'RE: https://activities.local/users/bob/statuses/1\n\nmy commentary',
+          quotedStatus
+        })
       )
     })
+  })
+
+  it('prefers quotedStatus.url over quotedStatus.id when initializing quote prefix', async () => {
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue('RE: https://activities.local/@bob/1\n\n')
+  })
+
+  it('strips the RE: quote prefix and preserves commentary when quote preview is dismissed', async () => {
+    const onDiscardQuote = vi.fn()
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={onDiscardQuote}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    fireEvent.change(textbox, {
+      target: {
+        value: 'RE: https://activities.local/@bob/1\n\nmy commentary'
+      }
+    })
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss quote' })
+    fireEvent.click(dismissButton)
+
+    expect(onDiscardQuote).toHaveBeenCalled()
+    expect(textbox).toHaveValue('my commentary')
+  })
+
+  it('clears text and disables post button when quote preview is dismissed without commentary', async () => {
+    const onDiscardQuote = vi.fn()
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={onDiscardQuote}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue('RE: https://activities.local/@bob/1\n\n')
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss quote' })
+    fireEvent.click(dismissButton)
+
+    expect(onDiscardQuote).toHaveBeenCalled()
+    expect(textbox).toHaveValue('')
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    expect(postButton).toBeDisabled()
+  })
+
+  it('combines RE: prefix and reply mentions when both quoting and replying', async () => {
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    const replyStatus = {
+      id: 'https://activities.local/users/alice/statuses/2',
+      url: 'https://activities.local/@alice/2',
+      actorId: 'https://activities.local/users/alice',
+      actor: {
+        id: 'https://activities.local/users/alice',
+        username: 'alice',
+        domain: 'activities.local',
+        name: 'Alice'
+      },
+      type: StatusType.enum.Note,
+      text: 'reply to me',
+      tags: [],
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: []
+    } as unknown as StatusNote
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        replyStatus={replyStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue(
+      'RE: https://activities.local/@bob/1\n\n@alice@activities.local '
+    )
   })
 
   it('disables the poll toggle while composing a quote (mutually exclusive)', async () => {

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -47,7 +47,8 @@ import {
   QuoteApprovalPolicy,
   Status,
   StatusNote,
-  StatusType
+  StatusType,
+  getOriginalStatus
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
@@ -159,6 +160,16 @@ const hasNewPostContent = (
   (value.trim().length > 0 ||
     extension.attachments.length > 0 ||
     Boolean(extension.fitnessFile))
+
+const getQuoteUrl = (quotedStatus: Status) => {
+  const original = getOriginalStatus(quotedStatus)
+  return original.url || original.id
+}
+
+const getQuotePrefix = (quotedStatus?: Status) => {
+  if (!quotedStatus) return ''
+  return `RE: ${getQuoteUrl(quotedStatus)}\n\n`
+}
 
 const hasEditPostContent = (
   status: EditableStatus,
@@ -761,6 +772,28 @@ export const PostBox: FC<Props> = ({
   }
 
   const onCloseQuote = () => {
+    if (quotedStatus) {
+      const quotePrefix = getQuotePrefix(quotedStatus)
+      const quoteUrl = getQuoteUrl(quotedStatus)
+      if (text.startsWith(quotePrefix)) {
+        const nextText = text.slice(quotePrefix.length)
+        setText(nextText)
+        textRef.current = nextText
+        setAllowPost(
+          hasNewPostContent(
+            nextText,
+            postExtensionRef.current,
+            maxStatusCharacters
+          )
+        )
+      } else if (text.trim() === `RE: ${quoteUrl}`) {
+        setText('')
+        textRef.current = ''
+        setAllowPost(
+          hasNewPostContent('', postExtensionRef.current, maxStatusCharacters)
+        )
+      }
+    }
     onDiscardQuote?.()
   }
 
@@ -977,36 +1010,56 @@ export const PostBox: FC<Props> = ({
     if (!replyStatus) {
       // Reset visibility to default when not replying
       dispatch(setVisibility('public'))
+    } else {
+      // Initialize visibility from reply status to inherit parent visibility
+      const replyVisibility = getVisibility(replyStatus.to, replyStatus.cc)
+      dispatch(setVisibility(replyVisibility))
+    }
+
+    const quotePrefix = getQuotePrefix(quotedStatus)
+
+    const defaultReplyMessage =
+      replyStatus && replyStatus.type === StatusType.enum.Note
+        ? getDefaultMessage(profile, replyStatus)
+        : null
+
+    if (defaultReplyMessage) {
+      const [replyText, replyStart, replyEnd] = defaultReplyMessage
+      const initialText = `${quotePrefix}${replyText}`
+      const start = quotePrefix.length + replyStart
+      const end = quotePrefix.length + replyEnd
+      setText(initialText)
+      textRef.current = initialText
+      setAllowPost(true)
+
+      setTimeout(() => {
+        if (postBoxRef.current) {
+          postBoxRef.current.selectionStart = start
+          postBoxRef.current.selectionEnd = end
+          postBoxRef.current.focus()
+        }
+      }, 0)
       return
     }
 
-    // Initialize visibility from reply status to inherit parent visibility
-    const replyVisibility = getVisibility(replyStatus.to, replyStatus.cc)
-    dispatch(setVisibility(replyVisibility))
+    if (quotePrefix) {
+      const initialText = quotePrefix
+      const start = quotePrefix.length
+      const end = quotePrefix.length
+      setText(initialText)
+      textRef.current = initialText
+      setAllowPost(true)
 
-    if (replyStatus.type !== StatusType.enum.Note) {
+      setTimeout(() => {
+        if (postBoxRef.current) {
+          postBoxRef.current.selectionStart = start
+          postBoxRef.current.selectionEnd = end
+          postBoxRef.current.focus()
+        }
+      }, 0)
       return
     }
-
-    const defaultMessage = getDefaultMessage(profile, replyStatus)
-    if (!defaultMessage) {
-      return
-    }
-
-    const [value, start, end] = defaultMessage
-    setText(value)
-    setAllowPost(true)
-
-    // We need to wait for render to focus and set selection
-    // Using setTimeout as a simple way to wait for next tick after render
-    setTimeout(() => {
-      if (postBoxRef.current) {
-        postBoxRef.current.selectionStart = start
-        postBoxRef.current.selectionEnd = end
-        postBoxRef.current.focus()
-      }
-    }, 0)
-  }, [profile, replyStatus, editStatus])
+  }, [profile, replyStatus, editStatus, quotedStatus])
 
   return (
     <div>

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -161,6 +161,9 @@ const hasNewPostContent = (
     extension.attachments.length > 0 ||
     Boolean(extension.fitnessFile))
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const getQuoteUrl = (quotedStatus: Status) => {
   const original = getOriginalStatus(quotedStatus)
   return original.url || original.id
@@ -773,10 +776,14 @@ export const PostBox: FC<Props> = ({
 
   const onCloseQuote = () => {
     if (quotedStatus) {
-      const quotePrefix = getQuotePrefix(quotedStatus)
-      const quoteUrl = getQuoteUrl(quotedStatus)
-      if (text.startsWith(quotePrefix)) {
-        const nextText = text.slice(quotePrefix.length)
+      const original = getOriginalStatus(quotedStatus)
+      const urls = [original.url, original.id].filter(Boolean) as string[]
+      const prefixRegex = new RegExp(
+        `^RE: (${urls.map(escapeRegExp).join('|')})\\s*`
+      )
+      const match = text.match(prefixRegex)
+      if (match) {
+        const nextText = text.slice(match[0].length)
         setText(nextText)
         textRef.current = nextText
         setAllowPost(
@@ -785,12 +792,6 @@ export const PostBox: FC<Props> = ({
             postExtensionRef.current,
             maxStatusCharacters
           )
-        )
-      } else if (text.trim() === `RE: ${quoteUrl}`) {
-        setText('')
-        textRef.current = ''
-        setAllowPost(
-          hasNewPostContent('', postExtensionRef.current, maxStatusCharacters)
         )
       }
     }
@@ -1023,32 +1024,24 @@ export const PostBox: FC<Props> = ({
         ? getDefaultMessage(profile, replyStatus)
         : null
 
-    if (defaultReplyMessage) {
-      const [replyText, replyStart, replyEnd] = defaultReplyMessage
+    if (defaultReplyMessage || quotePrefix) {
+      const [replyText, replyStart, replyEnd] = defaultReplyMessage ?? [
+        '',
+        0,
+        0
+      ]
       const initialText = `${quotePrefix}${replyText}`
       const start = quotePrefix.length + replyStart
       const end = quotePrefix.length + replyEnd
       setText(initialText)
       textRef.current = initialText
-      setAllowPost(true)
-
-      setTimeout(() => {
-        if (postBoxRef.current) {
-          postBoxRef.current.selectionStart = start
-          postBoxRef.current.selectionEnd = end
-          postBoxRef.current.focus()
-        }
-      }, 0)
-      return
-    }
-
-    if (quotePrefix) {
-      const initialText = quotePrefix
-      const start = quotePrefix.length
-      const end = quotePrefix.length
-      setText(initialText)
-      textRef.current = initialText
-      setAllowPost(true)
+      setAllowPost(
+        hasNewPostContent(
+          initialText,
+          postExtensionRef.current,
+          maxStatusCharacters
+        )
+      )
 
       setTimeout(() => {
         if (postBoxRef.current) {


### PR DESCRIPTION
## Summary

When creating a quote post inside the web timeline (`InlineStatusComposer` / `PostBox`), the composer previously opened with an empty textarea (`text = ''`) and a disabled submit button, leaving out the Mastodon-compatible `RE: <quote post url>` fallback link at the top of the post.

This PR fixes the web timeline composer by:
- Pre-populating the composer text with `RE: <quote post url>\n\n` when `quotedStatus` is provided (unwrapping target announces via `getOriginalStatus` and preferring `url` over `id`).
- Placing the selection/cursor after the prefix and enabling the post button.
- If replying and quoting simultaneously, placing `RE: <quote post url>\n\n` at the top of the post followed by the reply mentions.
- Stripping the quote prefix if the user dismisses the quote preview card (`[x]`), preserving any typed commentary.

## Verification

Definition of Done verification executed in order:
1. `yarn run prettier --write .` - Passed
2. `yarn lint` - Passed (0 errors)
3. `yarn typecheck` - Passed (0 errors)
4. `yarn build` - Passed (exit code 0)
5. `yarn test` - Passed (all 956 test files, 12,837 tests passed)