### PR TITLE
fix: record remote actor on inbound likes and show status total likes

### DIFF
--- a/app/(timeline)/[actor]/[status]/StatusLikes.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusLikes.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+
+import { StatusLikes } from './StatusLikes'
+import { useFavouritedBy } from './useFavouritedBy'
+
+vi.mock('./useFavouritedBy', () => ({
+  useFavouritedBy: vi.fn()
+}))
+
+const createMockAccount = (
+  overrides?: Partial<MastodonAccount>
+): MastodonAccount =>
+  ({
+    id: 'acc-1',
+    username: 'alice',
+    acct: 'alice@example.com',
+    display_name: 'Alice',
+    url: 'https://example.com/@alice',
+    uri: 'https://example.com/users/alice',
+    avatar: '',
+    avatar_static: '',
+    avatar_description: '',
+    header: '',
+    header_static: '',
+    header_description: '',
+    emojis: [],
+    fields: [],
+    locked: false,
+    bot: false,
+    group: false,
+    discoverable: true,
+    created_at: new Date().toISOString(),
+    note: '',
+    statuses_count: 0,
+    followers_count: 0,
+    following_count: 0,
+    source: {
+      privacy: 'public',
+      sensitive: false,
+      language: '',
+      note: '',
+      fields: []
+    },
+    ...overrides
+  }) as MastodonAccount
+
+describe('StatusLikes', () => {
+  const mockUseFavouritedBy = vi.mocked(useFavouritedBy)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseFavouritedBy.mockReturnValue({
+      accounts: [],
+      isLoading: false,
+      totalCount: 0
+    })
+  })
+
+  it('renders nothing when totalLikes is 0', () => {
+    const { container } = render(
+      <StatusLikes statusId="test-status-id" totalLikes={0} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders totalLikes count even when preview accounts are fewer', () => {
+    mockUseFavouritedBy.mockReturnValue({
+      accounts: [
+        createMockAccount({
+          id: 'acc-1',
+          username: 'alice',
+          display_name: 'Alice'
+        })
+      ],
+      isLoading: false,
+      totalCount: 1
+    })
+
+    render(<StatusLikes statusId="test-status-id" totalLikes={7} />)
+
+    expect(screen.getByText('7 likes')).toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('See all likes')).toBeInTheDocument()
+  })
+
+  it('uses singular like when totalLikes is 1', () => {
+    mockUseFavouritedBy.mockReturnValue({
+      accounts: [
+        createMockAccount({
+          id: 'acc-1',
+          username: 'bob',
+          display_name: 'Bob'
+        })
+      ],
+      isLoading: false,
+      totalCount: 1
+    })
+
+    render(<StatusLikes statusId="test-status-id" totalLikes={1} />)
+
+    expect(screen.getByText('1 like')).toBeInTheDocument()
+    expect(screen.queryByText('See all likes')).not.toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/[status]/StatusLikes.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusLikes.tsx
@@ -43,10 +43,7 @@ const getInitials = (account: MastodonAccount) => {
 
 const getPageOffset = (page: number) => (page - 1) * DIALOG_PAGE_SIZE
 
-export const StatusLikes: FC<Props> = ({
-  statusId,
-  totalLikes: _totalLikes
-}) => {
+export const StatusLikes: FC<Props> = ({ statusId, totalLikes }) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
 
@@ -73,8 +70,9 @@ export const StatusLikes: FC<Props> = ({
     enabled: isDialogOpen
   })
 
-  // Use the most recent total count from either source
-  const likesCount = isDialogOpen ? dialogTotalCount : recentTotalCount
+  // Prefer the status's known totalLikes, falling back to fetched counts
+  const fetchedCount = isDialogOpen ? dialogTotalCount : recentTotalCount
+  const likesCount = Math.max(totalLikes, fetchedCount)
 
   const totalPages = useMemo(() => {
     if (likesCount <= 0) return 1

--- a/lib/actions/emojiReaction.ts
+++ b/lib/actions/emojiReaction.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
@@ -13,6 +14,7 @@ import {
 import { EmojiReact, Like } from '@/lib/types/activitypub'
 import { NotificationType } from '@/lib/types/database/operations'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 // A reaction-bearing activity is either a litepub `EmojiReact` (Pleroma/Akkoma,
 // FEP-c0e0) or a Misskey-style `Like` carrying the emoji. Both are handled
@@ -220,6 +222,19 @@ export const emojiReactionRequest = async ({
   // hold, or an actor past the per-status cap. Notifying anyway would let a
   // sender replay one activity into unbounded notifications.
   if (!stored) return
+
+  try {
+    await recordActorIfNeeded({
+      actorId: activity.actor,
+      database
+    })
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to record actor for emoji reaction request',
+      actorId: activity.actor,
+      err: toLoggableError(error)
+    })
+  }
 
   const status = await database.getStatus({ statusId, withReplies: false })
   if (!status) return

--- a/lib/actions/like.test.ts
+++ b/lib/actions/like.test.ts
@@ -110,5 +110,26 @@ describe('Like action', () => {
         )
       ).toBe(false)
     })
+
+    it('records actor if needed when processing like request', async () => {
+      const recordActorSpy = vi.spyOn(
+        await import('@/lib/actions/utils'),
+        'recordActorIfNeeded'
+      )
+      await likeRequest({
+        activity: {
+          actor: ACTOR2_ID,
+          id: `${ACTOR2_ID}/like-post-record-actor`,
+          type: 'Like',
+          object: `${ACTOR1_ID}/statuses/post-1`
+        },
+        database
+      })
+      expect(recordActorSpy).toHaveBeenCalledWith({
+        actorId: ACTOR2_ID,
+        database
+      })
+      recordActorSpy.mockRestore()
+    })
   })
 })

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -1,3 +1,4 @@
+import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { LikeStatus } from '@/lib/activities/likeAction'
 import { Database } from '@/lib/database/types'
 import { buildLikeEmail } from '@/lib/services/email/templates/like'
@@ -6,6 +7,8 @@ import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotific
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import { NotificationType } from '@/lib/types/database/operations'
 import { getOriginalStatus } from '@/lib/types/domain/status'
+import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 interface LikeRequestParams {
   activity: LikeStatus
@@ -24,6 +27,19 @@ export const likeRequest = async ({
     statusId,
     actorId: request.actor
   })
+
+  try {
+    await recordActorIfNeeded({
+      actorId: request.actor,
+      database
+    })
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to record actor for like request',
+      actorId: request.actor,
+      err: toLoggableError(error)
+    })
+  }
 
   // Create like notification
   const status = await database.getStatus({ statusId })

