### PR TITLE
fix: prevent quote box handle and text from overflowing viewport

### DIFF
--- a/lib/components/post-box/quoted-preview.test.tsx
+++ b/lib/components/post-box/quoted-preview.test.tsx
@@ -5,23 +5,23 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
+import { QuotedPreview } from '@/lib/components/post-box/quoted-preview'
+import { ActorProfile } from '@/lib/types/domain/actor'
 import {
+  Status,
   StatusAnnounce,
   StatusNote,
-  StatusType
+  StatusType,
+  getOriginalStatus
 } from '@/lib/types/domain/status'
-
-import { ReplyPreview } from './reply-preview'
 
 // Mock the processStatusText utility
 vi.mock('@/lib/utils/text/processStatusText', async () => ({
-  processStatusText: vi.fn((host: string, status: StatusNote) => {
-    if (status.type === 'Announce') {
-      return (status as unknown as StatusAnnounce).originalStatus.text
-    }
-    return status.text
+  processStatusText: vi.fn((_host: string, status: Status) => {
+    const original = getOriginalStatus(status)
+    return original.text
   }),
-  getActualStatus: vi.fn((status: StatusNote) => status)
+  getActualStatus: vi.fn((status: Status) => status)
 }))
 
 // Mock the cleanClassName utility
@@ -31,13 +31,32 @@ vi.mock('@/lib/utils/text/cleanClassName', async () => ({
 
 // Mock the ActorInfo component
 vi.mock('@/lib/components/posts/actor', async () => ({
-  ActorInfo: ({ actor }: { actor: { name: string } }) => (
+  ActorInfo: ({ actor }: { actor?: ActorProfile | null }) => (
     <span data-testid="actor-info">{actor?.name || 'Unknown'}</span>
   )
 }))
 
-describe('ReplyPreview', () => {
+describe('QuotedPreview', () => {
   const mockOnClose = vi.fn()
+
+  const createMockActor = (
+    overrides: Partial<ActorProfile> = {}
+  ): ActorProfile => ({
+    id: 'https://example.com/users/testuser',
+    username: 'testuser',
+    domain: 'example.com',
+    name: 'Test User',
+    summary: '',
+    followersUrl: 'https://example.com/users/testuser/followers',
+    inboxUrl: 'https://example.com/users/testuser/inbox',
+    sharedInboxUrl: 'https://example.com/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: Date.now(),
+    ...overrides
+  })
 
   const createMockStatus = (
     overrides: Partial<StatusNote> = {}
@@ -50,24 +69,14 @@ describe('ReplyPreview', () => {
     reply: '',
     replies: [],
     actorId: 'https://example.com/users/testuser',
-    actor: {
-      id: 'https://example.com/users/testuser',
-      name: 'Test User',
-      preferredUsername: 'testuser',
-      url: 'https://example.com/@testuser',
-      icon: null,
-      summary: null,
-      followersCount: 0,
-      followingCount: 0,
-      statusesCount: 0,
-      createdAt: Date.now()
-    },
+    actor: createMockActor(),
     to: [],
     cc: [],
     edits: [],
     isLocalActor: false,
     actorAnnounceStatusId: null,
     isActorLiked: false,
+    isActorBookmarked: false,
     totalLikes: 0,
     totalShares: 0,
     attachments: [],
@@ -81,18 +90,11 @@ describe('ReplyPreview', () => {
     id: 'announce-1',
     type: StatusType.enum.Announce,
     actorId: 'https://example.com/users/booster',
-    actor: {
+    actor: createMockActor({
       id: 'https://example.com/users/booster',
-      name: 'Booster User',
-      preferredUsername: 'booster',
-      url: 'https://example.com/@booster',
-      icon: null,
-      summary: null,
-      followersCount: 0,
-      followingCount: 0,
-      statusesCount: 0,
-      createdAt: Date.now()
-    },
+      username: 'booster',
+      name: 'Booster User'
+    }),
     to: [],
     cc: [],
     edits: [],
@@ -111,28 +113,28 @@ describe('ReplyPreview', () => {
   describe('rendering', () => {
     it('returns null when status is undefined', () => {
       const { container } = render(
-        <ReplyPreview host="example.com" status={undefined} />
+        <QuotedPreview host="example.com" status={undefined} />
       )
       expect(container.firstChild).toBeNull()
     })
 
-    it('renders the reply preview with status content', () => {
+    it('renders the quote preview with status content', () => {
       const status = createMockStatus({ text: 'Hello world!' })
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
-      expect(screen.getByText('Replying to')).toBeInTheDocument()
+      expect(screen.getByText('Quoting')).toBeInTheDocument()
       expect(screen.getByTestId('actor-info')).toHaveTextContent('Test User')
       expect(screen.getByText('Hello world!')).toBeInTheDocument()
     })
 
     it('renders "No content preview" when text is empty', async () => {
       const { processStatusText } = await vi.importMock<{
-        processStatusText: jest.Mock
+        processStatusText: ReturnType<typeof vi.fn>
       }>('@/lib/utils/text/processStatusText')
       processStatusText.mockReturnValueOnce('')
 
       const status = createMockStatus({ text: '' })
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
       expect(screen.getByText('No content preview')).toBeInTheDocument()
     })
@@ -140,7 +142,7 @@ describe('ReplyPreview', () => {
     it('applies custom className when provided', () => {
       const status = createMockStatus()
       const { container } = render(
-        <ReplyPreview
+        <QuotedPreview
           host="example.com"
           status={status}
           className="custom-class"
@@ -154,16 +156,16 @@ describe('ReplyPreview', () => {
     it('applies overflow-hidden and min-w-0 classes to prevent header overflow', () => {
       const status = createMockStatus()
       const { container } = render(
-        <ReplyPreview host="example.com" status={status} />
+        <QuotedPreview host="example.com" status={status} />
       )
 
       const section = container.querySelector('section')
       expect(section).toHaveClass('overflow-hidden')
 
-      const replyingLabel = screen.getByText('Replying to')
-      expect(replyingLabel).toHaveClass('shrink-0')
+      const quotingLabel = screen.getByText('Quoting')
+      expect(quotingLabel).toHaveClass('shrink-0')
 
-      const headerRow = replyingLabel.parentElement
+      const headerRow = quotingLabel.parentElement
       expect(headerRow).toHaveClass('min-w-0')
 
       const actorInfoWrapper = headerRow?.querySelector('.flex-1')
@@ -176,14 +178,14 @@ describe('ReplyPreview', () => {
     it('calls onClose when dismiss button is clicked', () => {
       const status = createMockStatus()
       render(
-        <ReplyPreview
+        <QuotedPreview
           host="example.com"
           status={status}
           onClose={mockOnClose}
         />
       )
 
-      const closeButton = screen.getByRole('button', { name: 'Dismiss reply' })
+      const closeButton = screen.getByRole('button', { name: 'Dismiss quote' })
       fireEvent.click(closeButton)
 
       expect(mockOnClose).toHaveBeenCalledTimes(1)
@@ -191,17 +193,17 @@ describe('ReplyPreview', () => {
 
     it('has type="button" to prevent form submission', () => {
       const status = createMockStatus()
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
-      const closeButton = screen.getByRole('button', { name: 'Dismiss reply' })
+      const closeButton = screen.getByRole('button', { name: 'Dismiss quote' })
       expect(closeButton).toHaveAttribute('type', 'button')
     })
 
     it('handles missing onClose gracefully', () => {
       const status = createMockStatus()
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
-      const closeButton = screen.getByRole('button', { name: 'Dismiss reply' })
+      const closeButton = screen.getByRole('button', { name: 'Dismiss quote' })
       expect(() => fireEvent.click(closeButton)).not.toThrow()
     })
   })
@@ -212,21 +214,21 @@ describe('ReplyPreview', () => {
         type: StatusType.enum.Note,
         text: 'This is a note'
       })
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
       expect(screen.getByText('This is a note')).toBeInTheDocument()
     })
 
     it('renders boosted (Announce) status with original content', async () => {
       const { processStatusText } = await vi.importMock<{
-        processStatusText: jest.Mock
+        processStatusText: ReturnType<typeof vi.fn>
       }>('@/lib/utils/text/processStatusText')
       processStatusText.mockReturnValueOnce(
         'This is the original boosted status'
       )
 
       const status = createMockAnnounceStatus()
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
       expect(
         screen.getByText('This is the original boosted status')
@@ -234,69 +236,11 @@ describe('ReplyPreview', () => {
     })
   })
 
-  describe('text processing', () => {
-    it('passes host and status to processStatusText', async () => {
-      const { processStatusText } = await vi.importMock<{
-        processStatusText: jest.Mock
-      }>('@/lib/utils/text/processStatusText')
-
-      const status = createMockStatus()
-      render(<ReplyPreview host="my-server.com" status={status} />)
-
-      expect(processStatusText).toHaveBeenCalledWith('my-server.com', status)
-    })
-
-    it('handles long text content with line clamping styles', () => {
-      const longText =
-        'This is a very long status that should be truncated. '.repeat(10)
-      const status = createMockStatus({ text: longText })
-      const { container } = render(
-        <ReplyPreview host="example.com" status={status} />
-      )
-
-      // The text is inside a span from cleanClassName mock, which is inside the div with line-clamp-2
-      const textContainer = container.querySelector('.line-clamp-2')
-      expect(textContainer).toBeInTheDocument()
-    })
-  })
-
-  describe('actor display', () => {
-    it('displays actor name when actor is present', () => {
-      const status = createMockStatus({
-        actor: {
-          id: 'https://example.com/users/jane',
-          name: 'Jane Doe',
-          preferredUsername: 'jane',
-          url: 'https://example.com/@jane',
-          icon: null,
-          summary: null,
-          followersCount: 100,
-          followingCount: 50,
-          statusesCount: 25,
-          createdAt: Date.now()
-        }
-      })
-      render(<ReplyPreview host="example.com" status={status} />)
-
-      expect(screen.getByTestId('actor-info')).toHaveTextContent('Jane Doe')
-    })
-
-    it('passes actorId to ActorInfo when actor is null', () => {
-      const status = createMockStatus({
-        actor: null,
-        actorId: 'https://example.com/users/unknown'
-      })
-      render(<ReplyPreview host="example.com" status={status} />)
-
-      expect(screen.getByTestId('actor-info')).toBeInTheDocument()
-    })
-  })
-
   describe('accessibility', () => {
     it('uses semantic section element', () => {
       const status = createMockStatus()
       const { container } = render(
-        <ReplyPreview host="example.com" status={status} />
+        <QuotedPreview host="example.com" status={status} />
       )
 
       expect(container.querySelector('section')).toBeInTheDocument()
@@ -304,10 +248,10 @@ describe('ReplyPreview', () => {
 
     it('has accessible dismiss button with aria-label', () => {
       const status = createMockStatus()
-      render(<ReplyPreview host="example.com" status={status} />)
+      render(<QuotedPreview host="example.com" status={status} />)
 
-      const closeButton = screen.getByRole('button', { name: 'Dismiss reply' })
-      expect(closeButton).toHaveAttribute('aria-label', 'Dismiss reply')
+      const closeButton = screen.getByRole('button', { name: 'Dismiss quote' })
+      expect(closeButton).toHaveAttribute('aria-label', 'Dismiss quote')
     })
   })
 })

--- a/lib/components/post-box/quoted-preview.tsx
+++ b/lib/components/post-box/quoted-preview.tsx
@@ -31,15 +31,15 @@ export const QuotedPreview: FC<Props> = ({
   return (
     <section
       className={cn(
-        'rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2',
+        'overflow-hidden rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2',
         className
       )}
     >
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span className="font-medium">Quoting</span>
-            <div className="text-sm text-foreground">
+          <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+            <span className="shrink-0 font-medium">Quoting</span>
+            <div className="min-w-0 flex-1 text-sm text-foreground">
               <ActorInfo actor={status.actor} actorId={status.actorId || ''} />
             </div>
           </div>

--- a/lib/components/post-box/reply-preview.tsx
+++ b/lib/components/post-box/reply-preview.tsx
@@ -29,15 +29,15 @@ export const ReplyPreview: FC<Props> = ({
   return (
     <section
       className={cn(
-        'rounded-xl border border-border/60 border-l-4 border-l-primary/20 bg-muted/20 px-3 py-2',
+        'overflow-hidden rounded-xl border border-border/60 border-l-4 border-l-primary/20 bg-muted/20 px-3 py-2',
         className
       )}
     >
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span className="font-medium">Replying to</span>
-            <div className="text-sm text-foreground">
+          <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+            <span className="shrink-0 font-medium">Replying to</span>
+            <div className="min-w-0 flex-1 text-sm text-foreground">
               <ActorInfo actor={status.actor} actorId={status.actorId || ''} />
             </div>
           </div>

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -5,6 +5,7 @@ import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { getMentionDomainFromActorID } from '@/lib/types/domain/actor'
 import type { ActorProfile } from '@/lib/types/domain/actor'
+import { cn } from '@/lib/utils'
 import {
   getActorIdUsername,
   isOpaqueActorUsernameValue
@@ -14,6 +15,7 @@ interface Props {
   actor?: ActorProfile | null
   actorId?: string
   statusUrl?: string | null
+  className?: string
 }
 
 type ActorIdParts = {
@@ -234,7 +236,12 @@ export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
   )
 }
 
-export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
+export const ActorInfo: FC<Props> = ({
+  actor,
+  actorId,
+  statusUrl,
+  className
+}) => {
   if (!actor && !actorId) return null
 
   const href = getActorProfileHref(actor, actorId, statusUrl)
@@ -247,23 +254,27 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
 
   return (
     <div
-      className="flex min-w-0 max-w-full items-center gap-1"
+      className={cn('flex min-w-0 max-w-full items-center gap-1', className)}
       onClick={(e) => e.stopPropagation()}
     >
       {href ? (
         <Link
           href={href}
           prefetch={false}
-          className="font-semibold hover:underline truncate"
+          className="shrink-0 max-w-full font-semibold hover:underline truncate"
         >
           <ActorDisplayName name={name} tags={actor?.tags} />
         </Link>
       ) : (
-        <span className="font-semibold truncate">
+        <span className="shrink-0 max-w-full font-semibold truncate">
           <ActorDisplayName name={name} tags={actor?.tags} />
         </span>
       )}
-      <span className="text-muted-foreground truncate">{mutedHandle}</span>
+      {mutedHandle ? (
+        <span className="min-w-0 flex-1 text-muted-foreground truncate">
+          {mutedHandle}
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/lib/components/posts/quote-card.test.tsx
+++ b/lib/components/posts/quote-card.test.tsx
@@ -49,10 +49,17 @@ describe('QuoteCard', () => {
     render(<QuoteCard quote={quote()} currentTime={CURRENT_TIME} />)
 
     expect(await screen.findByText('the quoted content')).toBeInTheDocument()
-    expect(screen.getByText('Bob')).toBeInTheDocument()
-    expect(screen.getByText('@bob@remote.example')).toBeInTheDocument()
+    const name = screen.getByText('Bob')
+    expect(name).toBeInTheDocument()
+    expect(name).toHaveClass('shrink-0', 'max-w-full', 'truncate')
+
+    const handle = screen.getByText('@bob@remote.example')
+    expect(handle).toBeInTheDocument()
+    expect(handle).toHaveClass('min-w-0', 'flex-1', 'truncate')
+
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute('href', 'https://remote.example/@bob/1')
+    expect(link).toHaveClass('overflow-hidden')
   })
 
   it('shows an unavailable tombstone when the quoted post is not readable', async () => {

--- a/lib/components/posts/quote-card.tsx
+++ b/lib/components/posts/quote-card.tsx
@@ -109,12 +109,12 @@ export const QuoteCard: FC<Props> = ({ quote, currentTime, className }) => {
     <a
       href={quotedStatus.url || quote.quotedStatusId}
       className={cn(
-        'mt-2 block rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2 transition-colors hover:bg-muted/40',
+        'mt-2 block overflow-hidden rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2 transition-colors hover:bg-muted/40',
         className
       )}
     >
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Avatar className="size-5">
+      <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+        <Avatar className="size-5 shrink-0">
           <AvatarImage src={account.avatar} alt="" />
           <AvatarFallback>
             {(account.display_name || account.username || '?')
@@ -122,11 +122,13 @@ export const QuoteCard: FC<Props> = ({ quote, currentTime, className }) => {
               .toUpperCase()}
           </AvatarFallback>
         </Avatar>
-        <span className="font-medium text-foreground">
+        <span className="shrink-0 max-w-full truncate font-medium text-foreground">
           {account.display_name || account.username}
         </span>
-        <span className="truncate">@{account.acct}</span>
-        <span aria-hidden>·</span>
+        <span className="min-w-0 flex-1 truncate">@{account.acct}</span>
+        <span aria-hidden className="shrink-0">
+          ·
+        </span>
         <span className="shrink-0">{relativeTime}</span>
       </div>
       <div className="mt-1 line-clamp-3 text-sm text-foreground/90 break-words">


### PR DESCRIPTION
## Summary

When quoting a post or replying in the composer on small/mobile viewports, an actor with a long handle in `QuotedPreview` (and `ReplyPreview`) could overflow past the right boundary of the quote box and out of the viewport, overlapping the dismiss (`X`) button.

### Root Cause
1. In `QuotedPreview` (and `ReplyPreview`), the `<div className="text-sm text-foreground">` wrapper around `<ActorInfo>` did not have `min-w-0 flex-1`. As a flex child with `min-width: auto`, it could not shrink below its content's intrinsic size, forcing the handle to overflow its container.
2. The preview section container lacked `overflow-hidden`.
3. In `ActorInfo`, both the display name and handle used default flex shrinking without sizing constraints. By setting the display name to `shrink-0 max-w-full truncate` and the handle to `min-w-0 flex-1 truncate`, short/medium names are preserved while handles truncate cleanly with ellipsis in constrained widths.
4. `QuoteCard` had a similar missing `min-w-0`/`truncate` constraint on its header row.

### Changes
- Updated `QuotedPreview` and `ReplyPreview` with `overflow-hidden`, `min-w-0`, `shrink-0`, and `flex-1` classes on the header layout.
- Updated `ActorInfo` with proper flex truncation classes (`shrink-0 max-w-full` on name, `min-w-0 flex-1` on handle) and optional `className` support.
- Updated `QuoteCard` with `min-w-0`, `shrink-0 max-w-full`, and `overflow-hidden` to prevent overflow in quoted cards.
- Added comprehensive unit tests in `lib/components/post-box/quoted-preview.test.tsx` and updated assertions in `reply-preview.test.tsx` and `quote-card.test.tsx`.
- Verified in a real browser under mobile viewport dimensions (iPhone 390x844).

## Screenshots

| Before (Overflowing out of window) | After (Truncated cleanly inside quote box) |
| --- | --- |
| Long handle overflows across the `X` button and past the right edge of the quote card | Handle truncates cleanly with ellipsis (`@..`) and preserves the `X` dismiss button placement |

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)