### PR TITLE
Bump version to v1.161.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.2",
+  "version": "1.161.3",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.2`
- Base main SHA: `a935d9ccbd3ddecc8ecf03e67aa8f4bcbbe69f13`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
