### PR TITLE
refactor: record authenticated telemetry at correct boundary

### DIFF
--- a/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
+++ b/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
@@ -20,6 +20,20 @@ vi.mock('@/lib/services/queue', () => ({
   getQueue: () => ({ publish: mockPublish })
 }))
 
+const mockSpan = {
+  setAttribute: vi.fn(),
+  setStatus: vi.fn(),
+  end: vi.fn(),
+  recordException: vi.fn()
+}
+
+vi.mock('@/lib/utils/trace', () => ({
+  getTracer: () => ({
+    startActiveSpan: (_name: string, fn: (span: typeof mockSpan) => unknown) =>
+      fn(mockSpan)
+  })
+}))
+
 vi.mock('@/lib/services/fitness-files', () => ({
   deleteFitnessFile: vi.fn()
 }))
@@ -92,5 +106,13 @@ describe('DELETE /api/v1/accounts/fitness-files/[fitnessFileId]', () => {
     expect(mockDeleteFitnessFileFromStorage).toHaveBeenCalledTimes(1)
     // Heatmap regeneration is decoupled from delete, so nothing is enqueued.
     expect(mockPublish).not.toHaveBeenCalled()
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'fitnessFileId',
+      'fitness-file-1'
+    )
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'accountId',
+      expect.anything()
+    )
   })
 })

--- a/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.ts
+++ b/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.ts
@@ -134,17 +134,10 @@ export const DELETE = traceApiRoute(
   }),
   {
     addAttributes: async (_req, context) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { currentActor, params } = context as any
-      const { fitnessFileId } = (await params) ?? { fitnessFileId: undefined }
-      const account = currentActor?.account
-
+      const { fitnessFileId } = (await context?.params) ?? {}
       const attributes: Record<string, string | number | boolean> = {}
       if (fitnessFileId) {
         attributes.fitnessFileId = fitnessFileId
-      }
-      if (account?.id) {
-        attributes.accountId = account.id
       }
       return attributes
     }

