### PR TITLE
ci: exclude codeql, tag-version, and version-bump workflows in prod sync

### DIFF
--- a/.github/workflows/sync-main-to-prod.yml
+++ b/.github/workflows/sync-main-to-prod.yml
@@ -137,7 +137,7 @@ jobs:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
           # Ensure activities.next-internal sync workflows and unwanted workflows never enter activities.prod
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' '.github/workflows/codeql.yml' '.github/workflows/tag-version.yml' '.github/workflows/version-bump.yml' 2>/dev/null || true
 
           mapfile -t unmerged < <(git diff --name-only --diff-filter=U)
 
@@ -168,7 +168,7 @@ jobs:
             elif [[ "$f" =~ ^\.github/workflows/deploy-gcp\.yml ]]; then
               echo "Preserving activities.prod deploy-gcp.yml"
               git checkout --ours "$f"
-            elif [[ "$f" =~ ^\.github/workflows/(sync-main-to-|package\.yml|deploy-infra\.yml|cloudbuild\.yml) ]]; then
+            elif [[ "$f" =~ ^\.github/workflows/(sync-main-to-|package\.yml|deploy-infra\.yml|cloudbuild\.yml|codeql\.yml|tag-version\.yml|version-bump\.yml) ]]; then
               echo "Removing unwanted workflow from activities.prod: $f"
               git rm -f --ignore-unmatch "$f" 2>/dev/null || true
             else
@@ -216,7 +216,7 @@ jobs:
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
           # Ensure activities.next-internal sync workflows and unwanted workflows never enter activities.prod
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' '.github/workflows/codeql.yml' '.github/workflows/tag-version.yml' '.github/workflows/version-bump.yml' 2>/dev/null || true
 
           yarn install --no-immutable
 
@@ -352,7 +352,7 @@ jobs:
         if: steps.synced.outputs.skip == 'false'
         shell: bash
         run: |
-          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' 2>/dev/null || true
+          git rm -f --ignore-unmatch '.github/workflows/sync-main-to-*' '.github/workflows/package.yml' '.github/workflows/cloudbuild.yml' '.github/workflows/deploy-infra.yml' '.github/workflows/codeql.yml' '.github/workflows/tag-version.yml' '.github/workflows/version-bump.yml' 2>/dev/null || true
           git add -A
           git commit \
             -m "chore: sync main from activities.next (${MAIN_SHA})"


### PR DESCRIPTION
## Summary

Exclude `.github/workflows/codeql.yml`, `.github/workflows/tag-version.yml`, and `.github/workflows/version-bump.yml` from being synced into `activities.prod` and prevent them from being resurrected during automated merges.

### Background
- In `activities.prod`, release version bumps and tags are managed in `activities.next` and synced via merge commits. Running `version-bump.yml` in `activities.prod` fails on every push to `main` due to missing `PAT_TOKEN`, and `tag-version.yml` is redundant.
- `codeql.yml` fails on `activities.prod` because it is a private repository without GitHub Advanced Security / Code Scanning licensing.
- These workflow files are now stripped alongside `package.yml`, `cloudbuild.yml`, and `deploy-infra.yml` during git merge conflict resolution, healing, and merge commit creation steps in `.github/workflows/sync-main-to-prod.yml`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: no docs affected
- [x] If migrations changed: no migrations changed
- [x] `version` in `package.json` is untouched
- [x] No production or operational SQL in this description