### PR TITLE
fix: address review feedback on ActivityPub follow protocol and authorization hardening

### DIFF
--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -699,6 +699,44 @@ describe('POST /api/users/[username]/inbox', () => {
     expect(mockUndoFollowRequest).toHaveBeenCalled()
   })
 
+  it('dispatches reference-object Undo of Follow without embedded actor to undoFollowRequest and returns 202', async () => {
+    mockUndoFollowRequest.mockResolvedValueOnce(true)
+
+    const response = await POST(
+      new NextRequest('https://activities.local/api/users/llun/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: 'https://remote.test/users/alice/activities/undo-ref-obj',
+          type: 'Undo',
+          actor: 'https://remote.test/users/alice',
+          object: {
+            id: 'https://activities.local/follows/1',
+            type: 'Follow'
+          }
+        })
+      }),
+      { params: Promise.resolve({ username: 'llun' }) }
+    )
+
+    expect(response.status).toBe(202)
+    expect(mockUndoFollowRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: mockDatabase,
+        request: expect.objectContaining({
+          type: 'Undo',
+          actor: 'https://remote.test/users/alice',
+          object: expect.objectContaining({
+            id: 'https://activities.local/follows/1',
+            actor: 'https://remote.test/users/alice',
+            object: 'https://activities.local/users/llun',
+            type: 'Follow'
+          })
+        })
+      })
+    )
+  })
+
   it('treats partial Undo Like objects as accepted no-ops', async () => {
     const response = await POST(
       new NextRequest('https://activities.local/api/users/llun/inbox', {
@@ -1036,6 +1074,30 @@ describe('POST /api/users/[username]/inbox', () => {
             })
           })
         )
+      }
+    )
+
+    it.each([
+      {
+        type: 'Accept' as const,
+        handler: () => mockAcceptFollowRequest
+      },
+      {
+        type: 'Reject' as const,
+        handler: () => mockRejectFollowRequest
+      }
+    ])(
+      'returns 202 instead of 404 when $type follow is not found',
+      async ({ type, handler }) => {
+        mockHandleQuoteResponse.mockResolvedValue(false)
+        handler().mockResolvedValue(null)
+
+        const response = await POST(
+          quoteResponseRequest(type, 'https://activities.local/follows/1'),
+          { params: Promise.resolve({ username: 'llun' }) }
+        )
+
+        expect(response.status).toBe(202)
       }
     )
 

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -46,7 +46,7 @@ import {
   Reject,
   Undo
 } from '@/lib/types/activitypub'
-import { normalizeActorId } from '@/lib/utils/activitypub'
+import { actorIdsMatch } from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -137,16 +137,6 @@ const RelayHandshake = z
     object: z.union([z.string(), z.object({ id: z.string() }).passthrough()])
   })
   .passthrough()