--- a/app/api/v1/accounts/media/[mediaId]/route.test.ts
+++ b/app/api/v1/accounts/media/[mediaId]/route.test.ts
@@ -1,0 +1,265 @@
+import { NextRequest } from 'next/server'
+
+import { deleteMediaFile } from '@/lib/services/medias'
+import {
+  ERROR_400,
+  ERROR_401,
+  ERROR_404,
+  ERROR_500
+} from '@/lib/utils/response'
+
+import { DELETE, OPTIONS } from './route'
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const mockSpan = {
+  setAttribute: vi.fn(),
+  setStatus: vi.fn(),
+  end: vi.fn(),
+  recordException: vi.fn()
+}
+
+vi.mock('@/lib/utils/trace', () => ({
+  getTracer: () => ({
+    startActiveSpan: (_name: string, fn: (span: typeof mockSpan) => unknown) =>
+      fn(mockSpan)
+  })
+}))
+
+const mockCurrentActor: {
+  id: string
+  account?: { id: string }
+} = {
+  id: 'https://llun.test/users/llun',
+  account: { id: 'account-1' }
+}
+
+const mockDatabase = {
+  getMediaByIdForAccount: vi.fn(),
+  deleteMedia: vi.fn()
+}
+
+vi.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handler: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ mediaId?: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ mediaId?: string }> }) =>
+      handler(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+vi.mock('@/lib/services/medias', () => ({
+  deleteMediaFile: vi.fn()
+}))
+
+const mockDeleteMediaFile = deleteMediaFile as jest.MockedFunction<
+  typeof deleteMediaFile
+>
+
+describe('OPTIONS /api/v1/accounts/media/[mediaId]', () => {
+  it('returns 200 with allowed CORS methods', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-123',
+      {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://llun.test' }
+      }
+    )
+    const res = await OPTIONS(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('OPTIONS')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('DELETE')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://llun.test'
+    )
+  })
+})
+
+describe('DELETE /api/v1/accounts/media/[mediaId]', () => {
+  const sampleMedia = {
+    id: 'media-123',
+    actorId: 'https://llun.test/users/llun',
+    original: {
+      path: 'uploads/original.jpg',
+      bytes: 1024,
+      mimeType: 'image/jpeg'
+    },
+    thumbnail: {
+      path: 'uploads/thumbnail.jpg',
+      bytes: 256,
+      mimeType: 'image/jpeg'
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCurrentActor.account = { id: 'account-1' }
+    mockDatabase.getMediaByIdForAccount.mockResolvedValue(sampleMedia)
+    mockDatabase.deleteMedia.mockResolvedValue(true)
+    mockDeleteMediaFile.mockResolvedValue(true)
+  })
+
+  it('returns 401 when actor has no account', async () => {
+    mockCurrentActor.account = undefined
+
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-123',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-123' })
+    })
+
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json).toEqual(ERROR_401)
+    expect(mockDatabase.getMediaByIdForAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when mediaId is missing', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/accounts/media/', {
+      method: 'DELETE'
+    })
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: '' })
+    })
+
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json).toEqual(ERROR_400)
+    expect(mockDatabase.getMediaByIdForAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when media is not found or not owned by account', async () => {
+    mockDatabase.getMediaByIdForAccount.mockResolvedValue(null)
+
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-unknown',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-unknown' })
+    })
+
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json).toEqual(ERROR_404)
+    expect(mockDatabase.getMediaByIdForAccount).toHaveBeenCalledWith({
+      mediaId: 'media-unknown',
+      accountId: 'account-1'
+    })
+    expect(mockDeleteMediaFile).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when database deletion fails', async () => {
+    mockDatabase.deleteMedia.mockResolvedValue(false)
+
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-123',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-123' })
+    })
+
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual(ERROR_500)
+    expect(mockDatabase.deleteMedia).toHaveBeenCalledWith({
+      mediaId: 'media-123'
+    })
+  })
+
+  it('deletes storage files (original and thumbnail) and returns 200 on success', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-123',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-123' })
+    })
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ success: true })
+
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      mockDatabase,
+      'uploads/original.jpg'
+    )
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      mockDatabase,
+      'uploads/thumbnail.jpg'
+    )
+    expect(mockDatabase.deleteMedia).toHaveBeenCalledWith({
+      mediaId: 'media-123'
+    })
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('mediaId', 'media-123')
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'accountId',
+      expect.anything()
+    )
+  })
+
+  it('handles media without thumbnail', async () => {
+    mockDatabase.getMediaByIdForAccount.mockResolvedValue({
+      id: 'media-no-thumb',
+      actorId: 'https://llun.test/users/llun',
+      original: {
+        path: 'uploads/no-thumb.png',
+        bytes: 2048,
+        mimeType: 'image/png'
+      },
+      thumbnail: null
+    })
+
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-no-thumb',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-no-thumb' })
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockDeleteMediaFile).toHaveBeenCalledTimes(1)
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      mockDatabase,
+      'uploads/no-thumb.png'
+    )
+  })
+
+  it('proceeds even if storage file deletion rejects or returns false', async () => {
+    mockDeleteMediaFile.mockRejectedValue(new Error('Storage failure'))
+
+    const req = new NextRequest(
+      'https://llun.test/api/v1/accounts/media/media-123',
+      { method: 'DELETE' }
+    )
+    const res = await DELETE(req, {
+      params: Promise.resolve({ mediaId: 'media-123' })
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockDatabase.deleteMedia).toHaveBeenCalledWith({
+      mediaId: 'media-123'
+    })
+  })
+})

--- a/app/api/v1/accounts/media/[mediaId]/route.ts
+++ b/app/api/v1/accounts/media/[mediaId]/route.ts
@@ -120,17 +120,10 @@ export const DELETE = traceApiRoute(
   }),
   {
     addAttributes: async (_req, context) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { currentActor, params } = context as any
-      const { mediaId } = (await params) ?? { mediaId: undefined }
-      const account = currentActor?.account
-
+      const { mediaId } = (await context?.params) ?? {}
       const attributes: Record<string, string | number | boolean> = {}
       if (mediaId) {
         attributes.mediaId = mediaId
-      }
-      if (account?.id) {
-        attributes.accountId = account.id
       }
       return attributes
     }

