### PR TITLE
refactor: move queue schemas to config

### DIFF
--- a/lib/config/queue.test.ts
+++ b/lib/config/queue.test.ts
@@ -1,4 +1,41 @@
-import { getQueueConfig } from './queue'
+import fs from 'fs'
+import path from 'path'
+
+import {
+  DatabaseQueueConfig,
+  QStashConfig,
+  QueueConfig,
+  getQueueConfig
+} from './queue'
+
+const databaseMock = vi.fn()
+vi.mock('@/lib/database', () => {
+  databaseMock()
+  return {
+    getDatabase: vi.fn(),
+    getKnex: vi.fn()
+  }
+})
+
+const jobsMock = vi.fn()
+vi.mock('@/lib/jobs', () => {
+  jobsMock()
+  return {
+    JOBS: {}
+  }
+})
+
+const googleCloudTasksMock = vi.fn()
+vi.mock('@google-cloud/tasks', () => {
+  googleCloudTasksMock()
+  return {}
+})
+
+const qstashMock = vi.fn()
+vi.mock('@upstash/qstash', () => {
+  qstashMock()
+  return {}
+})
 
 describe('Queue config', () => {
   const originalEnv = process.env
@@ -9,6 +46,200 @@ describe('Queue config', () => {
 
   afterAll(() => {
     process.env = originalEnv
+  })
+
+  describe('DatabaseQueueConfig schema', () => {
+    it('accepts valid database queue config', () => {
+      const parsed = DatabaseQueueConfig.safeParse({
+        type: 'database',
+        maxRetries: 5,
+        pollIntervalMs: 2000
+      })
+      expect(parsed.success).toBe(true)
+      if (parsed.success) {
+        expect(parsed.data).toEqual({
+          type: 'database',
+          maxRetries: 5,
+          pollIntervalMs: 2000
+        })
+      }
+    })
+
+    it('accepts database queue config with minimal options', () => {
+      const parsed = DatabaseQueueConfig.safeParse({ type: 'database' })
+      expect(parsed.success).toBe(true)
+    })
+
+    it('rejects non-positive maxRetries', () => {
+      expect(
+        DatabaseQueueConfig.safeParse({ type: 'database', maxRetries: 0 })
+          .success
+      ).toBe(false)
+      expect(
+        DatabaseQueueConfig.safeParse({ type: 'database', maxRetries: -1 })
+          .success
+      ).toBe(false)
+    })
+
+    it('rejects non-positive pollIntervalMs', () => {
+      expect(
+        DatabaseQueueConfig.safeParse({ type: 'database', pollIntervalMs: 0 })
+          .success
+      ).toBe(false)
+      expect(
+        DatabaseQueueConfig.safeParse({
+          type: 'database',
+          pollIntervalMs: -100
+        }).success
+      ).toBe(false)
+    })
+
+    it('rejects incorrect type discriminator', () => {
+      expect(DatabaseQueueConfig.safeParse({ type: 'qstash' }).success).toBe(
+        false
+      )
+    })
+  })
+
+  describe('QStashConfig schema', () => {
+    it('accepts valid qstash queue config', () => {
+      const parsed = QStashConfig.safeParse({
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'test-token',
+        currentSigningKey: 'current-key',
+        nextSigningKey: 'next-key',
+        maxRetries: 3
+      })
+      expect(parsed.success).toBe(true)
+      if (parsed.success) {
+        expect(parsed.data).toEqual({
+          type: 'qstash',
+          url: 'https://qstash.example.com',
+          token: 'test-token',
+          currentSigningKey: 'current-key',
+          nextSigningKey: 'next-key',
+          maxRetries: 3
+        })
+      }
+    })
+
+    it('accepts zero maxRetries because nonnegative is allowed', () => {
+      const parsed = QStashConfig.safeParse({
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'test-token',
+        currentSigningKey: 'current-key',
+        nextSigningKey: 'next-key',
+        maxRetries: 0
+      })
+      expect(parsed.success).toBe(true)
+    })
+
+    it('rejects invalid URL', () => {
+      const parsed = QStashConfig.safeParse({
+        type: 'qstash',
+        url: 'not-a-valid-url',
+        token: 'test-token',
+        currentSigningKey: 'current-key',
+        nextSigningKey: 'next-key'
+      })
+      expect(parsed.success).toBe(false)
+    })
+
+    it('rejects negative maxRetries', () => {
+      const parsed = QStashConfig.safeParse({
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'test-token',
+        currentSigningKey: 'current-key',
+        nextSigningKey: 'next-key',
+        maxRetries: -1
+      })
+      expect(parsed.success).toBe(false)
+    })
+
+    it('rejects missing required signing keys', () => {
+      const parsed = QStashConfig.safeParse({
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'test-token'
+      })
+      expect(parsed.success).toBe(false)
+    })
+  })
+
+  describe('QueueConfig union schema', () => {
+    it('validates each variant within the discriminated union', () => {
+      const databaseParsed = QueueConfig.safeParse({
+        type: 'database',
+        maxRetries: 2
+      })
+      expect(databaseParsed.success).toBe(true)
+
+      const qstashParsed = QueueConfig.safeParse({
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'token',
+        currentSigningKey: 'k1',
+        nextSigningKey: 'k2'
+      })
+      expect(qstashParsed.success).toBe(true)
+
+      const cloudtasksParsed = QueueConfig.safeParse({
+        type: 'cloudtasks',
+        url: 'https://example.com/api/v1/queue/cloudtasks',
+        queue: 'tasks'
+      })
+      expect(cloudtasksParsed.success).toBe(true)
+
+      const unknownParsed = QueueConfig.safeParse({
+        type: 'unknown'
+      })
+      expect(unknownParsed.success).toBe(false)
+    })
+  })
+
+  describe('isolated import regression', () => {
+    it('does not load database, job registry, or optional queue SDKs on import', () => {
+      expect(databaseMock).not.toHaveBeenCalled()
+      expect(jobsMock).not.toHaveBeenCalled()
+      expect(googleCloudTasksMock).not.toHaveBeenCalled()
+      expect(qstashMock).not.toHaveBeenCalled()
+    })
+
+    it('does not load database, job registry, or optional queue SDKs on fresh dynamic import', async () => {
+      databaseMock.mockClear()
+      jobsMock.mockClear()
+      googleCloudTasksMock.mockClear()
+      qstashMock.mockClear()
+
+      vi.resetModules()
+      const imported = await import('./queue')
+
+      expect(imported.DatabaseQueueConfig).toBeDefined()
+      expect(imported.QStashConfig).toBeDefined()
+      expect(imported.CloudTasksConfig).toBeDefined()
+      expect(imported.QueueConfig).toBeDefined()
+      expect(imported.getQueueConfig).toBeDefined()
+
+      expect(databaseMock).not.toHaveBeenCalled()
+      expect(jobsMock).not.toHaveBeenCalled()
+      expect(googleCloudTasksMock).not.toHaveBeenCalled()
+      expect(qstashMock).not.toHaveBeenCalled()
+    })
+
+    it('has no static dependency on database, jobs, queue services, or optional queue SDKs', () => {
+      const source = fs.readFileSync(
+        path.join(process.cwd(), 'lib/config/queue.ts'),
+        'utf-8'
+      )
+      expect(source).not.toContain('@/lib/database')
+      expect(source).not.toContain('@/lib/jobs')
+      expect(source).not.toContain('@/lib/services/queue')
+      expect(source).not.toContain('@google-cloud/tasks')
+      expect(source).not.toContain('@upstash/qstash')
+    })
   })
 
   describe('getQueueConfig', () => {

--- a/lib/config/queue.ts
+++ b/lib/config/queue.ts
@@ -1,12 +1,23 @@
 import { z } from 'zod'
 
-import { DatabaseQueueConfig } from '@/lib/services/queue/database'
-import { QStashConfig } from '@/lib/services/queue/qstash'
-
 import { matcher } from './utils'
 
-export { DatabaseQueueConfig } from '@/lib/services/queue/database'
-export { QStashConfig } from '@/lib/services/queue/qstash'
+export const DatabaseQueueConfig = z.object({
+  type: z.literal('database'),
+  maxRetries: z.number().int().positive().optional(),
+  pollIntervalMs: z.number().int().positive().optional()
+})
+export type DatabaseQueueConfig = z.infer<typeof DatabaseQueueConfig>
+
+export const QStashConfig = z.object({
+  type: z.literal('qstash'),
+  url: z.string().url(),
+  token: z.string(),
+  currentSigningKey: z.string(),
+  nextSigningKey: z.string(),
+  maxRetries: z.number().int().nonnegative().optional()
+})
+export type QStashConfig = z.infer<typeof QStashConfig>
 
 export const CloudTasksConfig = z.object({
   type: z.literal('cloudtasks'),

--- a/lib/services/queue/database.test.ts
+++ b/lib/services/queue/database.test.ts
@@ -1,8 +1,12 @@
 import knex, { Knex } from 'knex'
 
+import { DatabaseQueueConfig as LeafDatabaseQueueConfig } from '@/lib/config/queue'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { Database } from '@/lib/database/types'
-import { DatabaseQueue } from '@/lib/services/queue/database'
+import {
+  DatabaseQueue,
+  DatabaseQueueConfig
+} from '@/lib/services/queue/database'
 import { JobMessage } from '@/lib/services/queue/type'
 
 describe('DatabaseQueue', () => {
@@ -23,6 +27,16 @@ describe('DatabaseQueue', () => {
 
   afterAll(async () => {
     await database.destroy()
+  })
+
+  it('re-exports DatabaseQueueConfig matching leaf queue config', () => {
+    expect(DatabaseQueueConfig).toBe(LeafDatabaseQueueConfig)
+    const parsed = DatabaseQueueConfig.safeParse({
+      type: 'database',
+      maxRetries: 5,
+      pollIntervalMs: 2000
+    })
+    expect(parsed.success).toBe(true)
   })
 
   it('declares runsInline as false', () => {

--- a/lib/services/queue/database.ts
+++ b/lib/services/queue/database.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod'
-
+import { DatabaseQueueConfig } from '@/lib/config/queue'
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
 import { withSpan } from '@/lib/utils/trace'
@@ -7,12 +6,7 @@ import { withSpan } from '@/lib/utils/trace'
 import { defaultJobHandle } from './base'
 import { JobMessage, Queue } from './type'
 
-export const DatabaseQueueConfig = z.object({
-  type: z.literal('database'),
-  maxRetries: z.number().int().positive().optional(),
-  pollIntervalMs: z.number().int().positive().optional()
-})
-export type DatabaseQueueConfig = z.infer<typeof DatabaseQueueConfig>
+export { DatabaseQueueConfig } from '@/lib/config/queue'
 
 export class DatabaseQueue implements Queue {
   readonly runsInline = false

--- a/lib/services/queue/qstash.test.ts
+++ b/lib/services/queue/qstash.test.ts
@@ -8,7 +8,9 @@ import {
 import type { Client } from '@upstash/qstash'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { QStashQueue } from './qstash'
+import { QStashConfig as LeafQStashConfig } from '@/lib/config/queue'
+
+import { QStashConfig, QStashQueue } from './qstash'
 
 const mockPublishJSON = vi.fn()
 const MockClient = vi.fn().mockImplementation(function (this: unknown) {
@@ -45,6 +47,18 @@ describe('QStashQueue', () => {
       } as unknown as Client
     })
     mockPublishJSON.mockClear()
+  })
+
+  it('re-exports QStashConfig matching leaf queue config', () => {
+    expect(QStashConfig).toBe(LeafQStashConfig)
+    const parsed = QStashConfig.safeParse({
+      type: 'qstash',
+      url: 'https://example.com/queue',
+      token: 'token',
+      currentSigningKey: 'key',
+      nextSigningKey: 'nextKey'
+    })
+    expect(parsed.success).toBe(true)
   })
 
   it('uses message id as deduplicationId', async () => {

--- a/lib/services/queue/qstash.ts
+++ b/lib/services/queue/qstash.ts
@@ -1,22 +1,14 @@
 import { context, propagation } from '@opentelemetry/api'
 import type { Client } from '@upstash/qstash'
-import { z } from 'zod'
 
+import { QStashConfig } from '@/lib/config/queue'
 import { dynamicImport } from '@/lib/utils/dynamicImport'
 import { withSpan } from '@/lib/utils/trace'
 
 import { defaultJobHandle } from './base'
 import { JobMessage, Queue } from './type'
 
-export const QStashConfig = z.object({
-  type: z.literal('qstash'),
-  url: z.string().url(),
-  token: z.string(),
-  currentSigningKey: z.string(),
-  nextSigningKey: z.string(),
-  maxRetries: z.number().int().nonnegative().optional()
-})
-export type QStashConfig = z.infer<typeof QStashConfig>
+export { QStashConfig } from '@/lib/config/queue'
 
 const MAX_JOB_TIMEOUT_SECONDS = 30
 const DEFAULT_MAX_JOB_RETRIES = 3


### PR DESCRIPTION
## Summary

- Move database and QStash queue schemas into the leaf queue configuration module.
- Preserve provider schema re-exports while removing config imports that pull database or optional queue SDKs.
- Add isolated-import coverage and schema compatibility tests.

## Validation

- `yarn run prettier --write .`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test` (13,090 passed)
