### PR TITLE
fix: stabilize account media pagination

### DIFF
--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -1,6 +1,12 @@
 import {
+  SQLITE_MAX_BINDINGS,
+  chunkArray,
+  isSQLiteClient
+} from '@/lib/database/sql/utils/knex'
+import {
   databaseBeforeAll,
-  getTestDatabaseTable
+  getTestDatabaseTable,
+  getTestDatabaseWithInstance
 } from '@/lib/database/testUtils'
 import { seedDatabase } from '@/lib/stub/database'
 import { DatabaseSeed } from '@/lib/stub/scenarios/database'
@@ -747,6 +753,303 @@ describe('MediaDatabase', () => {
         const item = result.items.find((m) => m.id === media!.id)
         expect(item).toBeDefined()
         expect(item?.statusId).toBe(statuses[0].id)
+      })
+
+      it('prevents cross-account attachments from contributing statusId to requesting account', async () => {
+        const actor1 = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        const actor2 = await database.getActorFromId({
+          id: actors.replyAuthor.id
+        })
+        expect(actor1?.account).toBeDefined()
+        expect(actor2?.account).toBeDefined()
+        const account1Id = actor1!.account!.id
+        const account2Id = actor2!.account!.id
+        expect(account1Id).not.toBe(account2Id)
+
+        const mediaAccount1 = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/cross-account-attachment-test.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        expect(mediaAccount1).toBeDefined()
+
+        const foreignStatuses = await database.getActorStatuses({
+          actorId: actors.replyAuthor.id,
+          limit: 1
+        })
+        expect(foreignStatuses.length).toBeGreaterThan(0)
+        const foreignStatusId = foreignStatuses[0].id
+
+        await database.createAttachment({
+          actorId: actors.replyAuthor.id,
+          statusId: foreignStatusId,
+          mediaType: 'image/jpeg',
+          url: mediaAccount1!.original.path,
+          width: 100,
+          height: 100,
+          mediaId: mediaAccount1!.id
+        })
+
+        const resultAccount1 = await database.getMediasWithStatusForAccount({
+          accountId: account1Id,
+          limit: 100
+        })
+
+        const item = resultAccount1.items.find(
+          (m) => m.id === String(mediaAccount1!.id)
+        )
+        expect(item).toBeDefined()
+        expect(item?.statusId).toBeUndefined()
+
+        const ownStatuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 1
+        })
+        expect(ownStatuses.length).toBeGreaterThan(0)
+        const ownStatusId = ownStatuses[0].id
+
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: ownStatusId,
+          mediaType: 'image/jpeg',
+          url: mediaAccount1!.original.path,
+          width: 100,
+          height: 100,
+          mediaId: mediaAccount1!.id
+        })
+
+        const resultWithOwn = await database.getMediasWithStatusForAccount({
+          accountId: account1Id,
+          limit: 100
+        })
+
+        const itemWithOwn = resultWithOwn.items.find(
+          (m) => m.id === String(mediaAccount1!.id)
+        )
+        expect(itemWithOwn).toBeDefined()
+        expect(itemWithOwn?.statusId).toBe(ownStatusId)
+      })
+
+      it('chunks attachment lookups under SQLite parameter limits while preserving ownership filtering and status IDs', async () => {
+        const {
+          database: isolatedDb,
+          instance,
+          prepare: prepareIsolated
+        } = getTestDatabaseWithInstance(true, databaseType)
+        await prepareIsolated()
+        await isolatedDb.migrate()
+
+        try {
+          await seedDatabase(isolatedDb)
+
+          const actor1 = await isolatedDb.getActorFromId({
+            id: actors.primary.id
+          })
+          const actor2 = await isolatedDb.getActorFromId({
+            id: actors.replyAuthor.id
+          })
+          expect(actor1?.account).toBeDefined()
+          expect(actor2?.account).toBeDefined()
+          const account1Id = actor1!.account!.id
+          const account2Id = actor2!.account!.id
+          expect(account1Id).not.toBe(account2Id)
+
+          // Insert 1000 owned media rows for account1. With 2 reserved bindings
+          // (actors.accountId and attachments.statusId <> ''), SQLite batch size
+          // is 997 (SQLITE_MAX_BINDINGS - 2), so 1000 items cross into a second chunk.
+          const mediaCount = 1000
+          const now = Date.now()
+          const mediaRows = Array.from({ length: mediaCount }, (_, index) => ({
+            id: index + 1,
+            actorId: actors.primary.id,
+            accountId: account1Id,
+            original: `/test/chunk-boundary-media-${index + 1}.jpg`,
+            originalBytes: 1024,
+            originalMimeType: 'image/jpeg',
+            originalMetaData: '{}',
+            createdAt: new Date(now - index * 1000),
+            updatedAt: new Date(now - index * 1000)
+          }))
+
+          for (const chunk of chunkArray(mediaRows, 50)) {
+            await instance('medias').insert(chunk)
+          }
+
+          // Media 1 (chunk 1): own attachment -> should return 'own-status-1'
+          // Media 2 (chunk 1): own attachment ('status-own-2') AND foreign attachment ('aaa-foreign-status-2').
+          //   Ownership filtering must ignore 'aaa-foreign-status-2' even though it sorts earlier in MIN(statusId).
+          // Media 500 (chunk 1): foreign attachment only -> should return undefined
+          // Media 501 (chunk 1): empty statusId attachment -> should return undefined
+          // Media 1000 (chunk 2): own attachment -> should return 'own-status-1000'
+          await instance('attachments').insert([
+            {
+              id: 'att-chunk-1',
+              actorId: actors.primary.id,
+              mediaId: '1',
+              statusId: 'own-status-1',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-1.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            },
+            {
+              id: 'att-chunk-2-own',
+              actorId: actors.primary.id,
+              mediaId: '2',
+              statusId: 'status-own-2',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-2.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            },
+            {
+              id: 'att-chunk-2-foreign',
+              actorId: actors.replyAuthor.id,
+              mediaId: '2',
+              statusId: 'aaa-foreign-status-2',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-2.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            },
+            {
+              id: 'att-chunk-500-foreign',
+              actorId: actors.replyAuthor.id,
+              mediaId: '500',
+              statusId: 'foreign-status-500',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-500.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            },
+            {
+              id: 'att-chunk-501-empty',
+              actorId: actors.primary.id,
+              mediaId: '501',
+              statusId: '',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-501.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            },
+            {
+              id: 'att-chunk-1000',
+              actorId: actors.primary.id,
+              mediaId: '1000',
+              statusId: 'own-status-1000',
+              mediaType: 'image/jpeg',
+              type: 'Document',
+              url: '/test/chunk-boundary-media-1000.jpg',
+              createdAt: new Date(now),
+              updatedAt: new Date(now)
+            }
+          ])
+
+          const attachmentQueries: { sql: string; bindings: unknown[] }[] = []
+          const onQuery = ({
+            sql,
+            bindings
+          }: {
+            sql: string
+            bindings?: unknown[]
+          }) => {
+            const normalizedSql = sql.toLowerCase()
+            if (
+              normalizedSql.includes('attachments') &&
+              normalizedSql.includes('medias') &&
+              normalizedSql.includes('group by')
+            ) {
+              attachmentQueries.push({ sql, bindings: bindings ?? [] })
+            }
+          }
+
+          instance.on('query', onQuery)
+          let result
+          try {
+            result = await isolatedDb.getMediasWithStatusForAccount({
+              accountId: account1Id,
+              limit: mediaCount
+            })
+          } finally {
+            instance.off('query', onQuery)
+          }
+
+          expect(attachmentQueries.length).toBeGreaterThan(0)
+          expect(result.items).toHaveLength(mediaCount)
+
+          if (isSQLiteClient(instance)) {
+            // 1000 items with batch size 997 produces exactly 2 chunks (997 and 3 items).
+            expect(attachmentQueries).toHaveLength(2)
+
+            // Every SQLite attachment query must strictly satisfy the parameter ceiling.
+            for (const query of attachmentQueries) {
+              expect(query.bindings.length).toBeLessThanOrEqual(
+                SQLITE_MAX_BINDINGS
+              )
+            }
+
+            // Chunk 1 has 997 IDs + 2 non-ID bindings (accountId and attachments.statusId <> '') = 999.
+            // If getWhereInBatchSize only reserved 1, chunk 1 would have 998 IDs + 2 = 1000 bindings,
+            // exceeding SQLite's limit.
+            expect(attachmentQueries[0].bindings).toHaveLength(
+              SQLITE_MAX_BINDINGS
+            )
+            expect(attachmentQueries[0].bindings[0]).toBe(account1Id)
+            expect(
+              attachmentQueries[0].bindings[
+                attachmentQueries[0].bindings.length - 1
+              ]
+            ).toBe('')
+
+            // Chunk 2 has remaining 3 IDs + 2 non-ID bindings = 5 bindings.
+            expect(attachmentQueries[1].bindings).toHaveLength(5)
+            expect(attachmentQueries[1].bindings[0]).toBe(account1Id)
+            expect(
+              attachmentQueries[1].bindings[
+                attachmentQueries[1].bindings.length - 1
+              ]
+            ).toBe('')
+          }
+
+          // Verify ownership filtering and correct status IDs across chunks:
+          // Chunk 1:
+          const item1 = result.items.find((m) => m.id === '1')
+          expect(item1).toBeDefined()
+          expect(item1?.statusId).toBe('own-status-1')
+
+          // Item 2 has own status 'status-own-2' preserved over foreign 'aaa-foreign-status-2'
+          const item2 = result.items.find((m) => m.id === '2')
+          expect(item2).toBeDefined()
+          expect(item2?.statusId).toBe('status-own-2')
+
+          // Item 500 only has foreign attachment, so statusId must remain undefined
+          const item500 = result.items.find((m) => m.id === '500')
+          expect(item500).toBeDefined()
+          expect(item500?.statusId).toBeUndefined()
+
+          // Item 501 has empty statusId, so statusId must remain undefined
+          const item501 = result.items.find((m) => m.id === '501')
+          expect(item501).toBeDefined()
+          expect(item501?.statusId).toBeUndefined()
+
+          // Chunk 2 (across the chunk boundary):
+          const item1000 = result.items.find((m) => m.id === '1000')
+          expect(item1000).toBeDefined()
+          expect(item1000?.statusId).toBe('own-status-1000')
+        } finally {
+          await isolatedDb.destroy()
+        }
       })
     })
 

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -13,7 +13,7 @@ describe('MediaDatabase', () => {
     await databaseBeforeAll(table)
   })
 
