### PR TITLE
Bump version to v1.158.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.10",
+  "version": "1.158.11",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.11.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.10`
- Base main SHA: `35fe1291129245aa7d72a4233798782515e71b48`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
