### PR TITLE
fix: support actor and profile URLs in webfinger and account lookups

### DIFF
--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -131,6 +131,44 @@ describe('GET /api/v1/accounts/lookup', () => {
     })
   })
 
+  it('resolves lookup when acct is an ActivityPub actor URL', async () => {
+    const actor = { id: 'https://llun.test/users/test1' }
+    const account = { id: 'test1', username: 'test1', acct: 'test1' }
+    mockGetActorFromUsername.mockResolvedValue(actor)
+    mockGetMastodonActorFromId.mockResolvedValue(account)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=https%3A%2F%2Fllun.test%2Fusers%2Ftest1'
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'test1',
+      domain: 'llun.test'
+    })
+  })
+
+  it('resolves lookup when acct is a profile URL', async () => {
+    const actor = { id: 'https://llun.test/users/test1' }
+    const account = { id: 'test1', username: 'test1', acct: 'test1' }
+    mockGetActorFromUsername.mockResolvedValue(actor)
+    mockGetMastodonActorFromId.mockResolvedValue(account)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=https%3A%2F%2Fllun.test%2F%40test1'
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'test1',
+      domain: 'llun.test'
+    })
+  })
+
   it('does not remotely resolve handles for trusted instance domains', async () => {
     mockGetActorFromUsername.mockResolvedValue(null)
     mockStoredToken.mockResolvedValue({

--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -169,6 +169,17 @@ describe('GET /api/v1/accounts/lookup', () => {
     })
   })
 
+  it('returns 400 when acct is a non-account URL', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=https%3A%2F%2Fllun.test%2Fusers%2Ftest1%2Fstatuses%2F123'
+      )
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockGetActorFromUsername).not.toHaveBeenCalled()
+  })
+
   it('does not remotely resolve handles for trusted instance domains', async () => {
     mockGetActorFromUsername.mockResolvedValue(null)
     mockStoredToken.mockResolvedValue({

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
+import { parseAccountUrlHandle } from '@/lib/utils/accountHandle'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { isOwnInstanceHost } from '@/lib/utils/host'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -35,7 +36,13 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const parseAccountHandle = (value: string, localDomain: string) => {
-  const normalized = value.trim().replace(/^@/, '')
+  const trimmed = value.trim()
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
+    const urlHandle = parseAccountUrlHandle(trimmed)
+    if (urlHandle) return urlHandle
+  }
+
+  const normalized = trimmed.replace(/^@/, '')
   const segments = normalized.split('@')
   if (segments.length > 2) return null
 

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -37,9 +37,9 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const parseAccountHandle = (value: string, localDomain: string) => {
   const trimmed = value.trim()
-  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
+  if (/^https?:\/\//i.test(trimmed)) {
     const urlHandle = parseAccountUrlHandle(trimmed)
-    if (urlHandle) return urlHandle
+    return urlHandle ?? null
   }
 
   const normalized = trimmed.replace(/^@/, '')

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -240,6 +240,38 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
+  it('resolves exact actor when query is an ActivityPub actor URL', async () => {
+    const localActor = {
+      id: 'https://llun.test/users/test1',
+      username: 'test1',
+      domain: 'llun.test',
+      account: { id: 'test1' }
+    }
+    mockGetActorFromUsername.mockResolvedValue(localActor)
+    mockSearchAccountIds.mockResolvedValue([localActor.id])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=https%3A%2F%2Fllun.test%2Fusers%2Ftest1&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'test1',
+      domain: 'llun.test'
+    })
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'https://llun.test/users/test1',
+      limit: 40,
+      offset: 0,
+      localDomain: 'llun.test',
+      exactActorIds: [localActor.id]
+    })
+  })
+
   it('clamps deep search offsets to the maximum', async () => {
     const response = await GET(
       new NextRequest(

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -10,7 +10,10 @@ import {
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
-import { parseAccountHandle } from '@/lib/utils/accountHandle'
+import {
+  parseAccountHandle,
+  parseAccountUrlHandle
+} from '@/lib/utils/accountHandle'
 import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { isOwnInstanceHost } from '@/lib/utils/host'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -92,7 +95,10 @@ export const GET = traceApiRoute(
       // hand, so its refresh only has to finish before serialization and runs
       // alongside the index search. This route is always authenticated
       // (OAuthGuardAnyScope).
-      const handle = resolve && offset === 0 ? parseAccountHandle(query) : null
+      const handle =
+        resolve && offset === 0
+          ? (parseAccountHandle(query) ?? parseAccountUrlHandle(query))
+          : null
       const storedExactActor = handle
         ? await database.getActorFromUsername({
             username: handle.username,

--- a/app/api/well-known/webfinger/route.test.ts
+++ b/app/api/well-known/webfinger/route.test.ts
@@ -111,4 +111,31 @@ describe('GET /api/well-known/webfinger', () => {
 
     expect(response.status).toBe(404)
   })
+
+  it('returns WebFinger JRD when queried with an actor URL resource', async () => {
+    database.getActorFromUsername.mockResolvedValue({
+      id: 'https://example.com/users/test',
+      username: 'test',
+      domain: 'example.com',
+      privateKey: 'key'
+    } as never)
+
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/.well-known/webfinger?resource=https%3A%2F%2Fexample.com%2Fusers%2Ftest'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(database.getActorFromUsername).toHaveBeenCalledWith({
+      username: 'test',
+      domain: 'example.com'
+    })
+    const data = await response.json()
+    expect(data).toMatchObject({
+      subject: 'acct:test@example.com',
+      aliases: ['https://example.com/@test', 'https://example.com/users/test']
+    })
+  })
 })

--- a/app/api/well-known/webfinger/route.ts
+++ b/app/api/well-known/webfinger/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { getWebFingerResponse } from '@/lib/services/wellknown'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -39,9 +40,11 @@ export const GET = traceApiRoute('webfinger', async (req: NextRequest) => {
     })
 
   const firstResource = Array.isArray(resource) ? resource[0] : resource
+  const host = headerHost(req.headers)
   const response = await getWebFingerResponse({
     database,
-    resource: firstResource
+    resource: firstResource,
+    fallbackDomain: host
   })
 
   if (!response)

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -278,7 +278,8 @@ describe('wellknown services', () => {
 describe('getWebFingerResponse', () => {
   // Mock database for webfinger tests
   const mockDatabase = {
-    getActorFromUsername: vi.fn()
+    getActorFromUsername: vi.fn(),
+    getActorFromId: vi.fn()
   }
 
   beforeEach(() => {
@@ -563,6 +564,97 @@ describe('getWebFingerResponse', () => {
           href: 'https://fitness.example/users/runner'
         })
       ])
+    })
+  })
+
+  it('resolves actor from ActivityPub actor URL resource', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://llun.dev/users/null',
+      username: 'null',
+      domain: 'llun.dev',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'https://llun.dev/users/null'
+    })
+
+    expect(mockDatabase.getActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'llun.dev'
+    })
+    expect(result).toMatchObject({
+      subject: 'acct:null@llun.dev',
+      aliases: ['https://llun.dev/@null', 'https://llun.dev/users/null']
+    })
+  })
+
+  it('resolves actor from profile URL resource', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://llun.dev/users/null',
+      username: 'null',
+      domain: 'llun.dev',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'https://llun.dev/@null'
+    })
+
+    expect(mockDatabase.getActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'llun.dev'
+    })
+    expect(result).toMatchObject({
+      subject: 'acct:null@llun.dev',
+      aliases: ['https://llun.dev/@null', 'https://llun.dev/users/null']
+    })
+  })
+
+  it('uses fallbackDomain for bare acct or username resource', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://llun.dev/users/null',
+      username: 'null',
+      domain: 'llun.dev',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'acct:null',
+      fallbackDomain: 'llun.dev'
+    })
+
+    expect(mockDatabase.getActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'llun.dev'
+    })
+    expect(result).toMatchObject({
+      subject: 'acct:null@llun.dev'
+    })
+  })
+
+  it('falls back to getActorFromId for custom actor URL', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue(null)
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://example.com/custom/path/actor',
+      username: 'custom',
+      domain: 'example.com',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'https://example.com/custom/path/actor'
+    })
+
+    expect(mockDatabase.getActorFromId).toHaveBeenCalledWith({
+      id: 'https://example.com/custom/path/actor'
+    })
+    expect(result).toMatchObject({
+      subject: 'acct:custom@example.com'
     })
   })
 })

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -636,8 +636,7 @@ describe('getWebFingerResponse', () => {
     })
   })
 
