### PR TITLE
Bump version to v1.161.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.0",
+  "version": "1.161.1",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.0`
- Base main SHA: `aa804af9d76b655c414c1adce3923844ba97f3f3`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
