### PR TITLE
feat: separate repeatable user operations from duplicate deliveries

### DIFF
--- a/app/api/v1/fitness/import/[batchId]/route.test.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.test.ts
@@ -904,4 +904,133 @@ describe('fitness import batch route', () => {
       'failed'
     )
   })
+
+  it('preserves job id on redelivery of the same generationId', async () => {
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      {
+        id: 'file-1',
+        actorId: 'https://llun.test/users/llun',
+        fileName: 'failed.fit',
+        fileType: 'fit',
+        path: 'fitness/failed.fit',
+        mimeType: 'application/vnd.ant.fit',
+        bytes: 1024,
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    const request1 = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'private', generationId: 'test-gen-1' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request1, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const firstJobId = getQueue().publish.mock.calls[0][0].id
+
+    getQueue().publish.mockClear()
+    const request2 = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'private', generationId: 'test-gen-1' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request2, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const secondJobId = getQueue().publish.mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+  })
+
+  it('preserves job id on redelivery of the same generation_id (snake_case)', async () => {
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      {
+        id: 'file-1',
+        actorId: 'https://llun.test/users/llun',
+        fileName: 'failed.fit',
+        fileType: 'fit',
+        path: 'fitness/failed.fit',
+        mimeType: 'application/vnd.ant.fit',
+        bytes: 1024,
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    const request1 = {
+      headers: new Headers(),
+      json: async () => ({
+        visibility: 'private',
+        generation_id: 'test-gen-snake'
+      })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request1, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const firstJobId = getQueue().publish.mock.calls[0][0].id
+
+    getQueue().publish.mockClear()
+    const request2 = {
+      headers: new Headers(),
+      json: async () => ({
+        visibility: 'private',
+        generation_id: 'test-gen-snake'
+      })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request2, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const secondJobId = getQueue().publish.mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+  })
+
+  it('generates distinct job ids on successive retry invocations without explicit generationId', async () => {
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      {
+        id: 'file-1',
+        actorId: 'https://llun.test/users/llun',
+        fileName: 'failed.fit',
+        fileType: 'fit',
+        path: 'fitness/failed.fit',
+        mimeType: 'application/vnd.ant.fit',
+        bytes: 1024,
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    const request1 = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'private' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request1, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const firstJobId = getQueue().publish.mock.calls[0][0].id
+
+    getQueue().publish.mockClear()
+    const request2 = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'private' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    await POST(request2, {
+      params: Promise.resolve({ batchId: 'batch-1' })
+    })
+    const secondJobId = getQueue().publish.mock.calls[0][0].id
+
+    expect(secondJobId).not.toBe(firstJobId)
+  })
 })

--- a/app/api/v1/fitness/import/[batchId]/route.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.ts
@@ -422,6 +422,8 @@ export const POST = traceApiRoute(
 
     const parsed = (await req.json().catch(() => ({}))) as {
       visibility?: string
+      generationId?: string
+      generation_id?: string
     }
     const visibility = parsed.visibility ?? 'public'
 
@@ -435,13 +437,17 @@ export const POST = traceApiRoute(
       })
     }
 
+    const generationId =
+      parsed.generationId ?? parsed.generation_id ?? crypto.randomUUID()
+
     try {
       const { retried } = await retryFitnessImportBatch({
         database,
         batchId,
         batchActorId,
         files,
-        visibility: visibilityParsed.data
+        visibility: visibilityParsed.data,
+        generationId
       })
 
       return apiResponse({

--- a/app/api/v1/fitness/retry-failed/route.test.ts
+++ b/app/api/v1/fitness/retry-failed/route.test.ts
@@ -235,4 +235,76 @@ describe('POST /api/v1/fitness/retry-failed', () => {
     expect(json.batches).toBe(1)
     expect(json.failedBatches).toBe(1)
   })
+
+  it('generates distinct job ids on successive retry-all calls', async () => {
+    db.getRetriableFitnessImportBatchIds.mockResolvedValue([
+      'strava-activity:100'
+    ])
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      fitnessFile({
+        id: 'f100',
+        importBatchId: 'strava-activity:100',
+        importStatus: 'failed'
+      })
+    ] as never)
+
+    const publish = getQueue().publish as jest.Mock
+    publish.mockResolvedValue(undefined)
+
+    await POST(buildRequest(), routeContext)
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockClear()
+    await POST(buildRequest(), routeContext)
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).not.toBe(firstJobId)
+  })
+
+  it('preserves job id on redelivery of the same generationId or generation_id', async () => {
+    db.getRetriableFitnessImportBatchIds.mockResolvedValue([
+      'strava-activity:100'
+    ])
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      fitnessFile({
+        id: 'f100',
+        importBatchId: 'strava-activity:100',
+        importStatus: 'failed'
+      })
+    ] as never)
+
+    const publish = getQueue().publish as jest.Mock
+    publish.mockResolvedValue(undefined)
+
+    const req1 = new NextRequest(
+      'https://llun.test/api/v1/fitness/retry-failed',
+      {
+        method: 'POST',
+        headers: {
+          Origin: 'https://llun.test',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ generation_id: 'retry-all-fixed-id' })
+      }
+    )
+    await POST(req1, routeContext)
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockClear()
+    const req2 = new NextRequest(
+      'https://llun.test/api/v1/fitness/retry-failed',
+      {
+        method: 'POST',
+        headers: {
+          Origin: 'https://llun.test',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ generation_id: 'retry-all-fixed-id' })
+      }
+    )
+    await POST(req2, routeContext)
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+  })
 })

