### PR TITLE
feat: derive repeatable child-job IDs from parent message ID

### DIFF
--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -707,7 +707,10 @@ describe('importStravaActivityJob', () => {
     // Gated on the same opt-in as the file-backed path: this test drives the
     // webhook shape, so the fallback note federates.
     expect(mockGetQueue().publish).toHaveBeenCalledWith(
-      expect.objectContaining({ name: SEND_NOTE_JOB_NAME })
+      expect.objectContaining({
+        name: SEND_NOTE_JOB_NAME,
+        id: getHashFromString('actor-1:strava-note:125')
+      })
     )
   })
 
@@ -1028,6 +1031,7 @@ describe('importStravaActivityJob', () => {
         statusId: 'status-existing'
       }
     ] as never)
+    database.getFitnessFile.mockReset()
     database.getFitnessFile.mockResolvedValueOnce({
       id: 'existing-file',
       actorId: 'actor-1',
@@ -1049,9 +1053,95 @@ describe('importStravaActivityJob', () => {
       }
     })
 
-    expect(mockGetQueue().publish).toHaveBeenCalledWith(
-      expect.objectContaining({ name: REGENERATE_FITNESS_MAPS_JOB_NAME })
+    const expectedChildId = getHashFromString(
+      'status-existing:existing-file:job-regen-map:regenerate-map'
     )
+    expect(mockGetQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+        id: expectedChildId,
+        data: {
+          actorId: 'actor-1',
+          fitnessFileIds: ['existing-file']
+        }
+      })
+    )
+  })
+
+  it('derives map regeneration fallback child ID from message.id (identical on redelivery, distinct across generations)', async () => {
+    const arrangeReimportWithoutMap = () => {
+      database.getFitnessFilesByBatchId.mockResolvedValue([
+        {
+          id: 'existing-file',
+          actorId: 'actor-1',
+          statusId: 'status-existing'
+        }
+      ] as never)
+      database.getFitnessFile.mockReset()
+      database.getFitnessFile.mockResolvedValue({
+        id: 'existing-file',
+        actorId: 'actor-1',
+        statusId: 'status-existing',
+        hasMapData: false
+      } as never)
+      database.getStatus.mockResolvedValue({
+        id: 'status-existing',
+        type: 'Note',
+        text: 'Already imported'
+      } as never)
+    }
+
+    // Generation 1 execution
+    arrangeReimportWithoutMap()
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-regen-gen1',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        stravaActivityId: '123'
+      }
+    })
+
+    const gen1Calls = (mockGetQueue().publish as jest.Mock).mock.calls
+    const gen1Job = gen1Calls[gen1Calls.length - 1][0]
+    const expectedGen1Id = getHashFromString(
+      'status-existing:existing-file:job-regen-gen1:regenerate-map'
+    )
+    expect(gen1Job.id).toBe(expectedGen1Id)
+
+    // Parent redelivery of Generation 1: identical parent message.id produces identical child ID
+    arrangeReimportWithoutMap()
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-regen-gen1',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        stravaActivityId: '123'
+      }
+    })
+
+    const redeliveryCalls = (mockGetQueue().publish as jest.Mock).mock.calls
+    const redeliveryJob = redeliveryCalls[redeliveryCalls.length - 1][0]
+    expect(redeliveryJob.id).toBe(expectedGen1Id)
+
+    // Generation 2 execution: different parent message.id produces different child ID
+    arrangeReimportWithoutMap()
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-regen-gen2',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        stravaActivityId: '123'
+      }
+    })
+
+    const gen2Calls = (mockGetQueue().publish as jest.Mock).mock.calls
+    const gen2Job = gen2Calls[gen2Calls.length - 1][0]
+    const expectedGen2Id = getHashFromString(
+      'status-existing:existing-file:job-regen-gen2:regenerate-map'
+    )
+    expect(gen2Job.id).toBe(expectedGen2Id)
+    expect(gen2Job.id).not.toBe(expectedGen1Id)
   })
 
   it('does not queue map regeneration on a fresh import (processing handles the primary map)', async () => {
@@ -1467,6 +1557,107 @@ describe('importStravaActivityJob', () => {
         actorId: 'actor-1',
         statusId: 'status-1'
       })
+      expect(updates[0].id).toBe(
+        getHashFromString(
+          'status-1:123:job-federation-photo-update:strava-photos:send-update-note'
+        )
+      )
+    })
+
+    it('derives photo update child ID from parent message.id (identical on redelivery, distinct across generations)', async () => {
+      database.getAttachments.mockResolvedValue([])
+      database.createAttachment.mockResolvedValue({} as never)
+      mockGetStravaActivityPhotos.mockResolvedValue([
+        { id: 'photo-1', url: 'https://images.example.com/photo-1.jpg' }
+      ] as never)
+      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(() =>
+        Promise.resolve(
+          new Response(Buffer.from('jpg'), {
+            headers: { 'content-type': 'image/jpeg', 'content-length': '3' }
+          })
+        )
+      )
+
+      const setupFreshImport = () => {
+        database.getFitnessFile
+          .mockResolvedValueOnce({
+            id: 'new-file',
+            actorId: 'actor-1',
+            statusId: undefined
+          } as never)
+          .mockResolvedValueOnce({
+            id: 'new-file',
+            actorId: 'actor-1',
+            statusId: 'status-1'
+          } as never)
+      }
+
+      try {
+        // Generation 1 execution
+        setupFreshImport()
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-photo-gen1',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+
+        const gen1Updates = (mockGetQueue().publish as jest.Mock).mock.calls
+          .map(([message]) => message)
+          .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+        const gen1Update = gen1Updates[gen1Updates.length - 1]
+        const expectedGen1Id = getHashFromString(
+          'status-1:123:job-photo-gen1:strava-photos:send-update-note'
+        )
+        expect(gen1Update.id).toBe(expectedGen1Id)
+
+        // Parent redelivery of Generation 1: identical parent message.id produces identical child ID
+        setupFreshImport()
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-photo-gen1',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+
+        const redeliveryUpdates = (
+          mockGetQueue().publish as jest.Mock
+        ).mock.calls
+          .map(([message]) => message)
+          .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+        const redeliveryUpdate = redeliveryUpdates[redeliveryUpdates.length - 1]
+        expect(redeliveryUpdate.id).toBe(expectedGen1Id)
+
+        // Generation 2 execution: different parent message.id produces different child ID
+        setupFreshImport()
+        await importStravaActivityJob(database as unknown as Database, {
+          id: 'job-photo-gen2',
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: 'actor-1',
+            stravaActivityId: '123',
+            publishSendNote: true
+          }
+        })
+
+        const gen2Updates = (mockGetQueue().publish as jest.Mock).mock.calls
+          .map(([message]) => message)
+          .filter((message) => message.name === SEND_UPDATE_NOTE_JOB_NAME)
+        const gen2Update = gen2Updates[gen2Updates.length - 1]
+        const expectedGen2Id = getHashFromString(
+          'status-1:123:job-photo-gen2:strava-photos:send-update-note'
+        )
+        expect(gen2Update.id).toBe(expectedGen2Id)
+        expect(gen2Update.id).not.toBe(expectedGen1Id)
+      } finally {
+        fetchSpy.mockRestore()
+      }
     })
 
     it('sends no photo update for an import that did not opt into federation', async () => {

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -888,7 +888,7 @@ export const importStravaActivityJob = createJobHandle(
       try {
         await getQueue().publish({
           id: getHashFromString(
-            `${importedFitnessFile.statusId}:${stravaActivityId}:strava-photos:send-update-note`
+            `${importedFitnessFile.statusId}:${stravaActivityId}:${message.id}:strava-photos:send-update-note`
           ),
           name: SEND_UPDATE_NOTE_JOB_NAME,
           data: { actorId, statusId: importedFitnessFile.statusId }
@@ -923,7 +923,7 @@ export const importStravaActivityJob = createJobHandle(
     ) {
       await getQueue().publish({
         id: getHashFromString(
-          `${importedFitnessFile.statusId}:${importedFitnessFile.id}:regenerate-map`
+          `${importedFitnessFile.statusId}:${importedFitnessFile.id}:${message.id}:regenerate-map`
         ),
         name: REGENERATE_FITNESS_MAPS_JOB_NAME,
         data: {

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -361,11 +361,14 @@ describe('publishScheduledStatusJob', () => {
       data: { scheduledStatusId: scheduled.id }
     })
     expect(publishArgs.delaySeconds).toBeGreaterThan(60)
-    // The early re-enqueue uses a distinct dedup id (suffixed `-reenqueue`) so
-    // QStash does not drop it as a duplicate of the original create enqueue.
-    expect(publishArgs.id).toBe(
-      getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}-reenqueue`)
+    // The early re-enqueue uses a distinct dedup id derived from message.id and
+    // scheduledAt so it cannot collide with the job currently executing or the
+    // original enqueue id.
+    const expectedReenqueueId = getHashFromString(
+      `job-early:${scheduled.scheduledAt}:reenqueue`
     )
+    expect(publishArgs.id).toBe(expectedReenqueueId)
+    expect(publishArgs.id).not.toBe('job-early')
     expect(publishArgs.id).not.toBe(
       getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`)
     )
@@ -375,6 +378,63 @@ describe('publishScheduledStatusJob', () => {
     expect(statuses.some((status) => status.text.includes(text))).toBe(false)
     const row = await database.getScheduledStatusById({ id: scheduled.id })
     expect(row).not.toBeNull()
+  })
+
+  it('produces distinct replacement IDs for repeated early delivery and identical IDs on redelivery', async () => {
+    const text = `Future scheduled note repeated early ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() + 15 * 60 * 1000,
+      params: baseParams({ text })
+    })
+
+    // First early execution
+    await publishScheduledStatusJob(database, {
+      id: 'job-early-gen1',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: {
+        scheduledStatusId: scheduled.id,
+        scheduledAt: scheduled.scheduledAt
+      }
+    })
+
+    const gen1Publish = (getQueue().publish as jest.Mock).mock.calls[0][0]
+    const gen1ReplacementId = gen1Publish.id
+    expect(gen1ReplacementId).toBe(
+      getHashFromString(`job-early-gen1:${scheduled.scheduledAt}:reenqueue`)
+    )
+    expect(gen1ReplacementId).not.toBe('job-early-gen1')
+
+    // Parent redelivery: identical message ID produces identical replacement ID
+    await publishScheduledStatusJob(database, {
+      id: 'job-early-gen1',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: {
+        scheduledStatusId: scheduled.id,
+        scheduledAt: scheduled.scheduledAt
+      }
+    })
+    const redeliveryPublish = (getQueue().publish as jest.Mock).mock.calls[1][0]
+    expect(redeliveryPublish.id).toBe(gen1ReplacementId)
+
+    // Repeated early delivery: the replacement job itself fires prematurely
+    await publishScheduledStatusJob(database, {
+      id: gen1ReplacementId,
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: {
+        scheduledStatusId: scheduled.id,
+        scheduledAt: scheduled.scheduledAt
+      }
+    })
+    const gen2Publish = (getQueue().publish as jest.Mock).mock.calls[2][0]
+    const gen2ReplacementId = gen2Publish.id
+    expect(gen2ReplacementId).toBe(
+      getHashFromString(
+        `${gen1ReplacementId}:${scheduled.scheduledAt}:reenqueue`
+      )
+    )
+    expect(gen2ReplacementId).not.toBe(gen1ReplacementId)
+    expect(gen2ReplacementId).not.toBe('job-early-gen1')
   })
 
   it('drops the scheduled row without publishing when the actor no longer exists', async () => {

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -55,14 +55,12 @@ export const publishScheduledStatusJob = createJobHandle(
     // is the path the in-process NoQueue always takes (it ignores delays).
     const remainingMs = row.scheduledAt - Date.now()
     if (remainingMs > EARLY_THRESHOLD_MS) {
-      // Use a distinct dedup id from the original create/reschedule enqueue
-      // (which is `${id}-${scheduledAt}`). QStash keeps the dedup window open
-      // for ~1h even after a message is consumed, so reusing the same id here
-      // would let QStash silently drop this re-enqueue and the status would
-      // never fire. The payload carries the current scheduledAt so the
-      // re-enqueued job stays valid against the obsolete-job check above.
+      // Derive the replacement job's ID from the current message and scheduled
+      // timestamp so it cannot collide with the job currently executing.
+      // Repeated early deliveries produce distinct, non-colliding IDs, while
+      // redelivery of the same parent produces an identical ID.
       await getQueue().publish({
-        id: getHashFromString(`${row.id}-${row.scheduledAt}-reenqueue`),
+        id: getHashFromString(`${message.id}:${row.scheduledAt}:reenqueue`),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: row.id, scheduledAt: row.scheduledAt },
         delaySeconds: scheduledDelaySeconds(row.scheduledAt)

--- a/lib/jobs/regenerateFitnessMapsJob.test.ts
+++ b/lib/jobs/regenerateFitnessMapsJob.test.ts
@@ -13,6 +13,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
 vi.mock('@/lib/services/queue', async () => ({
@@ -298,13 +299,68 @@ describe('regenerateFitnessMapsJob', () => {
     expect(oldMedia).toBeNull()
 
     expect(getQueue().publish).toHaveBeenCalledWith({
-      id: expect.any(String),
+      id: getHashFromString(
+        `${statusId}:job-regenerate-success:send-update-note:fitness-map`
+      ),
       name: SEND_UPDATE_NOTE_JOB_NAME,
       data: {
         actorId: actor.id,
         statusId
       }
     })
+  })
+
+  it('derives repeatable child job IDs from parent message.id (identical on redelivery, distinct across generations)', async () => {
+    const { statusId, fitnessFileId } = await setupStatusWithOldMap()
+
+    // Generation 1 execution
+    await regenerateFitnessMapsJob(database, {
+      id: 'job-regen-gen1',
+      name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+      data: {
+        actorId: actor.id,
+        fitnessFileIds: [fitnessFileId]
+      }
+    })
+
+    const gen1Calls = (getQueue().publish as jest.Mock).mock.calls
+    const gen1Call = gen1Calls[gen1Calls.length - 1][0]
+    const expectedGen1Id = getHashFromString(
+      `${statusId}:job-regen-gen1:send-update-note:fitness-map`
+    )
+    expect(gen1Call.id).toBe(expectedGen1Id)
+
+    // Parent redelivery of Generation 1: identical parent message.id produces identical child ID
+    await regenerateFitnessMapsJob(database, {
+      id: 'job-regen-gen1',
+      name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+      data: {
+        actorId: actor.id,
+        fitnessFileIds: [fitnessFileId]
+      }
+    })
+
+    const redeliveryCalls = (getQueue().publish as jest.Mock).mock.calls
+    const redeliveryCall = redeliveryCalls[redeliveryCalls.length - 1][0]
+    expect(redeliveryCall.id).toBe(expectedGen1Id)
+
+    // Generation 2 execution: new parent message.id produces a different child ID
+    await regenerateFitnessMapsJob(database, {
+      id: 'job-regen-gen2',
+      name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+      data: {
+        actorId: actor.id,
+        fitnessFileIds: [fitnessFileId]
+      }
+    })
+
+    const gen2Calls = (getQueue().publish as jest.Mock).mock.calls
+    const gen2Call = gen2Calls[gen2Calls.length - 1][0]
+    const expectedGen2Id = getHashFromString(
+      `${statusId}:job-regen-gen2:send-update-note:fitness-map`
+    )
+    expect(gen2Call.id).toBe(expectedGen2Id)
+    expect(gen2Call.id).not.toBe(expectedGen1Id)
   })
 
   // Every branch records the reason in `mapError` and leaves the file

--- a/lib/jobs/regenerateFitnessMapsJob.ts
+++ b/lib/jobs/regenerateFitnessMapsJob.ts
@@ -407,7 +407,9 @@ export const regenerateFitnessMapsJob = createJobHandle(
     await Promise.all(
       [...statusesNeedingUpdate].map((statusId) => {
         return getQueue().publish({
-          id: getHashFromString(`${statusId}:send-update-note:fitness-map`),
+          id: getHashFromString(
+            `${statusId}:${message.id}:send-update-note:fitness-map`
+          ),
           name: SEND_UPDATE_NOTE_JOB_NAME,
           data: {
             actorId,


### PR DESCRIPTION
## Summary
Derives repeatable child-job IDs from a structured tuple containing the child operation, parent `message.id`, and target identifier (Task A5b).

### Changes
- **Map regeneration Updates (`lib/jobs/regenerateFitnessMapsJob.ts`)**:
  - Derives `SEND_UPDATE_NOTE_JOB_NAME` child job ID using `${statusId}:${message.id}:send-update-note:fitness-map`.
  - Parent redelivery produces identical child IDs; a later parent generation produces different IDs.
- **Repeatable Strava map and photo work (`lib/jobs/importStravaActivityJob.ts`)**:
  - Derives late photo update note job ID using `${importedFitnessFile.statusId}:${stravaActivityId}:${message.id}:strava-photos:send-update-note`.
  - Derives map regeneration fallback job ID using `${importedFitnessFile.statusId}:${importedFitnessFile.id}:${message.id}:regenerate-map`.
  - Parent redelivery produces identical child IDs; distinct generations produce distinct IDs.
  - Stable one-time Create note IDs (`getHashFromString(`${actorId}:strava-note:${stravaActivityId}`)`) and federation opt-in gates are preserved.
- **Early scheduled publication (`lib/jobs/publishScheduledStatusJob.ts`)**:
  - Derives the replacement job's ID from `${message.id}:${row.scheduledAt}:reenqueue` so it cannot collide with the job currently executing.
  - Repeated early deliveries produce distinct, non-colliding replacement IDs, while parent redelivery produces identical IDs.
  - Preserves obsolete-schedule rejection and delay calculation.
- **Tests**:
  - Added parent redelivery and distinct generation tests to `regenerateFitnessMapsJob.test.ts`.
  - Added parent redelivery and distinct generation tests for photo updates and map regeneration fallback, and asserted stable Create note IDs in `importStravaActivityJob.test.ts`.
  - Added repeated early delivery and parent redelivery tests to `publishScheduledStatusJob.test.ts`.

### Verification
- `yarn run prettier --write .` (passed)
- `yarn lint` (passed: 0 errors)
- `yarn typecheck` (passed: 0 errors)
- `yarn build` (passed: 0 errors)
- `yarn test` (passed: 982/982 files, 13412/13412 tests)