### PR TITLE
Bump version to v1.160.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.160.1",
+  "version": "1.160.2",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.160.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.160.1`
- Base main SHA: `04fcf40c30e4748915514b9d75892b5fafc5a02f`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
