### PR TITLE
fix: verify fetched-object authority before use

### DIFF
--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -210,4 +210,100 @@ describe('createRelayAnnounceJob', () => {
     expect(stored.type).toEqual(StatusType.enum.Poll)
     expect(stored.choices).toHaveLength(2)
   })
+
+  it('rejects a relayed note whose fetched id is cross-origin', async () => {
+    const requestedNote = 'https://somewhere.test/statuses/requested-note'
+    const evilNote = 'https://attacker.test/statuses/evil-note'
+    fetchMock.mockOnceIf(
+      requestedNote,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: evilNote,
+        type: 'Note',
+        attributedTo: 'https://somewhere.test/actors/author',
+        content: '<p>Malicious cross-host id</p>',
+        published: '2026-08-30T00:00:00Z',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+    )
+
+    await createRelayAnnounceJob(database, {
+      id: 'job-cross-host',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(requestedNote, `${RELAY_ACTOR}/announce/cross-host`)
+    })
+
+    const requestedStatus = await database.getStatus({
+      statusId: requestedNote
+    })
+    expect(requestedStatus).toBeNull()
+    const evilStatus = await database.getStatus({ statusId: evilNote })
+    expect(evilStatus).toBeNull()
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).not.toContain(requestedNote)
+    expect(federated.map((status) => status.id)).not.toContain(evilNote)
+  })
+
+  it('rejects a relayed note whose fetched id is malformed or non-http', async () => {
+    const requestedNote = 'https://somewhere.test/statuses/malformed-fetched-id'
+    fetchMock.mockOnceIf(
+      requestedNote,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'not-a-valid-url',
+        type: 'Note',
+        attributedTo: 'https://somewhere.test/actors/author',
+        content: '<p>Malformed id</p>',
+        published: '2026-08-30T00:00:00Z',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+    )
+
+    await createRelayAnnounceJob(database, {
+      id: 'job-malformed-returned-id',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(requestedNote, `${RELAY_ACTOR}/announce/malformed-id`)
+    })
+
+    const requestedStatus = await database.getStatus({
+      statusId: requestedNote
+    })
+    expect(requestedStatus).toBeNull()
+  })
+
+  it('accepts a relayed note with a valid same-host canonical alias', async () => {
+    const requestedNote = 'https://somewhere.test/statuses/alias-note/'
+    const canonicalNote = 'https://somewhere.test/statuses/alias-note'
+    fetchMock.mockOnceIf(
+      requestedNote,
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: canonicalNote,
+        type: 'Note',
+        attributedTo: 'https://somewhere.test/actors/author',
+        content: '<p>Canonical alias</p>',
+        published: '2026-08-30T00:00:00Z',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+    )
+
+    await createRelayAnnounceJob(database, {
+      id: 'job-canonical-alias',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(requestedNote, `${RELAY_ACTOR}/announce/canonical-alias`)
+    })
+
+    const stored = await database.getStatus({ statusId: canonicalNote })
+    expect(stored).toBeDefined()
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).toContain(canonicalNote)
+  })
 })

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -8,6 +8,7 @@ import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
 import { Status } from '@/lib/types/domain/status'
+import { isSameActivityPubOrigin } from '@/lib/utils/activitypub'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
@@ -95,6 +96,9 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
       if (!signingActor) return
       const note = await getNote({ statusId: objectId, signingActor })
       if (!note) return
+      if (!isHttpUrl(note.id) || !isSameActivityPubOrigin(note.id, objectId)) {
+        return
+      }
       // createNoteJob or createPollJob enforces the author's federation policy and persists
       // the status; called without verifiedSenderActorId so the relay's
       // signature does not have to match the author.

--- a/lib/jobs/processForwardedActivityJob.test.ts
+++ b/lib/jobs/processForwardedActivityJob.test.ts
@@ -387,4 +387,181 @@ describe('processForwardedActivityJob', () => {
     expect(status.type).toEqual(StatusType.enum.Poll)
     expect(status.choices[0].totalVotes).toEqual(10)
   })
