### PR TITLE
fix: allow optional to and cc in activitypub content and announce schemas

### DIFF
--- a/lib/activities/announceStatus.ts
+++ b/lib/activities/announceStatus.ts
@@ -6,7 +6,7 @@ import { BaseActivity } from './actionsBase'
 export interface AnnounceStatus extends BaseActivity, ContextEntity {
   type: AnnounceAction
   published: string
-  to: string[]
-  cc: string[]
+  to?: string | string[] | null
+  cc?: string | string[] | null
   object: string
 }

--- a/lib/activities/createStatus.ts
+++ b/lib/activities/createStatus.ts
@@ -14,8 +14,8 @@ import { Signature } from '@/lib/types/activitypub/webfinger'
 export interface CreateStatus extends BaseActivity, ContextEntity {
   type: CreateAction
   published: string
-  to: string | string[]
-  cc: string | string[]
+  to?: string | string[] | null
+  cc?: string | string[] | null
   object:
     Note | Question | ImageContent | PageContent | ArticleContent | VideoContent
   signature?: Signature

--- a/lib/activities/getRemoteStatus.test.ts
+++ b/lib/activities/getRemoteStatus.test.ts
@@ -184,4 +184,46 @@ describe('getRemoteStatus', () => {
     await expect(getRemoteStatus({ statusId: STATUS_ID })).resolves.toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('fetches a public remote status when cc is omitted (e.g. Bridgy Fed)', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === STATUS_ID) {
+        return JSON.stringify({
+          id: STATUS_ID,
+          type: 'Note',
+          attributedTo: ACTOR_ID,
+          content: 'Hello from bridgy fed without cc',
+          to: [PUBLIC_STREAM],
+          published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+        })
+      }
+
+      if (req.url === ACTOR_ID) {
+        return JSON.stringify({
+          id: ACTOR_ID,
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: `${ACTOR_ID}/inbox`,
+          outbox: `${ACTOR_ID}/outbox`,
+          followers: `${ACTOR_ID}/followers`,
+          publicKey: {
+            id: `${ACTOR_ID}#main-key`,
+            owner: ACTOR_ID,
+            publicKeyPem: 'public key'
+          }
+        })
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    await expect(
+      getRemoteStatus({ statusId: STATUS_ID })
+    ).resolves.toMatchObject({
+      id: STATUS_ID,
+      actorId: ACTOR_ID,
+      text: 'Hello from bridgy fed without cc'
+    })
+  })
 })

