### PR TITLE
none: document required aggregate CI gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2128,13 +2128,11 @@ preserving legacy and fitness attachments` pins the surviving-null behaviour.
   build, four parallel test shards aggregated into an `All Tests` step, and
   Schema Dump Sync (regenerates the SQLite schema dump from the migrations and
   fails on drift) on every push and PR. Branch protection on `main` requires
-  exactly three status checks — `Lint and Prettier`, `Build`, `All Tests` — not
-  the `CI Success` aggregate job; `Schema Dump Sync` and `Type Check` are **not**
-  required checks, so a red **Type Check** currently blocks nothing at merge
-  time even though it is the only gate covering `*.test.ts(x)`. Adding
-  `Type Check` to the required list is a repo-settings change a maintainer has
-  to make; until then, treat it as advisory and check it by hand before
-  merging.
+  four status checks — `All Tests`, `Lint and Prettier`, `Build`, and `CI Success`
+  (strict: false). The `CI Success` aggregate job is fail-closed over all upstream
+  jobs (`Lint and Prettier`, `Type Check`, `Build`, `All Tests`, and
+  `Schema Dump Sync`), so failures in `Type Check` (the gate covering
+  `*.test.ts(x)`) or `Schema Dump Sync` block merging via `CI Success`.
   The test job pins `TEST_DATABASE_TYPE: sqlite`; `lib/database/testUtils.ts`
   also supports `TEST_DATABASE_TYPE=pg` (with `TEST_DATABASE_HOST` /
   `TEST_DATABASE_USERNAME` / `TEST_DATABASE_PASSWORD`; the port is fixed at 5432) for running the suite against a throwaway **local** PostgreSQL. In that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,6 +324,17 @@ Also:
 - **Link issues**: Reference related issues using `Fixes #123` or `Relates to #456`
 - **Keep PRs focused**: One feature/fix per PR
 
+### CI Status Checks
+
+Branch protection on `main` requires four status checks:
+
+- `All Tests`
+- `Lint and Prettier`
+- `Build`
+- `CI Success`
+
+`CI Success` is required and fail-closed over all upstream CI checks: lint (`Lint and Prettier`), typecheck (`Type Check`), build (`Build`), test shards (`All Tests`), and schema dump checks (`Schema Dump Sync`). If any upstream check fails, `CI Success` fails and blocks merging.
+
 ### PR Checklist
 
 - [ ] Code follows project style guidelines
@@ -333,6 +344,7 @@ Also:
 - [ ] TypeScript types are proper (no `any`)
 - [ ] Commit messages follow convention
 - [ ] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` pass
+- [ ] All CI status checks pass (including required check `CI Success`, fail-closed over lint, typecheck, build, tests, and schema dump checks)
 
 ## Project Structure
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1201,3 +1201,14 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
   explicitly `minor:`/`major:`.
 - Pre-commit gate is green in order: `yarn run prettier --write .`, `yarn lint`,
   `yarn typecheck`, `yarn build`, `yarn test`.
+- All required CI status checks pass (`All Tests`, `Lint and Prettier`, `Build`,
+  and `CI Success`).
+
+## CI checklist
+
+- Branch protection on `main` requires four status checks: `All Tests`,
+  `Lint and Prettier`, `Build`, and `CI Success`.
+- `CI Success` is required and fail-closed over lint (`Lint and Prettier`),
+  typecheck (`Type Check`), build (`Build`), tests (`All Tests`), and schema dump
+  checks (`Schema Dump Sync`). A failure in any upstream check blocks merging via
+  `CI Success`.


### PR DESCRIPTION
## Summary

Type Check and Schema Dump Sync could fail while all three previously required checks passed. Main branch protection now also requires the existing `CI Success` aggregate from GitHub Actions (app ID `15368`), so either failure blocks merging. This PR updates the agent, contributor, and review instructions to describe the enforced gate.

The repository-setting change preserves `All Tests`, `Lint and Prettier`, and `Build`, retains the existing strict setting, and leaves every unrelated protection field unchanged. The full protection configuration was read back and compared after applying the narrowly scoped required-check update. PR #1825 demonstrates the aggregate running on a real cleanup PR.

The workflow itself is unchanged. A fresh Gemini 3.8 Flash High review checked the proposed setting before it was applied; an independent review of this complete PR follows the local validation gate.

## Validation

Prettier, lint, typecheck, production build, and the complete test suite passed locally in the required order. Repository protection read-back confirms the four exact contexts and GitHub Actions app identity.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Documentation references to required CI checks updated
- [x] No migrations changed
- [x] `version` in `package.json` is untouched
- [x] No production or operational SQL in this description
