### PR TITLE
fix: enforce announce visibility

### DIFF
--- a/lib/jobs/createAnnounceJob.test.ts
+++ b/lib/jobs/createAnnounceJob.test.ts
@@ -17,6 +17,7 @@ import {
   StatusPoll,
   StatusType
 } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 enableFetchMocks()
 
@@ -507,5 +508,183 @@ describe('Announce action', () => {
     })) as StatusAnnounce
     expect(status).toBeDefined()
     expect(status.cc).toEqual([])
+  })
+
+  it('rejects public announce of an existing local followers-only status', async () => {
+    const statusId = stubNoteId()
+    const targetStatus = await database.createNote({
+      id: `${actor1?.id}/statuses/private-note-1`,
+      url: `${actor1?.id}/statuses/private-note-1`,
+      actorId: actor1!.id,
+      to: [`${actor1?.id}/followers`],
+      cc: [],
+      text: 'Local followers-only note'
+    })
+
+    await createAnnounceJob(database, {
+      id: 'id-public-boost-private',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: MockAnnounceStatus({
+        actorId: 'https://somewhere.test/actors/friend',
+        statusId,
+        announceStatusId: targetStatus.id
+      })
+    })
+
+    await expect(
+      database.getStatus({ statusId: `${statusId}/activity` })
+    ).resolves.toBeNull()
+  })
+
+  it('rejects public announce of an existing local direct status', async () => {
+    const statusId = stubNoteId()
+    const targetStatus = await database.createNote({
+      id: `${actor1?.id}/statuses/direct-note-1`,
+      url: `${actor1?.id}/statuses/direct-note-1`,
+      actorId: actor1!.id,
+      to: ['https://somewhere.test/actors/friend'],
+      cc: [],
+      text: 'Local direct note'
+    })
+
+    await createAnnounceJob(database, {
+      id: 'id-public-boost-direct',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: MockAnnounceStatus({
+        actorId: 'https://somewhere.test/actors/friend',
+        statusId,
+        announceStatusId: targetStatus.id
+      })
+    })
+
+    await expect(
+      database.getStatus({ statusId: `${statusId}/activity` })
+    ).resolves.toBeNull()
+  })
+
+  it('rejects unlisted announce of a followers-only status', async () => {
+    const statusId = stubNoteId()
+    const targetStatus = await database.createNote({
+      id: `${actor1?.id}/statuses/private-note-unlisted`,
+      url: `${actor1?.id}/statuses/private-note-unlisted`,
+      actorId: actor1!.id,
+      to: [`${actor1?.id}/followers`],
+      cc: [],
+      text: 'Local followers-only note for unlisted boost'
+    })
+
+    const announce = MockAnnounceStatus({
+      actorId: 'https://somewhere.test/actors/friend',
+      statusId,
+      announceStatusId: targetStatus.id
+    })
+    announce.to = ['https://somewhere.test/actors/friend/followers']
+    announce.cc = [ACTIVITY_STREAM_PUBLIC]
+
+    await createAnnounceJob(database, {
+      id: 'id-unlisted-boost-private',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: announce
+    })
+
+    await expect(
+      database.getStatus({ statusId: `${statusId}/activity` })
+    ).resolves.toBeNull()
+  })
+
+  it('rejects public announce of a remotely fetched followers-only status', async () => {
+    const statusId = stubNoteId()
+    const announceStatusId =
+      'https://somewhere.test/statuses/remote-followers-only'
+    fetchMock.mockOnceIf(
+      announceStatusId,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: announceStatusId,
+        type: 'Note',
+        attributedTo: 'https://somewhere.test/actors/friend',
+        content: '<p>remote followers only</p>',
+        published: '2026-08-30T04:27:44Z',
+        to: ['https://somewhere.test/actors/friend/followers'],
+        cc: []
+      })
+    )
+
+    await createAnnounceJob(database, {
+      id: 'id-remote-followers-only-boost',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: MockAnnounceStatus({
+        actorId: 'https://somewhere.test/actors/friend',
+        statusId,
+        announceStatusId
+      })
+    })
+
+    await expect(
+      database.getStatus({ statusId: `${statusId}/activity` })
+    ).resolves.toBeNull()
+  })
+
+  it('preserves authorized private announce of a followers-only status', async () => {
+    const statusId = stubNoteId()
+    const targetStatus = await database.createNote({
+      id: `${actor1?.id}/statuses/private-note-for-private-boost`,
+      url: `${actor1?.id}/statuses/private-note-for-private-boost`,
+      actorId: actor1!.id,
+      to: [`${actor1?.id}/followers`],
+      cc: [],
+      text: 'Local followers-only note for private boost'
+    })
+
+    const announce = MockAnnounceStatus({
+      actorId: 'https://somewhere.test/actors/friend',
+      statusId,
+      announceStatusId: targetStatus.id
+    })
+    announce.to = ['https://somewhere.test/actors/friend/followers']
+    announce.cc = [actor1!.id]
+
+    await createAnnounceJob(database, {
+      id: 'id-private-boost-private',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: announce
+    })
+
+    const savedAnnounce = (await database.getStatus({
+      statusId: `${statusId}/activity`
+    })) as StatusAnnounce | null
+    expect(savedAnnounce).not.toBeNull()
+    expect(savedAnnounce?.originalStatus?.id).toEqual(targetStatus.id)
+    expect(savedAnnounce?.to).toEqual([
+      'https://somewhere.test/actors/friend/followers'
+    ])
+  })
+
+  it('accepts public announce of an unlisted status', async () => {
+    const statusId = stubNoteId()
+    const targetStatus = await database.createNote({
+      id: `${actor1?.id}/statuses/unlisted-note-for-public-boost`,
+      url: `${actor1?.id}/statuses/unlisted-note-for-public-boost`,
+      actorId: actor1!.id,
+      to: [`${actor1?.id}/followers`],
+      cc: [ACTIVITY_STREAM_PUBLIC],
+      text: 'Local unlisted note'
+    })
+
+    await createAnnounceJob(database, {
+      id: 'id-public-boost-unlisted',
+      name: CREATE_ANNOUNCE_JOB_NAME,
+      data: MockAnnounceStatus({
+        actorId: 'https://somewhere.test/actors/friend',
+        statusId,
+        announceStatusId: targetStatus.id
+      })
+    })
+
+    const savedAnnounce = (await database.getStatus({
+      statusId: `${statusId}/activity`
+    })) as StatusAnnounce | null
+    expect(savedAnnounce).not.toBeNull()
+    expect(savedAnnounce?.originalStatus?.id).toEqual(targetStatus.id)
   })
 })