-  describe.each(table)('%s', (_, database) => {
+  describe.each(table)('%s', (databaseType, database) => {
     beforeAll(async () => {
       await seedDatabase(database)
     })
@@ -318,6 +318,435 @@ describe('MediaDatabase', () => {
         const testMedia = result.items.find((m) => m.id === String(media!.id))
         expect(testMedia).toBeDefined()
         expect(testMedia?.statusId).toBe(statuses[0].id)
+      })
+
+      it('does not duplicate media attached to multiple statuses and picks deterministic MIN statusId', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        expect(actor?.account).toBeDefined()
+        const accountId = actor!.account!.id
+
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/multi-attached-media.jpg',
+            bytes: 2048,
+            mimeType: 'image/jpeg',
+            metaData: { width: 400, height: 400 }
+          }
+        })
+        expect(media).toBeDefined()
+
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 3
+        })
+        expect(statuses.length).toBeGreaterThanOrEqual(2)
+
+        const statusId1 = statuses[0].id
+        const statusId2 = statuses[1].id
+        const expectedMinStatusId =
+          statusId1 < statusId2 ? statusId1 : statusId2
+
+        // Attach the same media to both statuses
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statusId1,
+          mediaType: 'image/jpeg',
+          url: media!.original.path,
+          width: 400,
+          height: 400,
+          mediaId: media!.id
+        })
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statusId2,
+          mediaType: 'image/jpeg',
+          url: media!.original.path,
+          width: 400,
+          height: 400,
+          mediaId: media!.id
+        })
+
+        const result = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 100
+        })
+
+        // Must appear exactly once in items
+        const matches = result.items.filter(
+          (item) => item.id === String(media!.id)
+        )
+        expect(matches).toHaveLength(1)
+        expect(matches[0].statusId).toBe(expectedMinStatusId)
+      })
+
+      it('returns unattached media with undefined statusId alongside attached media', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        expect(actor?.account).toBeDefined()
+        const accountId = actor!.account!.id
+
+        const unattached = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/regression-unattached.jpg',
+            bytes: 1200,
+            mimeType: 'image/jpeg',
+            metaData: { width: 300, height: 300 }
+          }
+        })
+
+        const attached = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/regression-attached.jpg',
+            bytes: 1400,
+            mimeType: 'image/jpeg',
+            metaData: { width: 300, height: 300 }
+          }
+        })
+
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 1
+        })
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statuses[0].id,
+          mediaType: 'image/jpeg',
+          url: attached!.original.path,
+          width: 300,
+          height: 300,
+          mediaId: attached!.id
+        })
+
+        const result = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 100
+        })
+
+        const unattachedItem = result.items.find(
+          (item) => item.id === String(unattached!.id)
+        )
+        const attachedItem = result.items.find(
+          (item) => item.id === String(attached!.id)
+        )
+
+        expect(unattachedItem).toBeDefined()
+        expect(unattachedItem?.statusId).toBeUndefined()
+        expect('statusId' in unattachedItem!).toBe(false)
+
+        expect(attachedItem).toBeDefined()
+        expect(attachedItem?.statusId).toBe(statuses[0].id)
+      })
+
+      it('orders deterministically by createdAt DESC, id DESC when timestamps are equal', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.extra.id
+        })
+        expect(actor?.account).toBeDefined()
+        const accountId = actor!.account!.id
+
+        // Create multiple media items in rapid succession so they share the same CURRENT_TIMESTAMP
+        const media1 = await database.createMedia({
+          actorId: actors.extra.id,
+          original: {
+            path: '/test/equal-time-1.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        const media2 = await database.createMedia({
+          actorId: actors.extra.id,
+          original: {
+            path: '/test/equal-time-2.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        const media3 = await database.createMedia({
+          actorId: actors.extra.id,
+          original: {
+            path: '/test/equal-time-3.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        expect(media1).toBeDefined()
+        expect(media2).toBeDefined()
+        expect(media3).toBeDefined()
+
+        const id1 = Number(media1!.id)
+        const id2 = Number(media2!.id)
+        const id3 = Number(media3!.id)
+        expect(id1).toBeLessThan(id2)
+        expect(id2).toBeLessThan(id3)
+
+        const result = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 100
+        })
+
+        const idx1 = result.items.findIndex(
+          (item) => item.id === String(media1!.id)
+        )
+        const idx2 = result.items.findIndex(
+          (item) => item.id === String(media2!.id)
+        )
+        const idx3 = result.items.findIndex(
+          (item) => item.id === String(media3!.id)
+        )
+
+        expect(idx1).toBeGreaterThanOrEqual(0)
+        expect(idx2).toBeGreaterThanOrEqual(0)
+        expect(idx3).toBeGreaterThanOrEqual(0)
+
+        // id DESC: media3 (largest id) comes before media2, which comes before media1
+        expect(idx3).toBeLessThan(idx2)
+        expect(idx2).toBeLessThan(idx1)
+      })
+
+      it('pages unique media cleanly across page boundaries without duplicates or offset drift', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.followRequester.id
+        })
+        expect(actor?.account).toBeDefined()
+        const accountId = actor!.account!.id
+
+        // Create 4 distinct media items
+        const createdMedias = []
+        for (let i = 0; i < 4; i++) {
+          const media = await database.createMedia({
+            actorId: actors.followRequester.id,
+            original: {
+              path: `/test/page-boundary-${i}.jpg`,
+              bytes: 1000 * (i + 1),
+              mimeType: 'image/jpeg',
+              metaData: { width: 100, height: 100 }
+            }
+          })
+          createdMedias.push(media!)
+        }
+
+        // Attach the first two medias to multiple statuses to verify attachments do not shift pagination
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 2
+        })
+        for (const media of createdMedias.slice(0, 2)) {
+          for (const status of statuses) {
+            await database.createAttachment({
+              actorId: actors.followRequester.id,
+              statusId: status.id,
+              mediaType: 'image/jpeg',
+              url: media.original.path,
+              width: 100,
+              height: 100,
+              mediaId: media.id
+            })
+          }
+        }
+
+        const page1 = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 2,
+          page: 1
+        })
+        const page2 = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 2,
+          page: 2
+        })
+
+        expect(page1.items).toHaveLength(2)
+        expect(page2.items).toHaveLength(2)
+
+        const page1Ids = page1.items.map((m) => m.id)
+        const page2Ids = page2.items.map((m) => m.id)
+
+        // No item on page 1 should appear on page 2
+        for (const id of page1Ids) {
+          expect(page2Ids).not.toContain(id)
+        }
+
+        // Total should match across pages
+        expect(page1.total).toBe(page2.total)
+        expect(page1.total).toBeGreaterThanOrEqual(4)
+      })
+
+      it('isolates media and attachments between different accounts', async () => {
+        const actor1 = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        const actor2 = await database.getActorFromId({
+          id: actors.replyAuthor.id
+        })
+        expect(actor1?.account).toBeDefined()
+        expect(actor2?.account).toBeDefined()
+        const account1Id = actor1!.account!.id
+        const account2Id = actor2!.account!.id
+        expect(account1Id).not.toBe(account2Id)
+
+        const mediaAccount1 = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/isolation-account-1.jpg',
+            bytes: 1111,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const mediaAccount2 = await database.createMedia({
+          actorId: actors.replyAuthor.id,
+          original: {
+            path: '/test/isolation-account-2.jpg',
+            bytes: 2222,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const statuses = await database.getActorStatuses({
+          actorId: actors.replyAuthor.id,
+          limit: 1
+        })
+        await database.createAttachment({
+          actorId: actors.replyAuthor.id,
+          statusId: statuses[0].id,
+          mediaType: 'image/jpeg',
+          url: mediaAccount2!.original.path,
+          width: 100,
+          height: 100,
+          mediaId: mediaAccount2!.id
+        })
+
+        const resultAccount1 = await database.getMediasWithStatusForAccount({
+          accountId: account1Id,
+          limit: 100
+        })
+        const resultAccount2 = await database.getMediasWithStatusForAccount({
+          accountId: account2Id,
+          limit: 100
+        })
+
+        // Account 1 sees mediaAccount1, never mediaAccount2
+        expect(
+          resultAccount1.items.some((m) => m.id === String(mediaAccount1!.id))
+        ).toBe(true)
+        expect(
+          resultAccount1.items.some((m) => m.id === String(mediaAccount2!.id))
+        ).toBe(false)
+
+        // Account 2 sees mediaAccount2, never mediaAccount1
+        expect(
+          resultAccount2.items.some((m) => m.id === String(mediaAccount2!.id))
+        ).toBe(true)
+        expect(
+          resultAccount2.items.some((m) => m.id === String(mediaAccount1!.id))
+        ).toBe(false)
+      })
+
+      it('validates and preserves numeric IDs across queries and attachment resolution', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        expect(actor?.account).toBeDefined()
+        const accountId = actor!.account!.id
+
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/numeric-id-media.jpg',
+            bytes: 3333,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        expect(media).toBeDefined()
+
+        // Verify ID is a numeric string
+        expect(typeof media!.id).toBe('string')
+        expect(/^\d+$/.test(media!.id)).toBe(true)
+        expect(Number(media!.id)).toBeGreaterThan(0)
+
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 1
+        })
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statuses[0].id,
+          mediaType: 'image/jpeg',
+          url: media!.original.path,
+          width: 100,
+          height: 100,
+          mediaId: media!.id
+        })
+
+        const result = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 100
+        })
+
+        const item = result.items.find((m) => m.id === media!.id)
+        expect(item).toBeDefined()
+        expect(item?.id).toBe(media!.id)
+        expect(item?.statusId).toBe(statuses[0].id)
+      })
+
+      it('resolves statusId when attachment has decimal numeric mediaId form', async () => {
+        const actor = await database.getActorFromId({
+          id: actors.primary.id
+        })
+        const accountId = actor!.account!.id
+
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/decimal-mediaId.jpg',
+            bytes: 1500,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 1
+        })
+        // attachments.mediaId is varchar(255) on SQLite, where decimal string forms
+        // like '27.0' can be stored from legacy number-bound IDs and exercise SQLite's
+        // dynamic type affinity in the join. On PostgreSQL, attachments.mediaId is an
+        // integer column, so fixtures must use the valid integer representation.
+        const attachmentMediaId =
+          databaseType === 'sqlite' ? `${media!.id}.0` : media!.id
+
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statuses[0].id,
+          mediaType: 'image/jpeg',
+          url: media!.original.path,
+          width: 100,
+          height: 100,
+          mediaId: attachmentMediaId
+        })
+
+        const result = await database.getMediasWithStatusForAccount({
+          accountId,
+          limit: 100
+        })
+
+        const item = result.items.find((m) => m.id === media!.id)
+        expect(item).toBeDefined()
+        expect(item?.statusId).toBe(statuses[0].id)
       })
     })
 

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -36,6 +36,7 @@ import { Attachment } from '@/lib/types/domain/attachment'
 
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 import { getCompatibleTime } from './utils/getCompatibleTime'
+import { chunkArray, getWhereInBatchSize } from './utils/knex'
 
 // PostgreSQL `integer` upper bound. An id above it does not merely miss: the
 // driver sends it as a parameter to an integer column and PostgreSQL answers