--- a/app/api/v1/fitness/retry-failed/route.ts
+++ b/app/api/v1/fitness/retry-failed/route.ts
@@ -41,6 +41,12 @@ export const POST = traceApiRoute(
     // bounded (no fan-out of concurrent queries/updates). A single batch's
     // failure must not block the rest — retryFitnessImportBatch rolls back its
     // own batch, and we count and log the failure here so it stays visible.
+    const body = (await req.json().catch(() => ({}))) as {
+      generationId?: string
+      generation_id?: string
+    }
+    const generationId =
+      body.generationId ?? body.generation_id ?? crypto.randomUUID()
     let retried = 0
     let batches = 0
     let failedBatches = 0
@@ -60,6 +66,7 @@ export const POST = traceApiRoute(
           batchActorId: currentActor.id,
           files: ownedFiles,
           visibility: RETRY_VISIBILITY,
+          generationId,
           now
         })
 

--- a/app/api/v1/statuses/[id]/interaction_policy/route.test.ts
+++ b/app/api/v1/statuses/[id]/interaction_policy/route.test.ts
@@ -145,4 +145,83 @@ describe('PUT /api/v1/statuses/[id]/interaction_policy', () => {
 
     expect(response.status).toBe(422)
   })
+
+  it('preserves job id on redelivery with operation_id or operationId', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/interaction-policy-redelivery`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const publish = getQueue().publish as jest.Mock
+
+    const res1 = await PUT(
+      putRequest(urlToId(statusId), {
+        quote_approval_policy: 'followers',
+        operation_id: 'op-fixed-id'
+      }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+    expect(res1.status).toBe(200)
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockClear()
+    const res2 = await PUT(
+      putRequest(urlToId(statusId), {
+        quote_approval_policy: 'followers',
+        operation_id: 'op-fixed-id'
+      }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+    expect(res2.status).toBe(200)
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+
+    // Also test camelCase operationId
+    publish.mockClear()
+    const res3 = await PUT(
+      putRequest(urlToId(statusId), {
+        quote_approval_policy: 'followers',
+        operationId: 'op-fixed-id'
+      }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+    expect(res3.status).toBe(200)
+    const thirdJobId = publish.mock.calls[0][0].id
+    expect(thirdJobId).toBe(firstJobId)
+  })
+
+  it('generates distinct job ids for successive policy changes without operation_id', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/interaction-policy-successive`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const publish = getQueue().publish as jest.Mock
+
+    await PUT(
+      putRequest(urlToId(statusId), { quote_approval_policy: 'followers' }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockClear()
+    await PUT(
+      putRequest(urlToId(statusId), { quote_approval_policy: 'nobody' }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).not.toBe(firstJobId)
+  })
 })

