### PR TITLE
ci: sync main directly to activities.prod

### DIFF
--- a/.github/workflows/sync-main-to-oltp-dispatch.yml
+++ b/.github/workflows/sync-main-to-oltp-dispatch.yml
@@ -132,13 +132,3 @@ jobs:
                 main_sha: '${{ steps.check.outputs.head_sha }}',
               },
             })
-
-            await github.rest.repos.createDispatchEvent({
-              owner: 'llun',
-              repo: 'activities.prod',
-              event_type: 'sync-from-activities-next',
-              client_payload: {
-                branch: 'main',
-                main_sha: '${{ steps.check.outputs.head_sha }}',
-              },
-            })

--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -344,19 +344,3 @@ jobs:
             -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
             -c credential.helper= \
             push origin HEAD:oltp
-
-      - name: Dispatch sync to activities.prod
-        if: steps.synced.outputs.skip == 'false'
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.PAT_TOKEN }}
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: 'llun',
-              repo: 'activities.prod',
-              event_type: 'sync-from-activities-next',
-              client_payload: {
-                branch: 'oltp',
-                main_sha: '${{ env.MAIN_SHA }}',
-              },
-            })

--- a/.github/workflows/sync-main-to-prod-dispatch.yml
+++ b/.github/workflows/sync-main-to-prod-dispatch.yml
@@ -1,0 +1,145 @@
+name: Queue Main to Activities.prod Sync
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Package
+      - CodeQL
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: queue-main-to-prod-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch Sync Runner
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required workflow results
+        id: check
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const requiredWorkflows = [
+              'CI',
+              'Package',
+              'CodeQL',
+            ]
+
+            const { owner, repo } = context.repo
+            const headSha = context.payload.workflow_run.head_sha
+            const headBranch = context.payload.workflow_run.head_branch
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner,
+                repo,
+                branch: headBranch,
+                event: 'push',
+                head_sha: headSha,
+                per_page: 100,
+              }
+            )
+
+            const latestRunsByName = new Map()
+
+            for (const run of runs) {
+              if (!requiredWorkflows.includes(run.name)) {
+                continue
+              }
+
+              const previousRun = latestRunsByName.get(run.name)
+
+              if (
+                !previousRun ||
+                run.run_attempt > previousRun.run_attempt ||
+                (
+                  run.run_attempt === previousRun.run_attempt &&
+                  new Date(run.updated_at) > new Date(previousRun.updated_at)
+                )
+              ) {
+                latestRunsByName.set(run.name, run)
+              }
+            }
+
+            const pending = []
+            const failed = []
+
+            core.summary.addHeading('Main-to-Activities.prod Sync Gate')
+            core.summary.addRaw(`Commit: \`${headSha}\`\n\n`)
+
+            for (const workflowName of requiredWorkflows) {
+              const run = latestRunsByName.get(workflowName)
+
+              if (!run) {
+                pending.push(workflowName)
+                core.summary.addRaw(`- ${workflowName}: missing\n`)
+                continue
+              }
+
+              core.summary.addRaw(
+                `- ${workflowName}: ${run.status}/${run.conclusion ?? 'n/a'} ` +
+                `(attempt ${run.run_attempt})\n`
+              )
+
+              if (run.status !== 'completed') {
+                pending.push(workflowName)
+                continue
+              }
+
+              if (run.conclusion !== 'success') {
+                failed.push(workflowName)
+              }
+            }
+
+            await core.summary.write()
+
+            if (pending.length > 0 || failed.length > 0) {
+              core.info(
+                `Skipping dispatch for ${headSha}. ` +
+                `Pending: ${pending.join(', ') || 'none'}. ` +
+                `Failed: ${failed.join(', ') || 'none'}.`
+              )
+              core.setOutput('ready', 'false')
+              return
+            }
+
+            core.setOutput('ready', 'true')
+            core.setOutput('head_sha', headSha)
+
+      - name: Dispatch sync workflow
+        if: steps.check.outputs.ready == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            // Dispatch locally to activities.next runner
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'sync-main-to-prod',
+              client_payload: {
+                main_sha: '${{ steps.check.outputs.head_sha }}',
+              },
+            })
+
+            // Also dispatch event to activities.prod
+            await github.rest.repos.createDispatchEvent({
+              owner: 'llun',
+              repo: 'activities.prod',
+              event_type: 'sync-main-to-prod',
+              client_payload: {
+                main_sha: '${{ steps.check.outputs.head_sha }}',
+              },
+            })

