### PR TITLE
Bump version to v1.161.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.1",
+  "version": "1.161.2",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.1`
- Base main SHA: `ad81c7192f2f1634f66459474581e35b282ba13c`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
