### PR TITLE
Bump version to v1.158.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.14",
+  "version": "1.158.15",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.15.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.14`
- Base main SHA: `ca23c3556272da34fddb57c4cfcfbed4acf2da12`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
