### PR TITLE
Bump version to v1.161.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.6",
+  "version": "1.161.7",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.6`
- Base main SHA: `9eca146efbb9e5ff9ab90c067ed858b678f8b221`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
