### PR TITLE
fix: harden activitypub actor matching, reference undo schema, and follow recipient validation

### DIFF
--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -425,7 +425,8 @@ describe('POST /api/users/[username]/inbox', () => {
       followRequest: expect.objectContaining({
         actor: 'https://remote.test/users/alice',
         type: 'Follow'
-      })
+      }),
+      recipientActorId: 'https://activities.local/users/llun'
     })
   })
 
@@ -452,7 +453,36 @@ describe('POST /api/users/[username]/inbox', () => {
       followRequest: expect.objectContaining({
         actor: 'https://remote.test/users/alice',
         type: 'Follow'
-      })
+      }),
+      recipientActorId: 'https://activities.local/users/llun'
+    })
+  })
+
+  it('processes verified actor inbox Follow request when object is an embedded actor object', async () => {
+    mockActivityBody = {
+      id: 'https://remote.test/users/alice/follows/2',
+      type: 'Follow',
+      actor: 'https://remote.test/users/alice',
+      object: {
+        id: 'https://activities.local/users/llun',
+        type: 'Person'
+      }
+    }
+    mockConsumeRequestBody = true
+
+    const response = await POST(createFollowRequest(), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockCreateFollower).toHaveBeenCalledWith({
+      database: mockDatabase,
+      followRequest: expect.objectContaining({
+        actor: 'https://remote.test/users/alice',
+        type: 'Follow',
+        object: 'https://activities.local/users/llun'
+      }),
+      recipientActorId: 'https://activities.local/users/llun'
     })
   })
 
@@ -713,6 +743,45 @@ describe('POST /api/users/[username]/inbox', () => {
           object: {
             id: 'https://activities.local/follows/1',
             type: 'Follow'
+          }
+        })
+      }),
+      { params: Promise.resolve({ username: 'llun' }) }
+    )
+
+    expect(response.status).toBe(202)
+    expect(mockUndoFollowRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: mockDatabase,
+        request: expect.objectContaining({
+          type: 'Undo',
+          actor: 'https://remote.test/users/alice',
+          object: expect.objectContaining({
+            id: 'https://activities.local/follows/1',
+            actor: 'https://remote.test/users/alice',
+            object: 'https://activities.local/users/llun',
+            type: 'Follow'
+          })
+        })
+      })
+    )
+  })
+
+  it('dispatches untyped reference-object Undo of Follow to undoFollowRequest and returns 202', async () => {
+    mockApplyRemoteUnblock.mockResolvedValueOnce(null)
+    mockUndoFollowRequest.mockResolvedValueOnce(true)
+
+    const response = await POST(
+      new NextRequest('https://activities.local/api/users/llun/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: 'https://remote.test/users/alice/activities/undo-ref-obj-untyped',
+          type: 'Undo',
+          actor: 'https://remote.test/users/alice',
+          object: {
+            id: 'https://activities.local/follows/1',
+            custom: 'extra-property'
           }
         })
       }),

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -106,7 +106,8 @@ const ReferenceUndo = z
       z.string(),
       z
         .object({
-          type: z.string()
+          id: z.string().optional(),
+          type: z.string().optional()
         })
         .passthrough()
     ])
@@ -450,6 +451,7 @@ export const POST = traceApiRoute(
               case 'Follow': {
                 const follow = await createFollower({
                   followRequest: activity as FollowRequest,
+                  recipientActorId: actor.id,
                   database
                 })
                 if (!follow) {

--- a/lib/actions/acceptFollowRequest.test.ts
+++ b/lib/actions/acceptFollowRequest.test.ts
@@ -291,5 +291,38 @@ describe('Accept follow action', () => {
       expect(result?.status).toEqual(FollowStatus.enum.Accepted)
       expect(sendNotificationAlerts).not.toHaveBeenCalled()
     })
+
+    it('sets follow status to Undo and returns follow with Undo status when actors are blocking', async () => {
+      const targetActorId =
+        'https://somewhere.test/actors/request-following-blocking'
+      const followRequest = await database.createFollow({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        status: FollowStatus.enum.Requested,
+        inbox: 'https://somewhere.test/inbox',
+        sharedInbox: 'https://somewhere.test/inbox'
+      })
+
+      vi.spyOn(database, 'isEitherBlocking').mockResolvedValueOnce(true)
+
+      const activity = MockFollowRequestResponse({
+        actorId: ACTOR1_ID,
+        targetActorId,
+        followResponseStatus: 'Accept',
+        followId: followRequest.id
+      }) as AcceptFollow
+
+      const result = await acceptFollowRequest({
+        activity,
+        database
+      })
+
+      expect(result).toBeTruthy()
+      expect(result?.status).toEqual(FollowStatus.enum.Undo)
+      const updatedFollow = await database.getFollowFromId({
+        followId: followRequest.id
+      })
+      expect(updatedFollow?.status).toEqual(FollowStatus.enum.Undo)
+    })
   })
 })