@@ -584,28 +585,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     // Then get the paginated items
     let itemsQuery = database('medias')
       .join('actors', 'medias.actorId', 'actors.id')
-      .leftJoin('attachments', 'medias.id', 'attachments.mediaId')
       .where('actors.accountId', accountId)
-      .distinct(
-        'medias.id',
-        'medias.actorId',
-        'medias.original',
-        'medias.originalBytes',
-        'medias.originalMimeType',
-        'medias.originalMetaData',
-        'medias.originalFileName',
-        'medias.thumbnail',
-        'medias.thumbnailBytes',
-        'medias.thumbnailMimeType',
-        'medias.thumbnailMetaData',
-        'medias.description',
-        'medias.focusX',
-        'medias.focusY',
-        'medias.blurhash',
-        'medias.createdAt',
-        'attachments.statusId'
-      )
+      .select(MEDIA_COLUMNS.map((column) => `medias.${column}`))
       .orderBy('medias.createdAt', 'desc')
+      .orderBy('medias.id', 'desc')
 
     if (maxCreatedAt) {
       itemsQuery = itemsQuery.where(
@@ -619,38 +602,52 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     const offset = (page - 1) * limit
     itemsQuery = itemsQuery.limit(limit).offset(offset)
 
-    const [total, data] = await Promise.all([totalPromise, itemsQuery])
+    const [total, data] = await Promise.all([
+      totalPromise,
+      itemsQuery as Promise<MediaRow[]>
+    ])
 
-    const items = data.map((item) => ({
-      id: String(item.id),
-      actorId: item.actorId,
-      original: {
-        path: item.original,
-        bytes: Number(item.originalBytes),
-        mimeType: item.originalMimeType,
-        metaData: parseMediaMetaData(item.originalMetaData),
-        ...(item.originalFileName ? { fileName: item.originalFileName } : {})
-      },
-      ...(item.thumbnail
-        ? {
-            thumbnail: {
-              path: item.thumbnail,
-              bytes: Number(item.thumbnailBytes),
-              mimeType: item.thumbnailMimeType,
-              metaData: parseMediaMetaData(item.thumbnailMetaData)
-            }
+    if (data.length === 0) {
+      return { items: [], total }
+    }
+
+    const numericIds = data
+      .map((item) => toMediaRowId(String(item.id)))
+      .filter((id): id is number => id !== null)
+
+    const statusIdByMediaId = new Map<string, string>()
+
+    if (numericIds.length > 0) {
+      const batchSize = getWhereInBatchSize(database)
+      for (const chunk of chunkArray(numericIds, batchSize)) {
+        const attachmentRows = await database('attachments')
+          .join('medias', 'medias.id', 'attachments.mediaId')
+          .whereIn('medias.id', chunk)
+          .whereNotNull('attachments.statusId')
+          .where('attachments.statusId', '<>', '')
+          .groupBy('medias.id')
+          .select('medias.id as mediaId')
+          .min({ statusId: 'attachments.statusId' })
+
+        for (const row of attachmentRows as {
+          mediaId: string | number
+          statusId: string | null
+        }[]) {
+          if (row.statusId) {
+            statusIdByMediaId.set(String(row.mediaId), row.statusId)
           }
-        : {}),
-      ...(item.description ? { description: item.description } : {}),
-      ...(item.focusX !== null &&
-      item.focusX !== undefined &&
-      item.focusY !== null &&
-      item.focusY !== undefined
-        ? { focus: { x: Number(item.focusX), y: Number(item.focusY) } }
-        : {}),
-      ...(item.blurhash ? { blurhash: item.blurhash } : {}),
-      ...(item.statusId ? { statusId: item.statusId } : {})
-    }))
+        }
+      }
+    }
+
+    const items = data.map((item) => {
+      const media = parseMediaRow(item)
+      const statusId = statusIdByMediaId.get(media.id)
+      return {
+        ...media,
+        ...(statusId ? { statusId } : {})
+      }
+    })
 
     return { items, total }
   },

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -618,10 +618,12 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     const statusIdByMediaId = new Map<string, string>()
 
     if (numericIds.length > 0) {
-      const batchSize = getWhereInBatchSize(database)
+      const batchSize = getWhereInBatchSize(database, 2)
       for (const chunk of chunkArray(numericIds, batchSize)) {
         const attachmentRows = await database('attachments')
           .join('medias', 'medias.id', 'attachments.mediaId')
+          .join('actors', 'attachments.actorId', 'actors.id')
+          .where('actors.accountId', accountId)
           .whereIn('medias.id', chunk)
           .whereNotNull('attachments.statusId')
           .where('attachments.statusId', '<>', '')


### PR DESCRIPTION
## Summary

Account media pagination included attachment status IDs in a distinct joined query, so a file reused by several statuses could appear repeatedly and distort page boundaries. This change selects the unique owned-media page first, ordered by creation time and media ID descending, then batch-resolves a deterministic representative status ID for each file. The total remains the count of owned media.

Coverage includes repeated attachments, unattached media, timestamp ties, page boundaries, other-account isolation and numeric ID handling. SQLite's legacy decimal-string attachment representation is tested only where that storage form is valid; PostgreSQL uses its integer column representation. No migration or package-version change is needed.

## Validation

All60 media tests pass on SQLite and on disposable local PostgreSQL17 using the explicit test port and one worker. Full required-gate results will be recorded after validation.

## Checklist

- [x] Five required local gates pass in order
- [x] No public interface, command, environment variable or documentation contract changed
- [x] No migrations changed
- [x] Package version untouched
- [x] No production or operational SQL in this description