--- a/scripts/maintenance/backfillMissingLikeActors.test.ts
+++ b/scripts/maintenance/backfillMissingLikeActors.test.ts
@@ -1,0 +1,311 @@
+import knex, { Knex } from 'knex'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { Database } from '@/lib/database/types'
+import { resolveStatusIdParam } from '@/lib/services/mastodon/resolveClientId'
+
+import {
+  backfillMissingLikeActors,
+  findMissingLikeActorIds,
+  parseArgs
+} from './backfillMissingLikeActors'
+
+vi.mock('@/lib/actions/utils', () => ({
+  recordActorIfNeeded: vi.fn()
+}))
+
+vi.mock('@/lib/services/mastodon/resolveClientId', () => ({
+  resolveStatusIdParam: vi.fn()
+}))
+
+describe('backfillMissingLikeActors parseArgs', () => {
+  it('defaults to live run with default batch size and no status filter', () => {
+    expect(parseArgs([])).toEqual({
+      dryRun: false,
+      batchSize: 50,
+      statusId: undefined
+    })
+  })
+
+  it('accepts bare, inline, and space-separated boolean flags', () => {
+    expect(parseArgs(['--dry-run'])).toEqual({
+      dryRun: true,
+      batchSize: 50,
+      statusId: undefined
+    })
+    expect(parseArgs(['--dry-run=false'])).toEqual({
+      dryRun: false,
+      batchSize: 50,
+      statusId: undefined
+    })
+    expect(parseArgs(['--dry-run', 'true'])).toEqual({
+      dryRun: true,
+      batchSize: 50,
+      statusId: undefined
+    })
+  })
+
+  it('accepts batch-size inline or space-separated', () => {
+    expect(parseArgs(['--batch-size', '10'])).toEqual({
+      dryRun: false,
+      batchSize: 10,
+      statusId: undefined
+    })
+    expect(parseArgs(['--batch-size=25'])).toEqual({
+      dryRun: false,
+      batchSize: 25,
+      statusId: undefined
+    })
+  })
+
+  it('accepts status-id inline or space-separated', () => {
+    expect(parseArgs(['--status-id', 'test-status'])).toEqual({
+      dryRun: false,
+      batchSize: 50,
+      statusId: 'test-status'
+    })
+    expect(parseArgs(['--status-id=test-status-2'])).toEqual({
+      dryRun: false,
+      batchSize: 50,
+      statusId: 'test-status-2'
+    })
+  })
+
+  it.each([
+    { description: 'a non-flag argument', args: ['status-id'] },
+    { description: 'an unknown flag', args: ['--unknown'] },
+    {
+      description: 'an invalid boolean flag value',
+      args: ['--dry-run', 'invalid']
+    },
+    { description: 'a zero batch size', args: ['--batch-size', '0'] },
+    { description: 'a negative batch size', args: ['--batch-size', '-5'] },
+    { description: 'a non-integer batch size', args: ['--batch-size', '1.5'] },
+    { description: 'a batch size with no value', args: ['--batch-size'] },
+    { description: 'a status-id with no value', args: ['--status-id'] }
+  ])('rejects $description', ({ args }) => {
+    expect(() => parseArgs(args)).toThrow()
+  })
+})
+
+describe('findMissingLikeActorIds', () => {
+  let db: Knex
+
+  beforeEach(async () => {
+    db = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    await db.schema.createTable('likes', (table) => {
+      table.string('actorId')
+      table.string('statusId')
+    })
+    await db.schema.createTable('actors', (table) => {
+      table.string('id').primary()
+    })
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  it('returns actorIds that exist in likes but not in actors', async () => {
+    await db('actors').insert([
+      { id: 'https://remote.test/users/known1' },
+      { id: 'https://remote.test/users/known2' }
+    ])
+
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/known1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing2',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing1',
+        statusId: 'https://local.test/status/2'
+      }
+    ])
+
+    const missing = await findMissingLikeActorIds(db)
+    expect(missing.sort()).toEqual([
+      'https://remote.test/users/missing1',
+      'https://remote.test/users/missing2'
+    ])
+  })
+
+  it('filters by statusId when specified', async () => {
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/missing1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing2',
+        statusId: 'https://local.test/status/2'
+      }
+    ])
+
+    const missing = await findMissingLikeActorIds(db, {
+      statusId: 'https://local.test/status/1'
+    })
+    expect(missing).toEqual(['https://remote.test/users/missing1'])
+  })
+
+  it('respects limit when specified', async () => {
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/missing1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing2',
+        statusId: 'https://local.test/status/2'
+      },
+      {
+        actorId: 'https://remote.test/users/missing3',
+        statusId: 'https://local.test/status/3'
+      }
+    ])
+
+    const missing = await findMissingLikeActorIds(db, { limit: 2 })
+    expect(missing).toHaveLength(2)
+  })
+})
+
+describe('backfillMissingLikeActors', () => {
+  let db: Knex
+  const fakeDatabase = {} as Database
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.mocked(recordActorIfNeeded).mockReset()
+    vi.mocked(resolveStatusIdParam).mockReset()
+
+    db = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    await db.schema.createTable('likes', (table) => {
+      table.string('actorId')
+      table.string('statusId')
+    })
+    await db.schema.createTable('actors', (table) => {
+      table.string('id').primary()
+    })
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  it('does not record actors in dry-run mode', async () => {
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/missing1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/missing2',
+        statusId: 'https://local.test/status/1'
+      }
+    ])
+
+    const result = await backfillMissingLikeActors({
+      database: fakeDatabase,
+      knexClient: db,
+      dryRun: true
+    })
+
+    expect(result).toEqual({ found: 2, recorded: 0, failed: 0 })
+    expect(recordActorIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('fetches and records missing actors in live mode', async () => {
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/actor1',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/actor2',
+        statusId: 'https://local.test/status/1'
+      },
+      {
+        actorId: 'https://remote.test/users/actor3',
+        statusId: 'https://local.test/status/1'
+      }
+    ])
+
+    vi.mocked(recordActorIfNeeded).mockImplementation(
+      async ({ actorId }: { actorId: string }) => {
+        if (actorId.endsWith('actor1')) {
+          return { id: actorId, username: 'actor1' } as never
+        }
+        if (actorId.endsWith('actor2')) {
+          return undefined
+        }
+        throw new Error('Network error')
+      }
+    )
+
+    const result = await backfillMissingLikeActors({
+      database: fakeDatabase,
+      knexClient: db,
+      dryRun: false,
+      batchSize: 2
+    })
+
+    expect(result).toEqual({ found: 3, recorded: 1, failed: 2 })
+    expect(recordActorIfNeeded).toHaveBeenCalledTimes(3)
+  })
+
+  it('resolves statusId parameter when filtering by status', async () => {
+    vi.mocked(resolveStatusIdParam).mockResolvedValue(
+      'https://local.test/statuses/resolved-1'
+    )
+    await db('likes').insert([
+      {
+        actorId: 'https://remote.test/users/actor1',
+        statusId: 'https://local.test/statuses/resolved-1'
+      },
+      {
+        actorId: 'https://remote.test/users/actor2',
+        statusId: 'https://local.test/statuses/resolved-2'
+      }
+    ])
+
+    vi.mocked(recordActorIfNeeded).mockResolvedValue({
+      id: 'https://remote.test/users/actor1',
+      username: 'actor1'
+    } as never)
+
+    const result = await backfillMissingLikeActors({
+      database: fakeDatabase,
+      knexClient: db,
+      dryRun: false,
+      statusId: 'public-id-1'
+    })
+
+    expect(resolveStatusIdParam).toHaveBeenCalledWith(
+      fakeDatabase,
+      'public-id-1'
+    )
+    expect(result).toEqual({ found: 1, recorded: 1, failed: 0 })
+    expect(recordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: 'https://remote.test/users/actor1',
+      database: fakeDatabase
+    })
+  })
+})

