### PR TITLE
feat: add loading skeleton for favorites page

### DIFF
--- a/app/(timeline)/favorites/loading.test.tsx
+++ b/app/(timeline)/favorites/loading.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import Loading, { FavoritesLoading } from './loading'
+
+describe('favorites loading', () => {
+  it('renders loading favorites skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading favorites')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports FavoritesLoading named component', () => {
+    render(<FavoritesLoading />)
+
+    expect(screen.getByLabelText('Loading favorites')).toBeInTheDocument()
+  })
+
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+    const leaves = Array.from(container.querySelectorAll('div, span')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('renders outline components for header and favorite posts without composer or header action', () => {
+    const { container } = render(<Loading />)
+
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader?.querySelector('.max-w-content')).toBeInTheDocument()
+
+    // Skeletons in the header mirror PageHeader font metrics (text-xl 28px -> h-7, text-xs 16px -> h-4)
+    expect(stickyHeader?.querySelector('h1 .skeleton')).toHaveClass('h-7')
+    expect(stickyHeader?.querySelector('h1 + div .skeleton')).toHaveClass('h-4')
+    // No action button in header
+    expect(stickyHeader?.querySelector('.shrink-0')).toBeNull()
+
+    // No post composer on favorites page
+    expect(screen.queryByLabelText('Post composer')).toBeNull()
+
+    // Favorite posts section
+    const postsSection = screen.getByLabelText('Favorite posts')
+    expect(postsSection).toBeInTheDocument()
+    expect(postsSection.children).toHaveLength(3)
+  })
+})

--- a/app/(timeline)/favorites/loading.tsx
+++ b/app/(timeline)/favorites/loading.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+
+export const FavoritesLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading favorites" className="space-y-6">
+      <PageHeader
+        title={<span className="skeleton block h-7 w-24 rounded-md" />}
+        description={<span className="skeleton block h-4 w-48 rounded" />}
+      />
+
+      <section
+        aria-label="Favorite posts"
+        className="divide-y overflow-hidden rounded-xl border bg-card shadow-sm"
+      >
+        {[0, 1, 2].map((index) => (
+          <div key={index} className="flex gap-3 px-4 py-3">
+            <div className="skeleton size-10 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex items-center gap-2">
+                <div className="skeleton h-4 w-32 rounded" />
+                <div className="skeleton h-3 w-20 rounded" />
+              </div>
+              <div className="space-y-1.5">
+                <div className="skeleton h-4 w-full rounded" />
+                <div className="skeleton h-4 w-4/5 rounded" />
+              </div>
+              <div className="flex gap-6 pt-2">
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+                <div className="skeleton h-4 w-8 rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}
+
+export default FavoritesLoading


### PR DESCRIPTION
## Summary

Adds a loading skeleton screen for the `/favorites` route (`app/(timeline)/favorites/loading.tsx`) that matches the layout and style of the timeline loading screen and the favorites page.

- Uses `PageHeader` directly to mirror the exact sticky chrome, font metrics (`h-7` for "Favorites" title, `h-4` for "Posts you have favorited" description), and breakout styling.
- Omits header action buttons because the favorites page has no action button in its header.
- Omits the post composer section because favorites does not include a post composer.
- Renders a divided card feed (`section.divide-y.overflow-hidden.rounded-xl.border.bg-card.shadow-sm`) with 3 post skeleton items (avatar, handle, content lines, action buttons).
- Uses `.skeleton` shimmer utility class across all placeholders.

## Changes

- `app/(timeline)/favorites/loading.tsx`: New `FavoritesLoading` component (default and named export) scoped to the favorites route.
- `app/(timeline)/favorites/loading.test.tsx`: Tests verifying accessibility (`aria-busy="true"`, `aria-label="Loading favorites"`), named & default exports, `.skeleton` utility usage on all placeholders, and outline components matching header and posts without composer or header actions.

## Screenshots

Verified in real browser via Playwright:
- Loading skeleton matches page layout with sticky header and card feed of post skeletons.
- Zero layout shift between skeleton and loaded favorites container.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)