-
-const actorIdsMatch = (firstActorId: string, secondActorId: string) => {
-  const normalizedFirstActorId = normalizeActorId(firstActorId)
-  const normalizedSecondActorId = normalizeActorId(secondActorId)
-
-  return (
-    Boolean(normalizedFirstActorId) &&
-    normalizedFirstActorId === normalizedSecondActorId
-  )
-}
 
 const logAcceptedWithoutSideEffects = ({
   activity,
@@ -393,8 +383,8 @@ export const POST = traceApiRoute(
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
-                    data: ERROR_404,
-                    responseStatusCode: 404
+                    data: DEFAULT_202,
+                    responseStatusCode: 202
                   })
                 }
                 return apiResponse({
@@ -446,8 +436,8 @@ export const POST = traceApiRoute(
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
-                    data: ERROR_404,
-                    responseStatusCode: 404
+                    data: DEFAULT_202,
+                    responseStatusCode: 202
                   })
                 }
                 return apiResponse({
@@ -585,12 +575,39 @@ export const POST = traceApiRoute(
                 }
 
                 const undoFollow = Follow.safeParse(undoObject)
-                if (undoFollow.success) {
-                  if (!actorIdsMatch(activity.actor, undoFollow.data.actor)) {
+                const undoFollowRef =
+                  !undoFollow.success &&
+                  typeof undoObject === 'object' &&
+                  undoObject !== null &&
+                  'id' in undoObject &&
+                  typeof undoObject.id === 'string' &&
+                  (!('type' in undoObject) || undoObject.type === 'Follow')
+                    ? {
+                        id: undoObject.id,
+                        actor:
+                          'actor' in undoObject &&
+                          typeof undoObject.actor === 'string'
+                            ? undoObject.actor
+                            : activity.actor,
+                        object:
+                          'object' in undoObject &&
+                          typeof undoObject.object === 'string'
+                            ? undoObject.object
+                            : actor.id,
+                        type: 'Follow' as const
+                      }
+                    : null
+
+                const followData = undoFollow.success
+                  ? undoFollow.data
+                  : undoFollowRef
+
+                if (followData) {
+                  if (!actorIdsMatch(activity.actor, followData.actor)) {
                     annotateInboxRejection('sender_actor_mismatch', {
                       verified_sender: activity.actor,
                       ...getActivityTraceAttributes(activity),
-                      activity_actor: undoFollow.data.actor
+                      activity_actor: followData.actor
                     })
                     return apiResponse({
                       req,
@@ -604,7 +621,7 @@ export const POST = traceApiRoute(
                     database,
                     request: {
                       ...activity,
-                      object: undoFollow.data
+                      object: followData
                     } as UndoFollow
                   })
                   if (!result) {
@@ -622,7 +639,7 @@ export const POST = traceApiRoute(
                   return apiResponse({
                     req,
                     allowedMethods: CORS_HEADERS,
-                    data: { target: undoFollow.data.object },
+                    data: { target: followData.object },
                     responseStatusCode: 202
                   })
                 }

--- a/lib/actions/acceptFollowRequest.test.ts
+++ b/lib/actions/acceptFollowRequest.test.ts
@@ -263,5 +263,33 @@ describe('Accept follow action', () => {
       expect(updatedRequest).toBeTruthy()
       expect(updatedRequest?.id).toEqual(followRequest.id)
     })
+
+    it('does not send duplicate notification alerts if already Accepted', async () => {
+      const targetActorId =
+        'https://somewhere.test/actors/request-following-dup'
+      const followRequest = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Accepted,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const activity = MockFollowRequestResponse({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        followResponseStatus: 'Accept',
+        followId: followRequest.id
+      }) as AcceptFollow
+
+      const result = await acceptFollowRequest({
+        activity,
+        database
+      })
+
+      expect(result).toBeTruthy()
+      expect(result?.status).toEqual(FollowStatus.enum.Accepted)
+      expect(sendNotificationAlerts).not.toHaveBeenCalled()
+    })
   })
 })

--- a/lib/actions/acceptFollowRequest.ts
+++ b/lib/actions/acceptFollowRequest.ts
@@ -54,17 +54,18 @@ export const acceptFollowRequest = async ({
       })
       .catch((error) => {
         logger.warn({
+          err: toLoggableError(error),
           message: 'Failed to queue Undo Follow federation',
           actorId: follow.actorId,
           targetActorId: follow.targetActorId,
-          followId: follow.id,
-          error
+          followId: follow.id
         })
       })
 
     return follow
   }
 
+  const wasAlreadyAccepted = follow.status === FollowStatus.enum.Accepted
   await database.updateFollowStatus({
     followId: follow.id,
     status: FollowStatus.enum.Accepted
@@ -75,7 +76,7 @@ export const acceptFollowRequest = async ({
     database.getActorFromId({ id: follow.targetActorId })
   ])
 
-  if (actor && targetActor?.account) {
+  if (!wasAlreadyAccepted && actor && targetActor?.account) {
     sendNotificationAlerts({
       database,
       actorId: targetActor.id,
@@ -100,8 +101,8 @@ export const acceptFollowRequest = async ({
   // updateFollowStatus committed Accepted so the job sees the follow.
   // Dedup id is per follow row (#backfill suffix keeps it clear of every
   // other job's id space; an Accept redelivery dedups, and the job is
-  // idempotent past the dedup window anyway).
-  if (actor?.privateKey) {
+  // safe against repeated execution anyway).
+  if (actor?.account) {
     getQueue()
       .publish({
         id: getHashFromString(`${follow.id}#backfill`),
@@ -118,5 +119,8 @@ export const acceptFollowRequest = async ({
       })
   }
 
-  return follow
+  return {
+    ...follow,
+    status: FollowStatus.enum.Accepted
+  }
 }

--- a/lib/actions/rejectFollowRequest.test.ts
+++ b/lib/actions/rejectFollowRequest.test.ts
@@ -65,5 +65,77 @@ describe('Reject follow action', () => {
       const updatedRequest = await rejectFollowRequest({ activity, database })
       expect(updatedRequest).toBeNull()
     })
+
+    it('handles Reject activity where object is a string URI (Lemmy / PeerTube format)', async () => {
+      const targetActorId = 'https://somewhere.test/actors/request-following-2'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const activity: RejectFollow = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://somewhere.test/activities/reject-1',
+        type: 'Reject',
+        actor: targetActorId,
+        object: `https://llun.test/${follow.id}`
+      }
+      const updated = await rejectFollowRequest({ activity, database })
+      expect(updated).toBeTruthy()
+      expect(updated?.id).toEqual(follow.id)
+      expect(updated?.status).toEqual(FollowStatus.enum.Rejected)
+    })
+
+    it('resolves follow via recipientActorId fallback when object is an arbitrary URI', async () => {
+      const targetActorId = 'https://somewhere.test/actors/request-following-3'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const activity: RejectFollow = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://somewhere.test/activities/reject-2',
+        type: 'Reject',
+        actor: targetActorId,
+        object: 'https://somewhere.test/arbitrary-follow-id'
+      }
+      const updated = await rejectFollowRequest({
+        activity,
+        database,
+        recipientActorId: ACTOR1_ID
+      })
+      expect(updated).toBeTruthy()
+      expect(updated?.id).toEqual(follow.id)
+      expect(updated?.status).toEqual(FollowStatus.enum.Rejected)
+    })
+
+    it('returns follow immediately if already Rejected (idempotent)', async () => {
+      const targetActorId = 'https://somewhere.test/actors/request-following-4'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Rejected,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const activity: RejectFollow = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://somewhere.test/activities/reject-3',
+        type: 'Reject',
+        actor: targetActorId,
+        object: `https://llun.test/${follow.id}`
+      }
+      const updated = await rejectFollowRequest({ activity, database })
+      expect(updated).toBeTruthy()
+      expect(updated?.status).toEqual(FollowStatus.enum.Rejected)
+    })
   })
 })

--- a/lib/actions/rejectFollowRequest.ts
+++ b/lib/actions/rejectFollowRequest.ts
@@ -27,5 +27,8 @@ export const rejectFollowRequest = async ({
     followId: follow.id,
     status: FollowStatus.enum.Rejected
   })
-  return follow
+  return {
+    ...follow,
+    status: FollowStatus.enum.Rejected
+  }
 }

--- a/lib/actions/resolveFollowFromActivity.test.ts
+++ b/lib/actions/resolveFollowFromActivity.test.ts
@@ -1,0 +1,198 @@
+import {
+  extractFollowIdCandidates,
+  extractFollowIdFromUri,
+  resolveFollowFromActivity
+} from '@/lib/actions/resolveFollowFromActivity'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { FollowStatus } from '@/lib/types/domain/follow'
+
+describe('resolveFollowFromActivity', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    await database.destroy()
+  })
+
+  describe('extractFollowIdCandidates', () => {
+    it('extracts UUID from path', () => {
+      const uuid = '01955ffb-46cb-7833-8a3c-b171f1636c2e'
+      const candidates = extractFollowIdCandidates(
+        `https://activities.local/follows/${uuid}`
+      )
+      expect(candidates).toContain(uuid)
+    })
+
+    it('extracts UUID from hash fragment', () => {
+      const uuid = '01955ffb-46cb-7833-8a3c-b171f1636c2e'
+      const candidates = extractFollowIdCandidates(
+        `https://activities.local/actors/alice#follows/${uuid}`
+      )
+      expect(candidates).toContain(uuid)
+    })
+
+    it('extracts UUID from hash fragment with trailing /undo', () => {
+      const uuid = '01955ffb-46cb-7833-8a3c-b171f1636c2e'
+      const candidates = extractFollowIdCandidates(
+        `https://activities.local/actors/alice#follows/${uuid}/undo`
+      )
+      expect(candidates).toContain(uuid)
+    })
+
+    it('filters out non-UUID tokens', () => {
+      const candidates = extractFollowIdCandidates(
+        'https://activities.local/actors/alice#follows/undo'
+      )
+      expect(candidates).toEqual([])
+    })
+
+    it('extracts from non-URL URI string if it contains a UUID', () => {
+      const uuid = '01955ffb-46cb-7833-8a3c-b171f1636c2e'
+      const candidates = extractFollowIdCandidates(`urn:follow:${uuid}`)
+      expect(candidates).toContain(uuid)
+    })
+  })
+
+  describe('extractFollowIdFromUri', () => {
+    it('returns first candidate or null', () => {
+      const uuid = '01955ffb-46cb-7833-8a3c-b171f1636c2e'
+      expect(
+        extractFollowIdFromUri(`https://activities.local/follows/${uuid}`)
+      ).toEqual(uuid)
+      expect(extractFollowIdFromUri('invalid-non-uuid')).toBeNull()
+    })
+  })
+
+  describe('resolveFollowFromActivity', () => {
+    it('resolves follow by candidate UUID when target actor matches activity.actor', async () => {
+      const targetActorId = 'https://somewhere.test/actors/test-target-1'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const resolved = await resolveFollowFromActivity({
+        activity: {
+          actor: targetActorId,
+          object: `https://llun.test/${follow.id}`
+        },
+        database,
+        recipientActorId: ACTOR1_ID
+      })
+
+      expect(resolved).toBeTruthy()
+      expect(resolved?.id).toEqual(follow.id)
+    })
+
+    it('rejects candidate UUID resolution if activity.actor does not match follow.targetActorId', async () => {
+      const targetActorId = 'https://somewhere.test/actors/test-target-2'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const resolved = await resolveFollowFromActivity({
+        activity: {
+          actor: 'https://attacker.test/actor',
+          object: `https://llun.test/${follow.id}`
+        },
+        database,
+        recipientActorId: ACTOR1_ID
+      })
+
+      expect(resolved).toBeNull()
+    })
+
+    it('resolves follow by embedded Follow object when sender matches target and recipient matches follower', async () => {
+      const targetActorId = 'https://somewhere.test/actors/test-target-3'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const resolved = await resolveFollowFromActivity({
+        activity: {
+          actor: targetActorId,
+          object: {
+            id: `https://somewhere.test/follows/follow-xyz`,
+            type: 'Follow',
+            actor: ACTOR1_ID,
+            object: targetActorId
+          }
+        },
+        database,
+        recipientActorId: ACTOR1_ID
+      })
+
+      expect(resolved).toBeTruthy()
+      expect(resolved?.id).toEqual(follow.id)
+    })
+
+    it('rejects embedded Follow object when recipientActorId does not match follow.actorId', async () => {
+      const targetActorId = 'https://somewhere.test/actors/test-target-4'
+      await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const resolved = await resolveFollowFromActivity({
+        activity: {
+          actor: targetActorId,
+          object: {
+            id: `https://somewhere.test/follows/follow-xyz2`,
+            type: 'Follow',
+            actor: ACTOR1_ID,
+            object: targetActorId
+          }
+        },
+        database,
+        recipientActorId: ACTOR2_ID
+      })
+
+      expect(resolved).toBeNull()
+    })
+
+    it('resolves follow via recipientActorId fallback when object is an arbitrary string URI', async () => {
+      const targetActorId = 'https://somewhere.test/actors/test-target-5'
+      const follow = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      const resolved = await resolveFollowFromActivity({
+        activity: {
+          actor: targetActorId,
+          object: 'https://somewhere.test/arbitrary-opaque-string'
+        },
+        database,
+        recipientActorId: ACTOR1_ID
+      })
+
+      expect(resolved).toBeTruthy()
+      expect(resolved?.id).toEqual(follow.id)
+    })
+  })
+})

--- a/lib/actions/resolveFollowFromActivity.ts
+++ b/lib/actions/resolveFollowFromActivity.ts
@@ -1,7 +1,7 @@
 import { Database } from '@/lib/database/types'
 import { FollowOrObjectRef } from '@/lib/types/activitypub/activities'
 import { Follow } from '@/lib/types/domain/follow'
-import { normalizeActorId } from '@/lib/utils/activitypub'
+import { actorIdsMatch } from '@/lib/utils/activitypub'
 
 interface ResolveFollowFromActivityParams {
   activity: {
@@ -12,27 +12,58 @@ interface ResolveFollowFromActivityParams {
   recipientActorId?: string
 }
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const UUID_GLOBAL_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+
 export const extractFollowIdCandidates = (uri: string): string[] => {
   const candidates: string[] = []
+
+  const uuidMatches = uri.match(UUID_GLOBAL_REGEX)
+  if (uuidMatches) {
+    candidates.push(...uuidMatches)
+  }
+
+  const followsMatch = uri.match(/follows\/([0-9a-fA-F-]+)/)
+  if (followsMatch && UUID_REGEX.test(followsMatch[1])) {
+    candidates.push(followsMatch[1])
+  }
+
   try {
     const url = new URL(uri)
     if (url.hash) {
       const hashSegments = url.hash.replace(/^#/, '').split('/').filter(Boolean)
+      for (const segment of hashSegments) {
+        if (UUID_REGEX.test(segment)) {
+          candidates.push(segment)
+        }
+      }
       if (hashSegments.length > 0) {
         candidates.push(hashSegments[hashSegments.length - 1])
       }
     }
     const pathSegments = url.pathname.split('/').filter(Boolean)
+    for (const segment of pathSegments) {
+      if (UUID_REGEX.test(segment)) {
+        candidates.push(segment)
+      }
+    }
     if (pathSegments.length > 0) {
       candidates.push(pathSegments[pathSegments.length - 1])
     }
   } catch {
     const segments = uri.split(/[/,#]/).filter(Boolean)
+    for (const segment of segments) {
+      if (UUID_REGEX.test(segment)) {
+        candidates.push(segment)
+      }
+    }
     if (segments.length > 0) {
       candidates.push(segments[segments.length - 1])
     }
   }
-  return [...new Set(candidates)]
+  return [...new Set(candidates)].filter((id) => UUID_REGEX.test(id))
 }
 
 export const extractFollowIdFromUri = (uri: string): string | null => {
@@ -60,16 +91,12 @@ export const resolveFollowFromActivity = async ({
     for (const candidateId of candidateIds) {
       const follow = await database.getFollowFromId({ followId: candidateId })
       if (follow) {
-        const matchesTarget =
-          !activity.actor ||
-          follow.targetActorId === activity.actor ||
-          follow.targetActorId.replace(/\/+$/, '') ===
-            activity.actor.replace(/\/+$/, '')
+        const matchesTarget = actorIdsMatch(
+          follow.targetActorId,
+          activity.actor
+        )
         const matchesRecipient =
-          !recipientActorId ||
-          follow.actorId === recipientActorId ||
-          follow.actorId.replace(/\/+$/, '') ===
-            recipientActorId.replace(/\/+$/, '')
+          !recipientActorId || actorIdsMatch(follow.actorId, recipientActorId)
 
         if (matchesTarget && matchesRecipient) {
           return follow
@@ -89,20 +116,25 @@ export const resolveFollowFromActivity = async ({
   ) {
     const actorId = activity.object.actor
     const targetActorId = activity.object.object
-    const targetMatchesSender =
-      !activity.actor ||
-      targetActorId === activity.actor ||
-      targetActorId.replace(/\/+$/, '') === activity.actor.replace(/\/+$/, '')
+    const targetMatchesSender = actorIdsMatch(targetActorId, activity.actor)
+    const matchesRecipient =
+      !recipientActorId || actorIdsMatch(actorId, recipientActorId)
 
-    if (targetMatchesSender) {
+    if (targetMatchesSender && matchesRecipient) {
+      const strippedActorId = actorId.replace(/\/+$/, '')
+      const strippedTargetActorId = targetActorId.replace(/\/+$/, '')
       const follow =
         (await database.getAcceptedOrRequestedFollow({
           actorId,
           targetActorId
         })) ??
         (await database.getAcceptedOrRequestedFollow({
-          actorId: actorId.replace(/\/+$/, ''),
-          targetActorId: targetActorId.replace(/\/+$/, '')
+          actorId: strippedActorId,
+          targetActorId: strippedTargetActorId
+        })) ??
+        (await database.getAcceptedOrRequestedFollow({
+          actorId: `${strippedActorId}/`,
+          targetActorId: `${strippedTargetActorId}/`
         }))
       if (follow) return follow
     }
@@ -111,17 +143,20 @@ export const resolveFollowFromActivity = async ({
   // Fallback: If recipientActorId (the local actor who sent the follow) is known,
   // query by (recipientActorId, activity.actor)
   if (recipientActorId) {
-    const normalizedRecipient =
-      normalizeActorId(recipientActorId) ?? recipientActorId
-    const normalizedSender = normalizeActorId(activity.actor) ?? activity.actor
+    const strippedRecipient = recipientActorId.replace(/\/+$/, '')
+    const strippedSender = activity.actor.replace(/\/+$/, '')
     const follow =
       (await database.getAcceptedOrRequestedFollow({
         actorId: recipientActorId,
         targetActorId: activity.actor
       })) ??
       (await database.getAcceptedOrRequestedFollow({
-        actorId: normalizedRecipient,
-        targetActorId: normalizedSender
+        actorId: strippedRecipient,
+        targetActorId: strippedSender
+      })) ??
+      (await database.getAcceptedOrRequestedFollow({
+        actorId: `${strippedRecipient}/`,
+        targetActorId: `${strippedSender}/`
       }))
     if (follow) return follow
   }

--- a/lib/actions/undoFollowRequest.ts
+++ b/lib/actions/undoFollowRequest.ts
@@ -2,6 +2,7 @@ import { extractFollowIdCandidates } from '@/lib/actions/resolveFollowFromActivi
 import { UndoFollow } from '@/lib/activities/undoFollow'
 import { Database } from '@/lib/database/types'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { actorIdsMatch } from '@/lib/utils/activitypub'
 
 interface UndoFollowRequestParams {
   database: Database
@@ -19,12 +20,7 @@ export const undoFollowRequest = async ({
         followId: candidateId
       })
       if (followById) {
-        if (
-          !request.actor ||
-          followById.actorId === request.actor ||
-          followById.actorId.replace(/\/+$/, '') ===
-            request.actor.replace(/\/+$/, '')
-        ) {
+        if (actorIdsMatch(followById.actorId, request.actor)) {
           if (followById.status === FollowStatus.enum.Undo) {
             return true
           }
@@ -41,16 +37,31 @@ export const undoFollowRequest = async ({
   const actorId = request.object.actor
   const targetActorId = request.object.object
 
+  if (!actorIdsMatch(request.actor, actorId)) {
+    return false
+  }
+
+  const strippedActorId = actorId.replace(/\/+$/, '')
+  const strippedTargetActorId = targetActorId.replace(/\/+$/, '')
+
   const follow =
     (await database.getAcceptedOrRequestedFollow({
       actorId,
       targetActorId
     })) ??
     (await database.getAcceptedOrRequestedFollow({
-      actorId: actorId.replace(/\/+$/, ''),
-      targetActorId: targetActorId.replace(/\/+$/, '')
+      actorId: strippedActorId,
+      targetActorId: strippedTargetActorId
+    })) ??
+    (await database.getAcceptedOrRequestedFollow({
+      actorId: `${strippedActorId}/`,
+      targetActorId: `${strippedTargetActorId}/`
     }))
   if (!follow) return false
+
+  if (follow.status === FollowStatus.enum.Undo) {
+    return true
+  }
 
   await database.updateFollowStatus({
     followId: follow.id,

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -856,7 +856,7 @@ export const acceptFollow = async (
     async (span) => {
       const activity: AcceptFollow = {
         '@context': ACTIVITY_STREAM_URL,
-        id: `${currentActor.id}#accepts/followers`,
+        id: `${currentActor.id}#accepts/followers/${crypto.randomUUID()}`,
         type: 'Accept',
         actor: currentActor.id,
         object: {
@@ -892,7 +892,7 @@ export const rejectFollow = async (
     async (span) => {
       const activity: RejectFollow = {
         '@context': ACTIVITY_STREAM_URL,
-        id: `${currentActor.id}#rejects/followers`,
+        id: `${currentActor.id}#rejects/followers/${crypto.randomUUID()}`,
         type: 'Reject',
         actor: currentActor.id,
         object: {

--- a/lib/types/activitypub/activities.ts
+++ b/lib/types/activitypub/activities.ts
@@ -63,7 +63,16 @@ export type Block = z.infer<typeof Block>
 export const FollowOrObjectRef = z.union([
   Follow,
   z
-    .object({ id: z.string(), type: z.literal(ENTITY_TYPE_FOLLOW) })
+    .object({
+      id: z.string().optional(),
+      type: z.literal(ENTITY_TYPE_FOLLOW)
+    })
+    .passthrough(),
+  z
+    .object({
+      id: z.string(),
+      type: z.undefined().optional()
+    })
     .passthrough(),
   z.string()
 ])
@@ -71,7 +80,7 @@ export type FollowOrObjectRef = z.infer<typeof FollowOrObjectRef>
 
 export const Accept = z.object({
   id: z.string(),
-  actor: z.string(),
+  actor: z.string().min(1),
   type: z.literal('Accept'),
   object: FollowOrObjectRef
 })
@@ -84,7 +93,7 @@ export type Accept = z.infer<typeof Accept>
 
 export const Reject = z.object({
   id: z.string(),
-  actor: z.string(),
+  actor: z.string().min(1),
   type: z.literal('Reject'),
   object: FollowOrObjectRef
 })

--- a/lib/utils/activitypub.ts
+++ b/lib/utils/activitypub.ts
@@ -72,6 +72,19 @@ export const isSameActivityPubOrigin = (
 export const normalizeActorId = (actorId: string | null | undefined) =>
   normalizeActivityPubUri(actorId?.split('#')[0])
 
+export const actorIdsMatch = (
+  firstActorId: string | null | undefined,
+  secondActorId: string | null | undefined
+): boolean => {
+  const normalizedFirstActorId = normalizeActorId(firstActorId)
+  const normalizedSecondActorId = normalizeActorId(secondActorId)
+
+  return (
+    Boolean(normalizedFirstActorId) &&
+    normalizedFirstActorId === normalizedSecondActorId
+  )
+}
+
 const ACTIVITY_STREAMS_NAMESPACE = 'https://www.w3.org/ns/activitystreams#'
 
 /**


### PR DESCRIPTION
## Summary
Addresses review feedback on the ActivityPub follow protocol and authorization hardening following #1778:

### Key Improvements
1. **Inbox Delivery Retry Storm Prevention (`app/api/users/[username]/inbox/route.ts`)**:
   - Inbound `Accept` and `Reject` activities now return HTTP 202 (`DEFAULT_202`) instead of 404 when the follow request is not found or already processed. This prevents remote Fediverse servers (e.g. Mastodon, Akkoma) from retrying delivery repeatedly on dropped or duplicate handshakes.
2. **Reference-Object `Undo(Follow)` Support (`app/api/users/[username]/inbox/route.ts` & `lib/types/activitypub/activities.ts`)**:
   - Supported object references `{ id: string, type?: 'Follow' }` in `Undo(Follow)` activities (sent by Lemmy, PeerTube, and NodeBB) by synthesizing actor/object context from the verified sender and recipient rather than dropping them as unsupported activities.
   - Relaxed `FollowOrObjectRef` in `lib/types/activitypub/activities.ts` to support objects with optional `id` or string URI refs while strictly rejecting non-Follow activities like `QuoteRequest`.
3. **Unique Activity URIs (`lib/activities/index.ts`)**:
   - Outbound `acceptFollow` and `rejectFollow` now append a UUID (`${currentActor.id}#accepts/followers/${crypto.randomUUID()}`), adhering to W3C ActivityPub §4.1 and preventing remote instances from deduplicating and discarding subsequent follow accepts/rejects.
4. **Authorization & Spoofing Invariants (`lib/actions/resolveFollowFromActivity.ts` & `lib/actions/undoFollowRequest.ts`)**:
   - Enforced strict sender matching against `follow.targetActorId` across candidate ID, embedded Follow object, and fallback resolution paths (removed `!activity.actor ||` bypass).
   - Enforced recipient matching (`follow.actorId === recipientActorId`) in the embedded Follow object resolution path to prevent cross-account follow injection.
   - Enforced `request.actor` matching `actorId` in `undoFollowRequest.ts`.
5. **ID Extraction & Actor Matching (`lib/actions/resolveFollowFromActivity.ts` & `lib/utils/activitypub.ts`)**:
   - Exported `actorIdsMatch` from `@/lib/utils/activitypub` for unified fragment- and host-normalized actor comparisons.
   - Extracted UUIDs globally from URIs in `extractFollowIdCandidates`, correctly extracting IDs from `#follows/<id>/undo` and `urn:` formats, and filtering to valid UUIDs.
   - Supported trailing slash variations on follow lookups.
6. **Idempotency & Logging Standards**:
   - Guarded follow notification emails on duplicate `Accept` redeliveries (`!wasAlreadyAccepted`) while preserving queue job deduplication on `#backfill`.
   - Updated caught error logging in `acceptFollowRequest.ts` to use `toLoggableError(error)` and pass `err`.
   - Updated `acceptFollowRequest` and `rejectFollowRequest` to return the updated status in memory.
7. **Test Coverage**:
   - Added unit test suite `lib/actions/resolveFollowFromActivity.test.ts`.
   - Added test coverage in `lib/actions/acceptFollowRequest.test.ts`, `lib/actions/rejectFollowRequest.test.ts`, and `app/api/users/[username]/inbox/route.test.ts`.

## Test Results
- `yarn run prettier --write .` (passed)
- `yarn lint` passed (Oxlint + custom rules, 0 errors)
- `yarn typecheck` passed (TypeScript 7 tsc CLI, 0 errors)
- `yarn build` passed (Next.js build, 0 errors)
- `yarn test` passed (958 test files, 12,906 tests passing)