### PR TITLE
Bump version to v1.160.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.159.1",
+  "version": "1.160.0",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.160.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.159.1`
- Base main SHA: `003479740244315a10cf2e0e259ee19fe7ed8671`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
