### PR TITLE
feat: add skeleton loading screen to search page

### DIFF
--- a/app/(timeline)/search/loading.test.tsx
+++ b/app/(timeline)/search/loading.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import Loading, { SearchLoading } from './loading'
+
+describe('search loading', () => {
+  it('renders loading search skeleton with accessibility attributes', () => {
+    render(<Loading />)
+
+    const loadingRegion = screen.getByLabelText('Loading search')
+    expect(loadingRegion).toBeInTheDocument()
+    expect(loadingRegion).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('exports SearchLoading named component', () => {
+    render(<SearchLoading />)
+
+    expect(screen.getByLabelText('Loading search')).toBeInTheDocument()
+  })
+
+  it('renders every placeholder with the shimmer skeleton utility', () => {
+    const { container } = render(<Loading />)
+    const leaves = Array.from(container.querySelectorAll('div, span')).filter(
+      (el) => el.children.length === 0
+    )
+    expect(leaves.length).toBeGreaterThan(0)
+    leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('renders outline components for header, search form, search tabs, and search results', () => {
+    const { container } = render(<Loading />)
+
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader?.querySelector('.max-w-content')).toBeInTheDocument()
+
+    // Skeletons in the header mirror PageHeader font metrics (text-xl 28px -> h-7, text-xs 16px -> h-4)
+    expect(stickyHeader?.querySelector('h1 .skeleton')).toHaveClass('h-7')
+    expect(stickyHeader?.querySelector('h1 + div .skeleton')).toHaveClass('h-4')
+    // No action button in header
+    expect(stickyHeader?.querySelector('.shrink-0')).toBeNull()
+
+    // No post composer on search page
+    expect(screen.queryByLabelText('Post composer')).toBeNull()
+
+    // Search form skeleton
+    const formSection = screen.getByLabelText('Search form')
+    expect(formSection).toBeInTheDocument()
+    expect(formSection.querySelector('.flex-1.skeleton')).toHaveClass('h-11')
+    expect(formSection.querySelector('.shrink-0.skeleton')).toHaveClass('h-11')
+
+    // Search tabs skeleton (4 tabs: all, accounts, statuses, hashtags)
+    const tabsSection = screen.getByLabelText('Search tabs')
+    expect(tabsSection).toBeInTheDocument()
+    expect(tabsSection.children).toHaveLength(4)
+    Array.from(tabsSection.children).forEach((tab) => {
+      expect(tab).toHaveClass('skeleton', 'h-8', 'rounded-md')
+    })
+
+    // Search results section with outlines for profile, post, and hashtag results
+    const resultsSection = screen.getByLabelText('Search results')
+    expect(resultsSection).toBeInTheDocument()
+    expect(resultsSection.children).toHaveLength(3)
+
+    // Profile item outline (size-11 avatar)
+    expect(
+      resultsSection.children[0]?.querySelector('.skeleton.size-11')
+    ).toBeInTheDocument()
+
+    // Post item outline (size-10 avatar and 4 actions)
+    expect(
+      resultsSection.children[1]?.querySelector('.skeleton.size-10')
+    ).toBeInTheDocument()
+    const postActions =
+      resultsSection.children[1]?.querySelectorAll('.pt-2 .skeleton')
+    expect(postActions).toHaveLength(4)
+
+    // Hashtag item outline (size-10 circle)
+    expect(
+      resultsSection.children[2]?.querySelector('.skeleton.size-10')
+    ).toBeInTheDocument()
+  })
+
+  it('is scoped to the search route so it does not cascade to other (timeline) subroutes', () => {
+    const rootTimelineLoadingPath = path.resolve(
+      process.cwd(),
+      'app/(timeline)/loading.tsx'
+    )
+    expect(fs.existsSync(rootTimelineLoadingPath)).toBe(false)
+  })
+})

--- a/app/(timeline)/search/loading.tsx
+++ b/app/(timeline)/search/loading.tsx
@@ -1,0 +1,75 @@
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+
+export const SearchLoading: FC = () => {
+  return (
+    <div aria-busy="true" aria-label="Loading search" className="space-y-6">
+      <PageHeader
+        title={<span className="skeleton block h-7 w-24 rounded-md" />}
+        description={<span className="skeleton block h-4 w-48 rounded" />}
+      />
+
+      <section aria-label="Search form" className="flex gap-2">
+        <div className="skeleton h-11 flex-1 rounded-md" />
+        <div className="skeleton h-11 w-20 shrink-0 rounded-md" />
+      </section>
+
+      <section
+        aria-label="Search tabs"
+        className="grid h-auto w-full grid-cols-4 gap-1 rounded-lg bg-muted p-1"
+      >
+        <div className="skeleton h-8 rounded-md" />
+        <div className="skeleton h-8 rounded-md" />
+        <div className="skeleton h-8 rounded-md" />
+        <div className="skeleton h-8 rounded-md" />
+      </section>
+
+      <section
+        aria-label="Search results"
+        className="divide-y divide-border/60 overflow-hidden rounded-lg border bg-background/80 shadow-sm"
+      >
+        <div className="flex items-start gap-3 p-4">
+          <div className="skeleton size-11 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <div className="skeleton h-4 w-32 rounded" />
+              <div className="skeleton h-3 w-24 rounded" />
+            </div>
+            <div className="skeleton h-3.5 w-4/5 rounded" />
+          </div>
+        </div>
+
+        <div className="flex gap-3 px-4 py-3">
+          <div className="skeleton size-10 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <div className="skeleton h-4 w-32 rounded" />
+              <div className="skeleton h-3 w-20 rounded" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="skeleton h-4 w-full rounded" />
+              <div className="skeleton h-4 w-4/5 rounded" />
+            </div>
+            <div className="flex gap-6 pt-2">
+              <div className="skeleton h-4 w-8 rounded" />
+              <div className="skeleton h-4 w-8 rounded" />
+              <div className="skeleton h-4 w-8 rounded" />
+              <div className="skeleton h-4 w-8 rounded" />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 p-4">
+          <div className="skeleton size-10 shrink-0 rounded-full" />
+          <div className="min-w-0 space-y-1.5">
+            <div className="skeleton h-4 w-28 rounded" />
+            <div className="skeleton h-3 w-16 rounded" />
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default SearchLoading

--- a/app/(timeline)/search/page.test.tsx
+++ b/app/(timeline)/search/page.test.tsx
@@ -1,0 +1,92 @@
+import { Suspense, isValidElement } from 'react'
+
+import { Actor } from '@/lib/types/domain/actor'
+
+import { SearchPageClient } from './SearchPageClient'
+import { SearchLoading } from './loading'
+import Page from './page'
+
+const mockRedirect = vi.fn()
+vi.mock('next/navigation', () => ({
+  redirect: (path: string) => {
+    mockRedirect(path)
+    throw new Error(`REDIRECT:${path}`)
+  }
+}))
+
+const mockGetConfig = vi.fn()
+vi.mock('@/lib/config', () => ({
+  getConfig: () => mockGetConfig()
+}))
+
+const mockGetDatabase = vi.fn()
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockGetDatabase()
+}))
+
+const mockGetServerAuthSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerAuthSession()
+}))
+
+const mockGetActorFromSession = vi.fn()
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: () => mockGetActorFromSession()
+}))
+
+describe('search page', () => {
+  const fakeActor: Actor = {
+    id: 'https://example.com/users/alice',
+    username: 'alice',
+    domain: 'example.com',
+    name: 'Alice',
+    summary: 'Hello world',
+    followersUrl: 'https://example.com/users/alice/followers',
+    inboxUrl: 'https://example.com/users/alice/inbox',
+    sharedInboxUrl: 'https://example.com/inbox',
+    publicKey: 'pubkey',
+    followingCount: 10,
+    followersCount: 20,
+    statusCount: 30,
+    lastStatusAt: 1000,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const fakeDatabase = {
+    getActorSettings: vi.fn().mockResolvedValue({ postLineLimit: 5 })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetConfig.mockReturnValue({
+      host: 'example.com',
+      mediaStorage: null
+    })
+    mockGetDatabase.mockReturnValue(fakeDatabase)
+  })
+
+  it('redirects unauthenticated sessions to /auth/signin', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+
+    await expect(Page()).rejects.toThrow('REDIRECT:/auth/signin')
+    expect(mockRedirect).toHaveBeenCalledWith('/auth/signin')
+  })
+
+  it('renders SearchPageClient wrapped in Suspense with SearchLoading fallback', async () => {
+    mockGetServerAuthSession.mockResolvedValue({ user: { id: 'user_1' } })
+    mockGetActorFromSession.mockResolvedValue(fakeActor)
+
+    const rendered = await Page()
+    expect(isValidElement(rendered)).toBe(true)
+    expect(rendered.type).toBe(Suspense)
+    expect(rendered.props.fallback).toEqual(<SearchLoading />)
+
+    const child = rendered.props.children
+    expect(isValidElement(child)).toBe(true)
+    expect(child.type).toBe(SearchPageClient)
+    expect(child.props.host).toBe('example.com')
+    expect(child.props.currentActor.username).toBe('alice')
+  })
+})

