### PR TITLE
feat: add timeline skeleton loading state

### DIFF
--- a/app/(timeline)/loading.test.tsx
+++ b/app/(timeline)/loading.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { TimelineLoading } from './loading'
+
+describe('timeline loading', () => {
+  it('renders loading timeline skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading timeline')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports TimelineLoading named component', () => {
+    render(<TimelineLoading />)
+
+    expect(screen.getByLabelText('Loading timeline')).toBeInTheDocument()
+  })
+
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    // jsdom paints no CSS so classes are the observable; every leaf <div> in
+    // this skeleton is a placeholder (containers always hold further divs),
+    // and a bare `length > 0` missed both a partial strip and a future
+    // unstyled row; the `.skeleton` definition itself is guarded by
+    // app/globals.skeleton.test.ts.
+    const { container } = render(<Loading />)
+    const leaves = Array.from(container.querySelectorAll('div')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('renders outline components for header, post composer, and timeline posts', () => {
+    const { container } = render(<Loading />)
+
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+
+    expect(screen.getByLabelText('Post composer')).toBeInTheDocument()
+    expect(screen.getByLabelText('Timeline posts')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/loading.test.tsx
+++ b/app/(timeline)/loading.test.tsx
@@ -42,8 +42,11 @@ describe('timeline loading', () => {
     const stickyHeader = container.querySelector('.sticky')
     expect(stickyHeader).toBeInTheDocument()
     expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader?.querySelector('.max-w-content')).toBeInTheDocument()
 
     expect(screen.getByLabelText('Post composer')).toBeInTheDocument()
-    expect(screen.getByLabelText('Timeline posts')).toBeInTheDocument()
+    const postsSection = screen.getByLabelText('Timeline posts')
+    expect(postsSection).toBeInTheDocument()
+    expect(postsSection.children).toHaveLength(3)
   })
 })

--- a/app/(timeline)/loading.tsx
+++ b/app/(timeline)/loading.tsx
@@ -54,7 +54,7 @@ export const TimelineLoading: FC = () => {
         className="divide-y overflow-hidden rounded-xl border bg-card shadow-sm"
       >
         {[0, 1, 2].map((index) => (
-          <div key={index} className="flex gap-3 p-4">
+          <div key={index} className="flex gap-3 px-4 py-3">
             <div className="skeleton size-10 shrink-0 rounded-full" />
             <div className="min-w-0 flex-1 space-y-2">
               <div className="flex items-center gap-2">

--- a/app/(timeline)/loading.tsx
+++ b/app/(timeline)/loading.tsx
@@ -1,0 +1,82 @@
+import { CSSProperties, FC } from 'react'
+
+const breakoutStyle: CSSProperties = {
+  marginLeft: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)',
+  marginRight: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)'
+}
+
+export const TimelineLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading timeline" className="space-y-6">
+      <div
+        className="sticky top-0 z-20 border-b bg-background/85 backdrop-blur"
+        style={breakoutStyle}
+      >
+        <div className="mx-auto max-w-content px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <div className="skeleton h-6 w-24 rounded-md" />
+              <div className="skeleton h-3.5 w-48 rounded" />
+            </div>
+            <div className="skeleton size-9 shrink-0 rounded-md" />
+          </div>
+        </div>
+      </div>
+
+      <section
+        aria-label="Post composer"
+        className="rounded-xl border bg-card p-4 shadow-sm"
+      >
+        <div className="flex items-start gap-3">
+          <div className="skeleton size-12 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-3">
+            <div className="skeleton h-16 w-full rounded-md" />
+          </div>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-y-2 border-t pt-3">
+          <div className="flex flex-wrap items-center gap-1">
+            <div className="skeleton size-8 rounded-md" />
+            <div className="skeleton size-8 rounded-md" />
+            <div className="skeleton size-8 rounded-md" />
+            <div className="skeleton size-8 rounded-md" />
+            <div className="skeleton size-8 rounded-md" />
+            <div className="skeleton size-8 rounded-md" />
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <div className="skeleton h-4 w-8 rounded" />
+            <div className="skeleton h-8 w-16 rounded-md" />
+          </div>
+        </div>
+      </section>
+
+      <section
+        aria-label="Timeline posts"
+        className="divide-y overflow-hidden rounded-xl border bg-card shadow-sm"
+      >
+        {[0, 1, 2].map((index) => (
+          <div key={index} className="flex gap-3 p-4">
+            <div className="skeleton size-10 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex items-center gap-2">
+                <div className="skeleton h-4 w-32 rounded" />
+                <div className="skeleton h-3 w-20 rounded" />
+              </div>
+              <div className="space-y-1.5">
+                <div className="skeleton h-4 w-full rounded" />
+                <div className="skeleton h-4 w-4/5 rounded" />
+              </div>
+              <div className="flex gap-6 pt-2">
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}
+
+export default TimelineLoading


### PR DESCRIPTION
## Summary

Adds an instant loading screen (`loading.tsx`) to the main Timeline route (`app/(timeline)/`), matching the outline components of `MainPageTimeline` and using the same shimmer animation utility (`.skeleton`) as the profile loading skeleton (`app/(timeline)/[actor]/loading.tsx`).

## What changed

1. **Timeline Loading Skeleton** (`app/(timeline)/loading.tsx`):
   - Exported `TimelineLoading` named and default component with `aria-busy="true"` and `aria-label="Loading timeline"`.
   - Mirrored the structure of `MainPageTimeline`:
     - **Sticky PageHeader**: Full-bleed breakout sticky header with title ("Timeline"), description ("Latest posts from your network."), and refresh button icon skeleton.
     - **Post Composer Card (`PostBox`)**: Box containing author avatar (`size-12`), textarea placeholder, and a bottom toolbar with attachment/feature icons, character counter, and submit button placeholder.
     - **Timeline Posts Feed (`Posts`)**: Framed card with divided status rows (3 post items), each showing avatar (`size-10`), author name, handle, text lines, and 4 interaction action buttons (reply, boost, like, bookmark).
   - All placeholders use the `.skeleton` shimmer CSS utility.

2. **Unit Tests** (`app/(timeline)/loading.test.tsx`):
   - Verified accessibility attributes (`aria-label="Loading timeline"`, `aria-busy="true"`).
   - Verified both named `TimelineLoading` and default export contracts.
   - Verified all leaf DOM nodes apply the `.skeleton` utility without `.animate-pulse`.
   - Verified presence of outline components and landmark accessibility regions (`Post composer`, `Timeline posts`).

## Screenshots

| Timeline Skeleton (Light) | Timeline Skeleton (Dark) |
| --- | --- |
| Verified in browser (matches PageHeader, Composer, and Feed) | Verified in browser (matches dark mode tokens) |

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)