--- a/.github/workflows/sync-main-to-prod-dispatch.yml
+++ b/.github/workflows/sync-main-to-prod-dispatch.yml
@@ -124,20 +124,9 @@ jobs:
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
-            // Dispatch locally to activities.next runner
             await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              event_type: 'sync-main-to-prod',
-              client_payload: {
-                main_sha: '${{ steps.check.outputs.head_sha }}',
-              },
-            })
-
-            // Also dispatch event to activities.prod
-            await github.rest.repos.createDispatchEvent({
-              owner: 'llun',
-              repo: 'activities.prod',
               event_type: 'sync-main-to-prod',
               client_payload: {
                 main_sha: '${{ steps.check.outputs.head_sha }}',

--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -136,8 +136,8 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
-          # Ensure activities.next-internal oltp workflows never enter activities.prod
-          git rm -f .github/workflows/sync-main-to-oltp*.yml 2>/dev/null || true
+          # Ensure activities.next-internal sync workflows never enter activities.prod
+          git rm -f .github/workflows/sync-main-to-oltp*.yml .github/workflows/sync-main-to-prod*.yml 2>/dev/null || true
 
           mapfile -t unmerged < <(git diff --name-only --diff-filter=U)
 
@@ -171,9 +171,9 @@ jobs:
             elif [[ "$f" =~ ^\.github/workflows/deploy-infra\.yml ]]; then
               echo "Preserving activities.prod deploy-infra.yml"
               git checkout --ours "$f"
-            elif [[ "$f" =~ ^\.github/workflows/sync-from-activities-next\.yml ]]; then
-              echo "Preserving activities.prod sync workflow"
-              git checkout --ours "$f"
+            elif [[ "$f" =~ ^\.github/workflows/sync-main-to- ]]; then
+              echo "Removing activities.next-internal sync workflow: $f"
+              git rm -f "$f"
             else
               code_files+=("$f")
             fi
@@ -218,8 +218,8 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
-          # Ensure activities.next-internal oltp workflows never enter activities.prod
-          git rm -f .github/workflows/sync-main-to-oltp*.yml 2>/dev/null || true
+          # Ensure activities.next-internal sync workflows never enter activities.prod
+          git rm -f .github/workflows/sync-main-to-oltp*.yml .github/workflows/sync-main-to-prod*.yml 2>/dev/null || true
 
           yarn install --no-immutable
 

--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -1,0 +1,384 @@
+name: Sync Main to Activities.prod
+
+on:
+  repository_dispatch:
+    types:
+      - sync-main-to-prod
+  workflow_dispatch:
+    inputs:
+      main_sha:
+        description: 'Commit SHA from activities.next main to sync (defaults to latest main)'
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+
+concurrency:
+  group: sync-main-to-prod
+  cancel-in-progress: true
+
+env:
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+  MAIN_SHA: ${{ github.event.client_payload.main_sha || github.event.inputs.main_sha }}
+  PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+
+jobs:
+  sync:
+    name: Merge main into activities.prod main
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Validate environment and inputs
+        shell: bash
+        run: |
+          if [ -z "${GEMINI_API_KEY}" ]; then
+            echo "Missing secrets.GEMINI_API_KEY" >&2
+            exit 1
+          fi
+
+          if [ -z "${PAT_TOKEN}" ]; then
+            echo "Missing secrets.PAT_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Checkout activities.prod
+        uses: actions/checkout@v4
+        with:
+          repository: llun/activities.prod
+          token: ${{ secrets.PAT_TOKEN }}
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Enable corepack
+        shell: bash
+        run: corepack enable
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Fetch activities.next main
+        shell: bash
+        run: |
+          git remote add next https://github.com/llun/activities.next.git
+          git fetch --no-tags next main
+
+          if [ -z "${MAIN_SHA}" ]; then
+            RESOLVED_SHA=$(git rev-parse next/main)
+            echo "MAIN_SHA=${RESOLVED_SHA}" >> "$GITHUB_ENV"
+            echo "Resolved MAIN_SHA to latest next/main: ${RESOLVED_SHA}"
+          else
+            git rev-parse "${MAIN_SHA}^{commit}"
+            echo "Using provided MAIN_SHA: ${MAIN_SHA}"
+          fi
+
+      - name: Skip if main is already synced
+        id: synced
+        shell: bash
+        run: |
+          if git merge-base --is-ancestor "${MAIN_SHA}" HEAD; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "activities.prod is already up to date with ${MAIN_SHA}."
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+            echo "New commits to merge from activities.next."
+          fi
+
+      - name: Prepare merge state
+        id: merge_state
+        if: steps.synced.outputs.skip == 'false'
+        shell: bash
+        run: |
+          git checkout -B prod-sync main
+
+          if git merge --no-commit --no-ff "${MAIN_SHA}"; then
+            echo "Clean merge without conflicts."
+            echo "has_conflicts=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if git ls-files -u | grep -q .; then
+            echo "Merge encountered conflicts."
+            echo "has_conflicts=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "git merge failed before conflict resolution" >&2
+          exit 1
+
+      - name: Set up Python
+        if: steps.synced.outputs.skip == 'false'
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install Aider
+        if: steps.synced.outputs.skip == 'false'
+        shell: bash
+        run: pip install aider-chat
+
+      - name: Resolve merge conflicts with Gemini
+        if: steps.synced.outputs.skip == 'false' && steps.merge_state.outputs.has_conflicts == 'true'
+        timeout-minutes: 30
+        env:
+          GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
+        run: |
+          # Ensure activities.next-internal oltp workflows never enter activities.prod
+          git rm -f .github/workflows/sync-main-to-oltp*.yml 2>/dev/null || true
+
+          mapfile -t unmerged < <(git diff --name-only --diff-filter=U)
+
+          if [ ${#unmerged[@]} -eq 0 ]; then
+            echo "No unmerged files found."
+            exit 0
+          fi
+
+          echo "Conflicted files: ${unmerged[*]}"
+
+          code_files=()
+          for f in "${unmerged[@]}"; do
+            if [ "$f" = "yarn.lock" ]; then
+              echo "Reconciling yarn.lock conflict via next/main version..."
+              git checkout --theirs yarn.lock
+            elif [[ "$f" =~ ^infrastructure/ ]]; then
+              echo "Preserving activities.prod infrastructure file: $f"
+              git checkout --ours "$f"
+            elif [ "$f" = ".gitignore" ]; then
+              echo "Preserving activities.prod .gitignore"
+              git checkout --ours .gitignore
+            elif [ "$f" = ".dockerignore" ]; then
+              echo "Preserving activities.prod .dockerignore"
+              git checkout --ours .dockerignore
+            elif [ "$f" = "cloudbuild.yaml" ]; then
+              echo "Preserving activities.prod cloudbuild.yaml"
+              git checkout --ours cloudbuild.yaml
+            elif [[ "$f" =~ ^\.github/workflows/deploy-gcp\.yml ]]; then
+              echo "Preserving activities.prod deploy-gcp.yml"
+              git checkout --ours "$f"
+            elif [[ "$f" =~ ^\.github/workflows/deploy-infra\.yml ]]; then
+              echo "Preserving activities.prod deploy-infra.yml"
+              git checkout --ours "$f"
+            elif [[ "$f" =~ ^\.github/workflows/sync-from-activities-next\.yml ]]; then
+              echo "Preserving activities.prod sync workflow"
+              git checkout --ours "$f"
+            else
+              code_files+=("$f")
+            fi
+          done
+
+          if [ ${#code_files[@]} -gt 0 ]; then
+            echo "Resolving code conflicts with Gemini: ${code_files[*]}"
+            python3 .github/scripts/resolve-merge-conflicts.py "${code_files[@]}"
+
+            for f in "${code_files[@]}"; do
+              if grep -qE '^(<{7}|={7}|>{7})' "$f"; then
+                echo "::error::Conflict markers still remain in $f after Gemini resolution" >&2
+                exit 1
+              fi
+            done
+
+            git add "${code_files[@]}"
+          fi
+
+          yarn install --no-immutable
+          git add yarn.lock
+
+      - name: Verify merge is still pending
+        if: steps.synced.outputs.skip == 'false'
+        shell: bash
+        run: |
+          if git ls-files -u | grep -q .; then
+            echo "Unmerged files remain after conflict resolution" >&2
+            git status --short
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify MERGE_HEAD >/dev/null; then
+            echo "Expected an uncommitted merge, but MERGE_HEAD is missing" >&2
+            git status --short
+            exit 1
+          fi
+
+      - name: Validate and heal merge state
+        if: steps.synced.outputs.skip == 'false'
+        timeout-minutes: 30
+        env:
+          GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
+        run: |
+          # Ensure activities.next-internal oltp workflows never enter activities.prod
+          git rm -f .github/workflows/sync-main-to-oltp*.yml 2>/dev/null || true
+
+          yarn install --no-immutable
+
+          heal_attempts=2
+          for attempt in $(seq 1 $heal_attempts); do
+            echo "Validating merge state (attempt ${attempt}/${heal_attempts})..."
+
+            yarn run prettier --write .
+            git add -u
+
+            lint_error=""
+            if ! lint_out=$(yarn lint 2>&1); then
+              echo "Lint check failed on attempt $attempt:"
+              echo "$lint_out"
+              lint_error="$lint_out"
+            fi
+
+            if [ -n "$lint_error" ]; then
+              if [ "$attempt" -lt "$heal_attempts" ]; then
+                echo "Attempting to fix lint errors with Gemini..."
+                mapfile -t changed_files < <(git diff --name-only origin/main)
+                target_files=()
+                for cf in "${changed_files[@]}"; do
+                  if [[ "$cf" =~ \.(ts|tsx|js|mjs|cjs|json)$ && "$cf" != "yarn.lock" && -f "$cf" ]]; then
+                    target_files+=("$cf")
+                  fi
+                done
+
+                if [ ${#target_files[@]} -gt 0 ]; then
+                  aider \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
+                    --no-auto-commits \
+                    --yes \
+                    --message "Fix the following lint errors according to AGENTS.md:
+          ${lint_error}" \
+                    "${target_files[@]}"
+                  yarn run prettier --write .
+                  git add -u
+                fi
+                continue
+              else
+                echo "::error::Lint check failed after healing attempts" >&2
+                exit 1
+              fi
+            fi
+
+            typecheck_error=""
+            if ! typecheck_out=$(yarn typecheck 2>&1); then
+              echo "Type check failed on attempt $attempt:"
+              echo "$typecheck_out"
+              typecheck_error="$typecheck_out"
+            fi
+
+            if [ -n "$typecheck_error" ]; then
+              if [ "$attempt" -lt "$heal_attempts" ]; then
+                echo "Attempting to fix typecheck errors with Gemini..."
+                mapfile -t changed_files < <(git diff --name-only origin/main)
+                target_files=()
+                for cf in "${changed_files[@]}"; do
+                  if [[ "$cf" =~ \.(ts|tsx|js|mjs|cjs|json)$ && "$cf" != "yarn.lock" && -f "$cf" ]]; then
+                    target_files+=("$cf")
+                  fi
+                done
+
+                if [ ${#target_files[@]} -gt 0 ]; then
+                  aider \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
+                    --no-auto-commits \
+                    --yes \
+                    --message "Fix the following TypeScript typecheck errors according to AGENTS.md:
+          ${typecheck_error}" \
+                    "${target_files[@]}"
+                  yarn run prettier --write .
+                  git add -u
+                fi
+                continue
+              else
+                echo "::error::Type check failed after healing attempts" >&2
+                exit 1
+              fi
+            fi
+
+            build_error=""
+            if ! build_out=$(BUILD_STANDALONE=true yarn build 2>&1); then
+              echo "Build failed on attempt $attempt:"
+              echo "$build_out"
+              build_error="$build_out"
+            fi
+
+            if [ -n "$build_error" ]; then
+              if [ "$attempt" -lt "$heal_attempts" ]; then
+                echo "Attempting to fix build errors with Gemini..."
+                mapfile -t changed_files < <(git diff --name-only origin/main)
+                target_files=()
+                for cf in "${changed_files[@]}"; do
+                  if [[ "$cf" =~ \.(ts|tsx|js|mjs|cjs|json)$ && "$cf" != "yarn.lock" && -f "$cf" ]]; then
+                    target_files+=("$cf")
+                  fi
+                done
+
+                if [ ${#target_files[@]} -gt 0 ]; then
+                  aider \
+                    --model gemini/gemini-3.8-flash \
+                    --model-metadata-file .github/aider/model-metadata.json \
+                    --model-settings-file .github/aider/model-settings.yml \
+                    --no-show-model-warnings \
+                    --no-auto-commits \
+                    --yes \
+                    --message "Fix the following build errors according to AGENTS.md:
+          ${build_error}" \
+                    "${target_files[@]}"
+                  yarn run prettier --write .
+                  git add -u
+                fi
+                continue
+              else
+                echo "::error::Build failed after healing attempts" >&2
+                exit 1
+              fi
+            fi
+
+            echo "All validations passed successfully."
+            break
+          done
+
+      - name: Create merge commit
+        if: steps.synced.outputs.skip == 'false'
+        shell: bash
+        run: |
+          git add -A
+          git commit \
+            -m "chore: sync main from activities.next (${MAIN_SHA})"
+
+      - name: Push to activities.prod main
+        if: steps.synced.outputs.skip == 'false'
+        shell: bash
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          if [ -z "${PAT_TOKEN}" ]; then
+            echo "Missing secrets.PAT_TOKEN" >&2
+            exit 1
+          fi
+
+          if [[ "${PAT_TOKEN}" == *$'\r'* || "${PAT_TOKEN}" == *$'\n'* ]]; then
+            echo "secrets.PAT_TOKEN must not contain line breaks" >&2
+            exit 1
+          fi
+
+          auth_header="$(printf 'x-access-token:%s' "${PAT_TOKEN}" | base64 -w 0)"
+          echo "::add-mask::${auth_header}"
+
+          git \
+            -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+            -c credential.helper= \
+            push origin HEAD:main


### PR DESCRIPTION
### Summary

Replicates the automated main-to-oltp sync workflow pattern in activities.next to sync activities.next main directly to activities.prod (repo llun/activities.prod), without relying on or tracking the oltp branch.

### Workflows Added
1. `.github/workflows/sync-main-to-prod-dispatch.yml`: Listens for completion of CI, Package, and CodeQL workflows on main; dispatches `sync-main-to-prod` event once all required checks succeed.
2. `.github/workflows/sync-main-to-prod.yml`: Receives `sync-main-to-prod` dispatch, checks out `llun/activities.prod` main, merges `activities.next` main, handles merge conflicts using Gemini (preserving production infrastructure and gitignore), validates the build, and pushes directly to `llun/activities.prod` main using PAT_TOKEN.