### PR TITLE
fix: restore actor management feedback

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -241,9 +241,7 @@
               "app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx",
               "lib/components/settings/DeleteActorDialog.tsx",
               "lib/components/settings/MediaManagement.tsx",
-              "lib/components/settings/ActorsSection.tsx",
-              "lib/components/actor-switcher/ActorSwitcher.tsx",
-              "lib/components/actor-switcher/AddActorDialog.tsx"
+              "lib/components/settings/ActorsSection.tsx"
             ]
           }
         ]

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -9,8 +9,10 @@ import {
   addCollectionAccounts,
   approveCollectionMembership,
   bookmarkStatus,
+  cancelActorDeletion,
   cancelFitnessRouteHeatmap,
   clearFitnessRouteHeatmaps,
+  createActor,
   createCollection,
   createDirectMessage,
   createPoll,
@@ -19,6 +21,7 @@ import {
   deleteFitnessRouteHeatmap,
   deleteStatus,
   follow,
+  getActorDomains,
   getActorStatuses,
   getBookmarks,
   getCollectionFeed,
@@ -36,6 +39,7 @@ import {
   revokeCollectionMembership,
   search,
   startStravaArchiveImport,
+  switchActor,
   triggerFitnessRouteHeatmap,
   undoBookmarkStatus,
   unfollow,
@@ -1499,4 +1503,266 @@ describe('client collection helpers', () => {
       expect(feedUrl.searchParams.get('min_id')).toBe(minStatusId)
     }
   )
+})
+
+describe('client actor management helpers', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getActorDomains', () => {
+    it('fetches allowed domains and host with GET and forwards abort signal', async () => {
+      const controller = new AbortController()
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          domains: ['example.com', 'activities.local'],
+          host: 'activities.local'
+        }),
+        { status: 200 }
+      )
+
+      const result = await getActorDomains({ signal: controller.signal })
+
+      expect(result).toEqual({
+        domains: ['example.com', 'activities.local'],
+        host: 'activities.local'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/domains',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+          signal: controller.signal
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Unauthorized to view domains' }),
+        { status: 401 }
+      )
+
+      await expect(getActorDomains()).rejects.toThrow(
+        'Unauthorized to view domains'
+      )
+    })
+
+    it('falls back to default error message on 500 without error body', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(getActorDomains()).rejects.toThrow(
+        'Failed to fetch actor domains'
+      )
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      await expect(getActorDomains()).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('createActor', () => {
+    it('sends POST with username and domain', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'new-actor-1',
+          username: 'newuser',
+          domain: 'activities.local'
+        }),
+        { status: 200 }
+      )
+
+      const result = await createActor({
+        username: 'newuser',
+        domain: 'activities.local'
+      })
+
+      expect(result).toEqual({
+        id: 'new-actor-1',
+        username: 'newuser',
+        domain: 'activities.local'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username: 'newuser',
+            domain: 'activities.local'
+          })
+        })
+      )
+    })
+
+    it('omits domain from request body when domain is undefined', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'new-actor-1',
+          username: 'newuser',
+          domain: 'activities.local'
+        }),
+        { status: 200 }
+      )
+
+      await createActor({ username: 'newuser' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username: 'newuser'
+          })
+        })
+      )
+    })
+
+    it('preserves explicit empty string domain in request body for server validation', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'new-actor-1',
+          username: 'newuser',
+          domain: ''
+        }),
+        { status: 200 }
+      )
+
+      await createActor({ username: 'newuser', domain: '' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username: 'newuser',
+            domain: ''
+          })
+        })
+      )
+    })
+
+    it('decodes API error message when username exists', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Username already exists' }),
+        { status: 400 }
+      )
+
+      await expect(
+        createActor({ username: 'existing', domain: 'activities.local' })
+      ).rejects.toThrow('Username already exists')
+    })
+
+    it('falls back to default error message when creating actor fails', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(
+        createActor({ username: 'bob', domain: 'activities.local' })
+      ).rejects.toThrow('Failed to create actor')
+    })
+
+    it('propagates network error', async () => {
+      fetchMock.mockRejectOnce(new Error('Failed to fetch'))
+
+      await expect(
+        createActor({ username: 'bob', domain: 'activities.local' })
+      ).rejects.toThrow('Failed to fetch')
+    })
+  })
+
+  describe('cancelActorDeletion', () => {
+    it('sends POST with actorId to cancel deletion', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          actorId: 'actor-1',
+          status: 'cancelled'
+        }),
+        { status: 200 }
+      )
+
+      const result = await cancelActorDeletion({ actorId: 'actor-1' })
+
+      expect(result).toEqual({
+        actorId: 'actor-1',
+        status: 'cancelled'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/cancel-deletion',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1' })
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'Cannot cancel deletion that is already in progress'
+        }),
+        { status: 400 }
+      )
+
+      await expect(cancelActorDeletion({ actorId: 'actor-1' })).rejects.toThrow(
+        'Cannot cancel deletion that is already in progress'
+      )
+    })
+
+    it('falls back to default error message on failure', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(cancelActorDeletion({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to cancel actor deletion'
+      )
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      await expect(cancelActorDeletion({ actorId: 'actor-1' })).rejects.toThrow(
+        'Network error'
+      )
+    })
+  })
+
+  describe('switchActor', () => {
+    it('sends POST with actorId and returns true on ok response', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      const result = await switchActor({ actorId: 'actor-2' })
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/switch',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-2' })
+        })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 400 })
+
+      const result = await switchActor({ actorId: 'actor-2' })
+
+      expect(result).toBe(false)
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network disconnected'))
+
+      await expect(switchActor({ actorId: 'actor-2' })).rejects.toThrow(
+        'Network disconnected'
+      )
+    })
+  })
 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -825,7 +825,7 @@ export const acceptFollowRequest = ({ id }: FollowRequestParams) =>
 export const rejectFollowRequest = ({ id }: FollowRequestParams) =>
   respondToFollowRequest(id, 'reject')
 
-interface SwitchActorParams {
+export interface SwitchActorParams {
   actorId: string
 }
 
@@ -839,6 +839,106 @@ export const switchActor = async ({ actorId }: SwitchActorParams) => {
     body: JSON.stringify({ actorId })
   })
   return response.ok