--- a/app/api/v1/accounts/media/route.test.ts
+++ b/app/api/v1/accounts/media/route.test.ts
@@ -59,11 +59,9 @@ vi.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
       })
 }))
 
-const createRouteContext = () =>
-  ({
-    params: Promise.resolve({}),
-    currentActor: mockCurrentActor
-  }) as unknown as { params: Promise<object> }
+const createRouteContext = () => ({
+  params: Promise.resolve({})
+})
 
 vi.mock('@/lib/services/medias/quota', () => ({
   getQuotaLimit: vi.fn().mockReturnValue(4294967296)
@@ -163,7 +161,6 @@ describe('GET /api/v1/accounts/media', () => {
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('page', 1)
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('limit', 25)
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith('accountId', 'account-1')
   })
 
   it('passes custom valid page and limit to database, response, and trace attributes', async () => {

--- a/app/api/v1/accounts/media/route.ts
+++ b/app/api/v1/accounts/media/route.ts
@@ -67,20 +67,12 @@ export const GET = traceApiRoute(
     })
   }),
   {
-    addAttributes: async (req, context) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { currentActor } = context as any
-      const account = currentActor?.account
+    addAttributes: async (req) => {
       const { page, limit } = parseAccountMediaPagination(req.url)
-
-      const attributes: Record<string, string | number | boolean> = {
+      return {
         page,
         limit
       }
-      if (account?.id) {
-        attributes.accountId = account.id
-      }
-      return attributes
     }
   }
 )

--- a/lib/services/guards/AuthenticatedGuard.test.ts
+++ b/lib/services/guards/AuthenticatedGuard.test.ts
@@ -1,8 +1,10 @@
+import { trace } from '@opentelemetry/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getTestSQLDatabaseWithInstance } from '@/lib/database/testUtils'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { setupRecordingTracer } from '@/lib/testing/recordingTracer'
 import { Actor } from '@/lib/types/domain/actor'
 
 import { AuthenticatedGuard } from './AuthenticatedGuard'
@@ -578,6 +580,159 @@ describe('AuthenticatedGuard', () => {
 
       expect(response.status).toBe(200)
       expect(mockHandler).toHaveBeenCalled()
+    })
+  })
+
+  describe('telemetry and trace annotations', () => {
+    let harness: ReturnType<typeof setupRecordingTracer>
+    let primaryActor: Actor
+
+    beforeAll(async () => {
+      const actor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      if (!actor) throw new Error('Actor not found')
+      primaryActor = actor
+    })
+
+    beforeEach(() => {
+      harness = setupRecordingTracer()
+    })
+
+    afterEach(() => {
+      harness.cleanup()
+    })
+
+    const runGuardInSpan = async (
+      guard: ReturnType<typeof AuthenticatedGuard>,
+      req: NextRequest
+    ) => {
+      return trace
+        .getTracer('test')
+        .startActiveSpan('testRoute', async (span) => {
+          try {
+            return await guard(req, { params: Promise.resolve({}) })
+          } finally {
+            span.end()
+          }
+        })
+    }
+
+    it('records authentication success attributes when authorized', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = AuthenticatedGuard(mockHandler)
+      const req = createRequest()
+      const response = await runGuardInSpan(guard, req)
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(harness.recordedSpans[0].attributes).toMatchObject({
+        'auth.authenticated': true,
+        'auth.auth_type': 'session',
+        'auth.actor_id': primaryActor.id,
+        'auth.user_id': primaryActor.account!.id
+      })
+    })
+
+    it('does not record auth success attributes when session is absent', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const guard = AuthenticatedGuard(mockHandler)
+      const req = createRequest()
+      const response = await runGuardInSpan(guard, req)
+
+      expect(response.status).toBe(307)
+      expect(mockHandler).not.toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(
+        harness.recordedSpans[0].attributes['auth.authenticated']
+      ).toBeUndefined()
+      expect(
+        harness.recordedSpans[0].attributes['auth.auth_type']
+      ).toBeUndefined()
+    })
+
+    it('does not record auth success attributes when cross-origin mutation is rejected', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = AuthenticatedGuard(mockHandler)
+      const req = createRequest('POST', { Origin: 'https://attacker.test' })
+      const response = await runGuardInSpan(guard, req)
+
+      expect(response.status).toBe(403)
+      expect(mockHandler).not.toHaveBeenCalled()
+      expect(harness.recordedSpans).toHaveLength(1)
+      expect(
+        harness.recordedSpans[0].attributes['auth.authenticated']
+      ).toBeUndefined()
+    })
+
+    it('does not record auth success attributes when actor is moderation-blocked', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      await database.setActorSuspended({
+        actorId: primaryActor.id,
+        suspended: true
+      })
+
+      try {
+        const guard = AuthenticatedGuard(mockHandler)
+        const req = createRequest()
+        const response = await runGuardInSpan(guard, req)
+
+        expect(response.status).toBe(403)
+        expect(mockHandler).not.toHaveBeenCalled()
+        expect(harness.recordedSpans).toHaveLength(1)
+        expect(
+          harness.recordedSpans[0].attributes['auth.authenticated']
+        ).toBeUndefined()
+      } finally {
+        await database.setActorSuspended({
+          actorId: primaryActor.id,
+          suspended: false
+        })
+      }
+    })
+
+    it('succeeds when tracing is disabled (no recording span)', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = AuthenticatedGuard(mockHandler)
+      const req = createRequest()
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+    })
+
+    it('proceeds and returns handler response when tracing throws an error', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const spy = vi.spyOn(trace, 'getActiveSpan').mockImplementation(() => {
+        throw new Error('Telemetry explosion')
+      })
+
+      try {
+        const guard = AuthenticatedGuard(mockHandler)
+        const req = createRequest()
+        const response = await guard(req, { params: Promise.resolve({}) })
+
+        expect(response.status).toBe(200)
+        expect(mockHandler).toHaveBeenCalled()
+      } finally {
+        spy.mockRestore()
+      }
     })
   })
 })

