### PR TITLE
ci: exclude package, deploy-infra, and cloudbuild workflows when syncing to activities.prod

### DIFF
--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -136,8 +136,8 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
-          # Ensure activities.next-internal sync workflows never enter activities.prod
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
+          # Ensure activities.next-internal sync workflows and unwanted workflows never enter activities.prod
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
 
           mapfile -t unmerged < <(git diff --name-only --diff-filter=U)
 
@@ -168,11 +168,8 @@ jobs:
             elif [[ "$f" =~ ^\.github/workflows/deploy-gcp\.yml ]]; then
               echo "Preserving activities.prod deploy-gcp.yml"
               git checkout --ours "$f"
-            elif [[ "$f" =~ ^\.github/workflows/deploy-infra\.yml ]]; then
-              echo "Preserving activities.prod deploy-infra.yml"
-              git checkout --ours "$f"
-            elif [[ "$f" =~ ^\.github/workflows/sync-main-to- ]]; then
-              echo "Removing activities.next-internal sync workflow: $f"
+            elif [[ "$f" =~ ^\.github/workflows/(sync-main-to-|package\.yml|deploy-infra\.yml|cloudbuild\.yml) ]]; then
+              echo "Removing unwanted workflow from activities.prod: $f"
               git rm -f --ignore-unmatch "$f" 2>/dev/null || true
             else
               code_files+=("$f")
@@ -218,8 +215,8 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
-          # Ensure activities.next-internal sync workflows never enter activities.prod
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
+          # Ensure activities.next-internal sync workflows and unwanted workflows never enter activities.prod
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
 
           yarn install --no-immutable
 
@@ -355,7 +352,7 @@ jobs:
         if: steps.synced.outputs.skip == 'false'
         shell: bash
         run: |
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
           git add -A
           git commit \
             -m "chore: sync main from activities.next (${MAIN_SHA})"


### PR DESCRIPTION
Ensure unwanted workflows (Docker Hub / GHCR packaging, automated infra deployment, and redundant Cloud Build triggers) are stripped and never resurrected when syncing main from activities.next to activities.prod.