### PR TITLE
feat: give queue claims ownership tokens

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,7 +240,8 @@ Instance administrators can inspect terminally failed tasks, view formatted payl
 - **Database Queue (`ACTIVITIES_QUEUE_TYPE=database`)**:
   - Tasks are persisted directly into the `queue_jobs` table in the database.
   - Processed asynchronously by the in-process runner (bootstrapped via `instrumentation.ts` when configured) or by a standalone worker process (`scripts/maintenance/runQueueWorker.ts`).
-  - Workers atomically claim batches of due jobs (`pending` -> `processing`).
+  - Workers atomically claim batches of due jobs (`pending` -> `processing`) using unique UUID ownership tokens (`claim_token`). Completion, retry, and failure settlement require matching the active token.
+  - Operational note: Old workers must be drained before a mixed-version rollout to ensure claims are settled with compatible token parameters. Claim tokens protect against concurrent or stale queue state transitions, but do not promise exactly-once external effects.
   - Unhandled job errors trigger polynomial backoff retry scheduling (`attempt^4 + 15` seconds, up to `ACTIVITIES_QUEUE_DATABASE_MAX_RETRIES` / default 16 attempts spanning ~7.5 days, matching Mastodon queue retry resilience).
   - Upon reaching maximum retries, failed tasks are stored in `dead_letter_jobs` and marked failed in `queue_jobs`, making them manageable via the Admin UI at `/admin/queues`.
 - **Google Cloud Tasks (`ACTIVITIES_QUEUE_TYPE=cloudtasks`)**:

--- a/knexfile.js
+++ b/knexfile.js
@@ -7,7 +7,7 @@ dotenvFlow.config()
 // The project is ESM-only ("type": "module"), so migrations are authored as
 // native ES modules (named `up`/`down` exports). Point `migrate:make` at the
 // ESM stub so generated migrations match.
-const migrations = { stub: 'migration.stub' }
+const migrations = { directory: './migrations', stub: 'migration.stub' }
 
 const withMigrations = () => ({ ...getKnexfileDatabaseConfig(), migrations })
 

