### PR TITLE
fix: reject non-action POST and invalid auth routes in proxy

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -356,6 +356,121 @@ describe('proxy', () => {
     )
   })
 
+  it('returns 404 for unknown auth routes', async () => {
+    for (const method of ['GET', 'POST']) {
+      const request = new NextRequest('https://llun.social/auth/callback', {
+        method
+      })
+
+      const response = await proxy(request)
+
+      expect(response?.status).toBe(404)
+      expect(response?.headers.get('Content-Security-Policy')).toContain(
+        "default-src 'none'"
+      )
+    }
+
+    const rootAuthRequest = new NextRequest('https://llun.social/auth', {
+      method: 'GET'
+    })
+    const rootAuthResponse = await proxy(rootAuthRequest)
+    expect(rootAuthResponse?.status).toBe(404)
+  })
+
+  it('allows valid auth pages to pass through', async () => {
+    for (const validPage of [
+      '/auth/signin',
+      '/auth/signup',
+      '/auth/error',
+      '/auth/confirmation',
+      '/auth/forgot-password',
+      '/auth/reset-password',
+      '/auth/select-actor',
+      '/auth/two-factor'
+    ]) {
+      const request = new NextRequest(`https://llun.social${validPage}`, {
+        method: 'GET'
+      })
+
+      const response = await proxy(request)
+
+      expect(response?.status).toBe(200)
+      expect(response?.headers.get('x-middleware-rewrite')).toBeNull()
+    }
+  })
+
+  it('rejects mutating methods on actor routes with 405 Method Not Allowed', async () => {
+    for (const method of ['POST', 'PUT', 'DELETE', 'PATCH']) {
+      const request = new NextRequest('https://llun.social/@alice/status-123', {
+        method
+      })
+
+      const response = await proxy(request)
+
+      expect(response?.status).toBe(405)
+      expect(response?.headers.get('allow')).toBe('GET, HEAD')
+      expect(response?.headers.get('Content-Security-Policy')).toContain(
+        "default-src 'none'"
+      )
+    }
+  })
+
+  it('rejects non-action POST requests to page routes with 404', async () => {
+    for (const path of ['/', '/settings', '/explore', '/notifications']) {
+      const request = new NextRequest(`https://llun.social${path}`, {
+        method: 'POST'
+      })
+
+      const response = await proxy(request)
+
+      expect(response?.status).toBe(404)
+    }
+  })
+
+  it('allows POST requests to API routes, OAuth endpoints, admin, and Server Actions', async () => {
+    const apiRequest = new NextRequest('https://llun.social/api/v1/statuses', {
+      method: 'POST'
+    })
+    const apiResponse = await proxy(apiRequest)
+    expect(apiResponse?.status).toBe(200)
+
+    const oauthRequest = new NextRequest('https://llun.social/oauth/token', {
+      method: 'POST'
+    })
+    const oauthResponse = await proxy(oauthRequest)
+    expect(oauthResponse?.status).toBe(200)
+
+    const adminRequest = new NextRequest('https://llun.social/admin/queues', {
+      method: 'POST'
+    })
+    const adminResponse = await proxy(adminRequest)
+    expect(adminResponse?.status).toBe(200)
+
+    const actionRequest = new NextRequest('https://llun.social/custom-action', {
+      method: 'POST',
+      headers: {
+        'next-action': 'action-id-123'
+      }
+    })
+    const actionResponse = await proxy(actionRequest)
+    expect(actionResponse?.status).toBe(200)
+  })
+
+  it('rewrites actor handles on HEAD requests', async () => {
+    const request = new NextRequest('https://internal.example.com/@alice', {
+      method: 'HEAD',
+      headers: {
+        host: 'internal.example.com'
+      }
+    })
+
+    const response = await proxy(request)
+
+    expect(response?.headers.get('x-middleware-rewrite')).toBe(
+      'https://internal.example.com/@alice@public.example.com'
+    )
+  })
+
   // Walk proxy.ts's static import graph, reporting every disallowed specifier
   // reached and the files visited on the way. The visited set is returned so a
   // caller can prove the walk got somewhere: if module resolution ever breaks,

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,9 +36,84 @@ const withContentSecurityPolicy = (
   return response
 }
 
