### PR TITLE
Bump version to v1.160.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.160.0",
+  "version": "1.160.1",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.160.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.160.0`
- Base main SHA: `93ebecc4daf79d2cad10e8a7e3dcda4df0ca94f7`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