--- a/scripts/maintenance/backfillMissingLikeActors.ts
+++ b/scripts/maintenance/backfillMissingLikeActors.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Backfills actor profiles for likes whose actorId is not yet in the `actors` table.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/maintenance/backfillMissingLikeActors.ts \
+ *     [--dry-run] [--batch-size 50] [--status-id <statusIdOrPublicId>]
+ *
+ * Options:
+ *   --dry-run    Report missing actors without fetching or writing them
+ *   --batch-size Number of actors to process per batch (default 50)
+ *   --status-id  Only backfill actors who liked this specific status
+ */
+import { loadEnvConfig } from '@next/env'
+import { Knex } from 'knex'
+
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { getDatabase, getKnex } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { resolveStatusIdParam } from '@/lib/services/mastodon/resolveClientId'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+const DEFAULT_BATCH_SIZE = 50
+
+export interface BackfillOptions {
+  dryRun?: boolean
+  batchSize?: number
+  statusId?: string
+}
+
+export interface BackfillResult {
+  found: number
+  recorded: number
+  failed: number
+}
+
+const parseBooleanFlagValue = (value?: string) => {
+  if (value === undefined || value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`Invalid boolean value: ${value}. Use true or false.`)
+}
+
+export const parseArgs = (args: string[]): BackfillOptions => {
+  let dryRun = false
+  let batchSize = DEFAULT_BATCH_SIZE
+  let statusId: string | undefined
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
+
+    if (rawKey === 'dry-run') {
+      if (inlineValue !== undefined) {
+        dryRun = parseBooleanFlagValue(inlineValue)
+      } else if (args[index + 1] === 'true' || args[index + 1] === 'false') {
+        dryRun = parseBooleanFlagValue(args[index + 1])
+        index += 1
+      } else {
+        dryRun = true
+      }
+      continue
+    }
+
+    if (rawKey === 'batch-size') {
+      const rawValue = inlineValue ?? args[index + 1]
+      if (rawValue === undefined) {
+        throw new Error('--batch-size requires a value')
+      }
+      if (inlineValue === undefined) {
+        index += 1
+      }
+      const parsed = Number(rawValue)
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(
+          `--batch-size must be a positive integer, got ${rawValue}`
+        )
+      }
+      batchSize = parsed
+      continue
+    }
+
+    if (rawKey === 'status-id') {
+      const rawValue = inlineValue ?? args[index + 1]
+      if (!rawValue) {
+        throw new Error('--status-id requires a value')
+      }
+      if (inlineValue === undefined) {
+        index += 1
+      }
+      statusId = rawValue
+      continue
+    }
+
+    throw new Error(`Unknown option: --${rawKey}`)
+  }
+
+  return { dryRun, batchSize, statusId }
+}
+
+export async function findMissingLikeActorIds(
+  knexClient: Knex,
+  options?: { statusId?: string; limit?: number }
+): Promise<string[]> {
+  let query = knexClient('likes')
+    .distinct('likes.actorId')
+    .leftJoin('actors', 'likes.actorId', 'actors.id')
+    .whereNull('actors.id')
+
+  if (options?.statusId) {
+    query = query.where('likes.statusId', options.statusId)
+  }
+
+  if (options?.limit) {
+    query = query.limit(options.limit)
+  }
+
+  const rows = await query.select('likes.actorId')
+  return rows.map((r) => r.actorId).filter(Boolean)
+}
+
+export async function backfillMissingLikeActors({
+  database,
+  knexClient,
+  dryRun = false,
+  batchSize = DEFAULT_BATCH_SIZE,
+  statusId
+}: {
+  database: Database
+  knexClient: Knex
+  dryRun?: boolean
+  batchSize?: number
+  statusId?: string
+}): Promise<BackfillResult> {
+  const resolvedStatusId = statusId
+    ? await resolveStatusIdParam(database, statusId)
+    : undefined
+
+  if (statusId) {
+    console.log(`Filtering for status: ${resolvedStatusId}`)
+  }
+
+  const missingActorIds = await findMissingLikeActorIds(knexClient, {
+    statusId: resolvedStatusId
+  })
+
+  console.log(`Found ${missingActorIds.length} missing actor(s) across likes.`)
+
+  if (dryRun) {
+    console.log('Dry-run mode: no actors will be fetched or saved.')
+    for (const actorId of missingActorIds) {
+      console.log(`  - ${actorId}`)
+    }
+    return { found: missingActorIds.length, recorded: 0, failed: 0 }
+  }
+
+  let recorded = 0
+  let failed = 0
+
+  for (let i = 0; i < missingActorIds.length; i += batchSize) {
+    const chunk = missingActorIds.slice(i, i + batchSize)
+    for (const actorId of chunk) {
+      try {
+        console.log(`Fetching actor: ${actorId}...`)
+        const result = await recordActorIfNeeded({ actorId, database })
+        if (result) {
+          recorded += 1
+          console.log(`  ✓ Recorded ${result.username ?? result.id}`)
+        } else {
+          failed += 1
+          console.log(`  ✗ Unable to record ${actorId}`)
+        }
+      } catch (err) {
+        failed += 1
+        console.error(
+          `  ✗ Error recording ${actorId}: ${(err as Error).message}`
+        )
+      }
+    }
+  }
+
+  console.log(
+    `Done. Found: ${missingActorIds.length}, Recorded: ${recorded}, Failed: ${failed}`
+  )
+
+  return { found: missingActorIds.length, recorded, failed }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const database = getDatabase()
+  if (!database) {
+    console.error('Database is not available')
+    process.exit(1)
+  }
+
+  const knexClient = getKnex()
+
+  try {
+    const result = await backfillMissingLikeActors({
+      database,
+      knexClient,
+      ...options
+    })
+    process.exit(result.failed > 0 ? 1 : 0)
+  } finally {
+    await database.destroy()
+  }
+}
+
+if (process.argv[1]?.endsWith('backfillMissingLikeActors.ts')) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Addresses like count mismatch where posts with remote likes show discrepancies between the action bar / Mastodon API `favourites_count` and the web status detail view underneath the post (e.g. 7 likes on the status vs 3 avatars/"3 likes" rendered):

1. **Record remote actors on inbound like/reaction activities**: In `lib/actions/like.ts` and `lib/actions/emojiReaction.ts`, incoming activities were incrementing status like counts and inserting into `likes`, but never invoked `recordActorIfNeeded`. As a result, actors that had not previously been cached locally were omitted when `GET /api/v1/statuses/:id/favourited_by` resolved actors via `database.getMastodonActorsFromIds`. Added `recordActorIfNeeded` on incoming likes and reactions.
2. **Display status total likes in `StatusLikes`**: In `app/(timeline)/[actor]/[status]/StatusLikes.tsx`, `totalLikes` was passed from `StatusBox` as `_totalLikes` and ignored, causing `likesCount` to default to preview accounts length (capped at preview limit). Used `totalLikes` as the source of truth (`Math.max(totalLikes, fetchedCount)`).
3. **Maintenance script to backfill missing actors**: Added `scripts/maintenance/backfillMissingLikeActors.ts` (with `--dry-run`, `--batch-size`, and `--status-id` options) to discover unrecorded `likes.actorId`s and call `recordActorIfNeeded`.
4. **Tests added**: Added tests in `StatusLikes.test.tsx`, `like.test.ts`, and `backfillMissingLikeActors.test.ts`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)