+}
+
+export interface ActorDomainsResult {
+  domains: string[]
+  host: string
+}
+
+export interface GetActorDomainsParams {
+  signal?: AbortSignal
+}
+
+/**
+ * Fetches the allowed domains for actor creation
+ */
+export const getActorDomains = async ({
+  signal
+}: GetActorDomainsParams = {}): Promise<ActorDomainsResult> => {
+  const response = await fetch('/api/v1/actors/domains', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    },
+    signal
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to fetch actor domains')
+  }
+
+  const data = await response.json()
+  return {
+    domains: Array.isArray(data?.domains) ? data.domains : [],
+    host: typeof data?.host === 'string' ? data.host : ''
+  }
+}
+
+export interface CreateActorParams {
+  username: string
+  domain?: string
+}
+
+export interface CreateActorResult {
+  id: string
+  username: string
+  domain: string
+}
+
+/**
+ * Creates a new actor for the current account
+ */
+export const createActor = async ({
+  username,
+  domain
+}: CreateActorParams): Promise<CreateActorResult> => {
+  const response = await fetch('/api/v1/actors', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      username,
+      domain
+    })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to create actor')
+  }
+
+  return (await response.json()) as CreateActorResult
+}
+
+export interface CancelActorDeletionParams {
+  actorId: string
+}
+
+export interface CancelActorDeletionResult {
+  actorId: string
+  status: string
+}
+
+/**
+ * Cancels a scheduled actor deletion
+ */
+export const cancelActorDeletion = async ({
+  actorId
+}: CancelActorDeletionParams): Promise<CancelActorDeletionResult> => {
+  const response = await fetch('/api/v1/actors/cancel-deletion', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to cancel actor deletion')
+  }
+
+  return (await response.json()) as CancelActorDeletionResult
 }
 
 interface MarkNotificationsReadParams {

--- a/lib/components/actor-switcher/ActorSwitcher.test.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.test.tsx
@@ -2,8 +2,10 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
+
+import { cancelActorDeletion, switchActor } from '@/lib/client'
 
 import { ActorSwitcher } from './ActorSwitcher'
 
@@ -24,14 +26,24 @@ vi.mock('next/link', () => ({
   )
 }))
 
+const mockRefresh = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
-    refresh: vi.fn()
+    refresh: mockRefresh
   }))
 }))
 
+vi.mock('@/lib/client', () => ({
+  switchActor: vi.fn(),
+  cancelActorDeletion: vi.fn()
+}))
+
+const mockAddActorDialog = vi.fn()
 vi.mock('./AddActorDialog', () => ({
-  AddActorDialog: () => null
+  AddActorDialog: (props: unknown) => {
+    mockAddActorDialog(props)
+    return null
+  }
 }))
 
 const alice = {
@@ -46,10 +58,45 @@ const bob = {
   domain: 'activities.local',
   name: 'Bob'
 }
+const scheduledActor = {
+  id: 'actor-3',
+  username: 'charlie',
+  domain: 'activities.local',
+  name: 'Charlie',
+  deletionStatus: 'scheduled'
+}
+const deletingActor = {
+  id: 'actor-4',
+  username: 'dave',
+  domain: 'activities.local',
+  name: 'Dave',
+  deletionStatus: 'deleting'
+}
 
 const profileHref = '/@alice@activities.local'
 
 describe('ActorSwitcher', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.mocked(switchActor).mockReset()
+    vi.mocked(cancelActorDeletion).mockReset()
+    mockRefresh.mockReset()
+    mockAddActorDialog.mockReset()
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: vi.fn() }
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation
+    })
+  })
+
   describe('with a single actor', () => {
     it('renders the whole row as a link to the profile without prefetch', () => {
       render(<ActorSwitcher currentActor={alice} actors={[alice]} />)
@@ -92,20 +139,259 @@ describe('ActorSwitcher', () => {
     it('renders the name/handle/arrow as the dropdown trigger, not a link', () => {
       render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
 
-      // The identity + chevron open the menu via a button trigger — they are
-      // not part of the profile link, so clicking them switches actors rather
-      // than navigating.
       const trigger = screen.getByRole('button')
       expect(trigger).toHaveTextContent('Alice')
       expect(trigger).toHaveTextContent('@alice@activities.local')
       expect(trigger.querySelector('.lucide-chevron-down')).toBeInTheDocument()
 
-      // Only the avatar is a link; the identity text is inside the button.
       const profileLinks = screen
         .getAllByRole('link')
         .filter((link) => link.getAttribute('href') === profileHref)
       expect(profileLinks).toHaveLength(1)
       expect(profileLinks[0]).not.toHaveTextContent('Alice')
+    })
+
+    it('switches actor and reloads page on successful selection', async () => {
+      vi.mocked(switchActor).mockResolvedValue(true)
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const bobItem = screen.getByText('Bob')
+      fireEvent.click(bobItem)
+
+      expect(switchActor).toHaveBeenCalledWith({ actorId: 'actor-2' })
+      await waitFor(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+    })
+
+    it('surfaces error feedback when switchActor returns false, survives dropdown closure, and succeeds on retry', async () => {
+      vi.mocked(switchActor).mockResolvedValueOnce(false)
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const bobItem = screen.getByText('Bob')
+      fireEvent.click(bobItem)
+
+      expect(switchActor).toHaveBeenCalledWith({ actorId: 'actor-2' })
+      expect(window.location.reload).not.toHaveBeenCalled()
+
+      const alert = await screen.findByRole('alert')
+      expect(alert).toHaveTextContent('Failed to switch actor')
+
+      // Dropdown closes on selection; verify error persists after closure
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      })
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Failed to switch actor'
+      )
+
+      // Retry: reopen dropdown and select actor again
+      vi.mocked(switchActor).mockResolvedValueOnce(true)
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const retryBobItem = screen.getByText('Bob')
+      fireEvent.click(retryBobItem)
+
+      expect(switchActor).toHaveBeenCalledTimes(2)
+      await waitFor(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('surfaces error feedback without unhandled rejection when switchActor rejects, and succeeds on retry', async () => {
+      vi.mocked(switchActor).mockRejectedValueOnce(
+        new Error('Network disconnected')
+      )
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const bobItem = screen.getByText('Bob')
+      fireEvent.click(bobItem)
+
+      expect(switchActor).toHaveBeenCalledWith({ actorId: 'actor-2' })
+      expect(window.location.reload).not.toHaveBeenCalled()
+
+      const alert = await screen.findByRole('alert')
+      expect(alert).toHaveTextContent('Network disconnected')
+
+      // Dropdown closes; retry after rejection
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      })
+
+      vi.mocked(switchActor).mockResolvedValueOnce(true)
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      fireEvent.click(screen.getByText('Bob'))
+      await waitFor(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('does not switch actor when clicking current actor', async () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const menuItems = screen.getAllByRole('menuitem')
+      fireEvent.click(menuItems[0])
+
+      expect(switchActor).not.toHaveBeenCalled()
+    })
+
+    it('does not switch actor if actor is scheduled for deletion', async () => {
+      render(
+        <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const scheduledItem = screen.getByText('Charlie')
+      fireEvent.click(scheduledItem)
+      expect(switchActor).not.toHaveBeenCalled()
+    })
+
+    it('does not switch actor if actor is deleting', async () => {
+      render(
+        <ActorSwitcher currentActor={alice} actors={[alice, deletingActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const deletingItem = screen.getByText('Dave')
+      fireEvent.click(deletingItem)
+      expect(switchActor).not.toHaveBeenCalled()
+    })
+
+    it('cancels deletion and refreshes route on cancel button click', async () => {
+      vi.mocked(cancelActorDeletion).mockResolvedValue({
+        actorId: 'actor-3',
+        status: 'cancelled'
+      })
+
+      render(
+        <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const cancelButton = screen.getByTitle('Cancel deletion')
+      fireEvent.click(cancelButton)
+
+      expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+      expect(switchActor).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled()
+      })
+    })
+
+    it('surfaces visible error feedback when cancel deletion fails, survives dropdown closure, and succeeds on retry', async () => {
+      vi.mocked(cancelActorDeletion).mockRejectedValueOnce(
+        new Error('Network error')
+      )
+
+      render(
+        <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      const menu = await screen.findByRole('menu')
+
+      const cancelButton = screen.getByTitle('Cancel deletion')
+      fireEvent.click(cancelButton)
+
+      expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+      expect(mockRefresh).not.toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { hidden: true })).toHaveTextContent(
+          'Network error'
+        )
+      })
+
+      // Close dropdown menu and verify visible error survives dropdown closure
+      fireEvent.keyDown(menu, { key: 'Escape' })
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      })
+      expect(screen.getByRole('alert')).toHaveTextContent('Network error')
+
+      // Retry: reopen menu, retry button is enabled and retry succeeds
+      vi.mocked(cancelActorDeletion).mockResolvedValueOnce({
+        actorId: 'actor-3',
+        status: 'cancelled'
+      })
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const retryCancelButton = screen.getByTitle('Cancel deletion')
+      expect(retryCancelButton).not.toBeDisabled()
+      fireEvent.click(retryCancelButton)
+
+      expect(cancelActorDeletion).toHaveBeenCalledTimes(2)
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled()
+      })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('opens add actor dialog when clicking add another actor item', async () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const addActorItem = screen.getByText('Add another actor')
+      fireEvent.click(addActorItem)
+
+      expect(mockAddActorDialog).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: true,
+          domain: 'activities.local'
+        })
+      )
+    })
+
+    it('reloads page and closes dialog on successful actor creation', () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const lastProps = mockAddActorDialog.mock.calls.at(-1)?.[0] as {
+        onSuccess: () => void
+      }
+      lastProps.onSuccess()
+
+      expect(window.location.reload).toHaveBeenCalled()
+      expect(mockAddActorDialog).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: false
+        })
+      )
     })
   })
 })

