### PR TITLE
feat(oltp): focus qstash and postgresql workspaces in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG UID="1001"
 ARG GID="1001"
 ARG ACTIVITIES_HOST="localhost"
 ARG ACTIVITIES_DATABASE_TYPE="knex"
-ARG ACTIVITIES_DATABASE_CLIENT="better-sqlite3"
+ARG ACTIVITIES_DATABASE_CLIENT="pg"
 ARG ACTIVITIES_DATABASE_SQLITE_FILENAME="/opt/activities.next/data.sqlite"
 ENV ACTIVITIES_HOST=${ACTIVITIES_HOST}
 ENV ACTIVITIES_DATABASE_TYPE=${ACTIVITIES_DATABASE_TYPE}
@@ -28,12 +28,12 @@ WORKDIR /opt/activities.next
 USER app
 
 FROM base AS build
-ARG WORKSPACES="activities.next"
+ARG WORKSPACES="activities.next @activities/pg @activities/qstash"
 ADD --chown=app:app . /opt/activities.next/
 RUN yarn config set -H enableGlobalCache true
 RUN yarn workspaces focus ${WORKSPACES}
 RUN yarn dedupe
-RUN ACTIVITIES_SECRET_PHASE=build-placeholder yarn knex migrate:latest --disable-transactions
+RUN if [ "$ACTIVITIES_DATABASE_CLIENT" = "better-sqlite3" ] || [ "$ACTIVITIES_DATABASE_CLIENT" = "sqlite3" ]; then ACTIVITIES_SECRET_PHASE=build-placeholder yarn knex migrate:latest --disable-transactions; else touch /opt/activities.next/data.sqlite; fi
 RUN ACTIVITIES_SECRET_PHASE=build-placeholder BUILD_STANDALONE=true yarn build
 
 FROM base AS output
@@ -51,6 +51,7 @@ COPY --from=build --chown=app:app /opt/activities.next/data.sqlite /opt/activiti
 # sibling libvips .so ship together with their original layout intact.
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/sharp /opt/activities.next/node_modules/sharp
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/@img /opt/activities.next/node_modules/@img
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/@upstash /opt/activities.next/node_modules/@upstash
 RUN rm -rf /opt/activities.next/.yarn
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,11 @@ COPY --from=build --chown=app:app /opt/activities.next/data.sqlite /opt/activiti
 # sibling libvips .so ship together with their original layout intact.
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/sharp /opt/activities.next/node_modules/sharp
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/@img /opt/activities.next/node_modules/@img
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/pg /opt/activities.next/node_modules/pg
 COPY --from=build --chown=app:app /opt/activities.next/node_modules/@upstash /opt/activities.next/node_modules/@upstash
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/crypto-js /opt/activities.next/node_modules/crypto-js
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/jose /opt/activities.next/node_modules/jose
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/neverthrow /opt/activities.next/node_modules/neverthrow
 RUN rm -rf /opt/activities.next/.yarn
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

Focus `@activities/pg` and `@activities/qstash` workspace packages in the Docker build for the OLTP deployment branch, configuring default PostgreSQL database client and QStash support while keeping minimal cloud tasks dependencies out.

Key changes:
- Merged modular workspace changes from `modular_dependency_grouping_strategy` (`packages/*`).
- Set default `ARG ACTIVITIES_DATABASE_CLIENT="pg"` in `Dockerfile`.
- Set `ARG WORKSPACES="activities.next @activities/pg @activities/qstash"` to bundle PostgreSQL driver (`pg`) and QStash (`@upstash/qstash`).
- Added conditional check for SQLite migration during docker build, creating placeholder SQLite database when targeting Postgres so build passes in isolated environments without live DB server.
- Copied full runtime dependencies (`pg`, `@upstash`, `crypto-js`, `jose`, `neverthrow`) into output stage image for complete runtime availability of dynamically imported QStash and PostgreSQL clients.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)