--- a/lib/jobs/createAnnounceJob.ts
+++ b/lib/jobs/createAnnounceJob.ts
@@ -8,6 +8,10 @@ import { dispatchCreateNoteOrPollJob } from '@/lib/jobs/dispatchCreateNoteOrPoll
 import { CREATE_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
+import {
+  isPublicOrUnlisted,
+  isStatusPubliclyReadable
+} from '@/lib/services/statusAccess'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Announce } from '@/lib/types/activitypub'
 import {
@@ -116,6 +120,23 @@ export const createAnnounceJob: JobHandle = createJobHandle(
     if (!targetStatus) {
       return
     }
+
+    const announceTo = toRecipientArray(status.to)
+    const announceCc = toRecipientArray(status.cc)
+
+    if (
+      isPublicOrUnlisted({ to: announceTo, cc: announceCc }) &&
+      !isStatusPubliclyReadable(targetStatus)
+    ) {
+      logger.warn({
+        message:
+          'Ignoring public or unlisted announce whose original status is not publicly readable',
+        announceId: status.id,
+        originalStatusId: targetStatus.id
+      })
+      return
+    }
+
     const existingAnnounce = await database.getStatus({
       statusId: status.id,
       withReplies: false
@@ -128,8 +149,8 @@ export const createAnnounceJob: JobHandle = createJobHandle(
       database.createAnnounce({
         id: status.id,
         actorId: status.actor,
-        to: toRecipientArray(status.to),
-        cc: toRecipientArray(status.cc),
+        to: announceTo,
+        cc: announceCc,
         originalStatusId: targetStatus.id
       })
     ])

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -5,6 +5,7 @@ import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 import {
   canActorReadStatus,
+  isPublicOrUnlisted,
   isStatusPubliclyReadable,
   resolveActorStatusesAudience
 } from './statusAccess'
@@ -53,6 +54,33 @@ describe('status access helpers', () => {
     ).toBe(true)
   })
 
+  it('correctly identifies public and unlisted recipients via isPublicOrUnlisted', () => {
+    expect(
+      isPublicOrUnlisted({
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+    ).toBe(true)
+    expect(
+      isPublicOrUnlisted({
+        to: [FOLLOWERS_URL],
+        cc: [ACTIVITY_STREAM_PUBLIC]
+      })
+    ).toBe(true)
+    expect(
+      isPublicOrUnlisted({
+        to: [FOLLOWERS_URL],
+        cc: []
+      })
+    ).toBe(false)
+    expect(
+      isPublicOrUnlisted({
+        to: [FOLLOWER_ID],
+        cc: []
+      })
+    ).toBe(false)
+  })
+
   it('does not treat followers-only or direct statuses as publicly readable', () => {
     expect(
       isStatusPubliclyReadable(
@@ -89,7 +117,7 @@ describe('status access helpers', () => {
       to: [ACTIVITY_STREAM_PUBLIC],
       cc: [],
       originalStatus: privateOriginal
-    } as Status
+    } as unknown as Status
 
     expect(isStatusPubliclyReadable(announce)).toBe(false)
   })
@@ -244,7 +272,7 @@ describe('status access helpers', () => {
       to: [ACTIVITY_STREAM_PUBLIC],
       cc: [],
       originalStatus
-    } as Status
+    } as unknown as Status
 
     await expect(
       canActorReadStatus({

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -6,7 +6,9 @@ import { getVisibility } from '@/lib/utils/getVisibility'
 
 import { getViewerFollow } from './getViewerFollow'
 
-const isPublicOrUnlisted = (status: Status): boolean => {
+export const isPublicOrUnlisted = (
+  status: Pick<Status, 'to' | 'cc'>
+): boolean => {
   const visibility = getVisibility(status.to, status.cc)
   return visibility === 'public' || visibility === 'unlisted'
 }

--- a/lib/services/timelines/main.test.ts
+++ b/lib/services/timelines/main.test.ts
@@ -51,6 +51,49 @@ const createAnnounce = async (
   return status
 }
 
+const createCustomStatus = async (
+  database: Database,
+  actorId: string,
+  text: string,
+  options?: {
+    to?: string[]
+    cc?: string[]
+    reply?: string
+  }
+) => {
+  const id = randomBytes(16).toString('hex')
+  const status = await database.createNote({
+    id: `${actorId}/statuses/${id}`,
+    url: `${actorId}/statuses/${id}`,
+    actorId,
+    to: options?.to ?? [ACTIVITY_STREAM_PUBLIC],
+    cc: options?.cc ?? [`${actorId}/followers`],
+    reply: options?.reply,
+    text
+  })
+  return status
+}
+
+const createCustomAnnounce = async (
+  database: Database,
+  actorId: string,
+  originalStatusId: string,
+  options?: {
+    to?: string[]
+    cc?: string[]
+  }
+) => {
+  const id = randomBytes(16).toString('hex')
+  const status = await database.createAnnounce({
+    actorId,
+    to: options?.to ?? [ACTIVITY_STREAM_PUBLIC],
+    cc: options?.cc ?? [`${actorId}/followers`],
+    id: `${actorId}/statuses/${id}/activity`,
+    originalStatusId
+  })
+  return status
+}
+
 describe('mainTimelineRule', () => {
   const database = getTestSQLDatabase()
 
@@ -400,6 +443,485 @@ describe('mainTimelineRule', () => {
         database,
         currentActor,
         status: followingAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for announce of an unauthorized followers-only status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const privateStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Private status for Actor1 followers',
+      { to: [`${ACTOR1_ID}/followers`], cc: [] }
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      privateStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toBeNull()
+  })
+
+  it('returns null for announce of an unauthorized direct status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const directStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Direct note for Actor2 only',
+      { to: [ACTOR2_ID], cc: [] }
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      directStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toBeNull()
+  })
+
+  it('returns main timeline for announce of an authorized followers-only status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const nonFollowedRoot = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Non-followed root'
+    )
+    const authorizedFollowersStatus = await createCustomStatus(
+      database,
+      ACTOR4_ID,
+      'Followers-only reply to non-followed actor',
+      {
+        to: [`${ACTOR4_ID}/followers`],
+        cc: [],
+        reply: nonFollowedRoot.id
+      }
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: authorizedFollowersStatus
+      })
+    ).toBeNull()
+
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      authorizedFollowersStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns main timeline for announce of an authorized direct status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const authorizedDirectStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Direct note addressed to Actor2 and Actor3',
+      { to: [ACTOR2_ID, ACTOR3_ID], cc: [] }
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: authorizedDirectStatus
+      })
+    ).toBeNull()
+
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      authorizedDirectStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns main timeline for announce of an unlisted status from non-followed actor', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const unlistedStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Unlisted status from non-followed actor',
+      { to: [`${ACTOR1_ID}/followers`], cc: [ACTIVITY_STREAM_PUBLIC] }
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      unlistedStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns null for announce of an unlisted status from a followed actor (already in timeline)', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const unlistedStatus = await createCustomStatus(
+      database,
+      ACTOR4_ID,
+      'Unlisted status from followed actor',
+      { to: [`${ACTOR4_ID}/followers`], cc: [ACTIVITY_STREAM_PUBLIC] }
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: unlistedStatus
+      })
+    ).toEqual(Timeline.MAIN)
+
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      unlistedStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toBeNull()
+  })
+
+  it('returns null for self-boost of a status already in timeline (own status)', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const selfStatus = await createStatus(database, ACTOR3_ID, 'My own status')
+    const selfAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR3_ID,
+      selfStatus.id
+    )
+    if (!selfAnnounce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: selfAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for self-boost of an unauthorized private status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const privateStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Private status Actor3 cannot read',
+      { to: [`${ACTOR1_ID}/followers`], cc: [] }
+    )
+    const selfAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR3_ID,
+      privateStatus.id
+    )
+    if (!selfAnnounce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: selfAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for nested announce of an unauthorized private original', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const privateStatus = await createCustomStatus(
+      database,
+      ACTOR1_ID,
+      'Private note for nested announce test',
+      { to: [`${ACTOR1_ID}/followers`], cc: [] }
+    )
+    const innerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR5_ID,
+      privateStatus.id
+    )
+    if (!innerAnnounce) fail('Inner announce must be defined')
+
+    const outerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      innerAnnounce.id
+    )
+    if (!outerAnnounce) fail('Outer announce must be defined')
+
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: outerAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns main timeline for nested announce of an authorized status not in timeline', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const publicStatus = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Public note for nested announce test'
+    )
+    const innerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR5_ID,
+      publicStatus.id
+    )
+    if (!innerAnnounce) fail('Inner announce must be defined')
+
+    const outerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      innerAnnounce.id
+    )
+    if (!outerAnnounce) fail('Outer announce must be defined')
+
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: outerAnnounce
+      })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns null for nested announce when root original is already in timeline', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const rootStatus = await createStatus(
+      database,
+      ACTOR4_ID,
+      'Root note followed by Actor3'
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: rootStatus
+      })
+    ).toEqual(Timeline.MAIN)
+
+    const innerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR5_ID,
+      rootStatus.id
+    )
+    if (!innerAnnounce) fail('Inner announce must be defined')
+
+    const outerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      innerAnnounce.id
+    )
+    if (!outerAnnounce) fail('Outer announce must be defined')
+
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: outerAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for announce when original status is independently selected in timeline', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const originalStatus = await createStatus(
+      database,
+      ACTOR2_ID,
+      'Independently selected original status'
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: originalStatus
+      })
+    ).toEqual(Timeline.MAIN)
+
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR4_ID,
+      originalStatus.id
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: announce
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for announce when announce wrapper is direct to another actor (unreadable wrapper)', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const publicStatus = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Public note with direct announce wrapper'
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      publicStatus.id,
+      { to: [ACTOR1_ID], cc: [] }
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toBeNull()
+  })
+
+  it('returns null for nested announce when inner announce wrapper is unauthorized', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const publicStatus = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Public note for nested announce with unauthorized inner wrapper'
+    )
+    const innerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR5_ID,
+      publicStatus.id,
+      { to: [ACTOR1_ID], cc: [] }
+    )
+    if (!innerAnnounce) fail('Inner announce must be defined')
+
+    const outerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      innerAnnounce.id
+    )
+    if (!outerAnnounce) fail('Outer announce must be defined')
+
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: outerAnnounce
+      })
+    ).toBeNull()
+  })
+
+  it('returns main timeline for authorized followers-only announce wrapper of a public status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const publicStatus = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Public note for followers-only announce wrapper'
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      publicStatus.id,
+      { to: [`${ACTOR2_ID}/followers`], cc: [] }
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns main timeline for authorized direct announce wrapper of a public status', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const publicStatus = await createStatus(
+      database,
+      ACTOR1_ID,
+      'Public note for direct announce wrapper'
+    )
+    const announce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      publicStatus.id,
+      { to: [ACTOR3_ID], cc: [] }
+    )
+    if (!announce) fail('Announce must be defined')
+    expect(
+      await mainTimelineRule({ database, currentActor, status: announce })
+    ).toEqual(Timeline.MAIN)
+  })
+
+  it('returns null for nested announce when all boosters and original author are followed and root is already in timeline', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    const rootStatus = await createStatus(
+      database,
+      ACTOR4_ID,
+      'Root note by followed Actor4'
+    )
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: rootStatus
+      })
+    ).toEqual(Timeline.MAIN)
+
+    // Actor3 follows Actor2
+    const innerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR2_ID,
+      rootStatus.id
+    )
+    if (!innerAnnounce) fail('Inner announce must be defined')
+
+    // Actor3 follows Actor4
+    const outerAnnounce = await createCustomAnnounce(
+      database,
+      ACTOR4_ID,
+      innerAnnounce.id
+    )
+    if (!outerAnnounce) fail('Outer announce must be defined')
+
+    expect(
+      await mainTimelineRule({
+        database,
+        currentActor,
+        status: outerAnnounce
       })
     ).toBeNull()
   })

