### PR TITLE
fix: preserve home timeline cursor after deletion

### DIFF
--- a/app/(timeline)/MainPageTimeline.test.tsx
+++ b/app/(timeline)/MainPageTimeline.test.tsx
@@ -2,11 +2,18 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
+import { getTimeline } from '@/lib/client'
+import { Timeline } from '@/lib/services/timelines/types'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusAnnounce,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 
 import { MainPageTimeline } from './MainPageTimeline'
 
@@ -33,22 +40,104 @@ vi.mock('@/lib/components/scroll-to-top-button', () => ({
 vi.mock('@/lib/components/posts/posts', () => ({
   Posts: ({
     statuses,
-    currentTime
+    currentTime,
+    onPostDeleted
   }: {
     statuses: Status[]
     currentTime: number
+    onPostDeleted?: (status: Status) => void
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
-      {statuses.map((status) => (
-        <div key={status.id}>{status.id}</div>
-      ))}
+      <button
+        type="button"
+        data-testid="trigger-delete-unknown"
+        onClick={() =>
+          onPostDeleted?.({
+            id: 'https://activities.local/users/llun/s/unknown',
+            actorId: 'https://activities.local/users/llun',
+            actor: null,
+            to: [],
+            cc: [],
+            edits: [],
+            isLocalActor: true,
+            createdAt: 0,
+            updatedAt: 0,
+            type: StatusType.enum.Note,
+            url: 'https://activities.local/users/llun/s/unknown',
+            text: 'unknown',
+            summary: null,
+            reply: '',
+            replies: [],
+            actorAnnounceStatusId: null,
+            isActorLiked: false,
+            isActorBookmarked: false,
+            totalLikes: 0,
+            totalShares: 0,
+            attachments: [],
+            tags: []
+          })
+        }
+      >
+        delete unknown
+      </button>
+      {statuses.map((status) => {
+        const target =
+          status.type === StatusType.enum.Announce
+            ? status.originalStatus
+            : status
+        return (
+          <div key={status.id} data-testid={`post-${status.id}`}>
+            <span data-testid={`post-id-${status.id}`}>{status.id}</span>
+            <button
+              type="button"
+              data-testid={`trigger-delete-${status.id}`}
+              onClick={() => onPostDeleted?.(status)}
+            >
+              delete status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-delete-target-${status.id}`}
+              onClick={() => onPostDeleted?.(target)}
+            >
+              delete target
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-delete-clone-${status.id}`}
+              onClick={() => onPostDeleted?.({ ...target })}
+            >
+              delete clone
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }))
 
 vi.mock('@/lib/components/ui/button', () => ({
-  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    'aria-label': ariaLabel
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    'aria-label'?: string
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  )
 }))
 
 const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
@@ -68,7 +157,10 @@ const profile: ActorProfile = {
   createdAt: FIXED_CURRENT_TIME
 }
 
-const createStatus = (id: string): Status => ({
+const createStatus = (
+  id: string,
+  overrides: Partial<StatusNote> = {}
+): StatusNote => ({
   id,
   actorId: profile.id,
   actor: profile,
@@ -86,9 +178,31 @@ const createStatus = (id: string): Status => ({
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
+  totalShares: 0,
   attachments: [],
-  tags: []
+  tags: [],
+  ...overrides
+})
+
+const createAnnounceStatus = (
+  id: string,
+  originalStatus: Status,
+  overrides: Partial<StatusAnnounce> = {}
+): StatusAnnounce => ({
+  id,
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: FIXED_CURRENT_TIME,
+  updatedAt: FIXED_CURRENT_TIME,
+  type: StatusType.enum.Announce,
+  originalStatus,
+  ...overrides
 })
 
 class MockIntersectionObserver {
@@ -101,6 +215,10 @@ describe('MainPageTimeline', () => {
   beforeAll(() => {
     ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
       MockIntersectionObserver
+  })
+
+  beforeEach(() => {
+    vi.mocked(getTimeline).mockReset()
   })
 
   it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
@@ -132,5 +250,279 @@ describe('MainPageTimeline', () => {
     } finally {
       dateNowSpy.mockRestore()
     }
+  })
+
+  it('removes a direct post from the feed when delete callback is invoked', () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, post2]}
+      />
+    )
+
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/1')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/2')
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-https://activities.local/users/llun/s/1'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/1')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/2')
+    ).toBeInTheDocument()
+  })
+
+  it('removes a displayed boost wrapper when its original status is deleted', () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const original2 = createStatus('https://activities.local/users/llun/s/2')
+    const boost2 = createAnnounceStatus(
+      'https://activities.local/users/llun/s/boost-2',
+      original2
+    )
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, boost2]}
+      />
+    )
+
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/boost-2')
+    ).toBeInTheDocument()
+
+    // Trigger delete with original2 (the boosted original)
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-target-https://activities.local/users/llun/s/boost-2'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/boost-2')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/1')
+    ).toBeInTheDocument()
+  })
+
+  it('removes a post when delete callback receives a different object instance with the same ID', () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, post2]}
+      />
+    )
+
+    // Trigger delete clone (different object instance, identical ID)
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-clone-https://activities.local/users/llun/s/1'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/1')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/2')
+    ).toBeInTheDocument()
+  })
+
+  it('leaves the feed unchanged when an unknown ID is deleted', () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, post2]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('trigger-delete-unknown'))
+
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/1')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/2')
+    ).toBeInTheDocument()
+  })
+
+  it('preserves unrelated rows, ordering, and concurrent updates', () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+    const post3 = createStatus('https://activities.local/users/llun/s/3')
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, post2, post3]}
+      />
+    )
+
+    // Delete post2 then post1 in succession (concurrent updates)
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-https://activities.local/users/llun/s/2'
+      )
+    )
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-https://activities.local/users/llun/s/1'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/1')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/2')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/3')
+    ).toBeInTheDocument()
+  })
+
+  it('preserves the server-provided pagination cursor and fetches the next page after deletion', async () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+    const post3 = createStatus('https://activities.local/users/llun/s/3')
+
+    vi.mocked(getTimeline).mockResolvedValueOnce({
+      statuses: [post3],
+      nextMaxStatusId: 'cursor-server-page-2',
+      prevMinStatusId: null
+    })
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1, post2]}
+        initialNextMaxStatusId="cursor-server-page-1"
+      />
+    )
+
+    // Delete the last visible item (post2)
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-https://activities.local/users/llun/s/2'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/2')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/1')
+    ).toBeInTheDocument()
+
+    // Click Load more to fetch next page
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenCalledTimes(1)
+    })
+
+    // The cursor MUST be the server-provided 'cursor-server-page-1', NOT replaced with post1.id!
+    expect(getTimeline).toHaveBeenCalledWith({
+      timeline: Timeline.MAIN,
+      maxStatusId: 'cursor-server-page-1'
+    })
+
+    // Next page post3 should now be rendered
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('post-https://activities.local/users/llun/s/3')
+      ).toBeInTheDocument()
+    })
+    expect(
+      screen.getByTestId('post-https://activities.local/users/llun/s/1')
+    ).toBeInTheDocument()
+  })
+
+  it('allows fetching the next page after all visible items are deleted', async () => {
+    const post1 = createStatus('https://activities.local/users/llun/s/1')
+    const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+    vi.mocked(getTimeline).mockResolvedValueOnce({
+      statuses: [post2],
+      nextMaxStatusId: null,
+      prevMinStatusId: null
+    })
+
+    render(
+      <MainPageTimeline
+        host="activities.local"
+        currentTime={FIXED_CURRENT_TIME}
+        profile={profile}
+        isMediaUploadEnabled={false}
+        statuses={[post1]}
+        initialNextMaxStatusId="cursor-page-1"
+      />
+    )
+
+    // Delete the only visible item
+    fireEvent.click(
+      screen.getByTestId(
+        'trigger-delete-https://activities.local/users/llun/s/1'
+      )
+    )
+
+    expect(
+      screen.queryByTestId('post-https://activities.local/users/llun/s/1')
+    ).not.toBeInTheDocument()
+
+    // Load more should still be available with the server-provided cursor
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenCalledTimes(1)
+    })
+
+    expect(getTimeline).toHaveBeenCalledWith({
+      timeline: Timeline.MAIN,
+      maxStatusId: 'cursor-page-1'
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('post-https://activities.local/users/llun/s/2')
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -13,7 +13,11 @@ import { Button } from '@/lib/components/ui/button'
 import { Timeline } from '@/lib/services/timelines/types'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
 interface MainPageTimelineProps {
@@ -64,14 +68,26 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
   }
 
   const onPostDeleted = (status: Status) => {
-    const statusIndex = currentStatuses.indexOf(status)
-    const newStatuses = [
-      ...currentStatuses.slice(0, statusIndex),
-      ...currentStatuses.slice(statusIndex + 1)
-    ]
-    setCurrentStatuses(newStatuses)
-    lastStatusIdRef.current =
-      newStatuses.length > 0 ? newStatuses[newStatuses.length - 1].id : null
+    const deletedStatusId = status.id
+    setCurrentStatuses((previousStatuses) => {
+      const nextStatuses = previousStatuses.filter((item) => {
+        if (item.id === deletedStatusId) {
+          return false
+        }
+        if (
+          item.type === StatusType.enum.Announce &&
+          (item.originalStatus.id === deletedStatusId ||
+            getOriginalStatus(item).id === deletedStatusId)
+        ) {
+          return false
+        }
+        return true
+      })
+      if (nextStatuses.length === previousStatuses.length) {
+        return previousStatuses
+      }
+      return nextStatuses
+    })
   }
 
   const loadMoreStatuses = useCallback(async () => {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -19,7 +19,6 @@
     // tsconfig.json.
     "app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx",
     "app/(nosidebar)/oauth/authorize/page.test.tsx",
-    "app/(timeline)/MainPageTimeline.test.tsx",
     "app/(timeline)/[actor]/ActorTimelines.test.tsx",
     "app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx",
     "app/(timeline)/[actor]/[status]/StatusBox.test.tsx",


### PR DESCRIPTION
## Summary
- remove home-timeline entries by status ID through a functional state update
- remove displayed boosts when their original status is deleted without overwriting the server pagination cursor
- cover callback-driven direct, boost-original, cloned-ID, unknown-ID, concurrent-deletion, and pagination-after-deletion cases; typecheck the component test

## Validation
- `yarn run prettier --write .`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test` (972 files, 13,063 tests)
- Browser: signed into an isolated local SQLite fixture at `127.0.0.1:3203`, verified the home timeline renders seeded posts/media and Load more completes. Screenshot captured during this verification.