--- a/lib/actions/acceptFollowRequest.ts
+++ b/lib/actions/acceptFollowRequest.ts
@@ -62,7 +62,10 @@ export const acceptFollowRequest = async ({
         })
       })
 
-    return follow
+    return {
+      ...follow,
+      status: FollowStatus.enum.Undo
+    }
   }
 
   const wasAlreadyAccepted = follow.status === FollowStatus.enum.Accepted

--- a/lib/actions/createFollower.test.ts
+++ b/lib/actions/createFollower.test.ts
@@ -173,4 +173,58 @@ describe('createFollower', () => {
     expect(follow).toEqual(request)
     expect(acceptFollow).not.toHaveBeenCalled()
   })
+
+  it('returns null if recipientActorId does not match target actor', async () => {
+    const request = MockFollowRequest({
+      actorId: 'https://another.network/users/intruder',
+      targetActorId: actor.id
+    })
+    const follow = await createFollower({
+      database,
+      followRequest: request,
+      recipientActorId: 'https://somewhere.else/users/someone-else'
+    })
+    expect(follow).toBeNull()
+  })
+
+  it('returns null if target actor has no privateKey (remote actor)', async () => {
+    vi.spyOn(database, 'getActorFromId').mockResolvedValueOnce({
+      ...actor,
+      id: 'https://remote.example.com/users/cached',
+      privateKey: ''
+    })
+    const request = MockFollowRequest({
+      actorId: 'https://another.network/users/intruder',
+      targetActorId: 'https://remote.example.com/users/cached'
+    })
+    const follow = await createFollower({
+      database,
+      followRequest: request
+    })
+    expect(follow).toBeNull()
+  })
+
+  it('accepts follow request when recipientActorId matches target actor with trailing slash', async () => {
+    getActorSettingsSpy = vi
+      .spyOn(database, 'getActorSettings')
+      .mockResolvedValueOnce({
+        iconUrl: undefined,
+        headerImageUrl: undefined,
+        followersUrl: actor.followersUrl,
+        inboxUrl: actor.inboxUrl,
+        sharedInboxUrl: actor.sharedInboxUrl,
+        manuallyApprovesFollowers: false
+      })
+
+    const request = MockFollowRequest({
+      actorId: 'https://another.network/users/trailing-recipient',
+      targetActorId: actor.id
+    })
+    const follow = await createFollower({
+      database,
+      followRequest: request,
+      recipientActorId: `${actor.id}/`
+    })
+    expect(follow).toEqual(request)
+  })
 })

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -9,13 +9,16 @@ import { followGroupKey } from '@/lib/services/notifications/followGrouping'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { NotificationType } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { actorIdsMatch } from '@/lib/utils/activitypub'
 
 interface CreateFollowerParams {
   followRequest: FollowRequest
+  recipientActorId?: string
   database: Database
 }
 export const createFollower = async ({
   followRequest,
+  recipientActorId,
   database
 }: CreateFollowerParams) => {
   let targetActor = await database.getActorFromId({
@@ -27,6 +30,14 @@ export const createFollower = async ({
     })
   }
   if (!targetActor) return null
+
+  if (recipientActorId && !actorIdsMatch(targetActor.id, recipientActorId)) {
+    return null
+  }
+
+  if (!targetActor.privateKey) {
+    return null
+  }
 
   const followerActor = await recordActorIfNeeded({
     actorId: followRequest.actor,

--- a/lib/actions/resolveFollowFromActivity.test.ts
+++ b/lib/actions/resolveFollowFromActivity.test.ts
@@ -59,6 +59,16 @@ describe('resolveFollowFromActivity', () => {
       const candidates = extractFollowIdCandidates(`urn:follow:${uuid}`)
       expect(candidates).toContain(uuid)
     })
+
+    it('caps candidate count to at most 8', () => {
+      const uuids = Array.from(
+        { length: 15 },
+        (_, i) => `01955ffb-46cb-7833-8a3c-${String(i).padStart(12, '0')}`
+      )
+      const uri = `https://activities.local/follows/${uuids.join('/')}`
+      const candidates = extractFollowIdCandidates(uri)
+      expect(candidates.length).toEqual(8)
+    })
   })
 
   describe('extractFollowIdFromUri', () => {

--- a/lib/actions/resolveFollowFromActivity.ts
+++ b/lib/actions/resolveFollowFromActivity.ts
@@ -63,7 +63,9 @@ export const extractFollowIdCandidates = (uri: string): string[] => {
       candidates.push(segments[segments.length - 1])
     }
   }
-  return [...new Set(candidates)].filter((id) => UUID_REGEX.test(id))
+  return [...new Set(candidates)]
+    .filter((id) => UUID_REGEX.test(id))
+    .slice(0, 8)
 }
 
 export const extractFollowIdFromUri = (uri: string): string | null => {

--- a/lib/types/activitypub/activities.ts
+++ b/lib/types/activitypub/activities.ts
@@ -31,7 +31,13 @@ export const Follow = z.object({
   id: z.string(),
   type: z.literal(ENTITY_TYPE_FOLLOW),
   actor: z.string(),
-  object: z.string()
+  object: z.union([
+    z.string(),
+    z
+      .object({ id: z.string() })
+      .passthrough()
+      .transform((o) => o.id)
+  ])
 })
 
 export type Follow = z.infer<typeof Follow>

--- a/lib/utils/activitypub.test.ts
+++ b/lib/utils/activitypub.test.ts
@@ -1,10 +1,12 @@
 import {
+  actorIdsMatch,
   extractActivityPubId,
   isSameActivityPubOrigin,
   normalizeActivityPubAnnounce,
   normalizeActivityPubContent,
   normalizeActivityPubRecipients,
-  normalizeActivityPubType
+  normalizeActivityPubType,
+  normalizeActorId
 } from './activitypub'
 
 describe('normalizeActivityPubType', () => {
@@ -371,5 +373,97 @@ describe('isSameActivityPubOrigin', () => {
     expect(isSameActivityPubOrigin(first, second)).toEqual(expected)
     // The question is symmetric; a caller must not have to know the order.
     expect(isSameActivityPubOrigin(second, first)).toEqual(expected)
+  })
+})
+
+describe('normalizeActorId', () => {
+  it.each([
+    {
+      description: 'strips hash fragment',
+      input: 'https://example.com/users/alice#main-key',
+      expected: 'https://example.com/users/alice'
+    },
+    {
+      description: 'strips trailing slashes from path',
+      input: 'https://example.com/users/alice/',
+      expected: 'https://example.com/users/alice'
+    },
+    {
+      description: 'strips trailing slashes and hash fragment',
+      input: 'https://example.com/users/alice/#main-key',
+      expected: 'https://example.com/users/alice'
+    },
+    {
+      description: 'normalizes origin root trailing slash',
+      input: 'https://example.com/',
+      expected: 'https://example.com'
+    },
+    {
+      description: 'lowercases scheme and host',
+      input: 'HTTPS://EXAMPLE.COM/Users/Alice',
+      expected: 'https://example.com/Users/Alice'
+    },
+    {
+      description: 'returns null for null / undefined / empty string',
+      input: null,
+      expected: null
+    },
+    {
+      description: 'returns null for blank node',
+      input: '_:b0',
+      expected: null
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(normalizeActorId(input)).toEqual(expected)
+  })
+})
+
+describe('actorIdsMatch', () => {
+  it.each([
+    {
+      description: 'matches identical URIs',
+      first: 'https://example.com/users/alice',
+      second: 'https://example.com/users/alice',
+      expected: true
+    },
+    {
+      description: 'matches URIs differing only by trailing slash',
+      first: 'https://example.com/users/alice',
+      second: 'https://example.com/users/alice/',
+      expected: true
+    },
+    {
+      description: 'matches URIs with key fragments',
+      first: 'https://example.com/users/alice#main-key',
+      second: 'https://example.com/users/alice',
+      expected: true
+    },
+    {
+      description: 'matches URIs with trailing slash and key fragments',
+      first: 'https://example.com/users/alice/#main-key',
+      second: 'https://example.com/users/alice',
+      expected: true
+    },
+    {
+      description: 'does not match different users',
+      first: 'https://example.com/users/alice',
+      second: 'https://example.com/users/bob',
+      expected: false
+    },
+    {
+      description: 'does not match different domains',
+      first: 'https://example.com/users/alice',
+      second: 'https://another.com/users/alice',
+      expected: false
+    },
+    {
+      description: 'returns false when either actor is null or undefined',
+      first: 'https://example.com/users/alice',
+      second: null,
+      expected: false
+    }
+  ])('$description', ({ first, second, expected }) => {
+    expect(actorIdsMatch(first, second)).toBe(expected)
+    expect(actorIdsMatch(second, first)).toBe(expected)
   })
 })

--- a/lib/utils/activitypub.ts
+++ b/lib/utils/activitypub.ts
@@ -69,8 +69,14 @@ export const isSameActivityPubOrigin = (
   }
 }
 
-export const normalizeActorId = (actorId: string | null | undefined) =>
-  normalizeActivityPubUri(actorId?.split('#')[0])
+export const normalizeActorId = (
+  actorId: string | null | undefined
+): string | null => {
+  const withoutFragment = actorId?.split('#')[0]
+  const normalized = normalizeActivityPubUri(withoutFragment)
+  if (!normalized) return null
+  return normalized.replace(/\/+$/, '')
+}
 
 export const actorIdsMatch = (
   firstActorId: string | null | undefined,


### PR DESCRIPTION
## Summary

Following second-round code review loops across Protocol, Security, and Standards subagents, this PR hardens ActivityPub follow/unfollow federation handling:

1. **Actor ID Trailing Slash Normalization (`lib/utils/activitypub.ts`)**:
   - Updates `normalizeActorId` to strip trailing slashes via `.replace(/\/+$/, '')`.
   - Fixes false-positive HTTP 403 `sender_actor_mismatch` on inbound `Undo(Follow)` when remote platforms (such as Meta Threads or WordPress ActivityPub) have trailing slash variations.
   - Adds unit tests in `lib/utils/activitypub.test.ts`.

2. **Reference-Object `Undo` Schema Fix (`app/api/users/[username]/inbox/route.ts`)**:
   - Updates `ReferenceUndo.object` to allow `{ id: z.string().optional(), type: z.string().optional() }.passthrough()`.
   - Prevents untyped reference objects (`{ id: "https://..." }`) from being rejected by `Activity.safeParse` as unsupported activity shapes.
   - Adds unit test in `app/api/users/[username]/inbox/route.test.ts`.

3. **AS2 Embedded Actor Object Support in `Follow` (`lib/types/activitypub/activities.ts`)**:
   - Updates `Follow.object` to accept `z.union([z.string(), z.object({ id: z.string() }).passthrough().transform(o => o.id)])`.
   - Transparently accepts AS2-compliant embedded actor objects while retaining string ID type compatibility.
   - Adds unit test in `app/api/users/[username]/inbox/route.test.ts`.

4. **Inbox Recipient & Local Actor Validation (`lib/actions/createFollower.ts`)**:
   - Passes `recipientActorId: actor.id` to `createFollower`.
   - Enforces `actorIdsMatch(targetActor.id, recipientActorId)` to prevent cross-account follow injection.
   - Enforces `Boolean(targetActor.privateKey)` to prevent following cached remote actors via local user inboxes.
   - Adds unit tests in `lib/actions/createFollower.test.ts`.

5. **Bounded Candidate ID Extraction (`lib/actions/resolveFollowFromActivity.ts`)**:
   - Limits `extractFollowIdCandidates` to `.slice(0, 8)` to prevent candidate ID database query amplification.
   - Adds unit test in `lib/actions/resolveFollowFromActivity.test.ts`.

6. **In-Memory Follow Status Consistency (`lib/actions/acceptFollowRequest.ts`)**:
   - Returns `{ ...follow, status: FollowStatus.enum.Undo }` on the mutual blocking path to match the persisted status.
   - Adds unit test in `lib/actions/acceptFollowRequest.test.ts`.

## Verification Results

Full 5-stage Definition of Done sequence passed in order:
- `yarn run prettier --write .` (exit code 0)
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (exit code 0)
- `yarn test` (958 test files passed, 12,927 tests passed)