### PR TITLE
Bump version to v1.161.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.3",
+  "version": "1.161.4",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.3`
- Base main SHA: `9638722bae329978802daf5f2f6e349b383b7ae7`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
