### PR TITLE
Bump version to v1.160.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.160.2",
+  "version": "1.160.3",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.160.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.160.2`
- Base main SHA: `fe08083e21bd614cc6e382a3b1803127b067f3a7`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