+const VALID_AUTH_PAGES = new Set([
+  '/auth/signin',
+  '/auth/signup',
+  '/auth/error',
+  '/auth/confirmation',
+  '/auth/forgot-password',
+  '/auth/reset-password',
+  '/auth/select-actor',
+  '/auth/two-factor'
+])
+
 export async function proxy(request: NextRequest) {
-  if (request.method === 'GET') {
-    const pathname = request.nextUrl.pathname
+  const pathname = request.nextUrl.pathname
+
+  // Reject non-existent auth subpaths (e.g. /auth/callback) early with 404
+  // so they do not fall through to the dynamic `/[actor]/[status]` route.
+  if (
+    (pathname === '/auth' || pathname.startsWith('/auth/')) &&
+    !VALID_AUTH_PAGES.has(pathname)
+  ) {
+    return withContentSecurityPolicy(
+      new NextResponse(null, { status: 404 }),
+      request
+    )
+  }
+
+  // Actor routes (/@username, /@username/statusId, etc.) only accept GET and HEAD.
+  // Reject mutating methods with 405 Method Not Allowed rather than letting Next.js
+  // treat POST as an unregistered Server Action (which throws 500).
+  if (pathname.startsWith('/@')) {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return withContentSecurityPolicy(
+        new NextResponse(null, {
+          status: 405,
+          headers: { Allow: 'GET, HEAD' }
+        }),
+        request
+      )
+    }
+  }
+
+  // Next.js App Router treats ANY POST request to a page route as a Server Action invocation.
+  // If the page does not define Server Actions and no action ID is provided, Next.js throws
+  // "Failed to find Server Action" and produces a 500 error.
+  // In activities.next, POST requests are only valid on API route handlers (/api/*), OAuth
+  // route handlers (/oauth/*), and admin Server Actions (/admin/* or with Next-Action header).
+  // All other page POSTs are rejected cleanly here.
+  if (
+    request.method === 'POST' &&
+    !pathname.startsWith('/api/') &&
+    !pathname.startsWith('/oauth/') &&
+    !pathname.startsWith('/admin') &&
+    !request.headers.has('next-action')
+  ) {
+    return withContentSecurityPolicy(
+      new NextResponse(null, { status: 404 }),
+      request
+    )
+  }
+
+  // Reject mutating methods (PUT, DELETE, PATCH) targeted at non-API routes.
+  if (
+    (request.method === 'PUT' ||
+      request.method === 'DELETE' ||
+      request.method === 'PATCH') &&
+    !pathname.startsWith('/api/') &&
+    !pathname.startsWith('/oauth/')
+  ) {
+    return withContentSecurityPolicy(
+      new NextResponse(null, {
+        status: 405,
+        headers: { Allow: 'GET, HEAD' }
+      }),
+      request
+    )
+  }
+
+  if (request.method === 'GET' || request.method === 'HEAD') {
     const acceptValue = request.headers.get('Accept')
 
     if (


### PR DESCRIPTION
### Summary

Fixes an issue where `POST /auth/callback` (or invalid auth subpaths and non-action POST requests on page routes) fell through to the dynamic route `/[actor]/[status]`, causing Next.js App Router to interpret the request as a Server Action invocation and throw a 500 error (`Failed to find Server Action. This request might be from an older or newer deployment`).

### Changes
- In `proxy.ts`:
  - Early-reject non-existent `/auth/*` subpaths with 404 (only valid auth pages like `/auth/signin`, `/auth/signup`, etc. pass through).
  - Explicitly restrict actor routes (`/@username/*`) to `GET` and `HEAD`, rejecting other methods with 405 Method Not Allowed.
  - Reject `POST` requests to non-API/non-OAuth/non-admin page routes that do not carry the `next-action` header with a clean 404 response.
  - Reject mutating HTTP methods (`PUT`, `DELETE`, `PATCH`) on non-API routes with 405 Method Not Allowed.
  - Allow `HEAD` requests to follow the same canonical actor handle rewrites as `GET`.
- In `proxy.test.ts`:
  - Added unit test coverage for invalid auth routes, valid auth routes pass-through, mutating methods on actor routes, non-action page POST rejection, API/OAuth/action POST pass-through, and HEAD handle rewrites.