### PR TITLE
none: revert version from 2.0.0 to 1.161.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "2.0.0",
+  "version": "1.161.0",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary

- Revert `package.json` version from 2.0.0 to 1.161.0 (minor bump from 1.160.7).
- The v2.0.0 tag has been removed locally and on remote.
- The release will be tagged as `v1.161.0` once merged.

## Validation

- `yarn run prettier --write .`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test` (13,131 passed)
