### PR TITLE
Bump version to v1.161.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.4",
+  "version": "1.161.5",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.4`
- Base main SHA: `0f2ee511a64de48b750506ec53ecf696f8c7dce8`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
