### PR TITLE
Bump version to v1.161.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.7",
+  "version": "1.161.8",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.7`
- Base main SHA: `4d4004df8b7988c32515a4fcfc97c09810c332e6`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