--- a/lib/components/actor-switcher/ActorSwitcher.test.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.test.tsx
@@ -256,7 +256,12 @@ describe('ActorSwitcher', () => {
       expect(switchActor).not.toHaveBeenCalled()
     })
 
-    it('does not switch actor if actor is scheduled for deletion', async () => {
+    it('does not switch actor if actor is scheduled for deletion and instead cancels deletion', async () => {
+      vi.mocked(cancelActorDeletion).mockResolvedValue({
+        actorId: 'actor-3',
+        status: 'cancelled'
+      })
+
       render(
         <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
       )
@@ -268,6 +273,85 @@ describe('ActorSwitcher', () => {
       const scheduledItem = screen.getByText('Charlie')
       fireEvent.click(scheduledItem)
       expect(switchActor).not.toHaveBeenCalled()
+      expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled()
+      })
+    })
+
+    it('cancels scheduled deletion on keyboard selection and does not silently close without action', async () => {
+      vi.mocked(cancelActorDeletion).mockResolvedValue({
+        actorId: 'actor-3',
+        status: 'cancelled'
+      })
+
+      render(
+        <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const menuItems = screen.getAllByRole('menuitem')
+      const scheduledItem = menuItems.find((item) =>
+        item.textContent?.includes('Charlie')
+      )
+      expect(scheduledItem).toBeDefined()
+
+      fireEvent.keyDown(scheduledItem!, { key: 'Enter' })
+
+      expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+      expect(switchActor).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled()
+      })
+    })
+
+    it('prevents duplicate cancel requests until refreshed state arrives and sets type="button"', async () => {
+      vi.mocked(cancelActorDeletion).mockResolvedValue({
+        actorId: 'actor-3',
+        status: 'cancelled'
+      })
+
+      const { rerender } = render(
+        <ActorSwitcher currentActor={alice} actors={[alice, scheduledActor]} />
+      )
+
+      const trigger = screen.getByRole('button')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+
+      const cancelButton = screen.getByTitle('Cancel deletion')
+      expect(cancelButton).toHaveAttribute('type', 'button')
+
+      // First cancel click
+      fireEvent.click(cancelButton)
+
+      expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+      expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+
+      // Duplicate cancel click before refreshed state arrives
+      fireEvent.click(cancelButton)
+      expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+
+      // Also selecting the row while cancellation is in progress does not send duplicate cancel
+      const scheduledItem = screen.getByText('Charlie')
+      fireEvent.click(scheduledItem)
+      expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+
+      // Refreshed state arrives from server
+      rerender(
+        <ActorSwitcher
+          currentActor={alice}
+          actors={[alice, { ...scheduledActor, deletionStatus: null }]}
+        />
+      )
+
+      // Reopen menu: Charlie is no longer pending deletion
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      await screen.findByRole('menu')
+      expect(screen.queryByTitle('Cancel deletion')).not.toBeInTheDocument()
     })
 
     it('does not switch actor if actor is deleting', async () => {

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-import { switchActor } from '@/lib/client'
+import { cancelActorDeletion, switchActor } from '@/lib/client'
 import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import {
@@ -39,6 +39,7 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [isSwitching, setIsSwitching] = useState(false)
   const [isCancelling, setIsCancelling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'
@@ -55,13 +56,18 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
     if (actor?.deletionStatus) return
 
     setIsSwitching(true)
+    setError(null)
     try {
       const didSwitch = await switchActor({ actorId })
 
       if (didSwitch) {
         // Use hard navigation to ensure full page reload with new actor
         window.location.reload()
+      } else {
+        setError('Failed to switch actor')
       }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to switch actor')
     } finally {
       setIsSwitching(false)
     }
@@ -72,16 +78,14 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
     if (isCancelling) return
 
     setIsCancelling(true)
+    setError(null)
     try {
-      const response = await fetch('/api/v1/actors/cancel-deletion', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actorId })
-      })
-
-      if (response.ok) {
-        router.refresh()
-      }
+      await cancelActorDeletion({ actorId })
+      router.refresh()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to cancel actor deletion'
+      )
     } finally {
       setIsCancelling(false)
     }
@@ -228,6 +232,12 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      {error ? (
+        <p role="alert" className="text-sm text-destructive mt-1 px-2">
+          {error}
+        </p>
+      ) : null}
 
       <AddActorDialog
         open={isDialogOpen}

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -3,7 +3,7 @@
 import { Check, ChevronDown, Clock, Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { cancelActorDeletion, switchActor } from '@/lib/client'
 import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
@@ -38,8 +38,14 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
   const router = useRouter()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [isSwitching, setIsSwitching] = useState(false)
+  const isCancellingRef = useRef(false)
   const [isCancelling, setIsCancelling] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    isCancellingRef.current = false
+    setIsCancelling(false)
+  }, [actors])
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'
@@ -73,21 +79,25 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
     }
   }
 
