### PR TITLE
Bump version to v1.158.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.11",
+  "version": "1.158.12",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.12.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.11`
- Base main SHA: `8a9dcd467388802afad4af951cc699eee10f90bd`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