--- a/lib/services/guards/AuthenticatedGuard.ts
+++ b/lib/services/guards/AuthenticatedGuard.ts
@@ -9,6 +9,7 @@ import {
   isActorConfirmationPending,
   isActorModerationBlocked
 } from './accountState'
+import { annotateAuthSuccess } from './authTrace'
 import { getRedirectUrl } from './getRedirectUrl'
 import { hasSameOriginProof } from './sameOriginProof'
 import { AppRouterParams, AuthenticatedApiHandle } from './types'
@@ -55,6 +56,15 @@ export const AuthenticatedGuard =
     ) {
       return apiErrorResponse(403)
     }
+
+    annotateAuthSuccess({
+      authType: 'session',
+      actorId: currentActor.id,
+      userId:
+        currentActor.account?.id ??
+        (session.user as { id?: string })?.id ??
+        null
+    })
 
     return handle(req, { currentActor, database, params: context.params })
   }


### PR DESCRIPTION
## Summary
- Calls `annotateAuthSuccess` from `authTrace` within `AuthenticatedGuard` after session resolution and all authorization checks succeed, stamping session auth type, actor ID, and account/user ID onto the active OpenTelemetry span.
- Removes pre-authentication route-context casts (`context as any`) in `app/api/v1/accounts/media/route.ts`, `app/api/v1/accounts/media/[mediaId]/route.ts`, and `app/api/v1/accounts/fitness-files/[fitnessFileId]/route.ts` that assumed `currentActor` already exists.
- Keeps route attributes limited to information actually available at the route boundary (e.g. parsed pagination for media list, mediaId and fitnessFileId from route params).
- Adds unit tests in `AuthenticatedGuard.test.ts` for successful auth telemetry annotation, unauthenticated/rejected requests, disabled tracing, and tracing failure handling.
- Creates `app/api/v1/accounts/media/[mediaId]/route.test.ts` covering CORS OPTIONS, 400/401/404/500/200 scenarios, and trace attributes.