### PR TITLE
fix: resolve @google-cloud/tasks module in standalone docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,12 @@ COPY --from=build --chown=app:app /opt/activities.next/data.sqlite /opt/activiti
 # the image. Without it the instrumentation hook fails to load and every
 # request 500s. Re-copy the full sharp install so the .node binary and its
 # sibling libvips .so ship together with their original layout intact.
+# Similarly, @google-cloud/tasks dynamically requires protos/protos.json and
+# configuration files via json-helper.cjs which the standalone tracer misses.
+# Re-copy it as a guaranteed fallback.
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/sharp /opt/activities.next/node_modules/sharp
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/@img /opt/activities.next/node_modules/@img
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/@google-cloud/tasks /opt/activities.next/node_modules/@google-cloud/tasks
 RUN rm -rf /opt/activities.next/.yarn
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -113,6 +113,18 @@ describe('next config runtime isolation', () => {
     ])
   })
 
+  it('includes required standalone packages in outputFileTracingIncludes', async () => {
+    const { default: loadedNextConfig } = await loadNextConfig()
+
+    expect(loadedNextConfig.outputFileTracingIncludes?.['/**/*']).toEqual(
+      expect.arrayContaining([
+        './node_modules/sharp/**/*',
+        './node_modules/@img/**/*',
+        './node_modules/@google-cloud/tasks/**/*'
+      ])
+    )
+  })
+
   it('does not reference ACTIVITIES runtime variables in next config source', () => {
     expect(
       fs.readFileSync(path.join(originalCwd, 'next.config.ts'), 'utf-8')

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,8 +36,14 @@ const nextConfig: NextConfig = {
   // which "node_modules/sharp/**" also covers) into the trace. The Dockerfile
   // re-copies these as a guaranteed fallback in case hoisting or glob matching
   // ever changes.
+  // Similarly, @google-cloud/tasks dynamically loads protos/protos.json and
+  // client configs via json-helper.cjs which @vercel/nft misses.
   outputFileTracingIncludes: {
-    '/**/*': ['./node_modules/sharp/**/*', './node_modules/@img/**/*']
+    '/**/*': [
+      './node_modules/sharp/**/*',
+      './node_modules/@img/**/*',
+      './node_modules/@google-cloud/tasks/**/*'
+    ]
   },
   assetPrefix: '/activities',
   allowedDevOrigins:


### PR DESCRIPTION
## Summary
Fixes a `MODULE_NOT_FOUND` runtime error when starting the application in Docker/Cloud Run after adding `@google-cloud/tasks`.

### Cause
`@google-cloud/tasks` dynamically requires `build/protos/protos.json` and client configs via `json-helper.cjs`. During `next build` with `output: 'standalone'`, `@vercel/nft` cannot statically resolve this dynamic `require()` call, causing `protos.json` to be omitted from `.next/standalone/node_modules/@google-cloud/tasks`. When the Docker image booted, loading `@google-cloud/tasks` during server initialization failed with:
```
Cannot find module '/opt/activities.next/node_modules/@google-cloud/tasks/build/protos/protos.json'
```

### Changes
- Updated `next.config.ts`: Added `'./node_modules/@google-cloud/tasks/**/*'` to `outputFileTracingIncludes['/**/*']` so that standalone file tracing includes all JSON configs and protos.
- Updated `Dockerfile`: Added `COPY --from=build --chown=app:app /opt/activities.next/node_modules/@google-cloud/tasks /opt/activities.next/node_modules/@google-cloud/tasks` to the `output` stage as a guaranteed fallback.
- Updated `next.config.test.ts`: Added test asserting that `outputFileTracingIncludes` covers `@google-cloud/tasks`.

## Test Results
- Verified that `BUILD_STANDALONE=true yarn build` packages `protos.json` and client configs into `.next/standalone`, allowing `CloudTasksClient` to initialize successfully in standalone mode.
- Full verification suite passed:
  - `yarn prettier:check`
  - `yarn lint`
  - `yarn typecheck`
  - `yarn build`
  - `yarn test` (962 files, 12,968 tests passed)