### PR TITLE
refactor: parse account-media pagination once

### DIFF
--- a/app/api/v1/accounts/media/pagination.test.ts
+++ b/app/api/v1/accounts/media/pagination.test.ts
@@ -1,0 +1,308 @@
+import {
+  ALLOWED_MEDIA_LIMITS,
+  DEFAULT_MEDIA_LIMIT,
+  DEFAULT_PAGE,
+  MAX_PAGE,
+  MIN_PAGE,
+  parseAccountMediaPagination
+} from './pagination'
+
+describe('parseAccountMediaPagination', () => {
+  describe('defaults and missing inputs', () => {
+    it('returns default pagination for undefined or null input', () => {
+      expect(parseAccountMediaPagination()).toEqual({
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_MEDIA_LIMIT
+      })
+      expect(parseAccountMediaPagination(null)).toEqual({
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_MEDIA_LIMIT
+      })
+      expect(parseAccountMediaPagination(undefined)).toEqual({
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_MEDIA_LIMIT
+      })
+    })
+
+    it('returns default pagination for empty string', () => {
+      expect(parseAccountMediaPagination('')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+
+    it('returns default pagination when query has no page or limit', () => {
+      expect(
+        parseAccountMediaPagination('https://example.com/api/v1/accounts/media')
+      ).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?other=123')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+
+    it('handles empty parameter values by falling back to defaults', () => {
+      expect(parseAccountMediaPagination('?page=&limit=')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+  })
+
+  describe('page parsing, clamping, and error handling', () => {
+    it('parses valid page numbers within bounds', () => {
+      expect(parseAccountMediaPagination('?page=1')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=5')).toEqual({
+        page: 5,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=500')).toEqual({
+        page: 500,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=10000')).toEqual({
+        page: MAX_PAGE,
+        limit: 25
+      })
+    })
+
+    it('clamps pages below MIN_PAGE to MIN_PAGE (1)', () => {
+      expect(parseAccountMediaPagination('?page=0')).toEqual({
+        page: MIN_PAGE,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=-1')).toEqual({
+        page: MIN_PAGE,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=-9999')).toEqual({
+        page: MIN_PAGE,
+        limit: 25
+      })
+    })
+
+    it('clamps pages above MAX_PAGE to MAX_PAGE (10,000)', () => {
+      expect(parseAccountMediaPagination('?page=10001')).toEqual({
+        page: MAX_PAGE,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=999999')).toEqual({
+        page: MAX_PAGE,
+        limit: 25
+      })
+    })
+
+    it('defaults malformed or non-numeric page input to 1', () => {
+      expect(parseAccountMediaPagination('?page=abc')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=true')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=NaN')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=Infinity')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=-Infinity')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=undefined')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=[object%20Object]')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+
+    it('preserves parseInt prefix acceptance for page', () => {
+      expect(parseAccountMediaPagination('?page=3abc')).toEqual({
+        page: 3,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=42 items')).toEqual({
+        page: 42,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=10000abc')).toEqual({
+        page: 10000,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?page=20000abc')).toEqual({
+        page: 10000,
+        limit: 25
+      })
+    })
+  })
+
+  describe('limit validation and allowed sets', () => {
+    it.each(ALLOWED_MEDIA_LIMITS)(
+      'accepts allowed limit %i',
+      (allowedLimit) => {
+        expect(parseAccountMediaPagination(`?limit=${allowedLimit}`)).toEqual({
+          page: 1,
+          limit: allowedLimit
+        })
+      }
+    )
+
+    it('preserves parseInt prefix acceptance for allowed limits', () => {
+      expect(parseAccountMediaPagination('?limit=25px')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=50items')).toEqual({
+        page: 1,
+        limit: 50
+      })
+      expect(parseAccountMediaPagination('?limit=100%')).toEqual({
+        page: 1,
+        limit: 100
+      })
+    })
+
+    it('defaults unsupported limits to 25', () => {
+      expect(parseAccountMediaPagination('?limit=10')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=20')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=30')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=75')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=200')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=0')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=-25')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=-50')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+
+    it('defaults malformed or non-numeric limit to 25', () => {
+      expect(parseAccountMediaPagination('?limit=abc')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=NaN')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=Infinity')).toEqual({
+        page: 1,
+        limit: 25
+      })
+      expect(parseAccountMediaPagination('?limit=null')).toEqual({
+        page: 1,
+        limit: 25
+      })
+    })
+  })
+
+  describe('input format compatibility', () => {
+    it('accepts a full URL string', () => {
+      const res = parseAccountMediaPagination(
+        'https://myinstance.social/api/v1/accounts/media?page=3&limit=50'
+      )
+      expect(res).toEqual({ page: 3, limit: 50 })
+    })
+
+    it('accepts a relative URL string', () => {
+      const res = parseAccountMediaPagination(
+        '/api/v1/accounts/media?page=4&limit=100'
+      )
+      expect(res).toEqual({ page: 4, limit: 100 })
+    })
+
+    it('accepts a query string with leading ?', () => {
+      const res = parseAccountMediaPagination('?page=2&limit=50')
+      expect(res).toEqual({ page: 2, limit: 50 })
+    })
+
+    it('accepts a query string without leading ?', () => {
+      const res = parseAccountMediaPagination('page=2&limit=50')
+      expect(res).toEqual({ page: 2, limit: 50 })
+    })
+
+    it('accepts a URL instance', () => {
+      const url = new URL(
+        'https://myinstance.social/api/v1/accounts/media?page=7&limit=50'
+      )
+      expect(parseAccountMediaPagination(url)).toEqual({ page: 7, limit: 50 })
+    })
+
+    it('accepts a URLSearchParams instance', () => {
+      const params = new URLSearchParams('page=8&limit=100')
+      expect(parseAccountMediaPagination(params)).toEqual({
+        page: 8,
+        limit: 100
+      })
+    })
+
+    it('accepts a Request or NextRequest instance', () => {
+      const request = new Request(
+        'https://myinstance.social/api/v1/accounts/media?page=9&limit=50'
+      )
+      expect(parseAccountMediaPagination(request)).toEqual({
+        page: 9,
+        limit: 50
+      })
+    })
+  })
+
+  describe('guarantee of finite values (no NaN reaches output)', () => {
+    const edgeCases = [
+      '',
+      '?',
+      '?page=NaN&limit=NaN',
+      '?page=Infinity&limit=-Infinity',
+      '?page=-Infinity&limit=Infinity',
+      '?page=foo&limit=bar',
+      '?page=&limit=',
+      '?page=-0&limit=+0',
+      '?page=1.5&limit=25.9'
+    ]
+
+    it.each(edgeCases)('ensures finite values for input %j', (input) => {
+      const result = parseAccountMediaPagination(input)
+      expect(Number.isFinite(result.page)).toBe(true)
+      expect(Number.isFinite(result.limit)).toBe(true)
+      expect(Number.isNaN(result.page)).toBe(false)
+      expect(Number.isNaN(result.limit)).toBe(false)
+      expect(result.page).toBeGreaterThanOrEqual(1)
+      expect(result.page).toBeLessThanOrEqual(10000)
+      expect(ALLOWED_MEDIA_LIMITS).toContain(result.limit)
+    })
+  })
+})

--- a/app/api/v1/accounts/media/pagination.test.ts
+++ b/app/api/v1/accounts/media/pagination.test.ts
@@ -270,13 +270,66 @@ describe('parseAccountMediaPagination', () => {
       })
     })
 
-    it('accepts a Request or NextRequest instance', () => {
+    it('accepts a Request instance', () => {
       const request = new Request(
         'https://myinstance.social/api/v1/accounts/media?page=9&limit=50'
       )
       expect(parseAccountMediaPagination(request)).toEqual({
         page: 9,
         limit: 50
+      })
+    })
+
+    it('accepts a NextRequest-like object with nextUrl', () => {
+      const nextRequest = {
+        nextUrl: new URL(
+          'https://myinstance.social/api/v1/accounts/media?page=6&limit=100'
+        )
+      }
+      expect(
+        parseAccountMediaPagination(nextRequest as unknown as Request)
+      ).toEqual({
+        page: 6,
+        limit: 100
+      })
+    })
+
+    it('isolates hash fragments so fragments never leak into query parameters', () => {
+      // URL with query and hash containing conflicting parameters
+      expect(
+        parseAccountMediaPagination(
+          'https://myinstance.social/api/v1/accounts/media?page=2#section&limit=100'
+        )
+      ).toEqual({
+        page: 2,
+        limit: 25
+      })
+
+      // URL with only a hash fragment (no query string)
+      expect(
+        parseAccountMediaPagination(
+          'https://myinstance.social/api/v1/accounts/media#page=5&limit=100'
+        )
+      ).toEqual({
+        page: 1,
+        limit: 25
+      })
+
+      // Query string with hash fragment at the end
+      expect(
+        parseAccountMediaPagination('page=3&limit=50#hash&limit=100')
+      ).toEqual({
+        page: 3,
+        limit: 50
+      })
+
+      // Request object with hash in URL
+      const requestWithHash = new Request(
+        'https://myinstance.social/api/v1/accounts/media?page=4#something&limit=100'
+      )
+      expect(parseAccountMediaPagination(requestWithHash)).toEqual({
+        page: 4,
+        limit: 25
       })
     })
   })

--- a/app/api/v1/accounts/media/pagination.ts
+++ b/app/api/v1/accounts/media/pagination.ts
@@ -1,0 +1,66 @@
+export const DEFAULT_PAGE = 1
+export const MIN_PAGE = 1
+export const MAX_PAGE = 10000
+
+export const ALLOWED_MEDIA_LIMITS = [25, 50, 100] as const
+export type MediaLimit = (typeof ALLOWED_MEDIA_LIMITS)[number]
+export const DEFAULT_MEDIA_LIMIT: MediaLimit = 25
+
+export interface AccountMediaPagination {
+  page: number
+  limit: MediaLimit
+}
+
+/**
+ * Parses pagination parameters (`page` and `limit`) for the account media route.
+ *
+ * - Accepts URLSearchParams, URL, Request, or string (full URL, relative path, or query string).
+ * - Preserves `parseInt` prefix acceptance (e.g. `'25foo'` -> 25).
+ * - Clamps `page` to 1..10,000.
+ * - Defaults malformed/non-finite `page` input to 1.
+ * - Restricts `limit` strictly to 25, 50, or 100; defaults any other value or malformed input to 25.
+ * - Guaranteed to return finite numbers for both `page` and `limit` (never `NaN` or `Infinity`).
+ */
+export function parseAccountMediaPagination(
+  input?: URLSearchParams | URL | Request | string | null
+): AccountMediaPagination {
+  let searchParams: URLSearchParams
+
+  if (input instanceof URLSearchParams) {
+    searchParams = input
+  } else if (input instanceof URL) {
+    searchParams = input.searchParams
+  } else if (typeof input === 'object' && input !== null && 'url' in input) {
+    const rawUrl = (input as Request).url
+    const queryIndex = rawUrl.indexOf('?')
+    searchParams = new URLSearchParams(
+      queryIndex !== -1 ? rawUrl.slice(queryIndex + 1) : ''
+    )
+  } else if (typeof input === 'string') {
+    const queryIndex = input.indexOf('?')
+    searchParams = new URLSearchParams(
+      queryIndex !== -1 ? input.slice(queryIndex + 1) : input
+    )
+  } else {
+    searchParams = new URLSearchParams()
+  }
+
+  const pageParam = searchParams.get('page')
+  const limitParam = searchParams.get('limit')
+
+  const parsedPage = pageParam ? parseInt(pageParam, 10) : DEFAULT_PAGE
+  const page = Number.isFinite(parsedPage)
+    ? Math.max(MIN_PAGE, Math.min(MAX_PAGE, parsedPage))
+    : DEFAULT_PAGE
+
+  const parsedLimit = limitParam
+    ? parseInt(limitParam, 10)
+    : DEFAULT_MEDIA_LIMIT
+  const limit: MediaLimit = (
+    ALLOWED_MEDIA_LIMITS as readonly number[]
+  ).includes(parsedLimit)
+    ? (parsedLimit as MediaLimit)
+    : DEFAULT_MEDIA_LIMIT
+
+  return { page, limit }
+}

--- a/app/api/v1/accounts/media/pagination.ts
+++ b/app/api/v1/accounts/media/pagination.ts
@@ -21,29 +21,70 @@ export interface AccountMediaPagination {
  * - Restricts `limit` strictly to 25, 50, or 100; defaults any other value or malformed input to 25.
  * - Guaranteed to return finite numbers for both `page` and `limit` (never `NaN` or `Infinity`).
  */
+function extractSearchParams(
+  input?: URLSearchParams | URL | Request | string | null
+): URLSearchParams {
+  if (!input) {
+    return new URLSearchParams()
+  }
+  if (input instanceof URLSearchParams) {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.searchParams
+  }
+  if (typeof input === 'object') {
+    if (
+      'searchParams' in input &&
+      input.searchParams instanceof URLSearchParams
+    ) {
+      return input.searchParams
+    }
+    if (
+      'nextUrl' in input &&
+      input.nextUrl &&
+      typeof input.nextUrl === 'object' &&
+      'searchParams' in input.nextUrl &&
+      input.nextUrl.searchParams instanceof URLSearchParams
+    ) {
+      return input.nextUrl.searchParams
+    }
+    if ('url' in input && typeof input.url === 'string') {
+      input = input.url
+    } else {
+      return new URLSearchParams()
+    }
+  }
+
+  if (typeof input === 'string') {
+    const withoutHash = input.split('#')[0]
+    const queryIndex = withoutHash.indexOf('?')
+    if (queryIndex !== -1) {
+      return new URLSearchParams(withoutHash.slice(queryIndex + 1))
+    }
+    if (withoutHash.includes('/') || withoutHash.includes('://')) {
+      return new URLSearchParams()
+    }
+    return new URLSearchParams(withoutHash)
+  }
+
+  return new URLSearchParams()
+}
+
+/**
+ * Parses pagination parameters (`page` and `limit`) for the account media route.
+ *
+ * - Accepts URLSearchParams, URL, Request, or string (full URL, relative path, or query string).
+ * - Preserves `parseInt` prefix acceptance (e.g. `'25foo'` -> 25).
+ * - Clamps `page` to 1..10,000.
+ * - Defaults malformed/non-finite `page` input to 1.
+ * - Restricts `limit` strictly to 25, 50, or 100; defaults any other value or malformed input to 25.
+ * - Guaranteed to return finite numbers for both `page` and `limit` (never `NaN` or `Infinity`).
+ */
 export function parseAccountMediaPagination(
   input?: URLSearchParams | URL | Request | string | null
 ): AccountMediaPagination {
-  let searchParams: URLSearchParams
-
-  if (input instanceof URLSearchParams) {
-    searchParams = input
-  } else if (input instanceof URL) {
-    searchParams = input.searchParams
-  } else if (typeof input === 'object' && input !== null && 'url' in input) {
-    const rawUrl = (input as Request).url
-    const queryIndex = rawUrl.indexOf('?')
-    searchParams = new URLSearchParams(
-      queryIndex !== -1 ? rawUrl.slice(queryIndex + 1) : ''
-    )
-  } else if (typeof input === 'string') {
-    const queryIndex = input.indexOf('?')
-    searchParams = new URLSearchParams(
-      queryIndex !== -1 ? input.slice(queryIndex + 1) : input
-    )
-  } else {
-    searchParams = new URLSearchParams()
-  }
+  const searchParams = extractSearchParams(input)
 
   const pageParam = searchParams.get('page')
   const limitParam = searchParams.get('limit')

--- a/app/api/v1/accounts/media/route.test.ts
+++ b/app/api/v1/accounts/media/route.test.ts
@@ -1,0 +1,305 @@
+import { NextRequest } from 'next/server'
+
+import { ERROR_401 } from '@/lib/utils/response'
+
+import { GET, OPTIONS } from './route'
+
+const mockSpan = {
+  setAttribute: vi.fn(),
+  setStatus: vi.fn(),
+  end: vi.fn(),
+  recordException: vi.fn()
+}
+
+vi.mock('@/lib/utils/trace', () => ({
+  getTracer: () => ({
+    startActiveSpan: (_name: string, fn: (span: typeof mockSpan) => unknown) =>
+      fn(mockSpan)
+  })
+}))
+
+const mockCurrentActor: {
+  id: string
+  account?: { id: string }
+} = {
+  id: 'https://llun.test/users/llun',
+  account: { id: 'account-1' }
+}
+
+const mockDatabase = {
+  getStorageUsageForAccount: vi.fn(),
+  getMediasWithStatusForAccount: vi.fn()
+}
+
+vi.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handler: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<object>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<object> }) =>
+      handler(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+const createRouteContext = () =>
+  ({
+    params: Promise.resolve({}),
+    currentActor: mockCurrentActor
+  }) as unknown as { params: Promise<object> }
+
+vi.mock('@/lib/services/medias/quota', () => ({
+  getQuotaLimit: vi.fn().mockReturnValue(4294967296)
+}))
+
+describe('OPTIONS /api/v1/accounts/media', () => {
+  it('returns 200 with allowed CORS methods', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/accounts/media', {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://llun.test' }
+    })
+    const res = await OPTIONS(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('OPTIONS')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://llun.test'
+    )
+  })
+})
+
+describe('GET /api/v1/accounts/media', () => {
+  const sampleMediaItem = {
+    id: '123',
+    actorId: 'https://llun.test/users/llun',
+    original: {
+      bytes: 1024,
+      mimeType: 'image/jpeg',
+      metaData: { width: 800, height: 600 }
+    },
+    thumbnail: {
+      bytes: 256,
+      mimeType: 'image/jpeg',
+      metaData: { width: 200, height: 150 }
+    },
+    description: 'Sample image',
+    statusId: 'status-456'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCurrentActor.account = { id: 'account-1' }
+    mockDatabase.getStorageUsageForAccount.mockResolvedValue(1280)
+    mockDatabase.getMediasWithStatusForAccount.mockResolvedValue({
+      items: [sampleMediaItem],
+      total: 1
+    })
+  })
+
+  it('returns 401 when actor has no account', async () => {
+    mockCurrentActor.account = undefined
+
+    const req = new NextRequest('https://llun.test/api/v1/accounts/media')
+    const res = await GET(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json).toEqual(ERROR_401)
+    expect(mockDatabase.getStorageUsageForAccount).not.toHaveBeenCalled()
+    expect(mockDatabase.getMediasWithStatusForAccount).not.toHaveBeenCalled()
+  })
+
+  it('handles default pagination parameters when query is omitted', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/accounts/media')
+    const res = await GET(req, createRouteContext())
+
+    expect(res.status).toBe(200)
+    expect(mockDatabase.getStorageUsageForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1'
+    })
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 1,
+      limit: 25
+    })
+
+    const json = await res.json()
+    expect(json).toEqual({
+      used: 1280,
+      limit: 4294967296,
+      total: 1,
+      page: 1,
+      itemsPerPage: 25,
+      medias: [
+        {
+          id: '123',
+          actorId: 'https://llun.test/users/llun',
+          bytes: 1280,
+          mimeType: 'image/jpeg',
+          width: 800,
+          height: 600,
+          description: 'Sample image',
+          statusId: 'status-456'
+        }
+      ]
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('accountId', 'account-1')
+  })
+
+  it('passes custom valid page and limit to database, response, and trace attributes', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=2&limit=50'
+    )
+    const res = await GET(req, createRouteContext())
+
+    expect(res.status).toBe(200)
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 2,
+      limit: 50
+    })
+
+    const json = await res.json()
+    expect(json.page).toBe(2)
+    expect(json.itemsPerPage).toBe(50)
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 2)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 50)
+  })
+
+  it('defaults malformed or non-numeric page and limit and prevents NaN from reaching database or trace', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=malformed&limit=invalid'
+    )
+    const res = await GET(req, createRouteContext())
+
+    expect(res.status).toBe(200)
+
+    // Verify database receives finite numbers, never NaN
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 1,
+      limit: 25
+    })
+
+    const json = await res.json()
+    expect(json.page).toBe(1)
+    expect(json.itemsPerPage).toBe(25)
+    expect(Number.isNaN(json.page)).toBe(false)
+    expect(Number.isNaN(json.itemsPerPage)).toBe(false)
+
+    // Verify trace attributes receive finite numbers, never NaN
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
+  })
+
+  it('accepts prefix numeric page and limit values', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=3foo&limit=100bar'
+    )
+    const res = await GET(req, createRouteContext())
+
+    expect(res.status).toBe(200)
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 3,
+      limit: 100
+    })
+
+    const json = await res.json()
+    expect(json.page).toBe(3)
+    expect(json.itemsPerPage).toBe(100)
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 3)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 100)
+  })
+
+  it('clamps out-of-bounds page inputs', async () => {
+    // Negative page
+    const reqNegative = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=-10'
+    )
+    await GET(reqNegative, { params: Promise.resolve({}) })
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 })
+    )
+
+    // Zero page
+    const reqZero = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=0'
+    )
+    await GET(reqZero, { params: Promise.resolve({}) })
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 })
+    )
+
+    // Above max page (10,000)
+    const reqHuge = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=50000'
+    )
+    await GET(reqHuge, { params: Promise.resolve({}) })
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 10000 })
+    )
+  })
+
+  it('defaults unsupported limits to 25', async () => {
+    const unsupported = [10, 20, 30, 75, 200, -25]
+    for (const limit of unsupported) {
+      vi.clearAllMocks()
+      const req = new NextRequest(
+        `https://llun.test/api/v1/accounts/media?limit=${limit}`
+      )
+      await GET(req, { params: Promise.resolve({}) })
+      expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 25 })
+      )
+    }
+  })
+
+  it('handles media items without thumbnails', async () => {
+    mockDatabase.getMediasWithStatusForAccount.mockResolvedValue({
+      items: [
+        {
+          id: '456',
+          actorId: 'https://llun.test/users/llun',
+          original: {
+            bytes: 2048,
+            mimeType: 'image/png',
+            metaData: { width: 1024, height: 768 }
+          },
+          description: null,
+          statusId: undefined
+        }
+      ],
+      total: 1
+    })
+
+    const req = new NextRequest('https://llun.test/api/v1/accounts/media')
+    const res = await GET(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.medias[0]).toEqual({
+      id: '456',
+      actorId: 'https://llun.test/users/llun',
+      bytes: 2048,
+      mimeType: 'image/png',
+      width: 1024,
+      height: 768,
+      description: null,
+      statusId: undefined
+    })
+  })
+})

