### PR TITLE
refactor: consolidate equivalent ActivityPub authority checks

### DIFF
--- a/lib/actions/handleQuoteRequest.test.ts
+++ b/lib/actions/handleQuoteRequest.test.ts
@@ -190,18 +190,59 @@ describe('handleQuoteRequest', () => {
     )
   })
 
-  it('returns false when a bare-id instrument is hosted on a foreign authority', async () => {
-    const createSpy = vi.fn()
-    const database = makeDatabase({ createSpy })
+  it.each([
+    {
+      description: 'cross-host URL',
+      instrument: 'https://evil.example/users/mallory/statuses/1'
+    },
+    { description: 'malformed URI', instrument: 'not-a-valid-uri' },
+    { description: 'hostless URI', instrument: 'urn:uuid:instrument-1' },
+    {
+      description: 'port mismatch',
+      instrument: 'https://remote.example:8443/users/quoter/statuses/9'
+    }
+  ])(
+    'returns false when instrument has invalid or mismatched origin ($description)',
+    async ({ instrument }) => {
+      const createSpy = vi.fn()
+      const database = makeDatabase({ createSpy })
+      const handled = await handleQuoteRequest({
+        database,
+        activity: activity({ instrument }),
+        inboxActor
+      })
+      expect(handled).toBe(false)
+      expect(createSpy).not.toHaveBeenCalled()
+    }
+  )
+
+  it('accepts an instrument matching requester with explicit port', async () => {
+    const quoterWithPort = 'https://remote.example:8443/users/quoter'
+    const instrumentWithPort =
+      'https://remote.example:8443/users/quoter/statuses/9'
+    const createSpy = vi.fn().mockResolvedValue({})
+    const database = {
+      ...makeDatabase({ createSpy }),
+      getActorFromId: vi.fn().mockResolvedValue({ id: quoterWithPort })
+    } as unknown as Database
+
     const handled = await handleQuoteRequest({
       database,
       activity: activity({
-        instrument: 'https://evil.example/users/mallory/statuses/1'
+        actor: quoterWithPort,
+        instrument: instrumentWithPort,
+        id: `${instrumentWithPort}/quote-request`
       }),
       inboxActor
     })
-    expect(handled).toBe(false)
-    expect(createSpy).not.toHaveBeenCalled()
+
+    expect(handled).toBe(true)
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusId: instrumentWithPort,
+        state: 'accepted'
+      })
+    )
   })
 
   it('returns false when the instrument is on our own host (never inbound)', async () => {

--- a/lib/actions/handleQuoteRequest.ts
+++ b/lib/actions/handleQuoteRequest.ts
@@ -11,6 +11,7 @@ import { buildQuoteAuthorizationUri } from '@/lib/services/quotes/quoteAuthoriza
 import { verifyQuoteInstrument } from '@/lib/services/quotes/verifyQuoteInstrument'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Actor } from '@/lib/types/domain/actor'
+import { isSameActivityPubOrigin } from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
@@ -34,15 +35,6 @@ const getInstrumentId = (instrument: unknown): string | null => {
     return (instrument as { id: string }).id
   }
   return null
-}
-
-// Two ids share authority when served from the same host.
-const sameHost = (a: string, b: string): boolean => {
-  try {
-    return new URL(a).host === new URL(b).host
-  } catch {
-    return false
-  }
 }
 
 /**
@@ -70,7 +62,7 @@ export const handleQuoteRequest = async ({
   // obvious forgeries — authorship is proven authoritatively below, since host
   // equality alone is not enough on a multi-user instance where the requester
   // could name a co-resident's note.
-  if (!sameHost(instrumentId, request.actor)) return false
+  if (!isSameActivityPubOrigin(instrumentId, request.actor)) return false
   try {
     if (new URL(instrumentId).host === getConfig().host) return false
   } catch {

--- a/lib/actions/handleQuoteResponse.test.ts
+++ b/lib/actions/handleQuoteResponse.test.ts
@@ -27,6 +27,7 @@ const makeDatabase = (
     edge: { statusId: string; quotedStatusId: string } | null
     edgeState: string
     updateSpy: ReturnType<typeof vi.fn>
+    getStatus: (params: { statusId: string }) => Promise<unknown>
   }> = {}
 ): Database =>
   ({
@@ -38,19 +39,26 @@ const makeDatabase = (
             state: overrides.edgeState ?? 'pending'
           }
         : overrides.edge
+          ? {
+              state: overrides.edgeState ?? 'pending',
+              ...overrides.edge
+            }
+          : null
     ),
     updateStatusQuoteState:
       overrides.updateSpy ?? vi.fn().mockResolvedValue(null),
-    getStatus: vi.fn().mockImplementation(({ statusId }) =>
-      Promise.resolve(
-        statusId === QUOTED_STATUS_ID
-          ? { type: 'Note', id: QUOTED_STATUS_ID, actorId: QUOTED_AUTHOR }
-          : {
-              id: QUOTING_STATUS_ID,
-              actorId: 'https://remote.example/users/me'
-            }
+    getStatus:
+      overrides.getStatus ??
+      vi.fn().mockImplementation(({ statusId }) =>
+        Promise.resolve(
+          statusId === QUOTED_STATUS_ID
+            ? { type: 'Note', id: QUOTED_STATUS_ID, actorId: QUOTED_AUTHOR }
+            : {
+                id: QUOTING_STATUS_ID,
+                actorId: 'https://remote.example/users/me'
+              }
+        )
       )
-    )
   }) as unknown as Database
 
 describe('handleQuoteResponse', () => {
@@ -227,24 +235,85 @@ describe('handleQuoteResponse', () => {
     )
   })
 
-  it('does not store a stamp hosted on a foreign authority', async () => {
+  it.each([
+    {
+      description: 'cross-host stamp',
+      stamp: 'https://evil.example/stamp/1'
+    },
+    { description: 'malformed URI', stamp: 'not-a-valid-uri' },
+    { description: 'hostless URI', stamp: 'urn:uuid:stamp-1' },
+    {
+      description: 'port mismatch',
+      stamp: 'https://target.example:8443/users/alice/quote_authorizations/abc'
+    }
+  ])(
+    'does not store a stamp with invalid or mismatched origin ($description)',
+    async ({ stamp }) => {
+      const updateSpy = vi.fn().mockResolvedValue(null)
+      const database = makeDatabase({ updateSpy })
+      await handleQuoteResponse({
+        database,
+        verifiedSenderActorId: QUOTED_AUTHOR,
+        activity: {
+          type: 'Accept',
+          actor: QUOTED_AUTHOR,
+          object: QUOTE_REQUEST_ID,
+          result: stamp
+        }
+      })
+
+      expect(updateSpy).toHaveBeenCalledWith({
+        statusId: QUOTING_STATUS_ID,
+        state: 'accepted',
+        authorizationUri: undefined
+      })
+    }
+  )
+
+  it('stores a stamp when stamp and quoted status share an explicit port', async () => {
+    const quotedStatusIdWithPort =
+      'https://target.example:8443/users/alice/statuses/1'
+    const quotedAuthorWithPort = 'https://target.example:8443/users/alice'
+    const stampWithPort =
+      'https://target.example:8443/users/alice/quote_authorizations/abc'
     const updateSpy = vi.fn().mockResolvedValue(null)
-    const database = makeDatabase({ updateSpy })
+    const database = makeDatabase({
+      edge: {
+        statusId: QUOTING_STATUS_ID,
+        quotedStatusId: quotedStatusIdWithPort
+      },
+      getStatus: vi.fn().mockImplementation(({ statusId }) =>
+        Promise.resolve(
+          statusId === quotedStatusIdWithPort
+            ? {
+                type: 'Note',
+                id: quotedStatusIdWithPort,
+                actorId: quotedAuthorWithPort
+              }
+            : {
+                id: QUOTING_STATUS_ID,
+                actorId: 'https://remote.example/users/me'
+              }
+        )
+      ),
+      updateSpy
+    })
+
     await handleQuoteResponse({
       database,
-      verifiedSenderActorId: QUOTED_AUTHOR,
+      verifiedSenderActorId: quotedAuthorWithPort,
       activity: {
         type: 'Accept',
-        actor: QUOTED_AUTHOR,
+        actor: quotedAuthorWithPort,
         object: QUOTE_REQUEST_ID,
-        result: 'https://evil.example/stamp/1'
+        result: stampWithPort
       }
     })
 
     expect(updateSpy).toHaveBeenCalledWith({
       statusId: QUOTING_STATUS_ID,
       state: 'accepted',
-      authorizationUri: undefined
+      authorizationUri: stampWithPort
     })
   })
 

--- a/lib/actions/handleQuoteResponse.ts
+++ b/lib/actions/handleQuoteResponse.ts
@@ -3,7 +3,10 @@ import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
 import { verifyQuoteAuthorizationStamp } from '@/lib/services/quotes/verifyRemoteQuote'
 import { getOriginalStatus } from '@/lib/types/domain/status'
-import { normalizeActorId } from '@/lib/utils/activitypub'
+import {
+  isSameActivityPubOrigin,
+  normalizeActorId
+} from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
@@ -27,15 +30,6 @@ const refId = (value: unknown): string | null => {
     return (value as { id: string }).id
   }
   return null
-}
-
-// Two ids share authority when served from the same host.
-const sameHost = (a: string, b: string): boolean => {
-  try {
-    return new URL(a).host === new URL(b).host
-  } catch {
-    return false
-  }
 }
 
 /**
@@ -119,16 +113,15 @@ export const handleQuoteResponse = async ({
     // leave every receiver rendering an approved quote as unapproved — the
     // exact failure this whole change exists to fix. That trade is only safe
     // because a planted uri can no longer swallow an unrelated Delete.
-    const stampCheck =
-      stampUri && sameHost(stampUri, edge.quotedStatusId)
-        ? await verifyQuoteAuthorizationStamp({
-            database,
-            stampUri,
-            quotedAuthorId,
-            quotingStatusId: edge.statusId,
-            quotedStatusId: edge.quotedStatusId
-          })
-        : 'mismatch'
+    const stampCheck = isSameActivityPubOrigin(stampUri, edge.quotedStatusId)
+      ? await verifyQuoteAuthorizationStamp({
+          database,
+          stampUri: stampUri!,
+          quotedAuthorId,
+          quotingStatusId: edge.statusId,
+          quotedStatusId: edge.quotedStatusId
+        })
+      : 'mismatch'
     const authorizationUri =
       stampUri && stampCheck !== 'mismatch' ? stampUri : undefined
     if (stampCheck === 'unavailable') {

--- a/lib/jobs/processForwardedActivityJob.test.ts
+++ b/lib/jobs/processForwardedActivityJob.test.ts
@@ -105,6 +105,68 @@ describe('processForwardedActivityJob', () => {
     expect(status).toBeNull()
   })
 
+  it.each([
+    {
+      description: 'cross-host URL',
+      objectId: 'https://elsewhere.example/statuses/1'
+    },
+    { description: 'malformed URL', objectId: 'not-a-url' },
+    { description: 'hostless URN', objectId: 'urn:uuid:12345' },
+    {
+      description: 'different port',
+      objectId: 'https://writing.example:8443/users/ninetiger/statuses/1'
+    }
+  ])(
+    'never fetches an object pointer with invalid or mismatched origin ($description)',
+    async ({ objectId }) => {
+      await processForwardedActivityJob(
+        database,
+        jobMessage(forwardedActivity('Create', { id: objectId, type: 'Note' }))
+      )
+
+      const calls = fetchMock.mock.calls.filter(
+        (call) =>
+          typeof call?.[0] === 'string' &&
+          (call[0].includes('elsewhere.example') ||
+            call[0].includes('8443') ||
+            call[0].includes('urn:'))
+      )
+      expect(calls).toHaveLength(0)
+      const status = await database.getStatus({ statusId: objectId })
+      expect(status).toBeNull()
+    }
+  )
+
+  it('accepts and fetches an object pointer matching actor with explicit port', async () => {
+    const authorWithPort = 'https://writing.example:8443/users/ninetiger'
+    const noteWithPort =
+      'https://writing.example:8443/users/ninetiger/statuses/1'
+    fetchMock.mockResponseOnce(
+      JSON.stringify(
+        noteDocument({
+          id: noteWithPort,
+          url: noteWithPort,
+          attributedTo: authorWithPort
+        })
+      )
+    )
+
+    await processForwardedActivityJob(
+      database,
+      jobMessage({
+        id: `${authorWithPort}/statuses/1/activity`,
+        type: 'Create',
+        actor: authorWithPort,
+        object: { id: noteWithPort, type: 'Note' }
+      })
+    )
+
+    const status = await database.getStatus({ statusId: noteWithPort })
+    expect(status).toBeDefined()
+    expect(status?.actorId).toEqual(authorWithPort)
+    await database.deleteStatus({ statusId: noteWithPort })
+  })
+
   it.each([[404], [410]])(
     'deletes a stored status when origin confirms with %i',
     async (status) => {

--- a/lib/jobs/processForwardedActivityJob.ts
+++ b/lib/jobs/processForwardedActivityJob.ts
@@ -54,14 +54,6 @@ const isHttpUrl = (value: string): boolean => {
 const getObjectId = (object: string | { id: string }): string =>
   typeof object === 'string' ? object : object.id
 
-const sameHost = (first: string, second: string): boolean => {
-  try {
-    return new URL(first).host === new URL(second).host
-  } catch {
-    return false
-  }
-}
-
 interface ValidatedTombstone {
   id: string
 }
@@ -107,7 +99,7 @@ export const processForwardedActivityJob = createJobHandle(
       // The pointer must live on the claimed author's own origin: that is what
       // makes the re-fetch authoritative for THIS activity, and it stops a
       // forwarder from steering this instance into fetching arbitrary hosts.
-      if (!sameHost(objectId, activity.actor)) {
+      if (!isSameActivityPubOrigin(objectId, activity.actor)) {
         span.setAttribute('outcome', 'cross_origin_object')
         return
       }

--- a/lib/services/quotes/persistInboundQuoteEdge.test.ts
+++ b/lib/services/quotes/persistInboundQuoteEdge.test.ts
@@ -1,6 +1,9 @@
 import { BaseNote } from '@/lib/activities/note'
 import { Database } from '@/lib/database/types'
-import { resolveInboundQuotedStatus } from '@/lib/services/quotes/persistInboundQuoteEdge'
+import {
+  persistInboundQuoteEdge,
+  resolveInboundQuotedStatus
+} from '@/lib/services/quotes/persistInboundQuoteEdge'
 import { Status } from '@/lib/types/domain/status'
 
 const QUOTED_STATUS_ID = 'https://remote.test/users/alice/statuses/1'
@@ -8,6 +11,11 @@ const STAMP_URI = 'https://remote.test/users/alice/quote_authorizations/abc'
 
 vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
   getFederationSigningActor: vi.fn().mockResolvedValue({ id: 'signer' })
+}))
+
+const mockVerifyRemoteQuote = vi.fn().mockResolvedValue('accepted')
+vi.mock('@/lib/services/quotes/verifyRemoteQuote', () => ({
+  verifyRemoteQuote: (...params: unknown[]) => mockVerifyRemoteQuote(...params)
 }))
 
 const mockGetNote = vi.fn()
@@ -111,31 +119,6 @@ describe('resolveInboundQuotedStatus', () => {
     })
   })
 
-  it.each([
-    {
-      description: 'the quoted-note fetch rejects',
-      setup: () => mockGetNote.mockRejectedValue(new Error('fetch failed'))
-    },
-    {
-      description: 'storing the fetched note rejects',
-      setup: () => mockGetNote.mockResolvedValue({ id: QUOTED_STATUS_ID })
-    }
-  ])('degrades to null when $description', async ({ setup }) => {
-    setup()
-    const database = {
-      getStatus: vi.fn().mockResolvedValue(null)
-    } as unknown as Database
-
-    await expect(
-      resolveInboundQuotedStatus({
-        database,
-        note: note(STAMP_URI),
-        quotedStatusId: QUOTED_STATUS_ID,
-        storeNote: vi.fn().mockRejectedValue(new Error('store failed'))
-      })
-    ).resolves.toBeNull()
-  })
-
   it('degrades to null when the lookup confirming the stored note rejects', async () => {
     // The subtle one: a bare `return <promise>` inside the `try` settles this
     // function AFTER the catch frame is gone, so the rejection escapes and
@@ -157,5 +140,94 @@ describe('resolveInboundQuotedStatus', () => {
         storeNote: vi.fn().mockResolvedValue(undefined)
       })
     ).resolves.toBeNull()
+  })
+})
+
+describe('persistInboundQuoteEdge authority checks', () => {
+  const makeDb = (createStatusQuote = vi.fn().mockResolvedValue({})) =>
+    ({
+      getStatusQuote: vi.fn().mockResolvedValue(null),
+      createStatusQuote
+    }) as unknown as Database
+
+  it.each([
+    {
+      description: 'cross-host stamp',
+      stamp: 'https://evil.example/stamp/1'
+    },
+    { description: 'malformed stamp', stamp: 'not-a-url' },
+    { description: 'hostless stamp', stamp: 'urn:uuid:stamp-1' },
+    {
+      description: 'port mismatch',
+      stamp: 'https://remote.test:8080/users/alice/quote_authorizations/abc'
+    }
+  ])(
+    'does not persist authorizationUri with invalid or mismatched origin ($description)',
+    async ({ stamp }) => {
+      const createSpy = vi.fn().mockResolvedValue({})
+      const database = makeDb(createSpy)
+
+      await persistInboundQuoteEdge({
+        database,
+        note: note(stamp),
+        actorId: 'https://remote.test/users/bob',
+        quotedStatus: null,
+        quotedStatusId: QUOTED_STATUS_ID
+      })
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorizationUri: null
+        })
+      )
+    }
+  )
+
+  it('persists authorizationUri when stamp origin matches quotedStatusId', async () => {
+    const createSpy = vi.fn().mockResolvedValue({})
+    const database = makeDb(createSpy)
+
+    await persistInboundQuoteEdge({
+      database,
+      note: note(STAMP_URI),
+      actorId: 'https://remote.test/users/bob',
+      quotedStatus: null,
+      quotedStatusId: QUOTED_STATUS_ID
+    })
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationUri: STAMP_URI
+      })
+    )
+  })
+
+  it('persists authorizationUri when stamp and quotedStatusId share an explicit port', async () => {
+    const quotedStatusIdWithPort =
+      'https://remote.test:8080/users/alice/statuses/1'
+    const stampWithPort =
+      'https://remote.test:8080/users/alice/quote_authorizations/abc'
+    const createSpy = vi.fn().mockResolvedValue({})
+    const database = makeDb(createSpy)
+
+    await persistInboundQuoteEdge({
+      database,
+      note: {
+        id: 'https://remote.test:8080/users/bob/statuses/9',
+        type: 'Note',
+        attributedTo: 'https://remote.test:8080/users/bob',
+        quote: quotedStatusIdWithPort,
+        quoteAuthorization: stampWithPort
+      } as unknown as BaseNote,
+      actorId: 'https://remote.test:8080/users/bob',
+      quotedStatus: null,
+      quotedStatusId: quotedStatusIdWithPort
+    })
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationUri: stampWithPort
+      })
+    )
   })
 })

--- a/lib/services/quotes/persistInboundQuoteEdge.ts
+++ b/lib/services/quotes/persistInboundQuoteEdge.ts
@@ -4,6 +4,7 @@ import { Database } from '@/lib/database/types'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { verifyRemoteQuote } from '@/lib/services/quotes/verifyRemoteQuote'
 import { Status } from '@/lib/types/domain/status'
+import { isSameActivityPubOrigin } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
 
@@ -34,15 +35,6 @@ type PersistInboundQuoteEdgeParams = {
   quotedStatus: Status | null
   // The quoted status id the caller resolved from the note.
   quotedStatusId: string
-}
-
-// Two ids share authority when served from the same host.
-const sameHost = (a: string, b: string): boolean => {
-  try {
-    return new URL(a).host === new URL(b).host
-  } catch {
-    return false
-  }
 }
 
 /**
@@ -149,7 +141,7 @@ export const persistInboundQuoteEdge = async ({
   const authorizationUri =
     state === 'accepted' &&
     note.quoteAuthorization &&
-    sameHost(note.quoteAuthorization, quotedStatusId)
+    isSameActivityPubOrigin(note.quoteAuthorization, quotedStatusId)
       ? note.quoteAuthorization
       : undefined
 

--- a/lib/services/quotes/verifyRemoteQuote.test.ts
+++ b/lib/services/quotes/verifyRemoteQuote.test.ts
@@ -264,12 +264,53 @@ describe('verifyQuoteAuthorizationStamp', () => {
     await expect(check()).resolves.toBe('verified')
   })
 
-  it('refuses a stamp uri outside the quoted author authority without fetching', async () => {
-    const request = await mockStamp({ statusCode: 200, body: validStampBody() })
+  it.each([
+    {
+      description: 'cross-host URL',
+      stampUri: 'https://evil.example/quote_authorizations/1'
+    },
+    { description: 'malformed URI', stampUri: 'not-a-valid-uri' },
+    { description: 'hostless URI', stampUri: 'urn:uuid:stamp-1' },
+    {
+      description: 'port mismatch',
+      stampUri: 'https://llun.test:8080/users/target/quote_authorizations/1'
+    }
+  ])(
+    'refuses a stamp uri with invalid or mismatched origin ($description) without fetching',
+    async ({ stampUri }) => {
+      const request = await mockStamp({
+        statusCode: 200,
+        body: validStampBody()
+      })
+      await expect(check({ stampUri })).resolves.toBe('mismatch')
+      expect(request).not.toHaveBeenCalled()
+    }
+  )
+
+  it('accepts a stamp uri matching quoted author with explicit port', async () => {
+    const authorWithPort = 'https://llun.test:8080/users/target'
+    const stampWithPort =
+      'https://llun.test:8080/users/target/quote_authorizations/1'
+    await mockStamp({
+      statusCode: 200,
+      body: JSON.stringify({
+        id: stampWithPort,
+        type: 'QuoteAuthorization',
+        attributedTo: authorWithPort,
+        interactingObject: QUOTING_NOTE_ID,
+        interactionTarget: QUOTED_STATUS_ID
+      })
+    })
+
     await expect(
-      check({ stampUri: 'https://evil.example/quote_authorizations/1' })
-    ).resolves.toBe('mismatch')
-    expect(request).not.toHaveBeenCalled()
+      verifyQuoteAuthorizationStamp({
+        database,
+        stampUri: stampWithPort,
+        quotedAuthorId: authorWithPort,
+        quotingStatusId: QUOTING_NOTE_ID,
+        quotedStatusId: QUOTED_STATUS_ID
+      })
+    ).resolves.toBe('verified')
   })
 
   it.each([

--- a/lib/services/quotes/verifyRemoteQuote.ts
+++ b/lib/services/quotes/verifyRemoteQuote.ts
@@ -9,6 +9,7 @@ import {
   Status,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { isSameActivityPubOrigin } from '@/lib/utils/activitypub'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
@@ -21,19 +22,6 @@ type VerifyRemoteQuoteParams = {
   actorId: string
   // The quoted status, if we already have it locally; null otherwise.
   quotedStatus: Status | null
-}
-
-// Two ActivityPub ids share authority when they are served from the same host.
-// The stamp is authoritative only if the quoted author's own server hosts it, so
-// a stamp fetched from (or claiming an id on) any other host is not trusted —
-// this is what stops a quoter from serving a forged authorization that merely
-// *names* the quoted author in `attributedTo`.
-const sameAuthority = (a: string, b: string): boolean => {
-  try {
-    return new URL(a).host === new URL(b).host
-  } catch {
-    return false
-  }
 }
 
 /**
@@ -70,11 +58,11 @@ export const verifyQuoteAuthorizationStamp = async ({
   quotingStatusId: string
   quotedStatusId: string
 }): Promise<QuoteAuthorizationStampCheck> => {
-  if (!sameAuthority(stampUri, quotedAuthorId)) return 'mismatch'
+  if (!isSameActivityPubOrigin(stampUri, quotedAuthorId)) return 'mismatch'
   const stamp = await fetchQuoteAuthorization(database, stampUri)
   if (!stamp) return 'unavailable'
   const matches =
-    sameAuthority(stamp.id, quotedAuthorId) &&
+    isSameActivityPubOrigin(stamp.id, quotedAuthorId) &&
     stamp.attributedTo === quotedAuthorId &&
     stamp.interactingObject === quotingStatusId &&
     stamp.interactionTarget === quotedStatusId
@@ -157,8 +145,8 @@ export const verifyRemoteQuote = async ({
     // The stamp must actually be hosted under the quoted author's authority —
     // both the URL we fetched and the id the document claims — otherwise a
     // quoter could serve a forged stamp naming the author in `attributedTo`.
-    sameAuthority(stampUri, quotedAuthorId) &&
-    sameAuthority(stamp.id, quotedAuthorId) &&
+    isSameActivityPubOrigin(stampUri, quotedAuthorId) &&
+    isSameActivityPubOrigin(stamp.id, quotedAuthorId) &&
     // FEP-044f three-field match: issued by the quoted author, for this exact
     // quoting note, targeting this exact quoted status.
     stamp.attributedTo === quotedAuthorId &&


### PR DESCRIPTION
Consolidate duplicate `sameHost` and `sameAuthority` functions across quote handling, quote verification, quote edge persistence, and forwarded activity processing to use `isSameActivityPubOrigin` from `@/lib/utils/activitypub`.

Addresses Task B3 from the cleanup plan. Adds unit tests covering authority edge cases (mismatched ports, explicit matching ports, malformed URIs, hostless URNs).