### PR TITLE
fix(ci): use --ignore-unmatch to reliably strip internal workflows in sync-main-to-prod

### DIFF
--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -137,7 +137,7 @@ jobs:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
           # Ensure activities.next-internal sync workflows never enter activities.prod
-          git rm -f .github/workflows/sync-main-to-oltp*.yml .github/workflows/sync-main-to-prod*.yml 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
 
           mapfile -t unmerged < <(git diff --name-only --diff-filter=U)
 
@@ -173,7 +173,7 @@ jobs:
               git checkout --ours "$f"
             elif [[ "$f" =~ ^\.github/workflows/sync-main-to- ]]; then
               echo "Removing activities.next-internal sync workflow: $f"
-              git rm -f "$f"
+              git rm -f --ignore-unmatch "$f" 2>/dev/null || true
             else
               code_files+=("$f")
             fi
@@ -219,7 +219,7 @@ jobs:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
           # Ensure activities.next-internal sync workflows never enter activities.prod
-          git rm -f .github/workflows/sync-main-to-oltp*.yml .github/workflows/sync-main-to-prod*.yml 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
 
           yarn install --no-immutable
 
@@ -355,6 +355,7 @@ jobs:
         if: steps.synced.outputs.skip == 'false'
         shell: bash
         run: |
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
           git add -A
           git commit \
             -m "chore: sync main from activities.next (${MAIN_SHA})"


### PR DESCRIPTION
Uses `git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*'` so git safely removes all internal sync workflows without erroring on unmatched arguments, ensuring no `sync-main-to-*` files enter `activities.prod`.