-  const handleCancelDeletion = async (actorId: string, e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (isCancelling) return
+  const handleCancelDeletion = async (
+    actorId: string,
+    e?: React.MouseEvent | React.SyntheticEvent
+  ) => {
+    e?.stopPropagation()
+    if (isCancellingRef.current || isCancelling) return
 
+    isCancellingRef.current = true
     setIsCancelling(true)
     setError(null)
     try {
       await cancelActorDeletion({ actorId })
       router.refresh()
     } catch (err) {
+      isCancellingRef.current = false
+      setIsCancelling(false)
       setError(
         err instanceof Error ? err.message : 'Failed to cancel actor deletion'
       )
-    } finally {
-      setIsCancelling(false)
     }
   }
 
@@ -167,15 +177,22 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
           {actors.map((actor) => {
             const isPendingDeletion = actor.deletionStatus === 'scheduled'
             const isDeleting = actor.deletionStatus === 'deleting'
-            // Keep the row clickable for cancellation when deletion is scheduled.
-            const isDisabled = isSwitching || isDeleting
+            // Keep the row clickable for cancellation when deletion is scheduled,
+            // and disable when switching, deleting, or cancellation is in progress.
+            const isDisabled = isSwitching || isDeleting || isCancelling
 
             const reducedOpacity = isPendingDeletion || isDeleting
 
             return (
               <DropdownMenuItem
                 key={actor.id}
-                onClick={() => handleSwitchActor(actor.id)}
+                onSelect={() => {
+                  if (isPendingDeletion) {
+                    handleCancelDeletion(actor.id)
+                  } else if (!isDeleting) {
+                    handleSwitchActor(actor.id)
+                  }
+                }}
                 disabled={isDisabled}
                 className="flex items-center gap-3"
               >
@@ -214,7 +231,10 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
                   !isDeleting && <Check className="h-4 w-4 text-primary" />}
                 {isPendingDeletion && (
                   <button
-                    onClick={(e) => handleCancelDeletion(actor.id, e)}
+                    type="button"
+                    onClick={(e) => {
+                      handleCancelDeletion(actor.id, e)
+                    }}
                     disabled={isCancelling}
                     className="text-xs text-primary hover:text-primary/80 px-2 py-1 rounded hover:bg-muted cursor-pointer"
                     title="Cancel deletion"

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -236,7 +236,7 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
                       handleCancelDeletion(actor.id, e)
                     }}
                     disabled={isCancelling}
-                    className="text-xs text-primary hover:text-primary/80 px-2 py-1 rounded hover:bg-muted cursor-pointer"
+                    className="text-xs text-primary-text hover:text-primary-text px-2 py-1 rounded hover:bg-muted cursor-pointer"
                     title="Cancel deletion"
                   >
                     Cancel

--- a/lib/components/actor-switcher/AddActorDialog.test.tsx
+++ b/lib/components/actor-switcher/AddActorDialog.test.tsx
@@ -418,6 +418,37 @@ describe('AddActorDialog', () => {
       expect(switchActor).not.toHaveBeenCalled()
       expect(mockOnSuccess).not.toHaveBeenCalled()
     })
+
+    it('does not call onSuccess or reload when switchActor returns false', async () => {
+      vi.mocked(createActor).mockResolvedValue({
+        id: 'new-actor-id',
+        username: 'eve',
+        domain: defaultDomain
+      })
+      vi.mocked(switchActor).mockResolvedValue(false)
+
+      renderDialog()
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'eve' } })
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(createActor).toHaveBeenCalledWith({
+          username: 'eve',
+          domain: defaultDomain
+        })
+      })
+
+      expect(switchActor).toHaveBeenCalledWith({ actorId: 'new-actor-id' })
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to switch actor')).toBeInTheDocument()
+      })
+
+      expect(screen.getByRole('button', { name: 'Create actor' })).toBeEnabled()
+    })
   })
 
   describe('dialog cancellation and close behavior', () => {
@@ -464,6 +495,164 @@ describe('AddActorDialog', () => {
 
       expect(screen.queryByText('Failed')).not.toBeInTheDocument()
       expect(screen.getByLabelText('Username')).toHaveValue('')
+    })
+
+    it('does not reload or set stale visible state when closed during in-flight create', async () => {
+      const deferred = createDeferred<{
+        id: string
+        username: string
+        domain: string
+      }>()
+      vi.mocked(createActor).mockReturnValue(deferred.promise)
+      vi.mocked(switchActor).mockResolvedValue(true)
+
+      const { rerender } = renderDialog({ open: true })
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'frank' } })
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Creating...' })
+        ).toBeDisabled()
+      })
+
+      // Close dialog while create is in-flight
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Resolve in-flight creation after dialog closure
+      await act(async () => {
+        deferred.resolve({
+          id: 'frank-id',
+          username: 'frank',
+          domain: defaultDomain
+        })
+      })
+
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(switchActor).not.toHaveBeenCalled()
+
+      // Reopen dialog: visible state must be clean and not stale
+      rerender(
+        <AddActorDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.getByLabelText('Username')).toHaveValue('')
+      expect(
+        screen.queryByText('Failed to switch actor')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Create actor' })
+      ).toBeDisabled()
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+    })
+
+    it('does not set stale error state when closed during in-flight create rejection', async () => {
+      const deferred = createDeferred<{
+        id: string
+        username: string
+        domain: string
+      }>()
+      vi.mocked(createActor).mockReturnValue(deferred.promise)
+
+      const { rerender } = renderDialog({ open: true })
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'grace' } })
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Creating...' })
+        ).toBeDisabled()
+      })
+
+      // Close dialog while in flight
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      // Reject in-flight creation after dialog closure
+      await act(async () => {
+        deferred.reject(new Error('Backend error'))
+      })
+
+      // Reopen dialog: must not show the rejected error
+      rerender(
+        <AddActorDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.queryByText('Backend error')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('Username')).toHaveValue('')
+    })
+
+    it('prevents dismissal while switchActor is pending and reloads successfully when resolved', async () => {
+      const deferredSwitch = createDeferred<boolean>()
+      vi.mocked(createActor).mockResolvedValue({
+        id: 'heidi-id',
+        username: 'heidi',
+        domain: defaultDomain
+      })
+      vi.mocked(switchActor).mockReturnValue(deferredSwitch.promise)
+
+      renderDialog({ open: true })
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'heidi' } })
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(createActor).toHaveBeenCalled()
+        expect(switchActor).toHaveBeenCalledWith({ actorId: 'heidi-id' })
+      })
+
+      // While switchActor is pending, user dismissal is prevented
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+      expect(cancelButton).toBeDisabled()
+      fireEvent.click(cancelButton)
+      expect(mockOnOpenChange).not.toHaveBeenCalled()
+
+      expect(
+        screen.queryByRole('button', { name: 'Close' })
+      ).not.toBeInTheDocument()
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+      expect(mockOnOpenChange).not.toHaveBeenCalled()
+
+      fireEvent.pointerDown(document.body)
+      expect(mockOnOpenChange).not.toHaveBeenCalled()
+
+      // Resolve switchActor: normal successful reload remains
+      await act(async () => {
+        deferredSwitch.resolve(true)
+      })
+
+      await waitFor(() => {
+        expect(mockOnSuccess).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/lib/components/actor-switcher/AddActorDialog.test.tsx
+++ b/lib/components/actor-switcher/AddActorDialog.test.tsx
@@ -1,0 +1,469 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  type ActorDomainsResult,
+  createActor,
+  getActorDomains,
+  switchActor
+} from '@/lib/client'
+import { createDeferred } from '@/lib/testing/deferred'
+
+import { AddActorDialog } from './AddActorDialog'
+
+vi.mock('@/lib/client', () => ({
+  getActorDomains: vi.fn(),
+  createActor: vi.fn(),
+  switchActor: vi.fn()
+}))
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('AddActorDialog', () => {
+  const defaultDomain = 'activities.local'
+  const mockOnOpenChange = vi.fn()
+  const mockOnSuccess = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    vi.mocked(getActorDomains).mockReset()
+    vi.mocked(createActor).mockReset()
+    vi.mocked(switchActor).mockReset()
+    mockOnOpenChange.mockReset()
+    mockOnSuccess.mockReset()
+
+    vi.mocked(getActorDomains).mockResolvedValue({
+      domains: [defaultDomain],
+      host: defaultDomain
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const renderDialog = (
+    props: Partial<Parameters<typeof AddActorDialog>[0]> = {}
+  ) =>
+    render(
+      <AddActorDialog
+        open
+        onOpenChange={mockOnOpenChange}
+        domain={defaultDomain}
+        onSuccess={mockOnSuccess}
+        {...props}
+      />
+    )
+
+  describe('domain loading and selection', () => {
+    it('fetches allowed domains with an abort signal on open', async () => {
+      renderDialog()
+
+      expect(getActorDomains).toHaveBeenCalledWith({
+        signal: expect.any(AbortSignal)
+      })
+    })
+
+    it('renders radio group when multiple domains are available and selects host by default', async () => {
+      vi.mocked(getActorDomains).mockResolvedValue({
+        domains: ['alias.example', defaultDomain],
+        host: defaultDomain
+      })
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(screen.getByText('Domain')).toBeInTheDocument()
+      })
+
+      expect(
+        screen.getByLabelText(new RegExp(`${defaultDomain}.*\\(main\\)`))
+      ).toBeChecked()
+      expect(screen.getByLabelText('alias.example')).not.toBeChecked()
+      expect(
+        screen.getByText(`Your new handle will be @username@${defaultDomain}`)
+      ).toBeInTheDocument()
+    })
+
+    it('selects first domain when host domain is not in the allowed list', async () => {
+      vi.mocked(getActorDomains).mockResolvedValue({
+        domains: ['first.example', 'second.example'],
+        host: 'unlisted.example'
+      })
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('first.example')).toBeChecked()
+      })
+      expect(
+        screen.getByText('Your new handle will be @username@first.example')
+      ).toBeInTheDocument()
+    })
+
+    it('updates handle preview when user selects a different domain', async () => {
+      vi.mocked(getActorDomains).mockResolvedValue({
+        domains: [defaultDomain, 'secondary.example'],
+        host: defaultDomain
+      })
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(screen.getByText('secondary.example')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByLabelText('secondary.example'))
+
+      expect(screen.getByLabelText('secondary.example')).toBeChecked()
+      expect(
+        screen.getByText('Your new handle will be @username@secondary.example')
+      ).toBeInTheDocument()
+    })
+
+    it('does not re-fetch domains if domains have already loaded', async () => {
+      const { rerender } = renderDialog({ open: true })
+
+      await waitFor(() => {
+        expect(getActorDomains).toHaveBeenCalledTimes(1)
+      })
+
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      rerender(
+        <AddActorDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(getActorDomains).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('stale responses and cancellation', () => {
+    it('aborts in-flight domain request when dialog is closed', async () => {
+      const deferred = createDeferred<ActorDomainsResult>()
+      let capturedSignal: AbortSignal | undefined
+
+      vi.mocked(getActorDomains).mockImplementation((params) => {
+        capturedSignal = params?.signal
+        return deferred.promise
+      })
+
+      const { rerender } = renderDialog({ open: true })
+
+      expect(capturedSignal).toBeDefined()
+      expect(capturedSignal?.aborted).toBe(false)
+
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(capturedSignal?.aborted).toBe(true)
+
+      // Settling the promise after close should not update state or throw
+      await act(async () => {
+        deferred.resolve({
+          domains: ['late.example', defaultDomain],
+          host: defaultDomain
+        })
+      })
+
+      expect(screen.queryByText('late.example')).not.toBeInTheDocument()
+    })
+
+    it('aborts in-flight domain request when dialog unmounts', async () => {
+      const deferred = createDeferred<ActorDomainsResult>()
+      let capturedSignal: AbortSignal | undefined
+
+      vi.mocked(getActorDomains).mockImplementation((params) => {
+        capturedSignal = params?.signal
+        return deferred.promise
+      })
+
+      const { unmount } = renderDialog({ open: true })
+
+      expect(capturedSignal?.aborted).toBe(false)
+
+      unmount()
+
+      expect(capturedSignal?.aborted).toBe(true)
+
+      await act(async () => {
+        deferred.resolve({
+          domains: ['unmounted.example'],
+          host: defaultDomain
+        })
+      })
+    })
+
+    it('does not expose error when aborted by dialog closure', async () => {
+      const deferred = createDeferred<ActorDomainsResult>()
+
+      vi.mocked(getActorDomains).mockReturnValue(deferred.promise)
+
+      const { rerender } = renderDialog({ open: true })
+
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      await act(async () => {
+        deferred.reject(
+          new DOMException('The user aborted a request.', 'AbortError')
+        )
+      })
+
+      expect(screen.queryByText(/aborted/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('domain loading failures', () => {
+    it('exposes API domain loading failure through existing error UI', async () => {
+      vi.mocked(getActorDomains).mockRejectedValue(
+        new Error('Failed to fetch actor domains')
+      )
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to fetch actor domains')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('exposes network domain loading failure through existing error UI', async () => {
+      vi.mocked(getActorDomains).mockRejectedValue(new Error('Network error'))
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('client-side validation', () => {
+    it('shows error when username is empty or whitespace', async () => {
+      renderDialog()
+
+      const submitButton = screen.getByRole('button', { name: 'Create actor' })
+      const input = screen.getByLabelText('Username')
+
+      expect(submitButton).toBeDisabled()
+
+      fireEvent.change(input, { target: { value: '   ' } })
+      expect(submitButton).toBeDisabled()
+
+      fireEvent.submit(input.closest('form')!)
+
+      expect(screen.getByText('Username is required')).toBeInTheDocument()
+      expect(createActor).not.toHaveBeenCalled()
+    })
+
+    it('shows error when username contains invalid characters', async () => {
+      renderDialog()
+
+      const input = screen.getByLabelText('Username')
+
+      fireEvent.change(input, { target: { value: 'invalid user!' } })
+      fireEvent.submit(input.closest('form')!)
+
+      expect(
+        screen.getByText(
+          'Username can only contain letters, numbers, and underscores'
+        )
+      ).toBeInTheDocument()
+      expect(createActor).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('actor creation and switching', () => {
+    it('creates actor with trimmed username and selected domain, then switches', async () => {
+      vi.mocked(getActorDomains).mockResolvedValue({
+        domains: [defaultDomain, 'custom.domain'],
+        host: defaultDomain
+      })
+      vi.mocked(createActor).mockResolvedValue({
+        id: 'new-actor-id',
+        username: 'carol',
+        domain: 'custom.domain'
+      })
+      vi.mocked(switchActor).mockResolvedValue(true)
+
+      renderDialog()
+
+      await waitFor(() => {
+        expect(screen.getByText('custom.domain')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByLabelText('custom.domain'))
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'carol' } })
+
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(createActor).toHaveBeenCalledWith({
+          username: 'carol',
+          domain: 'custom.domain'
+        })
+      })
+
+      expect(switchActor).toHaveBeenCalledWith({ actorId: 'new-actor-id' })
+      expect(mockOnSuccess).toHaveBeenCalled()
+      expect(input).toHaveValue('')
+    })
+
+    it('shows creating state while creation request is in flight', async () => {
+      const deferred = createDeferred<{
+        id: string
+        username: string
+        domain: string
+      }>()
+      vi.mocked(createActor).mockReturnValue(deferred.promise)
+
+      renderDialog()
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'dan' } })
+
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Creating...' })
+        ).toBeDisabled()
+      })
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+
+      await act(async () => {
+        deferred.resolve({
+          id: 'dan-id',
+          username: 'dan',
+          domain: defaultDomain
+        })
+      })
+
+      await waitFor(() => {
+        expect(switchActor).toHaveBeenCalledWith({ actorId: 'dan-id' })
+      })
+    })
+
+    it('exposes API error when creation fails', async () => {
+      vi.mocked(createActor).mockRejectedValue(
+        new Error('Username already exists')
+      )
+
+      renderDialog()
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'existing_user' } })
+
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(screen.getByText('Username already exists')).toBeInTheDocument()
+      })
+
+      expect(switchActor).not.toHaveBeenCalled()
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: 'Create actor' })).toBeEnabled()
+    })
+
+    it('exposes network failure when creation encounters an error', async () => {
+      vi.mocked(createActor).mockRejectedValue(
+        new Error('Network disconnected')
+      )
+
+      renderDialog()
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'testuser' } })
+
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(screen.getByText('Network disconnected')).toBeInTheDocument()
+      })
+
+      expect(switchActor).not.toHaveBeenCalled()
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('dialog cancellation and close behavior', () => {
+    it('notifies parent on cancel button click', () => {
+      renderDialog()
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+      fireEvent.click(cancelButton)
+
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('resets username and error state when dialog is closed', async () => {
+      vi.mocked(createActor).mockRejectedValue(new Error('Failed'))
+
+      const { rerender } = renderDialog({ open: true })
+
+      const input = screen.getByLabelText('Username')
+      fireEvent.change(input, { target: { value: 'someuser' } })
+
+      fireEvent.submit(input.closest('form')!)
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed')).toBeInTheDocument()
+      })
+
+      rerender(
+        <AddActorDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      rerender(
+        <AddActorDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          domain={defaultDomain}
+          onSuccess={mockOnSuccess}
+        />
+      )
+
+      expect(screen.queryByText('Failed')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('Username')).toHaveValue('')
+    })
+  })
+})

