### PR TITLE
Bump version to v1.160.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.160.4",
+  "version": "1.160.5",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.160.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.160.4`
- Base main SHA: `5fd78b831a8c3fab523554035ba9de26214271ec`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