--- a/app/api/v1/statuses/[id]/interaction_policy/route.ts
+++ b/app/api/v1/statuses/[id]/interaction_policy/route.ts
@@ -27,7 +27,9 @@ interface Params {
 }
 
 const BodySchema = z.object({
-  quote_approval_policy: QuoteApprovalPolicy
+  quote_approval_policy: QuoteApprovalPolicy,
+  operation_id: z.string().optional(),
+  operationId: z.string().optional()
 })
 
 // PUT /api/v1/statuses/:id/interaction_policy — the author sets who may quote
@@ -69,6 +71,7 @@ export const PUT = traceApiRoute(
         statusId,
         currentActor,
         quoteApprovalPolicy: parsed.quote_approval_policy,
+        operationId: parsed.operation_id ?? parsed.operationId,
         database
       })
       // null = not found, not owned, or not a Note/Poll — author-only.

--- a/lib/actions/updateStatusInteractionPolicy.test.ts
+++ b/lib/actions/updateStatusInteractionPolicy.test.ts
@@ -1,0 +1,163 @@
+import { updateStatusInteractionPolicyFromUserInput } from '@/lib/actions/updateStatusInteractionPolicy'
+import { Database } from '@/lib/database/types'
+import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+const publish = vi.fn()
+
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: () => ({
+    publish
+  })
+}))
+
+const makeActor = (id: string = 'https://llun.test/users/alice'): Actor =>
+  ({
+    id,
+    username: 'alice',
+    domain: 'llun.test',
+    account: { id: 'acc-1' }
+  }) as unknown as Actor
+
+const makeStatus = (overrides: Partial<Status> = {}): Status =>
+  ({
+    id: 'https://llun.test/users/alice/statuses/1',
+    type: StatusType.enum.Note,
+    actorId: 'https://llun.test/users/alice',
+    isLocalActor: true,
+    text: 'Hello world',
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    ...overrides
+  }) as unknown as Status
+
+describe('updateStatusInteractionPolicyFromUserInput', () => {
+  const currentActor = makeActor()
+  let database: Database
+  let getStatus: ReturnType<typeof vi.fn>
+  let updateStatusQuoteApprovalPolicy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    publish.mockReset()
+    getStatus = vi.fn().mockResolvedValue(makeStatus())
+    updateStatusQuoteApprovalPolicy = vi
+      .fn()
+      .mockImplementation(async ({ quoteApprovalPolicy }) =>
+        makeStatus({ quoteApprovalPolicy })
+      )
+    database = {
+      getStatus,
+      updateStatusQuoteApprovalPolicy
+    } as unknown as Database
+  })
+
+  it('updates interaction policy and publishes note update job without modifying updatedAt', async () => {
+    const status = makeStatus()
+    const result = await updateStatusInteractionPolicyFromUserInput({
+      statusId: status.id,
+      currentActor,
+      quoteApprovalPolicy: 'nobody',
+      database
+    })
+
+    expect(result).not.toBeNull()
+    expect(updateStatusQuoteApprovalPolicy).toHaveBeenCalledWith({
+      statusId: status.id,
+      quoteApprovalPolicy: 'nobody'
+    })
+    // updatedAt is preserved unchanged
+    expect(result?.updatedAt).toBe(status.updatedAt)
+
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: SEND_UPDATE_NOTE_JOB_NAME,
+        data: {
+          actorId: currentActor.id,
+          statusId: status.id
+        }
+      })
+    )
+  })
+
+  it('gives the same job id on redelivery of the same logical operationId', async () => {
+    const status = makeStatus()
+    const operationId = 'op-fixed-123'
+
+    await updateStatusInteractionPolicyFromUserInput({
+      statusId: status.id,
+      currentActor,
+      quoteApprovalPolicy: 'nobody',
+      operationId,
+      database
+    })
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockReset()
+    await updateStatusInteractionPolicyFromUserInput({
+      statusId: status.id,
+      currentActor,
+      quoteApprovalPolicy: 'nobody',
+      operationId,
+      database
+    })
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+  })
+
+  it('gives different job ids for repeated policy changes without changing updatedAt or edit history', async () => {
+    const status = makeStatus()
+
+    await updateStatusInteractionPolicyFromUserInput({
+      statusId: status.id,
+      currentActor,
+      quoteApprovalPolicy: 'nobody',
+      database
+    })
+    const firstJobId = publish.mock.calls[0][0].id
+
+    publish.mockReset()
+    await updateStatusInteractionPolicyFromUserInput({
+      statusId: status.id,
+      currentActor,
+      quoteApprovalPolicy: 'public',
+      database
+    })
+    const secondJobId = publish.mock.calls[0][0].id
+
+    expect(secondJobId).not.toBe(firstJobId)
+  })
+
+  it('returns null and does not publish if caller is not the status author', async () => {
+    const otherActor = makeActor('https://llun.test/users/bob')
+    const result = await updateStatusInteractionPolicyFromUserInput({
+      statusId: 'https://llun.test/users/alice/statuses/1',
+      currentActor: otherActor,
+      quoteApprovalPolicy: 'nobody',
+      database
+    })
+
+    expect(result).toBeNull()
+    expect(updateStatusQuoteApprovalPolicy).not.toHaveBeenCalled()
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('returns null and does not publish if status type is Announce', async () => {
+    getStatus.mockResolvedValue(
+      makeStatus({ type: StatusType.enum.Announce as StatusType })
+    )
+
+    const result = await updateStatusInteractionPolicyFromUserInput({
+      statusId: 'https://llun.test/users/alice/statuses/1',
+      currentActor,
+      quoteApprovalPolicy: 'nobody',
+      database
+    })
+
+    expect(result).toBeNull()
+    expect(updateStatusQuoteApprovalPolicy).not.toHaveBeenCalled()
+    expect(publish).not.toHaveBeenCalled()
+  })
+})