--- a/lib/components/actor-switcher/AddActorDialog.tsx
+++ b/lib/components/actor-switcher/AddActorDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { createActor, getActorDomains, switchActor } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
@@ -36,6 +36,8 @@ export function AddActorDialog({
   const [domainsLoaded, setDomainsLoaded] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const createRequestIdRef = useRef(0)
 
   useEffect(() => {
     if (!open || domainsLoaded) {
@@ -91,6 +93,7 @@ export function AddActorDialog({
       return
     }
 
+    const currentRequestId = ++createRequestIdRef.current
     setIsLoading(true)
     try {
       const data = await createActor({
@@ -98,40 +101,90 @@ export function AddActorDialog({
         domain: selectedDomain
       })
 
+      if (currentRequestId !== createRequestIdRef.current) {
+        return
+      }
+
       // Switch to the new actor
-      await switchActor({ actorId: data.id })
+      const didSwitch = await switchActor({
+        actorId: data.id
+      })
+
+      if (currentRequestId !== createRequestIdRef.current) {
+        return
+      }
+
+      if (!didSwitch) {
+        setError('Failed to switch actor')
+        return
+      }
 
       setUsername('')
       onSuccess()
     } catch (err) {
+      if (currentRequestId !== createRequestIdRef.current) {
+        return
+      }
       setError(
         err instanceof Error
           ? err.message
           : 'An error occurred while creating the actor'
       )
     } finally {
-      setIsLoading(false)
+      if (currentRequestId === createRequestIdRef.current) {
+        setIsLoading(false)
+      }
     }
   }
 
   useEffect(() => {
     if (!open) {
+      createRequestIdRef.current++
       setUsername('')
       setError(null)
+      setIsLoading(false)
     }
   }, [open])
 
+  useEffect(() => {
+    return () => {
+      createRequestIdRef.current++
+    }
+  }, [])
+
   const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen && isLoading) {
+      return
+    }
     if (!newOpen) {
+      createRequestIdRef.current++
       setUsername('')
       setError(null)
+      setIsLoading(false)
     }
     onOpenChange(newOpen)
   }
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
+      <DialogContent
+        showCloseButton={!isLoading}
+        onEscapeKeyDown={(e) => {
+          if (isLoading) {
+            e.preventDefault()
+          }
+        }}
+        onPointerDownOutside={(e) => {
+          if (isLoading) {
+            e.preventDefault()
+          }
+        }}
+        onInteractOutside={(e) => {
+          if (isLoading) {
+            e.preventDefault()
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Add another actor</DialogTitle>
           <DialogDescription>

--- a/lib/components/actor-switcher/AddActorDialog.tsx
+++ b/lib/components/actor-switcher/AddActorDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 
-import { switchActor } from '@/lib/client'
+import { createActor, getActorDomains, switchActor } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import {
   Dialog,
@@ -42,30 +42,39 @@ export function AddActorDialog({
       return
     }
 
+    const controller = new AbortController()
+    let isCancelled = false
+
     const fetchDomains = async () => {
       try {
-        const response = await fetch('/api/v1/actors/domains')
-        if (response.ok) {
-          const data = await response.json()
-          if (data.domains && Array.isArray(data.domains) && data.host) {
-            setAvailableDomains(data.domains)
-            setHostDomain(data.host)
-            // Set the default domain to host if available
-            if (data.domains.includes(data.host)) {
-              setSelectedDomain(data.host)
-            } else if (data.domains.length > 0) {
-              setSelectedDomain(data.domains[0])
-            }
+        const data = await getActorDomains({ signal: controller.signal })
+        if (isCancelled) return
+
+        if (data.domains && Array.isArray(data.domains) && data.host) {
+          setAvailableDomains(data.domains)
+          setHostDomain(data.host)
+          // Set the default domain to host if available
+          if (data.domains.includes(data.host)) {
+            setSelectedDomain(data.host)
+          } else if (data.domains.length > 0) {
+            setSelectedDomain(data.domains[0])
           }
-          setDomainsLoaded(true)
         }
-      } catch {
-        // If fetch fails, keep the default domain
         setDomainsLoaded(true)
+      } catch (err) {
+        if (isCancelled || controller.signal.aborted) {
+          return
+        }
+        setError(err instanceof Error ? err.message : 'Failed to load domains')
       }
     }
 
     fetchDomains()
+
+    return () => {
+      isCancelled = true
+      controller.abort()
+    }
   }, [open, domainsLoaded])
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -84,33 +93,33 @@ export function AddActorDialog({
 
     setIsLoading(true)
     try {
-      const response = await fetch('/api/v1/actors', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          username: username.trim(),
-          domain: selectedDomain
-        })
+      const data = await createActor({
+        username: username.trim(),
+        domain: selectedDomain
       })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        setError(data.error || 'Failed to create actor')
-        return
-      }
 
       // Switch to the new actor
       await switchActor({ actorId: data.id })
 
       setUsername('')
       onSuccess()
-    } catch {
-      setError('An error occurred while creating the actor')
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'An error occurred while creating the actor'
+      )
     } finally {
       setIsLoading(false)
     }
   }
+
+  useEffect(() => {
+    if (!open) {
+      setUsername('')
+      setError(null)
+    }
+  }, [open])
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {

--- a/lib/components/settings/ActorsSection.test.tsx
+++ b/lib/components/settings/ActorsSection.test.tsx
@@ -2,13 +2,16 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { cancelActorDeletion, switchActor } from '@/lib/client'
 
 import { ActorsSection } from './ActorsSection'
 
+const mockRefresh = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
-    refresh: vi.fn()
+    refresh: mockRefresh
   }))
 }))
 
@@ -16,7 +19,16 @@ vi.mock('@/lib/components/actor-switcher', () => ({
   AddActorDialog: () => null
 }))
 
+vi.mock('@/lib/client', () => ({
+  cancelActorDeletion: vi.fn(),
+  switchActor: vi.fn()
+}))
+
 describe('ActorsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   const actors = [
     {
       id: 'actor-1',
@@ -31,6 +43,22 @@ describe('ActorsSection', () => {
       name: 'Bob'
     }
   ]
+
+  const scheduledActor = {
+    id: 'actor-3',
+    username: 'charlie',
+    domain: 'activities.local',
+    name: 'Charlie',
+    deletionStatus: 'scheduled' as const
+  }
+
+  const deletingActor = {
+    id: 'actor-4',
+    username: 'dave',
+    domain: 'activities.local',
+    name: 'Dave',
+    deletionStatus: 'deleting' as const
+  }
 
   it('shows the current actor after reload even when default differs', () => {
     render(
@@ -61,5 +89,136 @@ describe('ActorsSection', () => {
 
     expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.queryByText('(current)')).not.toBeInTheDocument()
+  })
+
+  it('renders pending deletion status and an enabled cancel button in dropdown', async () => {
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    expect(screen.getByText('Pending deletion')).toBeInTheDocument()
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    expect(cancelButton).toBeInTheDocument()
+    expect(cancelButton).not.toBeDisabled()
+
+    const menuItems = screen.getAllByRole('menuitem')
+    const scheduledItem = menuItems.find((item) =>
+      item.textContent?.includes('Charlie')
+    )
+    expect(scheduledItem).toBeDefined()
+    expect(scheduledItem).not.toHaveAttribute('aria-disabled', 'true')
+    expect(scheduledItem).not.toHaveAttribute('data-disabled')
+  })
+
+  it('cancels deletion and refreshes route on cancel button click', async () => {
+    vi.mocked(cancelActorDeletion).mockResolvedValue({
+      actorId: 'actor-3',
+      status: 'cancelled'
+    })
+
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    fireEvent.click(cancelButton)
+
+    expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+    await waitFor(() => {
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('does not switch selected actor when clicking the scheduled item row', async () => {
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const charlieText = screen.getByText('Charlie')
+    fireEvent.click(charlieText)
+
+    // Trigger still displays Alice (current actor not changed)
+    expect(trigger).toHaveTextContent('Alice')
+    expect(switchActor).not.toHaveBeenCalled()
+  })
+
+  it('surfaces error message when cancelActorDeletion fails', async () => {
+    vi.mocked(cancelActorDeletion).mockRejectedValueOnce(
+      new Error('Cancellation failed')
+    )
+
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    fireEvent.click(cancelButton)
+
+    expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+    expect(mockRefresh).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancellation failed')).toBeInTheDocument()
+    })
+  })
+
+  it('disables menu item for actor with deleting status', async () => {
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], deletingActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    expect(screen.getByText('Deleting...')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
+
+    const menuItems = screen.getAllByRole('menuitem')
+    const deletingItem = menuItems.find((item) =>
+      item.textContent?.includes('Dave')
+    )
+    expect(deletingItem).toBeDefined()
+    expect(deletingItem).toHaveAttribute('data-disabled')
+    expect(deletingItem).toHaveAttribute('aria-disabled', 'true')
   })
 })

--- a/lib/components/settings/ActorsSection.test.tsx
+++ b/lib/components/settings/ActorsSection.test.tsx
@@ -146,7 +146,12 @@ describe('ActorsSection', () => {
     })
   })
 
-  it('does not switch selected actor when clicking the scheduled item row', async () => {
+  it('does not switch selected actor when clicking the scheduled item row and instead cancels deletion', async () => {
+    vi.mocked(cancelActorDeletion).mockResolvedValue({
+      actorId: 'actor-3',
+      status: 'cancelled'
+    })
+
     render(
       <ActorsSection
         currentActor={actors[0]}
@@ -165,6 +170,127 @@ describe('ActorsSection', () => {
     // Trigger still displays Alice (current actor not changed)
     expect(trigger).toHaveTextContent('Alice')
     expect(switchActor).not.toHaveBeenCalled()
+    expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+    await waitFor(() => {
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('cancels deletion via keyboard selection of scheduled actor row', async () => {
+    vi.mocked(cancelActorDeletion).mockResolvedValue({
+      actorId: 'actor-3',
+      status: 'cancelled'
+    })
+
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const menuItems = screen.getAllByRole('menuitem')
+    const scheduledItem = menuItems.find((item) =>
+      item.textContent?.includes('Charlie')
+    )
+    expect(scheduledItem).toBeDefined()
+
+    fireEvent.keyDown(scheduledItem!, { key: 'Enter' })
+
+    expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+    expect(switchActor).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('prevents duplicate cancel requests until refreshed state arrives', async () => {
+    vi.mocked(cancelActorDeletion).mockResolvedValue({
+      actorId: 'actor-3',
+      status: 'cancelled'
+    })
+
+    const { rerender } = render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    expect(cancelButton).toHaveAttribute('type', 'button')
+
+    // First cancel click
+    fireEvent.click(cancelButton)
+
+    expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+    expect(cancelActorDeletion).toHaveBeenCalledWith({ actorId: 'actor-3' })
+
+    // Duplicate cancel click before refreshed state arrives
+    fireEvent.click(cancelButton)
+    expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+
+    // Selecting row also does not send duplicate cancel
+    const charlieText = screen.getByText('Charlie')
+    fireEvent.click(charlieText)
+    expect(cancelActorDeletion).toHaveBeenCalledTimes(1)
+
+    // Refreshed state arrives from server
+    rerender(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], { ...scheduledActor, deletionStatus: null }]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('sets explicit type="button" on all action buttons and cancel button', async () => {
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={[actors[0], scheduledActor]}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Switch to actor' })
+    ).toHaveAttribute('type', 'button')
+    expect(
+      screen.getByRole('button', { name: 'Set as default' })
+    ).toHaveAttribute('type', 'button')
+    expect(screen.getByRole('button', { name: 'Add actor' })).toHaveAttribute(
+      'type',
+      'button'
+    )
+
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    expect(trigger).toHaveAttribute('type', 'button')
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveAttribute(
+      'type',
+      'button'
+    )
   })
 
   it('surfaces error message when cancelActorDeletion fails', async () => {

--- a/lib/components/settings/ActorsSection.tsx
+++ b/lib/components/settings/ActorsSection.tsx
@@ -4,7 +4,7 @@ import { Check, ChevronDown, Clock, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-import { switchActor } from '@/lib/client'
+import { cancelActorDeletion, switchActor } from '@/lib/client'
 import { ActorInfo, AddActorDialog } from '@/lib/components/actor-switcher'
 import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
@@ -108,16 +108,16 @@ export function ActorsSection({
     if (isCancelling) return
 
     setIsCancelling(true)
+    setMessage(null)
     try {
-      const response = await fetch('/api/v1/actors/cancel-deletion', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actorId })
+      await cancelActorDeletion({ actorId })
+      router.refresh()
+    } catch (err) {
+      setMessage({
+        type: 'error',
+        text:
+          err instanceof Error ? err.message : 'Failed to cancel actor deletion'
       })
-
-      if (response.ok) {
-        router.refresh()
-      }
     } finally {
       setIsCancelling(false)
     }
@@ -191,12 +191,8 @@ export function ActorsSection({
                       setSelectedActorId(actor.id)
                     }
                   }}
-                  disabled={
-                    isSwitching ||
-                    isSavingDefault ||
-                    isPendingDeletion ||
-                    isDeleting
-                  }
+                  // Keep the row clickable for cancellation when deletion is scheduled.
+                  disabled={isSwitching || isSavingDefault || isDeleting}
                   className="flex items-center gap-3"
                 >
                   <Avatar

--- a/lib/components/settings/ActorsSection.tsx
+++ b/lib/components/settings/ActorsSection.tsx
@@ -2,7 +2,7 @@
 
 import { Check, ChevronDown, Clock, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { cancelActorDeletion, switchActor } from '@/lib/client'
 import { ActorInfo, AddActorDialog } from '@/lib/components/actor-switcher'
@@ -38,11 +38,17 @@ export function ActorsSection({
   )
   const [isSwitching, setIsSwitching] = useState(false)
   const [isSavingDefault, setIsSavingDefault] = useState(false)
+  const isCancellingRef = useRef(false)
   const [isCancelling, setIsCancelling] = useState(false)
   const [message, setMessage] = useState<{
     type: 'success' | 'error'
     text: string
   } | null>(null)
+
+  useEffect(() => {
+    isCancellingRef.current = false
+    setIsCancelling(false)
+  }, [actors])
 
   const selectedActor =
     actors.find((actor) => actor.id === selectedActorId) || actors[0]
@@ -104,22 +110,27 @@ export function ActorsSection({
     }
   }
 
-  const handleCancelDeletion = async (actorId: string) => {
-    if (isCancelling) return
+  const handleCancelDeletion = async (
+    actorId: string,
+    e?: React.MouseEvent | React.SyntheticEvent
+  ) => {
+    e?.stopPropagation()
+    if (isCancellingRef.current || isCancelling) return
 
+    isCancellingRef.current = true
     setIsCancelling(true)
     setMessage(null)
     try {
       await cancelActorDeletion({ actorId })
       router.refresh()
     } catch (err) {
+      isCancellingRef.current = false
+      setIsCancelling(false)
       setMessage({
         type: 'error',
         text:
           err instanceof Error ? err.message : 'Failed to cancel actor deletion'
       })
-    } finally {
-      setIsCancelling(false)
     }
   }
 
@@ -142,7 +153,7 @@ export function ActorsSection({
             <button
               type="button"
               className="flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-muted cursor-pointer"
-              disabled={isSwitching || isSavingDefault}
+              disabled={isSwitching || isSavingDefault || isCancelling}
             >
               <Avatar className="h-10 w-10">
                 {selectedActor?.iconUrl && (
@@ -182,17 +193,21 @@ export function ActorsSection({
               const isDeleting = actor.deletionStatus === 'deleting'
               const reducedOpacity = isPendingDeletion || isDeleting
               const isCurrent = actor.id === currentActor.id
+              const isDisabled =
+                isSwitching || isSavingDefault || isDeleting || isCancelling
 
               return (
                 <DropdownMenuItem
                   key={actor.id}
-                  onClick={() => {
-                    if (!isPendingDeletion && !isDeleting) {
+                  onSelect={() => {
+                    if (isPendingDeletion) {
+                      handleCancelDeletion(actor.id)
+                    } else if (!isDeleting) {
                       setSelectedActorId(actor.id)
                     }
                   }}
                   // Keep the row clickable for cancellation when deletion is scheduled.
-                  disabled={isSwitching || isSavingDefault || isDeleting}
+                  disabled={isDisabled}
                   className="flex items-center gap-3"
                 >
                   <Avatar
@@ -235,11 +250,11 @@ export function ActorsSection({
                   )}
                   {isPendingDeletion && (
                     <Button
+                      type="button"
                       size="sm"
                       variant="outline"
                       onClick={(e) => {
-                        e.stopPropagation()
-                        handleCancelDeletion(actor.id)
+                        handleCancelDeletion(actor.id, e)
                       }}
                       disabled={isCancelling}
                     >
@@ -262,21 +277,28 @@ export function ActorsSection({
 
         <div className="flex flex-col sm:flex-row sm:justify-end gap-2">
           <Button
+            type="button"
             onClick={handleSwitchActor}
             disabled={
-              isSwitching || !canSwitch || isSavingDefault || !hasMultipleActors
+              isSwitching ||
+              !canSwitch ||
+              isSavingDefault ||
+              !hasMultipleActors ||
+              isCancelling
             }
             className="w-full sm:w-auto"
           >
             {isSwitching ? 'Switching...' : 'Switch to actor'}
           </Button>
           <Button
+            type="button"
             onClick={handleSaveDefault}
             disabled={
               isSavingDefault ||
               !hasChanges ||
               isSwitching ||
-              !hasMultipleActors
+              !hasMultipleActors ||
+              isCancelling
             }
             variant="outline"
             className="w-full sm:w-auto"
@@ -284,9 +306,10 @@ export function ActorsSection({
             {isSavingDefault ? 'Saving...' : 'Set as default'}
           </Button>
           <Button
+            type="button"
             variant="outline"
             onClick={() => setIsDialogOpen(true)}
-            disabled={isSwitching || isSavingDefault}
+            disabled={isSwitching || isSavingDefault || isCancelling}
             className="w-full sm:w-auto"
           >
             <Plus className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Actor creation, domain loading, and deletion cancellation now use typed client helpers and show request failures in the UI. Creating an actor preserves the selected domain and reloads into the new actor only after switching succeeds. The dialog stays open while creation/switching is pending, and stale domain responses cannot update a closed dialog.

Scheduled-deletion actors can be restored using either keyboard selection or the pointer Cancel action, with duplicate requests blocked while refresh is pending. The narrow `ActorsSection` cancellation fix makes the same flow usable from the account page; its remaining request migration is still E1b. Only the ActorSwitcher and AddActorDialog fetch exceptions are removed.

Validation at `e2a45ca9d81d9f8a7999d07ce1260a2441077ce3`:

- Required local sequence passed: Prettier → lint → typecheck → build → test.
- Full suite: 973 files and 13,115 tests passed.
- Local SQLite browser checks passed: secondary-domain creation and reload persistence, duplicate-name feedback, dismissal attempts during a delayed real switch response, and keyboard/pointer cancellation in both account and desktop sidebar selectors.
- The final Cancel text color remains `rgb(184, 76, 5)` before and during hover. Browser and local server were closed after verification.

Two fresh independent Gemini reviews are CLEAR at the validated head. The user explicitly waived PR screenshot attachments for this PR; the completed local browser verification and screenshots remain preserved in the cleanup handoff directory.
