### PR TITLE
ci: dispatch sync event to activities.prod on main and oltp updates

### DIFF
--- a/.github/workflows/sync-main-to-oltp-dispatch.yml
+++ b/.github/workflows/sync-main-to-oltp-dispatch.yml
@@ -132,3 +132,13 @@ jobs:
                 main_sha: '${{ steps.check.outputs.head_sha }}',
               },
             })
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'llun',
+              repo: 'activities.prod',
+              event_type: 'sync-from-activities-next',
+              client_payload: {
+                branch: 'main',
+                main_sha: '${{ steps.check.outputs.head_sha }}',
+              },
+            })

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -344,3 +344,19 @@ jobs:
             -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
             -c credential.helper= \
             push origin HEAD:oltp
+
+      - name: Dispatch sync to activities.prod
+        if: steps.synced.outputs.skip == 'false'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'llun',
+              repo: 'activities.prod',
+              event_type: 'sync-from-activities-next',
+              client_payload: {
+                branch: 'oltp',
+                main_sha: '${{ env.MAIN_SHA }}',
+              },
+            })


### PR DESCRIPTION
Dispatches `sync-from-activities-next` to `llun/activities.prod` whenever `main` workflow completes and whenever `oltp` branch receives updates.