### PR TITLE
fix: delete canonical tombstone status alias on forwarded Delete

### DIFF
--- a/lib/jobs/processForwardedActivityJob.test.ts
+++ b/lib/jobs/processForwardedActivityJob.test.ts
@@ -564,4 +564,33 @@ describe('processForwardedActivityJob', () => {
     const stored = await database.getStatus({ statusId: NOTE_ID })
     expect(stored).toBeNull()
   })
+
+  it('deletes status stored under same-host canonical alias ID when forwarded Delete specifies non-canonical objectId', async () => {
+    const canonicalNoteId = `${NOTE_ID}-canonical`
+    await database.createNote({
+      id: canonicalNoteId,
+      url: canonicalNoteId,
+      actorId: AUTHOR,
+      text: 'canonical note to delete',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: canonicalNoteId,
+        type: 'Tombstone'
+      }),
+      { status: 200 }
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage(forwardedActivity('Delete', NOTE_ID))
+    )
+
+    const stored = await database.getStatus({ statusId: canonicalNoteId })
+    expect(stored).toBeNull()
+  })
 })

--- a/lib/jobs/processForwardedActivityJob.ts
+++ b/lib/jobs/processForwardedActivityJob.ts
@@ -62,20 +62,27 @@ const sameHost = (first: string, second: string): boolean => {
   }
 }
 
-const isTombstoneBody = async (
+interface ValidatedTombstone {
+  id: string
+}
+
+const getValidatedTombstone = async (
   body: string,
   objectId: string
-): Promise<boolean> => {
+): Promise<ValidatedTombstone | null> => {
   try {
     const compacted = await compactActivityPub(JSON.parse(body))
     const parsed = Tombstone.safeParse(compacted)
-    return (
+    if (
       parsed.success &&
       isHttpUrl(parsed.data.id) &&
       isSameActivityPubOrigin(parsed.data.id, objectId)
-    )
+    ) {
+      return { id: parsed.data.id }
+    }
+    return null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -141,10 +148,12 @@ export const processForwardedActivityJob = createJobHandle(
           span.setAttribute('outcome', 'origin_unreachable')
           return
         }
+        const tombstone =
+          statusCode === 200
+            ? await getValidatedTombstone(body, objectId)
+            : null
         const confirmed =
-          statusCode === 404 ||
-          statusCode === 410 ||
-          (statusCode === 200 && (await isTombstoneBody(body, objectId)))
+          statusCode === 404 || statusCode === 410 || Boolean(tombstone)
         if (!confirmed) {
           span.setAttribute('outcome', 'delete_unconfirmed')
           span.setAttribute('originStatusCode', statusCode)
@@ -154,10 +163,17 @@ export const processForwardedActivityJob = createJobHandle(
         // Still scope to the claimed author: a forged pointer at someone
         // else's (coincidentally 404ing) id must not delete a status the
         // claimed author does not own.
+        const actorId = normalizeActorId(activity.actor) ?? undefined
         await database.deleteStatus({
           statusId: objectId,
-          actorId: normalizeActorId(activity.actor) ?? undefined
+          actorId
         })
+        if (tombstone && tombstone.id !== objectId) {
+          await database.deleteStatus({
+            statusId: tombstone.id,
+            actorId
+          })
+        }
         span.setAttribute('outcome', 'delete_confirmed')
         return
       }


### PR DESCRIPTION
Follow-up fix for Task B2 (PR #1842):

When a forwarded Delete arrives for an alias objectId and origin serves a 200 Tombstone whose ID is a valid same-origin canonical alias differing from the requested objectId, both the requested objectId and the validated canonical tombstone ID are now deleted from local storage. Previously, if the status had been stored under its canonical alias upon Create, a subsequent forwarded Delete failed to delete the stored canonical row.

### Changes
- `lib/jobs/processForwardedActivityJob.ts`: `getValidatedTombstone` parses and validates Tombstone ID; `database.deleteStatus` deletes both `objectId` and `tombstone.id`.
- `lib/jobs/processForwardedActivityJob.test.ts`: Added test verifying deletion of a note stored under its canonical alias when forwarded Delete specifies non-canonical `objectId`.