### PR TITLE
fix(ci): drain tag stream with sed in version bump to prevent SIGPIPE

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -35,7 +35,7 @@ jobs:
             exit 0
           fi
 
-          NEW_VERSION=$(echo "$HEAD_MSG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+          NEW_VERSION=$(echo "$HEAD_MSG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sed -n '1p')
 
           if [ -z "$NEW_VERSION" ]; then
             echo "Could not extract version, skipping."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -117,7 +117,7 @@ jobs:
 
           git checkout --detach "$BASE_SHA"
 
-          LATEST_TAG=$(git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname | head -n 1)
+          LATEST_TAG=$(git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname | sed -n '1p')
 
           if [ -z "$LATEST_TAG" ]; then
             echo "No existing version tag found. Will create v1.0.0."


### PR DESCRIPTION
## Summary

Fixes the `Version Bump` workflow failure on `main` that failed for the last two commits with exit code 141 (`SIGPIPE`).

### Root Cause
Under `set -euo pipefail` in `.github/workflows/version-bump.yml`:
```bash
LATEST_TAG=$(git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname | head -n 1)
```
`git tag` outputs all reachable tags (490+ tags in the repository). `head -n 1` reads the first line and immediately terminates, closing the pipe. When `git tag` subsequently attempts to write to the closed pipe, the kernel sends `SIGPIPE` (signal 13), causing `git tag` to exit with status 141 (128 + 13). Because `set -o pipefail` is enabled, the pipeline reports 141 and bash aborts the step.

### Fix
Replace `head -n 1` with `sed -n '1p'` in `.github/workflows/version-bump.yml` (and `.github/workflows/tag-version.yml`):
- `sed -n '1p'` outputs only the first line while continuing to consume the rest of the stream to EOF without closing the pipe prematurely.
- `git tag` completes writing and exits cleanly with code 0, while any real errors from `git tag` still propagate under `pipefail`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)