### PR TITLE
feat: make queue terminal failure durable with dead letter transaction

### DIFF
--- a/app/api/v1/queue/cloudtasks/route.test.ts
+++ b/app/api/v1/queue/cloudtasks/route.test.ts
@@ -591,6 +591,63 @@ describe('POST /api/v1/queue/cloudtasks', () => {
     })
   })
 
+  it('returns 500 when database is unavailable on terminal failure', async () => {
+    mockHandle.mockRejectedValue(new Error('Permanent failure'))
+    vi.mocked(getDatabase).mockReturnValue(null)
+
+    const body = {
+      id: 'msg-terminal-nodb',
+      name: 'terminalJob',
+      data: {}
+    }
+    const request = new NextRequest(
+      'https://activities.local/api/v1/queue/cloudtasks',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          authorization: 'Bearer test-secret',
+          'x-cloudtasks-taskretrycount': '4',
+          'x-cloudtasks-taskexecutioncount': '4'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    expect(response.status).toBe(500)
+    const json = await response.json()
+    expect(json).toEqual({ error: 'Database unavailable' })
+  })
+
+  it('returns 500 when dead letter job persistence fails on terminal failure', async () => {
+    mockHandle.mockRejectedValue(new Error('Permanent failure'))
+    mockCreateDeadLetterJob.mockRejectedValue(new Error('DB connection lost'))
+
+    const body = {
+      id: 'msg-terminal-persist-fail',
+      name: 'terminalJob',
+      data: {}
+    }
+    const request = new NextRequest(
+      'https://activities.local/api/v1/queue/cloudtasks',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          authorization: 'Bearer test-secret',
+          'x-cloudtasks-taskretrycount': '4',
+          'x-cloudtasks-taskexecutioncount': '4'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    expect(response.status).toBe(500)
+    const json = await response.json()
+    expect(json).toEqual({ error: 'Failed to record dead letter job' })
+    expect(mockCreateDeadLetterJob).toHaveBeenCalled()
+  })
+
   it('returns 401 when authorization header has empty bearer token', async () => {
     const request = new NextRequest(
       'https://activities.local/api/v1/queue/cloudtasks',

--- a/app/api/v1/queue/cloudtasks/route.ts
+++ b/app/api/v1/queue/cloudtasks/route.ts
@@ -171,7 +171,22 @@ export const POST = traceApiRoute(
       })
 
       const database = getDatabase()
-      if (database) {
+      if (!database) {
+        logger.error({
+          job: jobMessage,
+          err,
+          message:
+            'Database unavailable for capturing dead letter job; returning 500 for retry'
+        })
+        return apiResponse({
+          req: request,
+          allowedMethods: [HttpMethod.enum.POST],
+          data: { error: 'Database unavailable' },
+          responseStatusCode: 500
+        })
+      }
+
+      try {
         await database.createDeadLetterJob({
           jobName: String(jobMessage.name),
           payload: jobMessage,
@@ -179,6 +194,19 @@ export const POST = traceApiRoute(
           errorStack: err.stack ?? null,
           attempts: retryCount + 1,
           status: 'failed'
+        })
+      } catch (dlqError) {
+        const deadLetterErr = toLoggableError(dlqError)
+        logger.error({
+          job: jobMessage,
+          err: deadLetterErr,
+          message: 'Failed to persist dead letter job; returning 500 for retry'
+        })
+        return apiResponse({
+          req: request,
+          allowedMethods: [HttpMethod.enum.POST],
+          data: { error: 'Failed to record dead letter job' },
+          responseStatusCode: 500
         })
       }
 

--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -291,6 +291,192 @@ describe('QueueJobDatabase', () => {
     expect(secondFail).toBe(false)
   })
 
+  describe('failQueueJobWithDeadLetter', () => {
+    it('verifies claim ownership, marks job failed, and writes dead-letter record', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-1',
+        name: 'deliverActivity',
+        payload: samplePayload,
+        attempts: 15
+      })
+
+      const claim = await database.claimQueueJob({ id: 'fail-dlq-1' })
+      expect(claim).not.toBeNull()
+
+      const err = new Error('Terminal upstream rejection')
+      const success = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-1',
+        claimToken: claim!.claimToken,
+        attempts: 16,
+        error: err
+      })
+
+      expect(success).toBe(true)
+
+      // Verify queue_jobs state
+      const queueJob = await database.getQueueJobById('fail-dlq-1')
+      expect(queueJob?.status).toBe('failed')
+      expect(queueJob?.attempts).toBe(16)
+      expect(queueJob?.claimToken).toBeNull()
+      expect(queueJob?.lastErrorMessage).toBe('Terminal upstream rejection')
+      expect(queueJob?.lastErrorStack).toBe(err.stack)
+
+      // Verify dead_letter_jobs state derived from owned row
+      const dlqJob = await database.getDeadLetterJobById('fail-dlq-1')
+      expect(dlqJob).not.toBeNull()
+      expect(dlqJob?.id).toBe('fail-dlq-1')
+      expect(dlqJob?.jobName).toBe('deliverActivity')
+      expect(dlqJob?.payload).toEqual(samplePayload)
+      expect(dlqJob?.errorMessage).toBe('Terminal upstream rejection')
+      expect(dlqJob?.errorStack).toBe(err.stack)
+      expect(dlqJob?.attempts).toBe(16)
+      expect(dlqJob?.status).toBe('failed')
+    })
+
+    it('handles non-Error error cleanly preserving string representation', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-str-err',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim = await database.claimQueueJob({ id: 'fail-dlq-str-err' })
+      expect(claim).not.toBeNull()
+
+      const success = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-str-err',
+        claimToken: claim!.claimToken,
+        attempts: 5,
+        error: 'raw-string-error'
+      })
+
+      expect(success).toBe(true)
+
+      const queueJob = await database.getQueueJobById('fail-dlq-str-err')
+      expect(queueJob?.lastErrorMessage).toBe('raw-string-error')
+      expect(queueJob?.lastErrorStack).toBeNull()
+
+      const dlqJob = await database.getDeadLetterJobById('fail-dlq-str-err')
+      expect(dlqJob?.errorMessage).toBe('raw-string-error')
+      expect(dlqJob?.errorStack).toBeNull()
+    })
+
+    it('rejects stale claim token and changes neither queue_jobs nor dead_letter_jobs', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-stale-1',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim = await database.claimQueueJob({ id: 'fail-dlq-stale-1' })
+      expect(claim).not.toBeNull()
+
+      const success = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-stale-1',
+        claimToken: 'stale-claim-token-uuid',
+        attempts: 16,
+        error: new Error('stale failure')
+      })
+
+      expect(success).toBe(false)
+
+      // queue_jobs must be unchanged
+      const queueJob = await database.getQueueJobById('fail-dlq-stale-1')
+      expect(queueJob?.status).toBe('processing')
+      expect(queueJob?.claimToken).toBe(claim?.claimToken)
+
+      // dead_letter_jobs must have no record
+      const dlqJob = await database.getDeadLetterJobById('fail-dlq-stale-1')
+      expect(dlqJob).toBeNull()
+    })
+
+    it('updates existing dead-letter record on duplicate terminal delivery', async () => {
+      // Create initial job and fail it
+      await database.createQueueJob({
+        id: 'fail-dlq-dup-1',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim1 = await database.claimQueueJob({ id: 'fail-dlq-dup-1' })
+      expect(claim1).not.toBeNull()
+
+      await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-dup-1',
+        claimToken: claim1!.claimToken,
+        attempts: 1,
+        error: new Error('First failure')
+      })
+
+      const initialDlq = await database.getDeadLetterJobById('fail-dlq-dup-1')
+      expect(initialDlq?.errorMessage).toBe('First failure')
+      expect(initialDlq?.attempts).toBe(1)
+
+      // Re-enqueue with the same ID and claim again
+      await database.createQueueJob({
+        id: 'fail-dlq-dup-1',
+        name: 'deliverActivity',
+        payload: samplePayload,
+        status: 'pending'
+      })
+
+      const claim2 = await database.claimQueueJob({ id: 'fail-dlq-dup-1' })
+      expect(claim2).not.toBeNull()
+
+      // Second terminal failure with same ID updates DLQ record
+      const success2 = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-dup-1',
+        claimToken: claim2!.claimToken,
+        attempts: 5,
+        error: new Error('Second updated failure')
+      })
+
+      expect(success2).toBe(true)
+
+      const updatedDlq = await database.getDeadLetterJobById('fail-dlq-dup-1')
+      expect(updatedDlq?.errorMessage).toBe('Second updated failure')
+      expect(updatedDlq?.attempts).toBe(5)
+    })
+
+    it('rolls back queue_jobs update if dead_letter_jobs write fails', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-rollback-1',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim = await database.claimQueueJob({ id: 'fail-dlq-rollback-1' })
+      expect(claim).not.toBeNull()
+
+      // Temporarily rename dead_letter_jobs table to force dead letter write failure
+      await knexDatabase.schema.renameTable(
+        'dead_letter_jobs',
+        'dead_letter_jobs_bak'
+      )
+
+      try {
+        await expect(
+          database.failQueueJobWithDeadLetter({
+            id: 'fail-dlq-rollback-1',
+            claimToken: claim!.claimToken,
+            attempts: 16,
+            error: new Error('Transaction rollback test error')
+          })
+        ).rejects.toThrow()
+
+        // Transaction must have rolled back: queue_jobs is STILL in 'processing' with original claimToken
+        const queueJob = await database.getQueueJobById('fail-dlq-rollback-1')
+        expect(queueJob?.status).toBe('processing')
+        expect(queueJob?.claimToken).toBe(claim!.claimToken)
+      } finally {
+        await knexDatabase.schema.renameTable(
+          'dead_letter_jobs_bak',
+          'dead_letter_jobs'
+        )
+      }
+    })
+  })
+
   it('reclaims stalled processing job with fresh claimToken and rejects stale worker settlement', async () => {
     const now = Date.now()
 

--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -475,6 +475,76 @@ describe('QueueJobDatabase', () => {
         )
       }
     })