--- a/lib/actions/updateStatusInteractionPolicy.ts
+++ b/lib/actions/updateStatusInteractionPolicy.ts
@@ -17,6 +17,7 @@ interface UpdateStatusInteractionPolicyFromUserInput {
   publish?: boolean
   status?: Status
   database: Database
+  operationId?: string
 }
 
 /**
@@ -33,7 +34,8 @@ export const updateStatusInteractionPolicyFromUserInput = async ({
   quoteApprovalPolicy,
   publish = true,
   status: preloadedStatus,
-  database
+  database,
+  operationId
 }: UpdateStatusInteractionPolicyFromUserInput): Promise<Status | null> =>
   withSpan(
     'actions',
@@ -60,8 +62,11 @@ export const updateStatusInteractionPolicyFromUserInput = async ({
       }
 
       if (publish) {
+        const effectiveOperationId = operationId ?? crypto.randomUUID()
         await getQueue().publish({
-          id: getHashFromString(`${statusId}#interaction-policy`),
+          id: getHashFromString(
+            `${statusId}#interaction-policy:${effectiveOperationId}`
+          ),
           name: SEND_UPDATE_NOTE_JOB_NAME,
           data: { actorId: currentActor.id, statusId }
         })

--- a/lib/services/fitness-files/retryImports.test.ts
+++ b/lib/services/fitness-files/retryImports.test.ts
@@ -270,4 +270,102 @@ describe('retryFitnessImportBatch', () => {
       'x'
     )
   })
+
+  it('gives the same job id on redelivery of the same generation', async () => {
+    const database = makeDatabase()
+    const generationId = 'gen-123'
+
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'manual-batch',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      generationId,
+      now: NOW
+    })
+    const firstJobId = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+
+    vi.clearAllMocks()
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'manual-batch',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      generationId,
+      now: NOW
+    })
+    const secondJobId = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+
+    expect(secondJobId).toBe(firstJobId)
+  })
+
+  it('gives different job ids for two successive retries of the same batch', async () => {
+    const database = makeDatabase()
+
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'manual-batch',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      now: NOW
+    })
+    const firstJobId = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+
+    vi.clearAllMocks()
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'manual-batch',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      now: NOW
+    })
+    const secondJobId = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+
+    expect(secondJobId).not.toBe(firstJobId)
+  })
+
+  it('gives different job ids for two successive retries of a Strava batch while redelivery stays stable', async () => {
+    const database = makeDatabase()
+    const generationId = 'strava-gen-fixed'
+
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'strava-activity:999',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      generationId,
+      now: NOW
+    })
+    const fixedJobId1 = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+
+    vi.clearAllMocks()
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'strava-activity:999',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      generationId,
+      now: NOW
+    })
+    const fixedJobId2 = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+    expect(fixedJobId2).toBe(fixedJobId1)
+
+    vi.clearAllMocks()
+    await retryFitnessImportBatch({
+      database,
+      batchId: 'strava-activity:999',
+      batchActorId: 'actor-1',
+      files: [file({ id: 'failed', importStatus: 'failed' })],
+      visibility: 'private',
+      now: NOW
+    })
+    const freshJobId = (getQueue().publish as jest.Mock).mock.calls[0][0].id
+    expect(freshJobId).not.toBe(fixedJobId1)
+  })
 })

--- a/lib/services/fitness-files/retryImports.ts
+++ b/lib/services/fitness-files/retryImports.ts
@@ -59,6 +59,7 @@ interface RetryFitnessImportBatchParams {
   batchActorId: string
   files: FitnessFile[]
   visibility: RetryFitnessVisibility
+  generationId?: string
   now?: number
 }
 
@@ -84,6 +85,7 @@ export const retryFitnessImportBatch = async ({
   batchActorId,
   files,
   visibility,
+  generationId,
   now = Date.now()
 }: RetryFitnessImportBatchParams): Promise<{ retried: number }> => {
   const retriableFiles = files
@@ -132,6 +134,7 @@ export const retryFitnessImportBatch = async ({
     })
   }
 
+  const effectiveGenerationId = generationId ?? crypto.randomUUID()
   const stravaActivityId = getStravaActivityIdFromBatchId(batchId)
   const retryJob = stravaActivityId
     ? {
@@ -140,7 +143,7 @@ export const retryFitnessImportBatch = async ({
         // is intentionally OMITTED here so the job falls back to the account's
         // configured default visibility from fitness settings. Do not add it back.
         id: getHashFromString(
-          `${batchActorId}:strava-activity-retry:${batchId}`
+          `${batchActorId}:strava-activity-retry:${batchId}:${effectiveGenerationId}`
         ),
         name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
         data: {
@@ -150,7 +153,7 @@ export const retryFitnessImportBatch = async ({
       }
     : {
         id: getHashFromString(
-          `${batchActorId}:fitness-import-retry:${batchId}`
+          `${batchActorId}:fitness-import-retry:${batchId}:${effectiveGenerationId}`
         ),
         name: IMPORT_FITNESS_FILES_JOB_NAME,
         data: {

--- a/lib/services/link-previews/syncStatusLinkPreview.test.ts
+++ b/lib/services/link-previews/syncStatusLinkPreview.test.ts
@@ -52,6 +52,8 @@ const makeStatus = (overrides: Partial<Status> = {}): Status =>
     actorId: 'https://llun.test/users/me',
     isLocalActor: true,
     text: 'Read https://example.com/article today',
+    createdAt: 1_000,
+    updatedAt: 1_000,
     ...overrides
   }) as unknown as Status
 
@@ -293,5 +295,48 @@ describe('syncStatusLinkPreview', () => {
     })
 
     expect(publish.mock.calls[0][0].id).not.toBe(firstId)
+  })
+
+  it('enqueues work again when returning to a previous URL (URL A -> B -> A sequence) while preserving redelivery stability', async () => {
+    // 1. Initial status with URL A at revision 1000
+    const statusRev1 = makeStatus({
+      updatedAt: 1_000,
+      text: 'First version https://example.com/url-a'
+    })
+    await syncStatusLinkPreview({ database, status: statusRev1 })
+    const jobA1Id = publish.mock.calls[0][0].id
+
+    // Redelivery of revision 1 produces stable id
+    publish.mockReset()
+    await syncStatusLinkPreview({ database, status: statusRev1 })
+    expect(publish.mock.calls[0][0].id).toBe(jobA1Id)
+
+    // 2. Status edited to URL B at revision 2000
+    publish.mockReset()
+    const statusRev2 = makeStatus({
+      updatedAt: 2_000,
+      text: 'Second version https://example.com/url-b'
+    })
+    await syncStatusLinkPreview({ database, status: statusRev2 })
+    const jobBId = publish.mock.calls[0][0].id
+    expect(jobBId).not.toBe(jobA1Id)
+
+    // 3. Status edited BACK to URL A at revision 3000
+    publish.mockReset()
+    const statusRev3 = makeStatus({
+      updatedAt: 3_000,
+      text: 'Third version back to https://example.com/url-a'
+    })
+    await syncStatusLinkPreview({ database, status: statusRev3 })
+    const jobA2Id = publish.mock.calls[0][0].id
+
+    // Job ID for URL A at revision 3 must NOT collide with revision 1, so it can enqueue again
+    expect(jobA2Id).not.toBe(jobA1Id)
+    expect(jobA2Id).not.toBe(jobBId)
+
+    // Redelivery of revision 3 is stable
+    publish.mockReset()
+    await syncStatusLinkPreview({ database, status: statusRev3 })
+    expect(publish.mock.calls[0][0].id).toBe(jobA2Id)
   })
 })

--- a/lib/services/link-previews/syncStatusLinkPreview.ts
+++ b/lib/services/link-previews/syncStatusLinkPreview.ts
@@ -72,10 +72,13 @@ export const syncStatusLinkPreview = async ({
     // A remote post reaches many servers at once; a local one has an author
     // waiting to see the card, and is a single request either way.
     const shouldDelay = !status.isLocalActor && !getQueue().runsInline
+    const statusRevision = status.updatedAt ?? status.createdAt ?? 0
     await getQueue().publish({
-      // Stable per (status, url): a redelivered message dedupes, while an edit
-      // pointing somewhere new gets its own job.
-      id: getHashFromString(`${status.id}:link-preview:${url}`),
+      // Stable per (status, revision, url): a redelivered message dedupes, while
+      // an edit pointing somewhere new or returning to a previous URL gets its own job.
+      id: getHashFromString(
+        `${status.id}:${statusRevision}:link-preview:${url}`
+      ),
       name: FETCH_LINK_PREVIEW_JOB_NAME,
       data: { statusId: status.id, url },
       // NoQueue has no scheduler and silently drops a delayed message, so the


### PR DESCRIPTION
## Summary
Separates repeatable user operations from duplicate deliveries across fitness import retries, status interaction policy mutations, and link-preview synchronization (Task A5a).

### Changes
- **Fitness import retries**: Added `generationId` parameter to `retryFitnessImportBatch`, including it in both Strava and standard fitness file queue retry job IDs. Reused the same generation ID across all batch publication attempts within a single manual retry invocation (`POST /api/v1/fitness/retry-failed`), while ensuring separate invocations produce distinct job IDs.
- **Interaction policy updates**: Added `operationId` parameter to `updateStatusInteractionPolicyFromUserInput` and incorporated it into the job ID without bumping `updatedAt` or recording edit history.
- **Link preview synchronization**: Incorporated status revision (`status.updatedAt` / `createdAt`) into the preview card fetch job ID so editing away from a URL and later returning to it (URL A -> B -> A sequence) enqueues preview card fetching again.
- **Redelivery & deduplication stability**: Stable queue job IDs are preserved for redelivery of the same logical operation across all three publisher paths.
- **Tests**: Added comprehensive unit tests covering two successive retries, redelivery stability, repeated interaction policy mutations without `edited_at` changes, and the URL A -> B -> A sequence.

### Verification
- `yarn run prettier --write .` (passed)
- `yarn lint` (passed: 0 errors)
- `yarn typecheck` (passed)
- `yarn build` (passed)
- `yarn test` (passed: 981/981 files, 13385/13385 tests)