--- a/app/(timeline)/search/page.tsx
+++ b/app/(timeline)/search/page.tsx
@@ -9,6 +9,7 @@ import { getActorProfile } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { SearchPageClient } from './SearchPageClient'
+import { SearchLoading } from './loading'
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
@@ -31,13 +32,7 @@ const Page = async () => {
   const settings = await database.getActorSettings({ actorId: actor.id })
 
   return (
-    <Suspense
-      fallback={
-        <div className="p-8 text-center text-muted-foreground">
-          <p className="text-sm font-medium">Loading search...</p>
-        </div>
-      }
-    >
+    <Suspense fallback={<SearchLoading />}>
       <SearchPageClient
         host={host}
         currentActor={getActorProfile(actor)}


### PR DESCRIPTION
## Summary

Adds a dedicated skeleton loading screen for the `/search` route (`app/(timeline)/search/loading.tsx`) that matches the layout and components of the search page (`SearchPageClient`), and updates `app/(timeline)/search/page.tsx` to use the skeleton component as its Suspense fallback.

- Uses `PageHeader` directly to mirror the exact sticky chrome and font metrics (`h-7` for "Search" title, `h-4` for "Find profiles, posts, and tags." description) with no header actions.
- Renders search form outline with `h-11 flex-1` search input and `h-11 w-20` submit button.
- Renders 4-tab bar outline (`All`, `Profiles`, `Posts`, `Hashtags`) with `h-8` tab trigger skeletons on a muted background.
- Renders a divided results section container (`section.divide-y.divide-border/60.overflow-hidden.rounded-lg.border.bg-background/80.shadow-sm`) with outline cards for profile results (`size-11` avatar, display name, handle, bio), post results (`size-10` avatar, author line, content lines, action buttons), and hashtag results (`size-10` icon, label, post count).
- Uses `.skeleton` shimmer utility class across all placeholders with no `animate-pulse`.
- Accessible attributes: `aria-busy="true"` and `aria-label="Loading search"`.

## Changes

- `app/(timeline)/search/loading.tsx`: New `SearchLoading` component (default and named export) scoped to the search route.
- `app/(timeline)/search/page.tsx`: Updated `<Suspense fallback={<SearchLoading />}>` so both server route streaming and client suspense render the skeleton.
- `app/(timeline)/search/loading.test.tsx`: Tests verifying accessibility (`aria-busy="true"`, `aria-label="Loading search"`), named & default exports, `.skeleton` utility usage on all placeholders, outline components matching header, form, tabs, and results, and route isolation.
- `app/(timeline)/search/page.test.tsx`: Tests verifying unauthenticated session redirect and Suspense wrapping with `SearchLoading` fallback.

## Screenshots

Verified in real browser (Chrome DevTools) in both light and dark themes:
- Loading skeleton matches search page layout (header, search bar, tabs, results).
- Shimmer animation active across placeholders and stilled under prefers-reduced-motion.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)