+
+    it('preserves existing job error and stack when error is omitted', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-no-err-1',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim1 = await database.claimQueueJob({ id: 'fail-dlq-no-err-1' })
+      expect(claim1).not.toBeNull()
+
+      // Schedule retry with an error to store error info on the row
+      await database.scheduleQueueJobRetry({
+        id: 'fail-dlq-no-err-1',
+        claimToken: claim1!.claimToken,
+        nextRunAt: new Date(Date.now() - 1000),
+        attempts: 15,
+        error: new Error('Prior retry failure message')
+      })
+
+      // Reclaim for final attempt
+      const claim2 = await database.claimQueueJob({ id: 'fail-dlq-no-err-1' })
+      expect(claim2).not.toBeNull()
+
+      // Terminal failure without passing error explicitly
+      const success = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-no-err-1',
+        claimToken: claim2!.claimToken,
+        attempts: 16
+      })
+
+      expect(success).toBe(true)
+
+      const queueJob = await database.getQueueJobById('fail-dlq-no-err-1')
+      expect(queueJob?.lastErrorMessage).toBe('Prior retry failure message')
+      expect(queueJob?.lastErrorStack).toBeDefined()
+
+      const dlq = await database.getDeadLetterJobById('fail-dlq-no-err-1')
+      expect(dlq?.errorMessage).toBe('Prior retry failure message')
+      expect(dlq?.errorStack).toBeDefined()
+    })
+
+    it('safely handles corrupt non-JSON payload in queue_jobs without throwing', async () => {
+      await database.createQueueJob({
+        id: 'fail-dlq-corrupt-1',
+        name: 'deliverActivity',
+        payload: samplePayload
+      })
+
+      const claim = await database.claimQueueJob({ id: 'fail-dlq-corrupt-1' })
+      expect(claim).not.toBeNull()
+
+      // Corrupt the payload directly in the database after claim
+      await knexDatabase('queue_jobs')
+        .where({ id: 'fail-dlq-corrupt-1' })
+        .update({ payload: 'corrupt-non-json-payload{{{' })
+
+      const success = await database.failQueueJobWithDeadLetter({
+        id: 'fail-dlq-corrupt-1',
+        claimToken: claim!.claimToken,
+        attempts: 16,
+        error: new Error('Corrupt job terminal error')
+      })
+
+      expect(success).toBe(true)
+
+      const dlq = await database.getDeadLetterJobById('fail-dlq-corrupt-1')
+      expect(dlq).not.toBeNull()
+      expect(dlq?.payload).toEqual({ raw: 'corrupt-non-json-payload{{{' })
+    })
   })
 
   it('reclaims stalled processing job with fresh claimToken and rejects stale worker settlement', async () => {

--- a/lib/database/sql/queueJob.ts
+++ b/lib/database/sql/queueJob.ts
@@ -8,6 +8,7 @@ import {
   ClaimQueueJobParams,
   ClaimedQueueJob,
   CreateQueueJobParams,
+  FailQueueJobWithDeadLetterParams,
   GetDueQueueJobsParams,
   QueueJob,
   QueueJobDatabase,
@@ -271,6 +272,85 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
       .update(updateData)
 
     return updatedCount > 0
+  },
+
+  async failQueueJobWithDeadLetter({
+    id,
+    claimToken,
+    attempts,
+    error
+  }: FailQueueJobWithDeadLetterParams): Promise<boolean> {
+    return await database.transaction(async (trx) => {
+      const job = await trx<SQLQueueJob>('queue_jobs')
+        .where({ id, claim_token: claimToken, status: 'processing' })
+        .first()
+
+      if (!job) {
+        return false
+      }
+
+      let lastErrorMessage: string | null = null
+      let lastErrorStack: string | null = null
+
+      if (error) {
+        if (error instanceof Error) {
+          lastErrorMessage = error.message
+          lastErrorStack = error.stack ?? null
+        } else {
+          lastErrorMessage = String(error)
+        }
+      }
+
+      const updatedAt = new Date()
+      const finalAttempts = attempts !== undefined ? attempts : job.attempts
+      const updateData: Record<string, unknown> = {
+        status: 'failed',
+        claim_token: null,
+        last_error_message: lastErrorMessage,
+        last_error_stack: lastErrorStack,
+        updated_at: updatedAt
+      }
+
+      if (attempts !== undefined) {
+        updateData.attempts = attempts
+      }
+
+      const updatedCount = await trx('queue_jobs')
+        .where({ id, claim_token: claimToken, status: 'processing' })
+        .update(updateData)
+
+      if (updatedCount === 0) {
+        return false
+      }
+
+      const payload = JSON.stringify(getCompatibleJSON(job.payload))
+      const errorMessage = lastErrorMessage || 'Job execution failed terminally'
+
+      await trx('dead_letter_jobs')
+        .insert({
+          id: job.id,
+          job_name: job.name,
+          payload,
+          error_message: errorMessage,
+          error_stack: lastErrorStack,
+          attempts: finalAttempts,
+          status: 'failed',
+          created_at: updatedAt,
+          updated_at: updatedAt
+        })
+        .onConflict('id')
+        .merge({
+          job_name: job.name,
+          payload,
+          error_message: errorMessage,
+          error_stack: lastErrorStack,
+          attempts: finalAttempts,
+          status: 'failed',
+          updated_at: updatedAt
+        })
+
+      return true
+    })
   },
 
   async getQueueJobById(id: string) {

--- a/lib/database/sql/queueJob.ts
+++ b/lib/database/sql/queueJob.ts
@@ -292,13 +292,16 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
       let lastErrorMessage: string | null = null
       let lastErrorStack: string | null = null
 
-      if (error) {
+      if (error !== undefined) {
         if (error instanceof Error) {
           lastErrorMessage = error.message
           lastErrorStack = error.stack ?? null
-        } else {
+        } else if (error !== null) {
           lastErrorMessage = String(error)
         }
+      } else {
+        lastErrorMessage = job.last_error_message
+        lastErrorStack = job.last_error_stack
       }
 
       const updatedAt = new Date()
@@ -323,8 +326,20 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
         return false
       }
 
-      const payload = JSON.stringify(getCompatibleJSON(job.payload))
-      const errorMessage = lastErrorMessage || 'Job execution failed terminally'
+      let payload: string
+      if (typeof job.payload === 'string') {
+        try {
+          payload = JSON.stringify(JSON.parse(job.payload))
+        } catch {
+          payload = JSON.stringify({ raw: job.payload })
+        }
+      } else {
+        payload = JSON.stringify(job.payload)
+      }
+      const errorMessage =
+        lastErrorMessage ||
+        job.last_error_message ||
+        'Job execution failed terminally'
 
       await trx('dead_letter_jobs')
         .insert({

--- a/lib/services/queue/databaseRunner.ts
+++ b/lib/services/queue/databaseRunner.ts
@@ -151,7 +151,7 @@ export const processDueQueueJobs = async (
               )
             }
           } else {
-            const failed = await database.failQueueJob({
+            const failed = await database.failQueueJobWithDeadLetter({
               id: claimedJob.id,
               claimToken: claimedJob.claimToken,
               attempts: nextAttempts,
@@ -159,16 +159,6 @@ export const processDueQueueJobs = async (
             })
 
             if (failed) {
-              await database.createDeadLetterJob({
-                id: claimedJob.id,
-                jobName: claimedJob.name,
-                payload: claimedJob.payload,
-                errorMessage: err.message,
-                errorStack: err.stack ?? null,
-                attempts: nextAttempts,
-                status: 'failed'
-              })
-
               span.addEvent('job_terminal_failure', {
                 'job.id': claimedJob.id,
                 'job.attempts': nextAttempts,

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -4322,6 +4322,13 @@ export interface ClaimQueueJobParams {
   stalledBefore?: Date
 }
 
+export interface FailQueueJobWithDeadLetterParams {
+  id: string
+  claimToken: string
+  attempts?: number
+  error?: Error | unknown
+}
+
 export interface QueueJobDatabase {
   createQueueJob(params: CreateQueueJobParams): Promise<QueueJob>
   getDueQueueJobs(params?: GetDueQueueJobsParams): Promise<QueueJob[]>
@@ -4340,6 +4347,9 @@ export interface QueueJobDatabase {
     attempts?: number
     error?: Error | unknown
   }): Promise<boolean>
+  failQueueJobWithDeadLetter(
+    params: FailQueueJobWithDeadLetterParams
+  ): Promise<boolean>
   getQueueJobById(id: string): Promise<QueueJob | null>
   deleteQueueJob(id: string): Promise<boolean>
   countQueueJobs(params?: { status?: QueueJobStatus }): Promise<number>


### PR DESCRIPTION
Introduce `failQueueJobWithDeadLetter({ id, claimToken, attempts, error })` to atomically verify claim ownership, mark the queue job as failed, and create or update its record in `dead_letter_jobs` within a single Knex transaction.

- Replaces separate queue failure and dead-letter creation in `databaseRunner.ts`.
- In `app/api/v1/queue/cloudtasks/route.ts`, returns a retryable 500 error when the database is unavailable or dead-letter persistence fails, acknowledging 200 OK only after successful persistence.
- Adds comprehensive unit tests covering transactional rollback on dead-letter write failure, duplicate terminal delivery upsert, stale claim rejection changing neither table, and CloudTasks failure handling.

Addresses Task A4 from the continuation plan.