--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -1,24 +1,17 @@
-import knex, { Knex } from 'knex'
-
-import { getSQLDatabase } from '@/lib/database/sql'
-import { Database } from '@/lib/database/types'
+import { getTestDatabaseWithInstance } from '@/lib/database/testUtils'
 import { JobMessage } from '@/lib/services/queue/type'
 
 describe('QueueJobDatabase', () => {
-  let knexDatabase: Knex
-  let database: Database
+  const {
+    database,
+    instance: knexDatabase,
+    prepare
+  } = getTestDatabaseWithInstance(true)
 
   beforeAll(async () => {
-    knexDatabase = knex({
-      client: 'better-sqlite3',
-      useNullAsDefault: true,
-      connection: {
-        filename: ':memory:'
-      }
-    })
-    database = getSQLDatabase(knexDatabase)
+    await prepare()
     await database.migrate()
-  })
+  }, 30000)
 
   afterAll(async () => {
     await database.destroy()
@@ -30,7 +23,7 @@ describe('QueueJobDatabase', () => {
     data: { inbox: 'https://example.com/inbox', activity: { type: 'Create' } }
   }
 
-  it('creates queue jobs and retrieves by id', async () => {
+  it('creates queue jobs and retrieves by id with null claimToken', async () => {
     const job = await database.createQueueJob({
       id: 'custom-id-1',
       name: 'deliverActivity',
@@ -45,6 +38,7 @@ describe('QueueJobDatabase', () => {
     expect(job.attempts).toBe(0)
     expect(job.maxRetries).toBe(16)
     expect(job.payload).toEqual(samplePayload)
+    expect(job.claimToken).toBeNull()
     expect(job.createdAt).toBeTypeOf('number')
     expect(job.nextRunAt).toBeTypeOf('number')
 
@@ -80,53 +74,153 @@ describe('QueueJobDatabase', () => {
     expect(ids).not.toContain('future-1')
   })
 
-  it('atomically claims a pending job, preventing duplicate processing', async () => {
+  it('atomically claims a pending job with claimToken, preventing duplicate processing', async () => {
     await database.createQueueJob({
       id: 'claimable-1',
       name: 'deliverActivity',
       payload: samplePayload
     })
 
-    const firstClaim = await database.claimQueueJob('claimable-1')
-    expect(firstClaim).toBe(true)
+    const firstClaim = await database.claimQueueJob({ id: 'claimable-1' })
+    expect(firstClaim).not.toBeNull()
+    expect(firstClaim?.id).toBe('claimable-1')
+    expect(firstClaim?.status).toBe('processing')
+    expect(firstClaim?.claimToken).toBeTypeOf('string')
+    expect(firstClaim?.claimToken).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    )
 
     // Second claim must fail because status is now processing
-    const secondClaim = await database.claimQueueJob('claimable-1')
-    expect(secondClaim).toBe(false)
+    const secondClaim = await database.claimQueueJob({ id: 'claimable-1' })
+    expect(secondClaim).toBeNull()
 
     const job = await database.getQueueJobById('claimable-1')
     expect(job?.status).toBe('processing')
+    expect(job?.claimToken).toBe(firstClaim?.claimToken)
   })
 
-  it('completes a job', async () => {
+  it('handles competing claims concurrently: exactly one worker succeeds', async () => {
+    await database.createQueueJob({
+      id: 'competing-claim-1',
+      name: 'deliverActivity',
+      payload: samplePayload
+    })
+
+    const claimAttempts = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        database.claimQueueJob({ id: 'competing-claim-1' })
+      )
+    )
+
+    const successfulClaims = claimAttempts.filter(
+      (result) => result !== null && result !== undefined
+    )
+    const failedClaims = claimAttempts.filter((result) => result === null)
+
+    expect(successfulClaims.length).toBe(1)
+    expect(failedClaims.length).toBe(7)
+    expect(successfulClaims[0]?.claimToken).toBeTypeOf('string')
+  })
+
+  it('rejects claim when a job was rescheduled between discovery and claim', async () => {
+    const now = Date.now()
+
+    await database.createQueueJob({
+      id: 'rescheduled-between-discovery-1',
+      name: 'deliverActivity',
+      payload: samplePayload,
+      nextRunAt: new Date(now - 5000)
+    })
+
+    // Discovered as due at `now`
+    const dueJobs = await database.getDueQueueJobs({ now: new Date(now) })
+    expect(
+      dueJobs.some((j) => j.id === 'rescheduled-between-discovery-1')
+    ).toBe(true)
+
+    // Job was rescheduled to future before claim executes
+    await knexDatabase('queue_jobs')
+      .where({ id: 'rescheduled-between-discovery-1' })
+      .update({
+        next_run_at: new Date(now + 60000)
+      })
+
+    // Claim attempted at `now` must fail because next_run_at > now
+    const claim = await database.claimQueueJob({
+      id: 'rescheduled-between-discovery-1',
+      now: new Date(now)
+    })
+    expect(claim).toBeNull()
+
+    const job = await database.getQueueJobById(
+      'rescheduled-between-discovery-1'
+    )
+    expect(job?.status).toBe('pending')
+  })
+
+  it('completes a job with valid claimToken and rejects invalid or stale claimToken', async () => {
     await database.createQueueJob({
       id: 'completable-1',
       name: 'deliverActivity',
       payload: samplePayload
     })
 
-    await database.claimQueueJob('completable-1')
-    const completed = await database.completeQueueJob('completable-1')
+    const claim = await database.claimQueueJob({ id: 'completable-1' })
+    expect(claim).not.toBeNull()
+
+    // Wrong token fails
+    const invalidTokenComplete = await database.completeQueueJob({
+      id: 'completable-1',
+      claimToken: 'wrong-token-uuid'
+    })
+    expect(invalidTokenComplete).toBe(false)
+
+    // Valid token succeeds
+    const completed = await database.completeQueueJob({
+      id: 'completable-1',
+      claimToken: claim!.claimToken
+    })
     expect(completed).toBe(true)
 
     const job = await database.getQueueJobById('completable-1')
     expect(job?.status).toBe('completed')
+    expect(job?.claimToken).toBeNull()
+
+    // Second completion with same token is rejected (status no longer processing)
+    const secondComplete = await database.completeQueueJob({
+      id: 'completable-1',
+      claimToken: claim!.claimToken
+    })
+    expect(secondComplete).toBe(false)
   })
 
-  it('schedules retry with updated attempts, error details, and resets status to pending', async () => {
+  it('schedules retry with valid claimToken and rejects invalid or stale claimToken', async () => {
     await database.createQueueJob({
       id: 'retryable-1',
       name: 'deliverActivity',
       payload: samplePayload
     })
 
-    await database.claimQueueJob('retryable-1')
+    const claim = await database.claimQueueJob({ id: 'retryable-1' })
+    expect(claim).not.toBeNull()
 
     const nextRun = new Date(Date.now() + 5000)
     const err = new Error('Simulated network timeout')
 
+    // Wrong token fails
+    const invalidTokenRetry = await database.scheduleQueueJobRetry({
+      id: 'retryable-1',
+      claimToken: 'wrong-token-uuid',
+      nextRunAt: nextRun,
+      attempts: 1,
+      error: err
+    })
+    expect(invalidTokenRetry).toBe(false)
+
+    // Valid token succeeds
     const scheduled = await database.scheduleQueueJobRetry({
       id: 'retryable-1',
+      claimToken: claim!.claimToken,
       nextRunAt: nextRun,
       attempts: 1,
       error: err
@@ -136,22 +230,46 @@ describe('QueueJobDatabase', () => {
     const job = await database.getQueueJobById('retryable-1')
     expect(job?.status).toBe('pending')
     expect(job?.attempts).toBe(1)
+    expect(job?.claimToken).toBeNull()
     expect(job?.lastErrorMessage).toBe('Simulated network timeout')
     expect(job?.lastErrorStack).toContain('Error: Simulated network timeout')
+
+    // Second retry with same token is rejected (status no longer processing)
+    const secondRetry = await database.scheduleQueueJobRetry({
+      id: 'retryable-1',
+      claimToken: claim!.claimToken,
+      nextRunAt: nextRun,
+      attempts: 2,
+      error: err
+    })
+    expect(secondRetry).toBe(false)
   })
 
-  it('fails a job terminally', async () => {
+  it('fails a job terminally with valid claimToken and rejects invalid or stale claimToken', async () => {
     await database.createQueueJob({
       id: 'failable-1',
       name: 'deliverActivity',
       payload: samplePayload
     })
 
-    await database.claimQueueJob('failable-1')
+    const claim = await database.claimQueueJob({ id: 'failable-1' })
+    expect(claim).not.toBeNull()
 
     const err = new Error('Permanent 410 Gone')
+
+    // Wrong token fails
+    const invalidTokenFail = await database.failQueueJob({
+      id: 'failable-1',
+      claimToken: 'wrong-token-uuid',
+      attempts: 16,
+      error: err
+    })
+    expect(invalidTokenFail).toBe(false)
+
+    // Valid token succeeds
     const failed = await database.failQueueJob({
       id: 'failable-1',
+      claimToken: claim!.claimToken,
       attempts: 16,
       error: err
     })
@@ -160,7 +278,66 @@ describe('QueueJobDatabase', () => {
     const job = await database.getQueueJobById('failable-1')
     expect(job?.status).toBe('failed')
     expect(job?.attempts).toBe(16)
+    expect(job?.claimToken).toBeNull()
     expect(job?.lastErrorMessage).toBe('Permanent 410 Gone')
+
+    // Second fail with same token is rejected
+    const secondFail = await database.failQueueJob({
+      id: 'failable-1',
+      claimToken: claim!.claimToken,
+      attempts: 17,
+      error: err
+    })
+    expect(secondFail).toBe(false)
+  })
+
+  it('reclaims stalled processing job with fresh claimToken and rejects stale worker settlement', async () => {
+    const now = Date.now()
+
+    await database.createQueueJob({
+      id: 'stalled-reclaim-1',
+      name: 'deliverActivity',
+      payload: samplePayload
+    })
+
+    // Worker 1 claims
+    const claim1 = await database.claimQueueJob({ id: 'stalled-reclaim-1' })
+    expect(claim1).not.toBeNull()
+
+    // Worker 1 crashes / stalls; backdate updated_at by 20 minutes
+    await knexDatabase('queue_jobs')
+      .where({ id: 'stalled-reclaim-1' })
+      .update({
+        status: 'processing',
+        updated_at: new Date(now - 20 * 60 * 1000)
+      })
+
+    // Worker 2 reclaims after 15 min stalled timeout
+    const stalledBefore = new Date(now - 15 * 60 * 1000)
+    const claim2 = await database.claimQueueJob({
+      id: 'stalled-reclaim-1',
+      now: new Date(now),
+      stalledBefore
+    })
+    expect(claim2).not.toBeNull()
+    expect(claim2?.claimToken).not.toEqual(claim1?.claimToken)
+
+    // Stale Worker 1 wakes up and tries to complete: rejected
+    const worker1Complete = await database.completeQueueJob({
+      id: 'stalled-reclaim-1',
+      claimToken: claim1!.claimToken
+    })
+    expect(worker1Complete).toBe(false)
+
+    // Active Worker 2 completes: accepted
+    const worker2Complete = await database.completeQueueJob({
+      id: 'stalled-reclaim-1',
+      claimToken: claim2!.claimToken
+    })
+    expect(worker2Complete).toBe(true)
+
+    const job = await database.getQueueJobById('stalled-reclaim-1')
+    expect(job?.status).toBe('completed')
   })
 
   it('counts and deletes jobs', async () => {
@@ -201,50 +378,11 @@ describe('QueueJobDatabase', () => {
     expect(reEnqueued.id).toBe('retry-upsert-1')
     expect(reEnqueued.status).toBe('pending')
     expect(reEnqueued.attempts).toBe(0)
+    expect(reEnqueued.claimToken).toBeNull()
 
     const fetched = await database.getQueueJobById('retry-upsert-1')
     expect(fetched?.status).toBe('pending')
     expect(fetched?.attempts).toBe(0)
-  })
-
-  it('recovers stalled processing jobs when stalledTimeoutMs is passed', async () => {
-    const now = Date.now()
-
-    // Create a job stuck in 'processing' since 30 minutes ago
-    await database.createQueueJob({
-      id: 'stalled-1',
-      name: 'deliverActivity',
-      payload: samplePayload,
-      status: 'processing'
-    })
-
-    // Manually backdate updated_at to simulate a crashed worker
-    await knexDatabase('queue_jobs')
-      .where({ id: 'stalled-1' })
-      .update({
-        status: 'processing',
-        updated_at: new Date(now - 30 * 60 * 1000)
-      })
-
-    // Without stalled timeout, getDueQueueJobs ignores it
-    const normalDue = await database.getDueQueueJobs({
-      now: new Date(now),
-      stalledTimeoutMs: 0
-    })
-    expect(normalDue.some((j) => j.id === 'stalled-1')).toBe(false)
-
-    // With stalled timeout (15 min), it is returned
-    const recoveredDue = await database.getDueQueueJobs({
-      now: new Date(now),
-      stalledTimeoutMs: 15 * 60 * 1000
-    })
-    expect(recoveredDue.some((j) => j.id === 'stalled-1')).toBe(true)
-
-    // And can be claimed by passing stalledBefore
-    const claimed = await database.claimQueueJob(
-      'stalled-1',
-      new Date(now - 15 * 60 * 1000)
-    )
-    expect(claimed).toBe(true)
+    expect(fetched?.claimToken).toBeNull()
   })
 })

--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -385,4 +385,48 @@ describe('QueueJobDatabase', () => {
     expect(fetched?.attempts).toBe(0)
     expect(fetched?.claimToken).toBeNull()
   })
+
+  it('recovers stalled processing jobs when stalledTimeoutMs is passed', async () => {
+    const now = Date.now()
+
+    // Create a job stuck in 'processing' since 30 minutes ago
+    await database.createQueueJob({
+      id: 'stalled-1',
+      name: 'deliverActivity',
+      payload: samplePayload,
+      status: 'processing'
+    })
+
+    // Manually backdate updated_at to simulate a crashed worker
+    await knexDatabase('queue_jobs')
+      .where({ id: 'stalled-1' })
+      .update({
+        status: 'processing',
+        updated_at: new Date(now - 30 * 60 * 1000)
+      })
+
+    // Without stalled timeout, getDueQueueJobs ignores it
+    const normalDue = await database.getDueQueueJobs({
+      now: new Date(now),
+      stalledTimeoutMs: 0
+    })
+    expect(normalDue.some((j) => j.id === 'stalled-1')).toBe(false)
+
+    // With stalled timeout (15 min), it is returned
+    const recoveredDue = await database.getDueQueueJobs({
+      now: new Date(now),
+      stalledTimeoutMs: 15 * 60 * 1000
+    })
+    expect(recoveredDue.some((j) => j.id === 'stalled-1')).toBe(true)
+
+    // And can be claimed by passing stalledBefore
+    const claimed = await database.claimQueueJob({
+      id: 'stalled-1',
+      now: new Date(now),
+      stalledBefore: new Date(now - 15 * 60 * 1000)
+    })
+    expect(claimed).not.toBeNull()
+    expect(claimed?.id).toBe('stalled-1')
+    expect(claimed?.claimToken).toBeDefined()
+  })
 })

--- a/lib/database/sql/queueJob.ts
+++ b/lib/database/sql/queueJob.ts
@@ -5,6 +5,8 @@ import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { JobMessage } from '@/lib/services/queue/type'
 import {
+  ClaimQueueJobParams,
+  ClaimedQueueJob,
   CreateQueueJobParams,
   GetDueQueueJobsParams,
   QueueJob,
@@ -20,6 +22,7 @@ export interface SQLQueueJob {
   max_retries: number
   next_run_at: number | Date | string
   status: QueueJobStatus
+  claim_token: string | null
   last_error_message: string | null
   last_error_stack: string | null
   created_at: number | Date | string
@@ -34,6 +37,7 @@ export const toQueueJob = (row: SQLQueueJob): QueueJob => ({
   maxRetries: row.max_retries,
   nextRunAt: getCompatibleTime(row.next_run_at),
   status: row.status,
+  claimToken: row.claim_token ?? null,
   lastErrorMessage: row.last_error_message,
   lastErrorStack: row.last_error_stack,
   createdAt: getCompatibleTime(row.created_at),
@@ -91,6 +95,7 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
       maxRetries,
       nextRunAt: nextRunAt.getTime(),
       status,
+      claimToken: null,
       lastErrorMessage,
       lastErrorStack,
       createdAt: currentTime.getTime(),
@@ -121,12 +126,20 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
     return rows.map(toQueueJob)
   },
 
-  async claimQueueJob(id: string, stalledBefore?: Date) {
+  async claimQueueJob({
+    id,
+    now = new Date(),
+    stalledBefore
+  }: ClaimQueueJobParams): Promise<ClaimedQueueJob | null> {
+    const claimToken = randomUUID()
     const updatedAt = new Date()
+
     const updatedCount = await database('queue_jobs')
       .where('id', id)
       .where((builder) => {
-        builder.where('status', 'pending')
+        builder.where((b) => {
+          b.where('status', 'pending').andWhere('next_run_at', '<=', now)
+        })
         if (stalledBefore) {
           builder.orWhere((b) => {
             b.where('status', 'processing').andWhere(
@@ -139,29 +152,52 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
       })
       .update({
         status: 'processing',
+        claim_token: claimToken,
+        updated_at: updatedAt
+      })
+
+    if (updatedCount === 0) return null
+
+    const row = await database<SQLQueueJob>('queue_jobs')
+      .where({ id, claim_token: claimToken })
+      .first()
+
+    if (!row) return null
+
+    return {
+      ...toQueueJob(row),
+      claimToken
+    }
+  },
+
+  async completeQueueJob({
+    id,
+    claimToken
+  }: {
+    id: string
+    claimToken: string
+  }) {
+    const updatedAt = new Date()
+    const updatedCount = await database('queue_jobs')
+      .where({ id, claim_token: claimToken, status: 'processing' })
+      .update({
+        status: 'completed',
+        claim_token: null,
         updated_at: updatedAt
       })
 
     return updatedCount > 0
   },
 
-  async completeQueueJob(id: string) {
-    const updatedAt = new Date()
-    const updatedCount = await database('queue_jobs').where({ id }).update({
-      status: 'completed',
-      updated_at: updatedAt
-    })
-
-    return updatedCount > 0
-  },
-
   async scheduleQueueJobRetry({
     id,
+    claimToken,
     nextRunAt,
     attempts,
     error
   }: {
     id: string
+    claimToken: string
     nextRunAt: Date | number
     attempts: number
     error?: Error | unknown
@@ -180,9 +216,10 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
 
     const updatedAt = new Date()
     const updatedCount = await database('queue_jobs')
-      .where({ id })
+      .where({ id, claim_token: claimToken, status: 'processing' })
       .update({
         status: 'pending',
+        claim_token: null,
         next_run_at: new Date(nextRunAt),
         attempts,
         last_error_message: lastErrorMessage,
@@ -195,10 +232,12 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
 
   async failQueueJob({
     id,
+    claimToken,
     attempts,
     error
   }: {
     id: string
+    claimToken: string
     attempts?: number
     error?: Error | unknown
   }) {
@@ -217,6 +256,7 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
     const updatedAt = new Date()
     const updateData: Record<string, unknown> = {
       status: 'failed',
+      claim_token: null,
       last_error_message: lastErrorMessage,
       last_error_stack: lastErrorStack,
       updated_at: updatedAt
@@ -227,7 +267,7 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
     }
 
     const updatedCount = await database('queue_jobs')
-      .where({ id })
+      .where({ id, claim_token: claimToken, status: 'processing' })
       .update(updateData)
 
     return updatedCount > 0

--- a/lib/services/queue/database.test.ts
+++ b/lib/services/queue/database.test.ts
@@ -94,8 +94,13 @@ describe('DatabaseQueue', () => {
     await queue.publish(message)
 
     // Simulate job failing terminally in database
+    const claimed = await database.claimQueueJob({
+      id: 'db-queue-dlq-retry-1'
+    })
+    expect(claimed).not.toBeNull()
     await database.failQueueJob({
       id: 'db-queue-dlq-retry-1',
+      claimToken: claimed!.claimToken,
       attempts: 16,
       error: new Error('Terminal failure')
     })

--- a/lib/services/queue/databaseRunner.test.ts
+++ b/lib/services/queue/databaseRunner.test.ts
@@ -233,6 +233,85 @@ describe('databaseRunner', () => {
     expect(job?.status).toBe('processing')
   })
 
+  it('rejects stale retry settlement when job is reclaimed by another worker during execution', async () => {
+    await database.createQueueJob({
+      id: 'job-stale-retry-1',
+      name: 'deliverActivity',
+      payload: sampleMessage,
+      attempts: 0,
+      maxRetries: 3,
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    const handleJob = async () => {
+      const now = Date.now()
+      await knexDatabase('queue_jobs')
+        .where({ id: 'job-stale-retry-1' })
+        .update({
+          updated_at: new Date(now - 30 * 60 * 1000)
+        })
+
+      await database.claimQueueJob({
+        id: 'job-stale-retry-1',
+        now: new Date(now),
+        stalledBefore: new Date(now - 15 * 60 * 1000)
+      })
+
+      throw new Error('Temporary 503')
+    }
+
+    const processed = await processDueQueueJobs(database, {
+      limit: 10,
+      handleJob
+    })
+
+    expect(processed).toBe(0)
+    const job = await database.getQueueJobById('job-stale-retry-1')
+    expect(job?.status).toBe('processing')
+    expect(job?.attempts).toBe(0)
+  })
+
+  it('rejects stale terminal failure settlement when job is reclaimed by another worker during execution', async () => {
+    await database.createQueueJob({
+      id: 'job-stale-fail-1',
+      name: 'deliverActivity',
+      payload: sampleMessage,
+      attempts: 2,
+      maxRetries: 3,
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    const handleJob = async () => {
+      const now = Date.now()
+      await knexDatabase('queue_jobs')
+        .where({ id: 'job-stale-fail-1' })
+        .update({
+          updated_at: new Date(now - 30 * 60 * 1000)
+        })
+
+      await database.claimQueueJob({
+        id: 'job-stale-fail-1',
+        now: new Date(now),
+        stalledBefore: new Date(now - 15 * 60 * 1000)
+      })
+
+      throw new Error('Permanent 500')
+    }
+
+    const processed = await processDueQueueJobs(database, {
+      limit: 10,
+      handleJob
+    })
+
+    expect(processed).toBe(0)
+    const job = await database.getQueueJobById('job-stale-fail-1')
+    expect(job?.status).toBe('processing')
+    expect(job?.attempts).toBe(2)
+
+    const dlq = await database.getDeadLetterJobById('job-stale-fail-1')
+    expect(dlq).toBeNull()
+  })
+
   it('starts and stops the queue runner loop', async () => {
     let callCount = 0
     const handleJob = async () => {

--- a/lib/services/queue/databaseRunner.test.ts
+++ b/lib/services/queue/databaseRunner.test.ts
@@ -135,7 +135,7 @@ describe('databaseRunner', () => {
     })
 
     // Simulate concurrent worker claiming it first
-    await database.claimQueueJob('job-concurrent-1')
+    await database.claimQueueJob({ id: 'job-concurrent-1' })
 
     let called = false
     const handleJob = async () => {
@@ -149,6 +149,88 @@ describe('databaseRunner', () => {
 
     expect(processed).toBe(0)
     expect(called).toBe(false)
+  })
+
+  it('executes the fresh claimed payload, not discovery query older row', async () => {
+    const originalMessage: JobMessage = {
+      id: 'fresh-payload-msg-old',
+      name: 'deliverActivity',
+      data: { version: 1 }
+    }
+    const updatedMessage: JobMessage = {
+      id: 'fresh-payload-msg-new',
+      name: 'deliverActivity',
+      data: { version: 2 }
+    }
+
+    await database.createQueueJob({
+      id: 'job-fresh-payload-1',
+      name: 'deliverActivity',
+      payload: originalMessage,
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    // Update database payload directly before runner claims
+    await knexDatabase('queue_jobs')
+      .where({ id: 'job-fresh-payload-1' })
+      .update({
+        payload: JSON.stringify(updatedMessage)
+      })
+
+    const executedPayloads: JobMessage[] = []
+    const handleJob = async (message: JobMessage) => {
+      executedPayloads.push(message)
+    }
+
+    const processed = await processDueQueueJobs(database, {
+      limit: 10,
+      handleJob
+    })
+
+    expect(processed).toBe(1)
+    expect(executedPayloads).toHaveLength(1)
+    expect(executedPayloads[0].id).toBe('fresh-payload-msg-new')
+    expect(executedPayloads[0].data).toEqual({ version: 2 })
+  })
+
+  it('rejects stale settlement when job is reclaimed by another worker during execution', async () => {
+    await database.createQueueJob({
+      id: 'job-stale-settlement-1',
+      name: 'deliverActivity',
+      payload: sampleMessage,
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    let reclaimDone = false
+    const handleJob = async () => {
+      // While handler is executing, backdate and simulate a concurrent stalled reclaim
+      const now = Date.now()
+      await knexDatabase('queue_jobs')
+        .where({ id: 'job-stale-settlement-1' })
+        .update({
+          updated_at: new Date(now - 30 * 60 * 1000)
+        })
+
+      const reclaimer = await database.claimQueueJob({
+        id: 'job-stale-settlement-1',
+        now: new Date(now),
+        stalledBefore: new Date(now - 15 * 60 * 1000)
+      })
+      expect(reclaimer).not.toBeNull()
+      reclaimDone = true
+    }
+
+    const processed = await processDueQueueJobs(database, {
+      limit: 10,
+      handleJob
+    })
+
+    expect(reclaimDone).toBe(true)
+    // First worker's completeQueueJob should have returned false due to token mismatch, so processedCount = 0
+    expect(processed).toBe(0)
+
+    const job = await database.getQueueJobById('job-stale-settlement-1')
+    expect(job?.status).toBe('processing')
   })
 
   it('starts and stops the queue runner loop', async () => {

--- a/lib/services/queue/databaseRunner.ts
+++ b/lib/services/queue/databaseRunner.ts
@@ -82,6 +82,19 @@ export const processDueQueueJobs = async (
               'job.attempts': claimedJob.attempts
             })
             processedCount++
+          } else {
+            span.addEvent('job_settlement_rejected_stale_claim', {
+              'job.id': claimedJob.id,
+              'job.action': 'complete'
+            })
+            logger.warn(
+              {
+                jobId: claimedJob.id,
+                jobName: claimedJob.name,
+                claimToken: claimedJob.claimToken
+              },
+              'Database queue job completion rejected: claim token is stale or superseded'
+            )
           }
         } catch (error) {
           const err = toLoggableError(error)
@@ -122,6 +135,20 @@ export const processDueQueueJobs = async (
                 'Database queue job failed, retry scheduled'
               )
               processedCount++
+            } else {
+              span.addEvent('job_settlement_rejected_stale_claim', {
+                'job.id': claimedJob.id,
+                'job.action': 'retry'
+              })
+              logger.warn(
+                {
+                  jobId: claimedJob.id,
+                  jobName: claimedJob.name,
+                  claimToken: claimedJob.claimToken,
+                  err
+                },
+                'Database queue job retry rejected: claim token is stale or superseded'
+              )
             }
           } else {
             const failed = await database.failQueueJob({
@@ -163,6 +190,20 @@ export const processDueQueueJobs = async (
                 'Database queue job failed terminally, captured in dead_letter_jobs'
               )
               processedCount++
+            } else {
+              span.addEvent('job_settlement_rejected_stale_claim', {
+                'job.id': claimedJob.id,
+                'job.action': 'fail'
+              })
+              logger.warn(
+                {
+                  jobId: claimedJob.id,
+                  jobName: claimedJob.name,
+                  claimToken: claimedJob.claimToken,
+                  err
+                },
+                'Database queue job terminal failure rejected: claim token is stale or superseded'
+              )
             }
           }
         }

--- a/lib/services/queue/databaseRunner.ts
+++ b/lib/services/queue/databaseRunner.ts
@@ -47,9 +47,13 @@ export const processDueQueueJobs = async (
   let processedCount = 0
 
   for (const job of dueJobs) {
-    const claimed = await database.claimQueueJob(job.id, stalledBefore)
-    if (!claimed) {
-      // Another worker/runner already claimed this job
+    const claimedJob = await database.claimQueueJob({
+      id: job.id,
+      now,
+      stalledBefore
+    })
+    if (!claimedJob) {
+      // Another worker/runner already claimed this job or it was rescheduled
       continue
     }
 
@@ -57,95 +61,110 @@ export const processDueQueueJobs = async (
       'queue',
       'databaseRunner.processJob',
       {
-        'job.id': job.id,
-        'job.name': job.name
+        'job.id': claimedJob.id,
+        'job.name': claimedJob.name
       },
       async (span) => {
-        span.addEvent('job_claimed', { 'job.id': job.id })
+        span.addEvent('job_claimed', {
+          'job.id': claimedJob.id,
+          'job.claim_token': claimedJob.claimToken
+        })
 
         try {
-          await handleJob(job.payload)
-          await database.completeQueueJob(job.id)
-          span.addEvent('job_completed', {
-            'job.id': job.id,
-            'job.attempts': job.attempts
+          await handleJob(claimedJob.payload)
+          const completed = await database.completeQueueJob({
+            id: claimedJob.id,
+            claimToken: claimedJob.claimToken
           })
-          processedCount++
+          if (completed) {
+            span.addEvent('job_completed', {
+              'job.id': claimedJob.id,
+              'job.attempts': claimedJob.attempts
+            })
+            processedCount++
+          }
         } catch (error) {
           const err = toLoggableError(error)
-          const nextAttempts = job.attempts + 1
+          const nextAttempts = claimedJob.attempts + 1
 
-          if (nextAttempts < job.maxRetries) {
+          if (nextAttempts < claimedJob.maxRetries) {
             const delaySeconds = calculatePolynomialBackoffSeconds(
               nextAttempts,
               backoffOptions
             )
             const nextRunAt = new Date(Date.now() + delaySeconds * 1000)
 
-            await database.scheduleQueueJobRetry({
-              id: job.id,
+            const retried = await database.scheduleQueueJobRetry({
+              id: claimedJob.id,
+              claimToken: claimedJob.claimToken,
               nextRunAt,
               attempts: nextAttempts,
               error: err
             })
 
-            span.addEvent('job_retry_scheduled', {
-              'job.id': job.id,
-              'job.attempts': nextAttempts,
-              'job.delay_seconds': delaySeconds,
-              'job.next_run_at': nextRunAt.toISOString(),
-              'error.message': err.message
-            })
+            if (retried) {
+              span.addEvent('job_retry_scheduled', {
+                'job.id': claimedJob.id,
+                'job.attempts': nextAttempts,
+                'job.delay_seconds': delaySeconds,
+                'job.next_run_at': nextRunAt.toISOString(),
+                'error.message': err.message
+              })
 
-            logger.warn(
-              {
-                jobId: job.id,
-                jobName: job.name,
-                attempts: nextAttempts,
-                nextRunAt,
-                err
-              },
-              'Database queue job failed, retry scheduled'
-            )
+              logger.warn(
+                {
+                  jobId: claimedJob.id,
+                  jobName: claimedJob.name,
+                  attempts: nextAttempts,
+                  nextRunAt,
+                  err
+                },
+                'Database queue job failed, retry scheduled'
+              )
+              processedCount++
+            }
           } else {
-            await database.failQueueJob({
-              id: job.id,
+            const failed = await database.failQueueJob({
+              id: claimedJob.id,
+              claimToken: claimedJob.claimToken,
               attempts: nextAttempts,
               error: err
             })
 
-            await database.createDeadLetterJob({
-              id: job.id,
-              jobName: job.name,
-              payload: job.payload,
-              errorMessage: err.message,
-              errorStack: err.stack ?? null,
-              attempts: nextAttempts,
-              status: 'failed'
-            })
-
-            span.addEvent('job_terminal_failure', {
-              'job.id': job.id,
-              'job.attempts': nextAttempts,
-              'error.message': err.message
-            })
-            span.recordException(err)
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: err.message
-            })
-
-            logger.error(
-              {
-                jobId: job.id,
-                jobName: job.name,
+            if (failed) {
+              await database.createDeadLetterJob({
+                id: claimedJob.id,
+                jobName: claimedJob.name,
+                payload: claimedJob.payload,
+                errorMessage: err.message,
+                errorStack: err.stack ?? null,
                 attempts: nextAttempts,
-                err
-              },
-              'Database queue job failed terminally, captured in dead_letter_jobs'
-            )
+                status: 'failed'
+              })
+
+              span.addEvent('job_terminal_failure', {
+                'job.id': claimedJob.id,
+                'job.attempts': nextAttempts,
+                'error.message': err.message
+              })
+              span.recordException(err)
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: err.message
+              })
+
+              logger.error(
+                {
+                  jobId: claimedJob.id,
+                  jobName: claimedJob.name,
+                  attempts: nextAttempts,
+                  err
+                },
+                'Database queue job failed terminally, captured in dead_letter_jobs'
+              )
+              processedCount++
+            }
           }
-          processedCount++
         }
       }
     )

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -4287,10 +4287,15 @@ export interface QueueJob {
   maxRetries: number
   nextRunAt: number
   status: QueueJobStatus
+  claimToken?: string | null
   lastErrorMessage?: string | null
   lastErrorStack?: string | null
   createdAt: number
   updatedAt: number
+}
+
+export interface ClaimedQueueJob extends QueueJob {
+  claimToken: string
 }
 
 export interface CreateQueueJobParams {
@@ -4311,19 +4316,27 @@ export interface GetDueQueueJobsParams {
   stalledTimeoutMs?: number
 }
 
+export interface ClaimQueueJobParams {
+  id: string
+  now?: Date
+  stalledBefore?: Date
+}
+
 export interface QueueJobDatabase {
   createQueueJob(params: CreateQueueJobParams): Promise<QueueJob>
   getDueQueueJobs(params?: GetDueQueueJobsParams): Promise<QueueJob[]>
-  claimQueueJob(id: string, stalledBefore?: Date): Promise<boolean>
-  completeQueueJob(id: string): Promise<boolean>
+  claimQueueJob(params: ClaimQueueJobParams): Promise<ClaimedQueueJob | null>
+  completeQueueJob(params: { id: string; claimToken: string }): Promise<boolean>
   scheduleQueueJobRetry(params: {
     id: string
+    claimToken: string
     nextRunAt: Date | number
     attempts: number
     error?: Error | unknown
   }): Promise<boolean>
   failQueueJob(params: {
     id: string
+    claimToken: string
     attempts?: number
     error?: Error | unknown
   }): Promise<boolean>

--- a/migrations/20260907071402_add_queue_job_claim_token.js
+++ b/migrations/20260907071402_add_queue_job_claim_token.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable('queue_jobs', (table) => {
+    table.string('claim_token', 255).nullable().defaultTo(null)
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable('queue_jobs', (table) => {
+    table.dropColumn('claim_token')
+  })
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1020,7 +1020,8 @@ CREATE TABLE public.queue_jobs (
     last_error_message text,
     last_error_stack text,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    claim_token character varying(255) DEFAULT NULL::character varying
 );
 
 CREATE TABLE public.recipients (
@@ -2112,3 +2113,4 @@ ALTER TABLE ONLY public.status_pins
 
 ALTER TABLE ONLY public."twoFactor"
     ADD CONSTRAINT twofactor_userid_foreign FOREIGN KEY ("userId") REFERENCES public.accounts(id) ON DELETE CASCADE;
+

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -285,7 +285,7 @@ CREATE TABLE `dead_letter_jobs` (`id` varchar(255), `job_name` varchar(255) not 
 CREATE INDEX `dead_letter_jobs_job_name_idx` on `dead_letter_jobs` (`job_name`);
 CREATE INDEX `dead_letter_jobs_status_idx` on `dead_letter_jobs` (`status`);
 CREATE INDEX `dead_letter_jobs_created_at_idx` on `dead_letter_jobs` (`created_at`);
-CREATE TABLE `queue_jobs` (`id` varchar(255), `name` varchar(255) not null, `payload` json not null, `attempts` integer not null default '0', `max_retries` integer not null default '16', `next_run_at` datetime not null default CURRENT_TIMESTAMP, `status` varchar(32) not null default 'pending', `last_error_message` text null, `last_error_stack` text null, `created_at` datetime default CURRENT_TIMESTAMP, `updated_at` datetime default CURRENT_TIMESTAMP, primary key (`id`));
+CREATE TABLE `queue_jobs` (`id` varchar(255), `name` varchar(255) not null, `payload` json not null, `attempts` integer not null default '0', `max_retries` integer not null default '16', `next_run_at` datetime not null default CURRENT_TIMESTAMP, `status` varchar(32) not null default 'pending', `last_error_message` text null, `last_error_stack` text null, `created_at` datetime default CURRENT_TIMESTAMP, `updated_at` datetime default CURRENT_TIMESTAMP, `claim_token` varchar(255) null default null, primary key (`id`));
 CREATE INDEX `queue_jobs_status_next_run_at_idx` on `queue_jobs` (`status`, `next_run_at`);
 CREATE INDEX `queue_jobs_name_idx` on `queue_jobs` (`name`);
 CREATE INDEX `queue_jobs_created_at_idx` on `queue_jobs` (`created_at`);


### PR DESCRIPTION
## Summary
Adds ownership tokens (`claim_token`) to database queue claims to prevent stale completions, retries, and failures across workers and ensure claims are securely owned during execution.

### Changes
- **Migration**: Added `20260907071402_add_queue_job_claim_token.js` adding nullable `claim_token varchar(255)` to `queue_jobs`.
- **Schema dumps**: Regenerated both `migrations/schema.sqlite.sql` and `migrations/schema.sql`.
- **Database operations & types**:
  - `claimQueueJob({ id, now, stalledBefore? })` atomically requires either a due pending job (`status = 'pending' AND next_run_at <= now`) or an eligible stalled processing job (`status = 'processing' AND updated_at <= stalledBefore`). It generates a fresh UUID `claim_token` and returns a `ClaimedQueueJob` with mandatory `claimToken` or `null`.
  - `completeQueueJob({ id, claimToken })`, `scheduleQueueJobRetry({ id, claimToken, ... })`, and `failQueueJob({ id, claimToken, ... })` require `claimToken` and `status = 'processing'`, clearing `claim_token` to `null` and rejecting stale tokens.
- **Database runner**:
  - Executes the freshly claimed payload from the returned claimed job, rather than older discovery query rows.
  - Passes `claimToken` to completion, retry, and terminal failure settlement, ensuring stale reclaimed executions do not count as processed.
- **Documentation**: Documented claim token semantics and the requirement that old workers be drained before mixed-version rollouts in `docs/architecture.md`.
- **Tests**: Comprehensive coverage for competing concurrent claims, rescheduling between discovery and claim, stale token rejection, and stalled reclaim on SQLite and PostgreSQL.

## Verification
- `yarn run prettier --write .` (passed)
- `yarn lint` (passed with 0 errors)
- `yarn typecheck` (passed with 0 errors)
- `yarn build` (passed)
- `yarn test lib/database/sql/queueJob.test.ts lib/services/queue` (all passed on SQLite in-memory)
- `TEST_DATABASE_TYPE=pg ... yarn test lib/database/sql/queueJob.test.ts` (all 11 tests passed on PostgreSQL 17)