### PR TITLE
Bump version to v1.159.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.159.0",
+  "version": "1.159.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.159.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.159.0`
- Base main SHA: `05ea927fdc7c57aa79b41c86c3cbb37687c9e3f3`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