--- a/lib/activities/getRemoteStatus.ts
+++ b/lib/activities/getRemoteStatus.ts
@@ -27,7 +27,9 @@ const publicStreams = [
 
 const hasPublicAudience = (value: BaseNote['to'] | BaseNote['cc']) => {
   const items = Array.isArray(value) ? value : [value]
-  return items.some((item) => publicStreams.includes(item))
+  return items.some(
+    (item) => typeof item === 'string' && publicStreams.includes(item)
+  )
 }
 
 export const getRemoteStatus = async ({

--- a/lib/activities/updateStatus.ts
+++ b/lib/activities/updateStatus.ts
@@ -15,8 +15,8 @@ import { BaseActivity } from './actionsBase'
 export interface UpdateStatus extends BaseActivity, ContextEntity {
   type: UpdateAction
   published: string
-  to: string | string[]
-  cc: string | string[]
+  to?: string | string[] | null
+  cc?: string | string[] | null
   object:
     Note | Question | ImageContent | PageContent | ArticleContent | VideoContent
   signature?: Signature

--- a/lib/jobs/createAnnounceJob.test.ts
+++ b/lib/jobs/createAnnounceJob.test.ts
@@ -485,4 +485,27 @@ describe('Announce action', () => {
       database.getStatus({ statusId: `${statusId}/activity` })
     ).resolves.toBeNull()
   })
+
+  it('accepts announce payload when cc is omitted', async () => {
+    const statusId = stubNoteId()
+    const announceStatusId = 'https://somewhere.test/statuses/announce-status'
+    const announce = MockAnnounceStatus({
+      actorId: ACTOR1_ID,
+      statusId,
+      announceStatusId
+    })
+    delete (announce as unknown as Record<string, unknown>).cc
+
+    await createAnnounceJob(database, {
+      id: 'id-without-cc',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: announce
+    })
+
+    const status = (await database.getStatus({
+      statusId: `${statusId}/activity`
+    })) as StatusAnnounce
+    expect(status).toBeDefined()
+    expect(status.cc).toEqual([])
+  })
 })

--- a/lib/types/activitypub/activities.test.ts
+++ b/lib/types/activitypub/activities.test.ts
@@ -1,0 +1,39 @@
+import { Announce } from '@/lib/types/activitypub/activities'
+
+describe('ActivityPub activities', () => {
+  const baseAnnounce = {
+    id: 'https://example.com/activities/1',
+    type: 'Announce',
+    actor: 'https://example.com/users/alice',
+    published: '2026-09-06T10:00:00Z',
+    object: 'https://remote.test/statuses/1',
+    to: 'https://www.w3.org/ns/activitystreams#Public',
+    cc: ['https://example.com/users/alice/followers']
+  }
+
+  it('validates a standard announce activity', () => {
+    const result = Announce.safeParse(baseAnnounce)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts announce when cc is omitted', () => {
+    const { cc: _cc, ...withoutCc } = baseAnnounce
+    const result = Announce.safeParse(withoutCc)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts announce when to is omitted', () => {
+    const { to: _to, ...withoutTo } = baseAnnounce
+    const result = Announce.safeParse(withoutTo)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts announce when to and cc are null', () => {
+    const result = Announce.safeParse({
+      ...baseAnnounce,
+      to: null,
+      cc: null
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/lib/types/activitypub/activities.ts
+++ b/lib/types/activitypub/activities.ts
@@ -155,8 +155,8 @@ export const Announce = z.object({
   actor: z.string(),
 
   published: z.string().describe('Object published datetime'),
-  to: z.union([z.string(), z.string().array()]),
-  cc: z.union([z.string(), z.string().array()]),
+  to: z.union([z.string(), z.string().array()]).nullish(),
+  cc: z.union([z.string(), z.string().array()]).nullish(),
   object: z.string()
 })
 export type Announce = z.infer<typeof Announce>

--- a/lib/types/activitypub/objects.test.ts
+++ b/lib/types/activitypub/objects.test.ts
@@ -167,3 +167,34 @@ describe('VideoContent and ImageContent schemas', () => {
     }
   })
 })
+
+describe('Note audience fields', () => {
+  const base = {
+    id: 'https://remote.example/notes/1',
+    type: 'Note' as const,
+    attributedTo: 'https://remote.example/users/alice',
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: ['https://remote.example/users/alice/followers'],
+    content: 'Hello world',
+    published: '2026-01-01T00:00:00Z'
+  }
+
+  it('accepts notes when cc is omitted (e.g. Bridgy Fed / Bluesky bridge)', () => {
+    const { cc: _cc, ...withoutCc } = base
+    const parsed = Note.safeParse(withoutCc)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts notes when to is omitted or nullish', () => {
+    const { to: _to, ...withoutTo } = base
+    const parsedWithoutTo = Note.safeParse(withoutTo)
+    expect(parsedWithoutTo.success).toBe(true)
+
+    const parsedWithNull = Note.safeParse({
+      ...base,
+      to: null,
+      cc: null
+    })
+    expect(parsedWithNull.success).toBe(true)
+  })
+})

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -102,8 +102,8 @@ export const BaseContent = z.object({
     .nullish(),
   attributedTo: z.string().describe('Note publisher'),
 
-  to: z.union([z.string(), z.string().array()]),
-  cc: z.union([z.string(), z.string().array()]),
+  to: z.union([z.string(), z.string().array()]).nullish(),
+  cc: z.union([z.string(), z.string().array()]).nullish(),
 
   inReplyTo: z.string().nullish(),
 


### PR DESCRIPTION
## Summary

Fixes Google Cloud Error Reporting issue `CPiAxs7vucTYqQE` where remote note fetching from Bridgy Fed (Bluesky bridge) or other ActivityPub servers threw a `ZodError` and failed to resolve:
`BaseNoteSchema.safeParse` failed with `invalid_union` on `["cc"]` (`expected string, received undefined` / `expected array, received undefined`).

In ActivityStreams 2.0 / ActivityPub §5.1, audience properties (`to`, `cc`, etc.) are optional and may be omitted (or set to `null`). For example, Bridgy Fed posts emit `to: ["https://www.w3.org/ns/activitystreams#Public"]` and no `cc` field.

### Changes:
- Relaxed `to` and `cc` to `.nullish()` in `BaseContent` schema (`lib/types/activitypub/objects.ts`), which automatically covers `Note`, `Question`, `ImageContent`, `PageContent`, `ArticleContent`, and `VideoContent`.
- Relaxed `to` and `cc` to `.nullish()` in `Announce` schema (`lib/types/activitypub/activities.ts`).
- Updated TypeScript activity interfaces `CreateStatus`, `UpdateStatus`, and `AnnounceStatus` to accept optional/nullish `to` and `cc`.
- Made `hasPublicAudience` in `lib/activities/getRemoteStatus.ts` guard against non-string / undefined items.
- Added comprehensive unit tests in `lib/types/activitypub/objects.test.ts`, `lib/types/activitypub/activities.test.ts`, `lib/activities/getRemoteStatus.test.ts`, and `lib/jobs/createAnnounceJob.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)