### PR TITLE
refactor: make infinite scroll observation survive conditional mounting

### DIFF
--- a/app/(timeline)/MainPageTimeline.test.tsx
+++ b/app/(timeline)/MainPageTimeline.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { getTimeline } from '@/lib/client'
@@ -26,7 +26,7 @@ vi.mock('@/lib/components/announcements/AnnouncementBanner', () => ({
 }))
 
 vi.mock('@/lib/components/page-header', () => ({
-  PageHeader: () => null
+  PageHeader: ({ actions }: { actions?: ReactNode }) => <div>{actions}</div>
 }))
 
 vi.mock('@/lib/components/post-box/post-box', () => ({
@@ -205,10 +205,27 @@ const createAnnounceStatus = (
   ...overrides
 })
 
+let observerCallbacks: ((entries: IntersectionObserverEntry[]) => void)[] = []
+const observeMock = vi.fn()
+const disconnectMock = vi.fn()
+
 class MockIntersectionObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  callback: (entries: IntersectionObserverEntry[]) => void
+  constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+    this.callback = callback
+    observerCallbacks.push(callback)
+  }
+  observe = observeMock
+  unobserve = vi.fn()
+  disconnect = disconnectMock
+}
+
+const triggerIntersection = (isIntersecting: boolean) => {
+  act(() => {
+    for (const cb of observerCallbacks) {
+      cb([{ isIntersecting } as IntersectionObserverEntry])
+    }
+  })
 }
 
 describe('MainPageTimeline', () => {
@@ -219,6 +236,9 @@ describe('MainPageTimeline', () => {
 
   beforeEach(() => {
     vi.mocked(getTimeline).mockReset()
+    observerCallbacks = []
+    observeMock.mockClear()
+    disconnectMock.mockClear()
   })
 
   it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
@@ -523,6 +543,229 @@ describe('MainPageTimeline', () => {
       expect(
         screen.getByTestId('post-https://activities.local/users/llun/s/2')
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('infinite-scroll sentinel observation', () => {
+    it('observes sentinel mounted after initially empty feed is refreshed', async () => {
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[]}
+          initialNextMaxStatusId={null}
+        />
+      )
+
+      expect(screen.getByText('Your timeline is empty')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Load more' })
+      ).not.toBeInTheDocument()
+      expect(observeMock).not.toHaveBeenCalled()
+
+      // Refresh timeline with new posts and nextMaxStatusId
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      vi.mocked(getTimeline).mockResolvedValueOnce({
+        statuses: [post1],
+        nextMaxStatusId: 'cursor-after-refresh',
+        prevMinStatusId: null
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Refresh timeline' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('post-https://activities.local/users/llun/s/1')
+        ).toBeInTheDocument()
+      })
+
+      // Sentinel should now be mounted and observed
+      expect(
+        screen.getByRole('button', { name: 'Load more' })
+      ).toBeInTheDocument()
+      expect(observeMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('automatically triggers next-page load when sentinel scrolls into view', async () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+      vi.mocked(getTimeline).mockResolvedValueOnce({
+        statuses: [post2],
+        nextMaxStatusId: 'cursor-page-2',
+        prevMinStatusId: null
+      })
+
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+          initialNextMaxStatusId="cursor-page-1"
+        />
+      )
+
+      expect(observeMock).toHaveBeenCalledTimes(1)
+
+      // Trigger visibility on the observer callback
+      triggerIntersection(true)
+
+      await waitFor(() => {
+        expect(getTimeline).toHaveBeenCalledTimes(1)
+      })
+
+      expect(getTimeline).toHaveBeenCalledWith({
+        timeline: Timeline.MAIN,
+        maxStatusId: 'cursor-page-1'
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('post-https://activities.local/users/llun/s/2')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('suppresses duplicate concurrent requests on repeated visibility notifications while loading', async () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+      let resolveTimeline: (value: unknown) => void
+      const timelinePromise = new Promise((resolve) => {
+        resolveTimeline = resolve
+      })
+      vi.mocked(getTimeline).mockReturnValueOnce(
+        timelinePromise as ReturnType<typeof getTimeline>
+      )
+
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+          initialNextMaxStatusId="cursor-page-1"
+        />
+      )
+
+      // Fire intersection multiple times in rapid succession while in-flight
+      triggerIntersection(true)
+      triggerIntersection(true)
+      triggerIntersection(true)
+
+      expect(getTimeline).toHaveBeenCalledTimes(1)
+
+      // Resolve in-flight request
+      await act(async () => {
+        resolveTimeline!({
+          statuses: [post2],
+          nextMaxStatusId: null,
+          prevMinStatusId: null
+        })
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('post-https://activities.local/users/llun/s/2')
+        ).toBeInTheDocument()
+      })
+
+      expect(getTimeline).toHaveBeenCalledTimes(1)
+    })
+
+    it('recovers from request failure allowing manual retry via load-more button', async () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      const post2 = createStatus('https://activities.local/users/llun/s/2')
+
+      // First call fails
+      vi.mocked(getTimeline).mockRejectedValueOnce(new Error('Network error'))
+
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+          initialNextMaxStatusId="cursor-page-1"
+        />
+      )
+
+      // Auto-load triggers error
+      triggerIntersection(true)
+
+      await waitFor(() => {
+        expect(getTimeline).toHaveBeenCalledTimes(1)
+      })
+
+      // Load more button remains available and enabled after failure
+      const loadMoreBtn = screen.getByRole('button', { name: 'Load more' })
+      expect(loadMoreBtn).not.toBeDisabled()
+
+      // Retry manually
+      vi.mocked(getTimeline).mockResolvedValueOnce({
+        statuses: [post2],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+
+      fireEvent.click(loadMoreBtn)
+
+      await waitFor(() => {
+        expect(getTimeline).toHaveBeenCalledTimes(2)
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('post-https://activities.local/users/llun/s/2')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('cleans up observer when sentinel unmounts after pagination is exhausted', async () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+
+      vi.mocked(getTimeline).mockResolvedValueOnce({
+        statuses: [],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+          initialNextMaxStatusId="cursor-page-1"
+        />
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Load more' })
+      ).toBeInTheDocument()
+
+      triggerIntersection(true)
+
+      await waitFor(() => {
+        expect(getTimeline).toHaveBeenCalledTimes(1)
+      })
+
+      // Pagination is exhausted: sentinel unmounts
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', { name: 'Load more' })
+        ).not.toBeInTheDocument()
+      })
+
+      // Disconnect was called during unmount
+      expect(disconnectMock).toHaveBeenCalled()
     })
   })
 })

--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { RefreshCw } from 'lucide-react'
-import { FC, useCallback, useEffect, useRef, useState } from 'react'
+import { FC, useCallback, useRef, useState } from 'react'
 
 import { getTimeline } from '@/lib/client'
 import { AnnouncementBanner } from '@/lib/components/announcements/AnnouncementBanner'
 import { PageHeader } from '@/lib/components/page-header'
 import { PostBox } from '@/lib/components/post-box/post-box'
 import { Posts } from '@/lib/components/posts/posts'
+import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { Timeline } from '@/lib/services/timelines/types'
@@ -45,8 +46,6 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
   )
   const [isLoadingMoreStatuses, setLoadingMoreStatuses] =
     useState<boolean>(false)
-  const [isLoadMoreVisible, setIsLoadMoreVisible] = useState<boolean>(false)
-  const loadMoreRef = useRef<HTMLDivElement>(null)
   const isLoadingRef = useRef<boolean>(false)
   const lastStatusIdRef = useRef<string | null>(
     initialNextMaxStatusId ||
@@ -120,35 +119,10 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
     }
   }, [])
 
-  // Set up IntersectionObserver for automatic loading
-  useEffect(() => {
-    const loadMoreElement = loadMoreRef.current
-    if (!loadMoreElement) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries
-        setIsLoadMoreVisible(entry.isIntersecting)
-
-        // Automatically load more when the button comes into view
-        // The loadMoreStatuses callback has its own guard against duplicate loads
-        if (entry.isIntersecting) {
-          loadMoreStatuses()
-        }
-      },
-      {
-        root: null,
-        rootMargin: '0px',
-        threshold: 0.1
-      }
-    )
-
-    observer.observe(loadMoreElement)
-
-    return () => {
-      observer.disconnect()
-    }
-  }, [loadMoreStatuses])
+  const { loadMoreRef, isLoadMoreVisible } = useLoadMoreOnVisible({
+    enabled: hasMoreStatuses,
+    onLoadMore: loadMoreStatuses
+  })
 
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
 


### PR DESCRIPTION
## Summary
Replaces MainPageTimeline's ad-hoc IntersectionObserver setup with the shared `useLoadMoreOnVisible` callback-ref hook (Task C2).

### Changes
- Migrated `app/(timeline)/MainPageTimeline.tsx` to use `useLoadMoreOnVisible`.
- Callback ref ensures that sentinels mounted after initial load, refresh, or empty state transitions are observed immediately.
- Preserved request gating (`isLoadingRef`), continuation cursors, and unmount disconnect cleanup.
- Added comprehensive unit tests in `app/(timeline)/MainPageTimeline.test.tsx` covering initially absent sentinels, subsequent mounting after refresh, automatic next-page load on visibility, suppression of duplicate concurrent requests, recovery after request failure, and observer disconnect on exhaustion.

### Verification
- Ran `yarn run prettier --write app/(timeline)/MainPageTimeline.tsx app/(timeline)/MainPageTimeline.test.tsx`
- Ran `yarn lint`
- Ran `yarn typecheck`
- Ran `yarn build`
- Ran `yarn test app/(timeline)/MainPageTimeline.test.tsx` (13/13 passing)