--- a/lib/services/timelines/main.ts
+++ b/lib/services/timelines/main.ts
@@ -1,5 +1,6 @@
+import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { FollowStatus } from '@/lib/types/domain/follow'
-import { StatusType } from '@/lib/types/domain/status'
+import { StatusType, getOriginalStatus } from '@/lib/types/domain/status'
 import { withSpan } from '@/lib/utils/trace'
 
 import { MainTimelineRule, Timeline } from './types'
@@ -57,6 +58,15 @@ export const mainTimelineRule: MainTimelineRule = async ({
           }
         }
 
+        const isAuthorized = await canActorReadStatus({
+          database,
+          currentActor,
+          status
+        })
+        if (!isAuthorized) {
+          return null
+        }
+
         const originalStatus = status.originalStatus
         const timeline = await mainTimelineRule({
           database,
@@ -64,6 +74,17 @@ export const mainTimelineRule: MainTimelineRule = async ({
           status: originalStatus
         })
         if (timeline === Timeline.MAIN) return null
+
+        const rootStatus = getOriginalStatus(status)
+        if (rootStatus.id !== originalStatus.id) {
+          const rootTimeline = await mainTimelineRule({
+            database,
+            currentActor,
+            status: rootStatus
+          })
+          if (rootTimeline === Timeline.MAIN) return null
+        }
+
         return Timeline.MAIN
       }
 

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -161,7 +161,6 @@
     "lib/services/notifications/getMastodonNotification.test.ts",
     "lib/services/notifications/groupNotifications.test.ts",
     "lib/services/oauth/userinfo.test.ts",
-    "lib/services/statusAccess.test.ts",
     "lib/services/strava/archiveReader.open.test.ts",
     "lib/services/timelines/getFilteredTimelinePage.test.ts",
     "lib/services/translation/translateStatus.test.ts",


### PR DESCRIPTION
Reject public and unlisted incoming boosts whose original status is not publicly readable, while preserving authorized private boosts. Home timeline eligibility now authorizes each hydrated Announce before deduplication and preserves nested-original deduplication.\n\nValidation: yarn run prettier --write .; yarn lint; yarn typecheck; yarn build; yarn test (972 files, 13080 tests).