-  it('falls back to getActorFromId for custom actor URL', async () => {
-    mockDatabase.getActorFromUsername.mockResolvedValue(null)
+  it('falls back to getActorFromId for custom actor URL even when fallbackDomain is set', async () => {
     mockDatabase.getActorFromId.mockResolvedValue({
       id: 'https://example.com/custom/path/actor',
       username: 'custom',
@@ -647,9 +646,11 @@ describe('getWebFingerResponse', () => {
 
     const result = await getWebFingerResponse({
       database: mockDatabase as unknown as Database,
-      resource: 'https://example.com/custom/path/actor'
+      resource: 'https://example.com/custom/path/actor',
+      fallbackDomain: 'example.com'
     })
 
+    expect(mockDatabase.getActorFromUsername).not.toHaveBeenCalled()
     expect(mockDatabase.getActorFromId).toHaveBeenCalledWith({
       id: 'https://example.com/custom/path/actor'
     })

--- a/lib/services/wellknown/webfinger.ts
+++ b/lib/services/wellknown/webfinger.ts
@@ -36,10 +36,7 @@ const getAccountFromResource = (
   if (!trimmedResource) return null
 
   // Support ActivityPub actor URLs (/users/:username) and profile URLs (/@:username)
-  if (
-    trimmedResource.startsWith('https://') ||
-    trimmedResource.startsWith('http://')
-  ) {
+  if (/^https?:\/\//i.test(trimmedResource)) {
     const urlHandle = parseAccountUrlHandle(trimmedResource)
     if (urlHandle) {
       return {
@@ -48,6 +45,7 @@ const getAccountFromResource = (
         normalizedDomain: urlHandle.domain.toLowerCase()
       }
     }
+    return null
   }
 
   const account = trimmedResource.toLowerCase().startsWith('acct:')
@@ -107,8 +105,7 @@ export const getWebFingerResponse = async ({
     !actor &&
     'getActorFromId' in database &&
     typeof database.getActorFromId === 'function' &&
-    (trimmedResource.startsWith('https://') ||
-      trimmedResource.startsWith('http://'))
+    /^https?:\/\//i.test(trimmedResource)
   ) {
     actor = await database.getActorFromId({ id: trimmedResource })
   }

--- a/lib/services/wellknown/webfinger.ts
+++ b/lib/services/wellknown/webfinger.ts
@@ -1,5 +1,6 @@
 import { getBaseURL } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { parseAccountUrlHandle } from '@/lib/utils/accountHandle'
 
 // Standard OStatus rel other servers look for to discover where to send a
 // visitor who typed their handle into a remote "follow from your server"
@@ -24,45 +25,93 @@ export interface WebFingerResponse {
 interface GetWebFingerParams {
   database: Database
   resource: string
+  fallbackDomain?: string
 }
 
-const getAccountFromResource = (resource: string) => {
+const getAccountFromResource = (
+  resource: string,
+  fallbackDomain?: string
+): { username: string; domain: string; normalizedDomain: string } | null => {
   const trimmedResource = resource.trim()
+  if (!trimmedResource) return null
+
+  // Support ActivityPub actor URLs (/users/:username) and profile URLs (/@:username)
+  if (
+    trimmedResource.startsWith('https://') ||
+    trimmedResource.startsWith('http://')
+  ) {
+    const urlHandle = parseAccountUrlHandle(trimmedResource)
+    if (urlHandle) {
+      return {
+        username: urlHandle.username,
+        domain: urlHandle.domain,
+        normalizedDomain: urlHandle.domain.toLowerCase()
+      }
+    }
+  }
+
   const account = trimmedResource.toLowerCase().startsWith('acct:')
     ? trimmedResource.slice('acct:'.length)
     : trimmedResource
-  const parts = account.split('@')
+  const normalizedAccount = account.replace(/^@/, '')
+  const parts = normalizedAccount.split('@')
 
-  if (parts.length !== 2) return null
+  if (parts.length === 2) {
+    const [username, domain] = parts.map((part) => part.trim())
+    if (!username || !domain) return null
 
-  const [username, domain] = parts.map((part) => part.trim())
-  if (!username || !domain) return null
-
-  return {
-    username,
-    domain,
-    normalizedDomain: domain.toLowerCase()
+    return {
+      username,
+      domain,
+      normalizedDomain: domain.toLowerCase()
+    }
   }
+
+  if (parts.length === 1 && fallbackDomain) {
+    const username = parts[0].trim()
+    const domain = fallbackDomain.trim()
+    if (!username || !domain) return null
+
+    return {
+      username,
+      domain,
+      normalizedDomain: domain.toLowerCase()
+    }
+  }
+
+  return null
 }
 
 export const getWebFingerResponse = async ({
   database,
-  resource
+  resource,
+  fallbackDomain
 }: GetWebFingerParams): Promise<WebFingerResponse | null> => {
-  const account = getAccountFromResource(resource)
-  if (!account) return null
+  const trimmedResource = resource.trim()
+  const account = getAccountFromResource(trimmedResource, fallbackDomain)
 
-  const actor =
-    (await database.getActorFromUsername({
-      username: account.username,
-      domain: account.domain
-    })) ??
-    (account.domain === account.normalizedDomain
-      ? null
-      : await database.getActorFromUsername({
-          username: account.username,
-          domain: account.normalizedDomain
-        }))
+  let actor = account
+    ? ((await database.getActorFromUsername({
+        username: account.username,
+        domain: account.domain
+      })) ??
+      (account.domain === account.normalizedDomain
+        ? null
+        : await database.getActorFromUsername({
+            username: account.username,
+            domain: account.normalizedDomain
+          })))
+    : null
+
+  if (
+    !actor &&
+    'getActorFromId' in database &&
+    typeof database.getActorFromId === 'function' &&
+    (trimmedResource.startsWith('https://') ||
+      trimmedResource.startsWith('http://'))
+  ) {
+    actor = await database.getActorFromId({ id: trimmedResource })
+  }
 
   // This is not local actors
   if (!actor?.privateKey) return null

--- a/lib/utils/accountHandle.test.ts
+++ b/lib/utils/accountHandle.test.ts
@@ -142,7 +142,7 @@ describe('parseActorUrlAccountHandle', () => {
       expected: { username: 'null', domain: 'example.com' }
     },
     {
-      description: 'decodes a valid percent encoded username',
+      description: 'parses a username with underscore',
       input: 'https://example.com/users/user_name',
       expected: { username: 'user_name', domain: 'example.com' }
     },
@@ -150,6 +150,11 @@ describe('parseActorUrlAccountHandle', () => {
       description: 'preserves host with explicit port',
       input: 'http://localhost:3000/users/test',
       expected: { username: 'test', domain: 'localhost:3000' }
+    },
+    {
+      description: 'rejects non-http/https protocol',
+      input: 'ftp://example.com/users/test',
+      expected: null
     },
     {
       description: 'rejects a profile url',
@@ -184,6 +189,17 @@ describe('parseAccountUrlHandle', () => {
       username: 'test',
       domain: 'example.com'
     })
+  })
+
+  it('resolves a profile URL with explicit port', () => {
+    expect(parseAccountUrlHandle('http://localhost:3000/@test')).toEqual({
+      username: 'test',
+      domain: 'localhost:3000'
+    })
+  })
+
+  it('returns null for non-http protocols', () => {
+    expect(parseAccountUrlHandle('ftp://example.com/@test')).toBeNull()
   })
 
   it('returns null for non-account URLs', () => {

--- a/lib/utils/accountHandle.test.ts
+++ b/lib/utils/accountHandle.test.ts
@@ -1,5 +1,7 @@
 import {
   parseAccountHandle,
+  parseAccountUrlHandle,
+  parseActorUrlAccountHandle,
   parseProfileUrlAccountHandle,
   stripAcctPrefix
 } from './accountHandle'
@@ -119,5 +121,75 @@ describe('parseProfileUrlAccountHandle', () => {
     }
   ])('$description', ({ input, expected }) => {
     expect(parseProfileUrlAccountHandle(input)).toEqual(expected)
+  })
+})
+
+describe('parseActorUrlAccountHandle', () => {
+  it.each([
+    {
+      description: 'parses a canonical actor url',
+      input: 'https://example.com/users/user',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'accepts a trailing slash',
+      input: 'https://example.com/users/user/',
+      expected: { username: 'user', domain: 'example.com' }
+    },
+    {
+      description: 'decodes a percent encoded username',
+      input: 'https://example.com/users/%6eull',
+      expected: { username: 'null', domain: 'example.com' }
+    },
+    {
+      description: 'decodes a valid percent encoded username',
+      input: 'https://example.com/users/user_name',
+      expected: { username: 'user_name', domain: 'example.com' }
+    },
+    {
+      description: 'preserves host with explicit port',
+      input: 'http://localhost:3000/users/test',
+      expected: { username: 'test', domain: 'localhost:3000' }
+    },
+    {
+      description: 'rejects a profile url',
+      input: 'https://example.com/@user',
+      expected: null
+    },
+    {
+      description: 'rejects a status url under users',
+      input: 'https://example.com/users/user/statuses/123',
+      expected: null
+    },
+    {
+      description: 'rejects a non-url',
+      input: 'user@example.com',
+      expected: null
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(parseActorUrlAccountHandle(input)).toEqual(expected)
+  })
+})
+
+describe('parseAccountUrlHandle', () => {
+  it('resolves an ActivityPub actor URL', () => {
+    expect(parseAccountUrlHandle('https://example.com/users/test')).toEqual({
+      username: 'test',
+      domain: 'example.com'
+    })
+  })
+
+  it('resolves a profile URL', () => {
+    expect(parseAccountUrlHandle('https://example.com/@test')).toEqual({
+      username: 'test',
+      domain: 'example.com'
+    })
+  })
+
+  it('returns null for non-account URLs', () => {
+    expect(
+      parseAccountUrlHandle('https://example.com/users/test/statuses/1')
+    ).toBeNull()
+    expect(parseAccountUrlHandle('user@example.com')).toBeNull()
   })
 })

--- a/lib/utils/accountHandle.ts
+++ b/lib/utils/accountHandle.ts
@@ -32,9 +32,38 @@ export const parseProfileUrlAccountHandle = (value: string) => {
     const profileHandle = decodeURIComponent(match[1])
     const handle = profileHandle.includes('@')
       ? `@${profileHandle.replace(/^@/, '')}`
-      : `@${profileHandle}@${url.hostname}`
+      : `@${profileHandle}@${url.host}`
     return parseAccountHandle(handle)
   } catch {
     return null
   }
+}
+
+/**
+ * Reads the account handle out of an ActivityPub actor URL (`https://d/users/user`).
+ * Returns null for any other URL shape.
+ */
+export const parseActorUrlAccountHandle = (value: string) => {
+  try {
+    const url = new URL(value)
+    const match = /^\/users\/([^/]+)\/?$/.exec(url.pathname)
+    if (!match) return null
+
+    const username = decodeURIComponent(match[1])
+    return parseAccountHandle(`@${username}@${url.host}`)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reads the account handle out of any supported account URL:
+ * - ActivityPub actor URL: `https://d/users/user`
+ * - Profile URL: `https://d/@user` or `https://d/@user@other`
+ * Returns null for any other URL shape or non-URL value.
+ */
+export const parseAccountUrlHandle = (value: string) => {
+  return (
+    parseActorUrlAccountHandle(value) ?? parseProfileUrlAccountHandle(value)
+  )
 }

--- a/lib/utils/accountHandle.ts
+++ b/lib/utils/accountHandle.ts
@@ -26,6 +26,7 @@ export const stripAcctPrefix = (value: string) => {
 export const parseProfileUrlAccountHandle = (value: string) => {
   try {
     const url = new URL(value)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
     const match = /^\/@([^/]+)\/?$/.exec(url.pathname)
     if (!match) return null
 
@@ -46,6 +47,7 @@ export const parseProfileUrlAccountHandle = (value: string) => {
 export const parseActorUrlAccountHandle = (value: string) => {
   try {
     const url = new URL(value)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
     const match = /^\/users\/([^/]+)\/?$/.exec(url.pathname)
     if (!match) return null
 


### PR DESCRIPTION
## Summary

- Resolves 404 error on WebFinger (`/.well-known/webfinger`) when the `resource` query parameter is an ActivityPub actor URL (e.g. `https://llun.dev/users/null` per RFC 7033 §4.1/§4.4) or profile URL (e.g. `https://llun.dev/@null`).
- Previously, `getAccountFromResource` strictly split on `@` expecting `[acct:]username@domain`, which yielded length 1 for actor URLs and caused WebFinger to immediately return 404 without querying the database.
- Added URL handle extraction via `parseAccountUrlHandle` (supporting `/users/:username` and `/@:username`), plus fallback to `database.getActorFromId({ id: resource })` in `getWebFingerResponse` for custom actor URLs.
- Injected `fallbackDomain` from request `Host` header for bare handles (e.g. `acct:username` or `username`).
- Fixed similar handle-parsing assumptions in other lookup endpoints:
  - `/api/v1/accounts/lookup`: `parseAccountHandle` now recognizes actor and profile URLs via `parseAccountUrlHandle`.
  - `/api/v1/accounts/search`: When searching accounts with `resolve=true` and query `q` is an actor or profile URL, exact actor resolution now uses `parseAccountUrlHandle(query)`.
- Added unit and route tests covering actor URL parsing, WebFinger responses, and Mastodon API account lookups/searches.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR (No migrations)
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)
