### PR TITLE
Bump version to v1.158.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.15",
+  "version": "1.158.16",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.158.16.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.158.15`
- Base main SHA: `c70634cfba79b5cbc72ff96cd8fa0787612f9998`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
