### PR TITLE
Bump version to v1.161.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.8",
+  "version": "1.161.9",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.9.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.8`
- Base main SHA: `a216cfa81af420bc74b487707cd8f87ebce45a80`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
