### PR TITLE
fix(ci): set persist-credentials false in sync-main-to-prod

### DIFF
--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -46,13 +46,13 @@ jobs:
           fi
 
       - name: Checkout activities.prod
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: llun/activities.prod
           token: ${{ secrets.PAT_TOKEN }}
           ref: main
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Enable corepack
         shell: bash


### PR DESCRIPTION
Sets `persist-credentials: false` on `actions/checkout@v7` in `sync-main-to-prod.yml`. This prevents `actions/checkout` from injecting an Authorization header into `.git/config`, which caused a fatal `remote: Duplicate header: Authorization (HTTP 400)` error when pushing to `llun/activities.prod` via custom authorization header.