### PR TITLE
Bump version to v1.158.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.12",
+  "version": "1.158.13",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.13.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.12`
- Base main SHA: `611eab3ef091a527d4b432a0b0fb559c547a7eea`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
