### PR TITLE
none: make PR screenshots optional in repository guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@ See AGENTS.md → Commit & Pull Request Guidelines. -->
 
 ## Screenshots
 
-<!-- Required for UI changes (before/after where useful). Delete this section
-for changes with no visual surface. -->
+<!-- Optional for UI changes (not required). Delete this section if not
+providing screenshots or for changes with no visual surface. -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Every change, however small, is done only when ALL of these hold:
 3. Every document the change makes stale is updated in the same PR (see **Documentation Maintenance**).
 4. If a migration was added/edited/removed, BOTH schema dumps are regenerated (see **Database Backends & Local Setup**; CI fails on SQLite-dump drift).
 5. The commit subject and PR title carry the correct conventional prefix, and `package.json` `version` is untouched (see **Commit & Pull Request Guidelines**).
-6. UI changes are verified in a real browser (see **Local Manual / Browser Testing**) with screenshots in the PR.
+6. UI changes are verified in a real browser (see **Local Manual / Browser Testing**) (screenshots in the PR are not required).
 
 For the most common task shapes, follow the step-by-step **Task Recipes** section below instead of improvising.
 
@@ -2362,7 +2362,7 @@ each ends with the Definition of Done gate.
 3. Pass timestamps as `Date.now()` numbers from Server Components; Client Components accept `currentTime: number` and never call `Date.now()`/`new Date()` during render (see **Date Serialization**).
 4. If the page shows status posts, render them through the shared `Posts`/`Post` components and turn actions on with `currentActor` + `showActions` — never a bespoke post/action row or per-status action callbacks (see **Status Posts & Actions**).
 5. All client-side data calls go through named functions in `lib/client.ts` (lint-enforced).
-6. Add component tests (`/** @vitest-environment jsdom */` docblock) and verify the page in a real browser (see **Local Manual / Browser Testing**); include screenshots in the PR.
+6. Add component tests (`/** @vitest-environment jsdom */` docblock) and verify the page in a real browser (see **Local Manual / Browser Testing**); screenshots in the PR are not required.
 7. Run the Definition of Done gate.
 
 ## Documentation Maintenance
@@ -2389,7 +2389,7 @@ each ends with the Definition of Done gate.
   - `minor:` for backwards-compatible new features (minor version bump)
   - `fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`, etc. for everything else (patch version bump)
 - PRs should include a clear summary, linked issues (if any), test results, and notes for config/migrations.
-- Include screenshots or clips for UI changes.
+- Screenshots or clips for UI changes are optional and not required.
 - **Never put production or operational SQL in PR descriptions** (or anywhere committed in the repo). One-off database mutations for a deployment — hotfix `UPDATE`/`INSERT`/`DELETE` statements, data backfills, or any copy-pasteable production runbook — must not live in the PR body. Describe **what** operational change is needed and **why** in prose, and deliver the actual SQL through the deployment runbook or a private ops channel instead. This targets operational/runbook SQL — it does **not** restrict application query code: Knex query-builder calls and `knex.raw`/`whereRaw` in `lib/` are normal application code and unaffected. The database files that legitimately live in the repo, all under `migrations/`, are the Knex migrations (JavaScript/TypeScript that define schema changes — not raw `.sql`) and the reference schema dumps (`migrations/schema.sql`, `migrations/schema.sqlite.sql`); illustrative SQL in the `docs/` setup and maintenance guides (e.g. `docs/postgresql-setup.md` and the schema-dump steps) is also fine. This keeps environment-specific identifiers, hostnames, and runbooks out of the public Git history.
 
 ### Version Bump Prefixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,7 +320,7 @@ Also:
   - What problem does this solve?
   - What approach did you take?
   - Any breaking changes?
-  - Screenshots for UI changes
+  - Screenshots for UI changes (optional, not required)
 - **Link issues**: Reference related issues using `Fixes #123` or `Relates to #456`
 - **Keep PRs focused**: One feature/fix per PR
 


### PR DESCRIPTION
## Summary

Update repository guidelines (`AGENTS.md`), contributor documentation (`CONTRIBUTING.md`), and the PR template to clarify that screenshots in pull requests are optional and not required.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [ ] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)