### PR TITLE
Bump version to v1.158.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.8",
+  "version": "1.158.9",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.9.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.8`
- Base main SHA: `7ed6d1f5c7a0d1715618c4d271078036c3336842`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