--- a/app/api/v1/accounts/media/route.test.ts
+++ b/app/api/v1/accounts/media/route.test.ts
@@ -4,6 +4,14 @@ import { ERROR_401 } from '@/lib/utils/response'
 
 import { GET, OPTIONS } from './route'
 
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
 const mockSpan = {
   setAttribute: vi.fn(),
   setStatus: vi.fn(),
@@ -226,47 +234,117 @@ describe('GET /api/v1/accounts/media', () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 100)
   })
 
-  it('clamps out-of-bounds page inputs', async () => {
+  it('handles empty parameter values by falling back to defaults across db, response, and trace', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=&limit='
+    )
+    const res = await GET(req, createRouteContext())
+
+    expect(res.status).toBe(200)
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 1,
+      limit: 25
+    })
+
+    const json = await res.json()
+    expect(json.page).toBe(1)
+    expect(json.itemsPerPage).toBe(25)
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
+  })
+
+  it('clamps out-of-bounds page inputs with parity across db, response, and trace', async () => {
     // Negative page
+    vi.clearAllMocks()
     const reqNegative = new NextRequest(
       'https://llun.test/api/v1/accounts/media?page=-10'
     )
-    await GET(reqNegative, { params: Promise.resolve({}) })
-    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
-      expect.objectContaining({ page: 1 })
-    )
+    const resNegative = await GET(reqNegative, createRouteContext())
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 1,
+      limit: 25
+    })
+    const jsonNegative = await resNegative.json()
+    expect(jsonNegative.page).toBe(1)
+    expect(jsonNegative.itemsPerPage).toBe(25)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
 
     // Zero page
