### PR TITLE
Bump version to v1.161.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.5",
+  "version": "1.161.6",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.5`
- Base main SHA: `24c3b3d59a1445c15c9897f9aef9ef8666617bf6`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
