### PR TITLE
Bump version to v1.159.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.158.17",
+  "version": "1.159.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.159.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.158.17`
- Base main SHA: `49f42593e2b7b585769e900c41b9bb55726d2362`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