+    vi.clearAllMocks()
     const reqZero = new NextRequest(
       'https://llun.test/api/v1/accounts/media?page=0'
     )
-    await GET(reqZero, { params: Promise.resolve({}) })
-    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
-      expect.objectContaining({ page: 1 })
-    )
+    const resZero = await GET(reqZero, createRouteContext())
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 1,
+      limit: 25
+    })
+    const jsonZero = await resZero.json()
+    expect(jsonZero.page).toBe(1)
+    expect(jsonZero.itemsPerPage).toBe(25)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
 
     // Above max page (10,000)
+    vi.clearAllMocks()
     const reqHuge = new NextRequest(
       'https://llun.test/api/v1/accounts/media?page=50000'
     )
-    await GET(reqHuge, { params: Promise.resolve({}) })
-    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
-      expect.objectContaining({ page: 10000 })
-    )
+    const resHuge = await GET(reqHuge, createRouteContext())
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 10000,
+      limit: 25
+    })
+    const jsonHuge = await resHuge.json()
+    expect(jsonHuge.page).toBe(10000)
+    expect(jsonHuge.itemsPerPage).toBe(25)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 10000)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
   })
 
-  it('defaults unsupported limits to 25', async () => {
+  it('defaults unsupported limits to 25 with parity across db, response, and trace', async () => {
     const unsupported = [10, 20, 30, 75, 200, -25]
     for (const limit of unsupported) {
       vi.clearAllMocks()
       const req = new NextRequest(
         `https://llun.test/api/v1/accounts/media?limit=${limit}`
       )
-      await GET(req, { params: Promise.resolve({}) })
-      expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith(
-        expect.objectContaining({ limit: 25 })
-      )
+      const res = await GET(req, createRouteContext())
+      expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+        accountId: 'account-1',
+        page: 1,
+        limit: 25
+      })
+      const json = await res.json()
+      expect(json.page).toBe(1)
+      expect(json.itemsPerPage).toBe(25)
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
     }
+  })
+
+  it('isolates URL hash fragments from query pagination', async () => {
+    // Hash fragment should never leak into query pagination
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media?page=2#heading&limit=100'
+    )
+    const res = await GET(req, createRouteContext())
+    expect(mockDatabase.getMediasWithStatusForAccount).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      page: 2,
+      limit: 25
+    })
+    const json = await res.json()
+    expect(json.page).toBe(2)
+    expect(json.itemsPerPage).toBe(25)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 2)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
   })
 
   it('handles media items without thumbnails', async () => {

--- a/app/api/v1/accounts/media/route.ts
+++ b/app/api/v1/accounts/media/route.ts
@@ -5,6 +5,8 @@ import { logger } from '@/lib/utils/logger'
 import { ERROR_401, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
+import { parseAccountMediaPagination } from './pagination'
+
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
@@ -25,15 +27,7 @@ export const GET = traceApiRoute(
       })
     }
 
-    // Parse pagination parameters from URL with defaults and validation
-    const url = new URL(req.url)
-    const pageParam = url.searchParams.get('page')
-    const limitParam = url.searchParams.get('limit')
-
-    const page = Math.max(1, Math.min(10000, parseInt(pageParam || '1', 10)))
-    const limit = [25, 50, 100].includes(parseInt(limitParam || '25', 10))
-      ? parseInt(limitParam || '25', 10)
-      : 25
+    const { page, limit } = parseAccountMediaPagination(req.url)
 
     // Get storage usage
     const used = await database.getStorageUsageForAccount({
@@ -77,13 +71,7 @@ export const GET = traceApiRoute(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { currentActor } = context as any
       const account = currentActor?.account
-      const url = new URL(req.url)
-      const pageParam = url.searchParams.get('page')
-      const limitParam = url.searchParams.get('limit')
-      const page = Math.max(1, Math.min(10000, parseInt(pageParam || '1', 10)))
-      const limit = [25, 50, 100].includes(parseInt(limitParam || '25', 10))
-        ? parseInt(limitParam || '25', 10)
-        : 25
+      const { page, limit } = parseAccountMediaPagination(req.url)
 
       const attributes: Record<string, string | number | boolean> = {
         page,


### PR DESCRIPTION
## Summary

Extracts account-media pagination parsing into route-local `pagination.ts` and reuses `parseAccountMediaPagination` in both the route handler and tracing attributes (`app/api/v1/accounts/media/route.ts`).

- Returns finite `{ page, limit }` values with prefix numeric acceptance.
- Clamps `page` between 1 and 10,000, defaulting invalid, empty, or non-numeric values to 1.
- Restricts `limit` to 25, 50, or 100 (defaulting to 25).
- Ensures no `NaN` reaches database queries or OpenTelemetry span attributes.
- Adds route-level and utility test suites (`pagination.test.ts` and `route.test.ts`).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)