### PR TITLE
fix: quote in post box with full status url

### DIFF
--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -18,7 +18,7 @@ import { Attachment } from '@/lib/types/domain/attachment'
 import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
 import { resizeImage } from '@/lib/utils/resizeImage'
 
-import { PostBox } from './post-box'
+import { PostBox, getQuotePrefix, getQuoteUrl } from './post-box'
 
 vi.mock('@/lib/client', () => ({
   createNote: vi.fn(),
@@ -316,6 +316,128 @@ describe('PostBox edit media', () => {
 
     const textbox = screen.getByPlaceholderText('What is on your mind?')
     expect(textbox).toHaveValue('RE: https://activities.local/@bob/1\n\n')
+  })
+
+  it('constructs full status URL using publicId when url is not set', async () => {
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const quotedStatus = {
+      id: publicId,
+      publicId,
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue(
+      `RE: https://activities.local/@bob@activities.local/${publicId}\n\n`
+    )
+  })
+
+  it('constructs full status URL when status id is a bare UUIDv7 without url', async () => {
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const quotedStatus = {
+      id: publicId,
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    expect(textbox).toHaveValue(
+      `RE: https://activities.local/@bob@activities.local/${publicId}\n\n`
+    )
+  })
+
+  it('strips the RE: quote prefix and preserves commentary when quote with publicId URL is dismissed', async () => {
+    const onDiscardQuote = vi.fn()
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const quotedStatus = {
+      id: publicId,
+      publicId,
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={onDiscardQuote}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    fireEvent.change(textbox, {
+      target: {
+        value: `RE: https://activities.local/@bob@activities.local/${publicId}\n\nmy commentary`
+      }
+    })
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss quote' })
+    fireEvent.click(dismissButton)
+
+    expect(onDiscardQuote).toHaveBeenCalled()
+    expect(textbox).toHaveValue('my commentary')
   })
 
   it('strips the RE: quote prefix and preserves commentary when quote preview is dismissed', async () => {
@@ -1833,6 +1955,117 @@ describe('PostBox attachment ref guard', () => {
       expect.objectContaining({
         attachments: [expect.objectContaining({ name: 'a.png' })]
       })
+    )
+  })
+})
+
+describe('getQuoteUrl', () => {
+  const host = 'activities.local'
+  const actor: ActorProfile = {
+    ...profile,
+    username: 'bob',
+    domain: 'activities.local',
+    name: 'Bob'
+  }
+
+  it('prefers original.url when it is already a full absolute web URL', () => {
+    const status = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe('https://activities.local/@bob/1')
+  })
+
+  it('constructs canonical URL with publicId when original.publicId is present', () => {
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const status = {
+      id: 'https://activities.local/users/bob/statuses/internal-id',
+      publicId,
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe(
+      `https://activities.local/@bob@activities.local/${publicId}`
+    )
+  })
+
+  it('constructs canonical URL when status id is a bare UUIDv7 publicId', () => {
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const status = {
+      id: publicId,
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe(
+      `https://activities.local/@bob@activities.local/${publicId}`
+    )
+  })
+
+  it('constructs canonical URL when status id ends with a UUIDv7 publicId', () => {
+    const publicId = '01956621-4506-76f6-8653-d4233375fe51'
+    const status = {
+      id: `https://activities.local/users/bob/statuses/${publicId}`,
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe(
+      `https://activities.local/@bob@activities.local/${publicId}`
+    )
+  })
+
+  it('resolves relative path in url against host', () => {
+    const status = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: '/@bob/1',
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe('https://activities.local/@bob/1')
+  })
+
+  it('encodes remote actor status id when isLocalActor is false', () => {
+    const remoteActor: ActorProfile = {
+      ...profile,
+      username: 'charlie',
+      domain: 'remote.social',
+      name: 'Charlie'
+    }
+    const status = {
+      id: 'https://remote.social/statuses/999',
+      actor: remoteActor,
+      isLocalActor: false,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe(
+      `https://activities.local/@charlie@remote.social/${encodeURIComponent('https://remote.social/statuses/999')}`
+    )
+  })
+
+  it('falls back to /statuses/:id when actor is missing', () => {
+    const status = {
+      id: '01956621-4506-76f6-8653-d4233375fe51',
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuoteUrl(status, host)).toBe(
+      'https://activities.local/statuses/01956621-4506-76f6-8653-d4233375fe51'
+    )
+  })
+
+  it('returns empty string from getQuotePrefix when quotedStatus is undefined', () => {
+    expect(getQuotePrefix(undefined, host)).toBe('')
+  })
+
+  it('formats quote prefix with RE: and trailing double newline', () => {
+    const status = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      url: 'https://activities.local/@bob/1',
+      actor,
+      type: StatusType.enum.Note
+    } as unknown as Status
+    expect(getQuotePrefix(status, host)).toBe(
+      'RE: https://activities.local/@bob/1\n\n'
     )
   })
 })

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -55,6 +55,7 @@ import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import { cn } from '@/lib/utils'
 import { formatFileSize } from '@/lib/utils/formatFileSize'
 import { getVisibility } from '@/lib/utils/getVisibility'
+import { isPublicId } from '@/lib/utils/publicId'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
 import { processStatusTextContent } from '@/lib/utils/text/processStatusText'
@@ -164,14 +165,79 @@ const hasNewPostContent = (
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-const getQuoteUrl = (quotedStatus: Status) => {
+export const getQuoteUrl = (quotedStatus: Status, host: string): string => {
   const original = getOriginalStatus(quotedStatus)
-  return original.url || original.id
+  const resolvedHost =
+    host || (typeof window !== 'undefined' ? window.location.host : '')
+  const baseURL = (
+    resolvedHost.includes('://') ? resolvedHost : `https://${resolvedHost}`
+  ).replace(/\/+$/, '')
+
+  // 1. If original.url is already a full absolute web URL, prefer it
+  if (
+    original.url &&
+    /^https?:\/\//i.test(original.url) &&
+    !original.url.includes('/users/')
+  ) {
+    return original.url
+  }
+
+  // 2. If actor is present, construct canonical web status URL
+  if (original.actor) {
+    const idTail = original.id ? original.id.split('/').pop() : undefined
+    const urlTail = original.url ? original.url.split('/').pop() : undefined
+    const publicId =
+      original.publicId ||
+      (isPublicId(original.id) ? original.id : undefined) ||
+      (original.url && isPublicId(original.url) ? original.url : undefined) ||
+      (idTail && isPublicId(idTail) ? idTail : undefined) ||
+      (urlTail && isPublicId(urlTail) ? urlTail : undefined)
+
+    if (publicId) {
+      return `${baseURL}/${getMention(original.actor, true)}/${publicId}`
+    }
+
+    if (original.isLocalActor === false && original.id) {
+      return `${baseURL}/${getMention(original.actor, true)}/${encodeURIComponent(original.id)}`
+    }
+  }
+
+  // 3. If original.url is a full absolute URL
+  if (original.url && /^https?:\/\//i.test(original.url)) {
+    return original.url
+  }
+
+  // 4. If original.url is a relative path
+  if (original.url && original.url.startsWith('/')) {
+    return `${baseURL}${original.url}`
+  }
+
+  // 5. If original.id is a full absolute URL
+  if (original.id && /^https?:\/\//i.test(original.id)) {
+    return original.id
+  }
+
+  // 6. If original.id is a relative path
+  if (original.id && original.id.startsWith('/')) {
+    return `${baseURL}${original.id}`
+  }
+
+  // 7. If original.actor exists and we have an id or url tail
+  if (original.actor && (original.id || original.url)) {
+    const segment = original.id || original.url
+    return `${baseURL}/${getMention(original.actor, true)}/${encodeURIComponent(segment)}`
+  }
+
+  // 8. Fallback to full URL using id or url
+  const fallbackId = original.url || original.id
+  return fallbackId
+    ? `${baseURL}/statuses/${encodeURIComponent(fallbackId)}`
+    : baseURL
 }
 
-const getQuotePrefix = (quotedStatus?: Status) => {
+export const getQuotePrefix = (quotedStatus?: Status, host = ''): string => {
   if (!quotedStatus) return ''
-  return `RE: ${getQuoteUrl(quotedStatus)}\n\n`
+  return `RE: ${getQuoteUrl(quotedStatus, host)}\n\n`
 }
 
 const hasEditPostContent = (
@@ -777,7 +843,13 @@ export const PostBox: FC<Props> = ({
   const onCloseQuote = () => {
     if (quotedStatus) {
       const original = getOriginalStatus(quotedStatus)
-      const urls = [original.url, original.id].filter(Boolean) as string[]
+      const quoteUrl = getQuoteUrl(quotedStatus, host)
+      const urls = [
+        quoteUrl,
+        original.url,
+        original.id,
+        original.publicId
+      ].filter(Boolean) as string[]
       const prefixRegex = new RegExp(
         `^RE: (${urls.map(escapeRegExp).join('|')})\\s*`
       )
@@ -1017,7 +1089,7 @@ export const PostBox: FC<Props> = ({
       dispatch(setVisibility(replyVisibility))
     }
 
-    const quotePrefix = getQuotePrefix(quotedStatus)
+    const quotePrefix = getQuotePrefix(quotedStatus, host)
 
     const defaultReplyMessage =
       replyStatus && replyStatus.type === StatusType.enum.Note
@@ -1052,7 +1124,7 @@ export const PostBox: FC<Props> = ({
       }, 0)
       return
     }
-  }, [profile, replyStatus, editStatus, quotedStatus])
+  }, [profile, replyStatus, editStatus, quotedStatus, host])
 
   return (
     <div>


### PR DESCRIPTION
## Summary

Fix quote in post box to always construct a full status URL with `RE: ` instead of only inserting a bare ID or UUID.

Previously, `getQuoteUrl` fell back to `original.url || original.id`. When a status had an empty/undefined `url` and a bare UUID `id` (or `publicId`), this resulted in inserting `RE: <bare UUID>` into the compose textarea (e.g. `RE: 01956621-4506-76f6-8653-d4233375fe51\n\n`) rather than the full canonical status URL (`RE: https://<host>/@user@domain/<publicId>\n\n`).

### Changes
- Updated `getQuoteUrl(quotedStatus: Status, host: string): string` in `lib/components/post-box/post-box.tsx` to resolve the base URL and construct the canonical web status URL using `host`, actor mention, and `publicId` (or encoded remote ID / relative path resolution).
- Passed `host` into `getQuotePrefix(quotedStatus, host)` inside `PostBox`'s initialization `useEffect` and added `host` to dependencies.
- Updated `onCloseQuote` to include `quoteUrl` in the list of candidate URLs stripped when dismissing the quote preview, ensuring clean removal of the prefix while preserving commentary.
- Added unit and component tests in `lib/components/post-box/post-box.test.tsx`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)