### PR TITLE
Bump version to v1.158.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.9",
+  "version": "1.158.10",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.10.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.9`
- Base main SHA: `67fc80bc457563654b6550ab28e704b0800e8846`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