+
+  it('rejects a forwarded Create whose fetched note id is cross-origin', async () => {
+    const evilNoteId = 'https://attacker.example/statuses/evil'
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        noteDocument({
+          id: evilNoteId
+        })
+      )
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Create', { id: NOTE_ID, type: 'Note' }))
+    )
+
+    const requestedStatus = await database.getStatus({ statusId: NOTE_ID })
+    expect(requestedStatus).toBeNull()
+    const evilStatus = await database.getStatus({ statusId: evilNoteId })
+    expect(evilStatus).toBeNull()
+  })
+
+  it('rejects a forwarded Create whose fetched note id is malformed or non-http', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        noteDocument({
+          id: 'not-a-valid-url'
+        })
+      )
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Create', { id: NOTE_ID, type: 'Note' }))
+    )
+
+    const status = await database.getStatus({ statusId: NOTE_ID })
+    expect(status).toBeNull()
+  })
+
+  it('accepts a forwarded Create with a same-host canonical alias', async () => {
+    const canonicalNoteId = `${NOTE_ID}-canonical`
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        noteDocument({
+          id: canonicalNoteId
+        })
+      )
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Create', { id: NOTE_ID, type: 'Note' }))
+    )
+
+    const status = await database.getStatus({ statusId: canonicalNoteId })
+    expect(status).toBeDefined()
+    expect(status?.actorId).toEqual(AUTHOR)
+  })
+
+  it('rejects a forwarded Update whose fetched note id is cross-origin', async () => {
+    await database.createNote({
+      id: NOTE_ID,
+      url: NOTE_ID,
+      actorId: AUTHOR,
+      text: 'original text',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const evilNoteId = 'https://attacker.example/statuses/evil-update'
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        noteDocument({
+          id: evilNoteId,
+          content: '<p>malicious update</p>'
+        })
+      )
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Update', { id: NOTE_ID, type: 'Note' }))
+    )
+
+    const stored = await database.getStatus({ statusId: NOTE_ID })
+    expect(stored).toBeDefined()
+    if (stored?.type === 'Note') {
+      expect(stored.text).toEqual('original text')
+    } else {
+      expect.fail('Expected stored status to be a Note')
+    }
+  })
+
+  it('does not confirm Delete when origin serves a Tombstone with cross-origin id', async () => {
+    await database.createNote({
+      id: NOTE_ID,
+      url: NOTE_ID,
+      actorId: AUTHOR,
+      text: 'surviving note',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://attacker.example/statuses/other',
+        type: 'Tombstone'
+      }),
+      { status: 200 }
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Delete', NOTE_ID))
+    )
+
+    const stored = await database.getStatus({ statusId: NOTE_ID })
+    expect(stored).toBeDefined()
+  })
+
+  it('does not confirm Delete when origin serves a Tombstone with malformed id', async () => {
+    await database.createNote({
+      id: NOTE_ID,
+      url: NOTE_ID,
+      actorId: AUTHOR,
+      text: 'surviving note',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'malformed-id',
+        type: 'Tombstone'
+      }),
+      { status: 200 }
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Delete', NOTE_ID))
+    )
+
+    const stored = await database.getStatus({ statusId: NOTE_ID })
+    expect(stored).toBeDefined()
+  })
+
+  it('confirms Delete when origin serves a Tombstone with same-host canonical alias id', async () => {
+    await database.createNote({
+      id: NOTE_ID,
+      url: NOTE_ID,
+      actorId: AUTHOR,
+      text: 'note to delete',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: `${NOTE_ID}-canonical`,
+        type: 'Tombstone'
+      }),
+      { status: 200 }
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Delete', NOTE_ID))
+    )
+
+    const stored = await database.getStatus({ statusId: NOTE_ID })
+    expect(stored).toBeNull()
+  })
 })

--- a/lib/jobs/processForwardedActivityJob.ts
+++ b/lib/jobs/processForwardedActivityJob.ts
@@ -7,7 +7,10 @@ import { getConfig } from '@/lib/config'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { ENTITY_TYPE_QUESTION, Tombstone } from '@/lib/types/activitypub'
-import { normalizeActorId } from '@/lib/utils/activitypub'
+import {
+  isSameActivityPubOrigin,
+  normalizeActorId
+} from '@/lib/utils/activitypub'
 import { request } from '@/lib/utils/request'
 import { withSpan } from '@/lib/utils/trace'
 
@@ -59,10 +62,18 @@ const sameHost = (first: string, second: string): boolean => {
   }
 }
 
-const isTombstoneBody = async (body: string): Promise<boolean> => {
+const isTombstoneBody = async (
+  body: string,
+  objectId: string
+): Promise<boolean> => {
   try {
     const compacted = await compactActivityPub(JSON.parse(body))
-    return Tombstone.safeParse(compacted).success
+    const parsed = Tombstone.safeParse(compacted)
+    return (
+      parsed.success &&
+      isHttpUrl(parsed.data.id) &&
+      isSameActivityPubOrigin(parsed.data.id, objectId)
+    )
   } catch {
     return false
   }
@@ -133,7 +144,7 @@ export const processForwardedActivityJob = createJobHandle(
         const confirmed =
           statusCode === 404 ||
           statusCode === 410 ||
-          (statusCode === 200 && (await isTombstoneBody(body)))
+          (statusCode === 200 && (await isTombstoneBody(body, objectId)))
         if (!confirmed) {
           span.setAttribute('outcome', 'delete_unconfirmed')
           span.setAttribute('originStatusCode', statusCode)
@@ -166,6 +177,10 @@ export const processForwardedActivityJob = createJobHandle(
       const note = await getNote({ statusId: objectId, signingActor })
       if (!note) {
         span.setAttribute('outcome', 'origin_fetch_failed')
+        return
+      }
+      if (!isHttpUrl(note.id) || !isSameActivityPubOrigin(note.id, objectId)) {
+        span.setAttribute('outcome', 'returned_id_unauthorized')
         return
       }
       // The fetched note must be attributed to the actor the forwarded


### PR DESCRIPTION
## Summary
When fetching remote objects in `createRelayAnnounceJob` and `processForwardedActivityJob`, verify that the fetched object ID matches the ActivityPub origin/authority of the requested `objectId` before processing or persisting.

### Changes
- In `lib/jobs/createRelayAnnounceJob.ts`: validates `note.id` with `isHttpUrl(note.id) && isSameActivityPubOrigin(note.id, objectId)` after fetch before querying or mutating database state.
- In `lib/jobs/processForwardedActivityJob.ts`: validates `note.id` on Create/Update with `isHttpUrl(note.id) && isSameActivityPubOrigin(note.id, objectId)` (setting span outcome `'returned_id_unauthorized'`); validates `tombstone.id` on Delete with `isHttpUrl(tombstone.id) && isSameActivityPubOrigin(tombstone.id, objectId)` before confirming deletion.
- Added comprehensive unit tests in `createRelayAnnounceJob.test.ts` and `processForwardedActivityJob.test.ts` for cross-origin IDs, malformed/non-HTTP IDs, and valid same-origin canonical aliases.

## Verification
- `yarn run prettier --write .` (passed)
- `yarn lint` (passed with 0 errors)
- `yarn typecheck` (passed with 0 errors)
- `yarn build` (passed)
- `yarn test` (all 37 job suites, 555 tests passed)