### PR TITLE
feat: preserve inherited JSON-LD context in outbox items

### DIFF
--- a/lib/activities/getActorCollections.test.ts
+++ b/lib/activities/getActorCollections.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  getActorCollections,
   isCollectionPageUrl,
   parseTotalItems
 } from '@/lib/activities/getActorCollections'
+import { Actor } from '@/lib/types/activitypub'
+import { request } from '@/lib/utils/request'
+
+vi.mock('@/lib/utils/request', () => ({ request: vi.fn() }))
 
 describe('parseTotalItems', () => {
   it('returns null for undefined, null, and non-number types', () => {
@@ -56,5 +61,147 @@ describe('isCollectionPageUrl', () => {
         'https://example.com/users/alice/followers'
       )
     ).toBe(false)
+  })
+})
+
+describe('getActorCollections context inheritance', () => {
+  const mockRequest = vi.mocked(request)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('carries root collection context into inline collection page', async () => {
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          { rootTerm: 'https://example.com/ns#root' }
+        ],
+        id: 'https://example.com/outbox',
+        type: 'OrderedCollection',
+        totalItems: 1,
+        orderedItems: ['https://example.com/status/1']
+      })
+    })
+
+    const person = {
+      id: 'https://example.com/user',
+      outbox: 'https://example.com/outbox'
+    } as Actor
+    const result = await getActorCollections({ person, field: 'outbox' })
+    expect(result?.page?.['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      { rootTerm: 'https://example.com/ns#root' }
+    ])
+    expect(result?.totalItems).toBe(1)
+  })
+
+  it('carries root collection context into fetched page when page omits @context', async () => {
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          { rootTerm: 'https://example.com/ns#root' }
+        ],
+        id: 'https://example.com/outbox',
+        type: 'OrderedCollection',
+        totalItems: 42,
+        first: 'https://example.com/outbox/page/1'
+      })
+    })
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        id: 'https://example.com/outbox/page/1',
+        type: 'OrderedCollectionPage',
+        partOf: 'https://example.com/outbox',
+        next: 'https://example.com/outbox/page/2',
+        prev: 'https://example.com/outbox/page/0',
+        totalItems: 42,
+        orderedItems: ['https://example.com/status/1']
+      })
+    })
+
+    const person = {
+      id: 'https://example.com/user',
+      outbox: 'https://example.com/outbox'
+    } as Actor
+    const result = await getActorCollections({ person, field: 'outbox' })
+    expect(result?.page?.['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      { rootTerm: 'https://example.com/ns#root' }
+    ])
+    expect(result?.totalItems).toBe(42)
+    expect(result?.page?.next).toBe('https://example.com/outbox/page/2')
+    expect(result?.page?.prev).toBe('https://example.com/outbox/page/0')
+  })
+
+  it('combines root and page contexts with root definitions preceding page definitions', async () => {
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': { rootTerm: 'https://example.com/ns#root' },
+        id: 'https://example.com/outbox',
+        type: 'OrderedCollection',
+        first: 'https://example.com/outbox/page/1'
+      })
+    })
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': { pageTerm: 'https://example.com/ns#page' },
+        id: 'https://example.com/outbox/page/1',
+        type: 'OrderedCollectionPage',
+        orderedItems: []
+      })
+    })
+
+    const person = {
+      id: 'https://example.com/user',
+      outbox: 'https://example.com/outbox'
+    } as Actor
+    const result = await getActorCollections({ person, field: 'outbox' })
+    expect(result?.page?.['@context']).toEqual([
+      { rootTerm: 'https://example.com/ns#root' },
+      { pageTerm: 'https://example.com/ns#page' }
+    ])
+  })
+
+  it('resets context inheritance when fetched page specifies @context: null', async () => {
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': { rootTerm: 'https://example.com/ns#root' },
+        id: 'https://example.com/outbox',
+        type: 'OrderedCollection',
+        first: 'https://example.com/outbox/page/1'
+      })
+    })
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({
+        '@context': null,
+        id: 'https://example.com/outbox/page/1',
+        type: 'OrderedCollectionPage',
+        orderedItems: []
+      })
+    })
+
+    const person = {
+      id: 'https://example.com/user',
+      outbox: 'https://example.com/outbox'
+    } as Actor
+    const result = await getActorCollections({ person, field: 'outbox' })
+    expect(result?.page?.['@context']).toBeNull()
   })
 })

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -9,6 +9,9 @@ import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
 import { withSpan } from '@/lib/utils/trace'
+import { isRecord } from '@/lib/utils/typeGuards'
+
+import { applyInheritedContext } from './inheritActivityPubContext'
 
 interface Params {
   person: Actor
@@ -166,7 +169,12 @@ export const getActorCollections = async ({
             totalItems: collectionTotalItems
           }
         }
-        const page = JSON.parse(response.body) as OrderedCollectionPage
+        const rawPage = JSON.parse(response.body) as OrderedCollectionPage
+        const page = (
+          isRecord(rawPage)
+            ? applyInheritedContext(collection['@context'], rawPage)
+            : rawPage
+        ) as OrderedCollectionPage
         const pageTotalItems = parseTotalItems(page.totalItems)
         return {
           page,

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -1426,4 +1426,306 @@ describe('getActorPosts', () => {
       'https://framatube.org/thumb.jpg'
     )
   })
+
+  describe('context inheritance (Task B4)', () => {
+    it('inherits root-only context definitions into items and embedded objects', async () => {
+      const actorId = 'https://root-context.example/users/actor'
+      const statusId = `${actorId}/statuses/root-1`
+      const person = MockActivityPubPerson({
+        id: actorId,
+        withContext: true
+      }) as Actor
+
+      fetchMock.resetMocks()
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `${actorId}/outbox`) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                { rootText: 'https://www.w3.org/ns/activitystreams#content' }
+              ],
+              id: `${actorId}/outbox`,
+              type: 'OrderedCollection',
+              totalItems: 1,
+              orderedItems: [
+                {
+                  id: `${statusId}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: statusId,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    rootText: 'Hello from root-only context definition',
+                    published: new Date().toISOString()
+                  }
+                }
+              ]
+            })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      const response = await getActorPosts({ database, person })
+      expect(response.statuses).toHaveLength(1)
+      expect(response.statuses[0].id).toBe(statusId)
+      expect(response.statuses[0].text).toBe(
+        'Hello from root-only context definition'
+      )
+      expect(response.statusesCount).toBe(1)
+    })
+
+    it('inherits page-only context definitions into items on separately fetched pages', async () => {
+      const actorId = 'https://page-context.example/users/actor'
+      const statusId = `${actorId}/statuses/page-1`
+      const pageUrl = `${actorId}/outbox?page=1`
+      const person = MockActivityPubPerson({
+        id: actorId,
+        withContext: true
+      }) as Actor
+
+      fetchMock.resetMocks()
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `${actorId}/outbox`) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              id: `${actorId}/outbox`,
+              type: 'OrderedCollection',
+              totalItems: 5,
+              first: pageUrl
+            })
+          }
+        }
+        if (req.url === pageUrl) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                { pageText: 'https://www.w3.org/ns/activitystreams#content' }
+              ],
+              id: pageUrl,
+              type: 'OrderedCollectionPage',
+              partOf: `${actorId}/outbox`,
+              next: `${actorId}/outbox?page=2`,
+              prev: null,
+              orderedItems: [
+                {
+                  id: `${statusId}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: statusId,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    pageText: 'Hello from page-only context definition',
+                    published: new Date().toISOString()
+                  }
+                }
+              ]
+            })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      const response = await getActorPosts({ database, person })
+      expect(response.statuses).toHaveLength(1)
+      expect(response.statuses[0].text).toBe(
+        'Hello from page-only context definition'
+      )
+      expect(response.statusesCount).toBe(5)
+      expect(response.nextPageUrl).toBe(`${actorId}/outbox?page=2`)
+    })
+
+    it('allows item-level context definitions to override inherited definitions', async () => {
+      const actorId = 'https://override-context.example/users/actor'
+      const statusId = `${actorId}/statuses/override-1`
+      const person = MockActivityPubPerson({
+        id: actorId,
+        withContext: true
+      }) as Actor
+
+      fetchMock.resetMocks()
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `${actorId}/outbox`) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                { customText: 'https://example.com/unrelated#text' }
+              ],
+              id: `${actorId}/outbox`,
+              type: 'OrderedCollection',
+              totalItems: 1,
+              orderedItems: [
+                {
+                  '@context': {
+                    customText: 'https://www.w3.org/ns/activitystreams#content'
+                  },
+                  id: `${statusId}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: statusId,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    customText:
+                      'Overridden definition successfully parsed as content',
+                    published: new Date().toISOString()
+                  }
+                }
+              ]
+            })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      const response = await getActorPosts({ database, person })
+      expect(response.statuses).toHaveLength(1)
+      expect(response.statuses[0].text).toBe(
+        'Overridden definition successfully parsed as content'
+      )
+    })
+
+    it('resets context inheritance when an item specifies @context: null', async () => {
+      const actorId = 'https://null-reset.example/users/actor'
+      const status1Id = `${actorId}/statuses/item-1`
+      const status2Id = `${actorId}/statuses/item-2`
+      const person = MockActivityPubPerson({
+        id: actorId,
+        withContext: true
+      }) as Actor
+
+      fetchMock.resetMocks()
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `${actorId}/outbox`) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                { rootText: 'https://www.w3.org/ns/activitystreams#content' }
+              ],
+              id: `${actorId}/outbox`,
+              type: 'OrderedCollection',
+              totalItems: 2,
+              orderedItems: [
+                // Item 1 inherits root context -> rootText becomes content
+                {
+                  id: `${status1Id}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: status1Id,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    rootText: 'Item 1 inherits root context',
+                    published: new Date().toISOString()
+                  }
+                },
+                // Item 2 resets inheritance via null -> rootText is unrecognized and stripped,
+                // leaving only standard content
+                {
+                  '@context': null,
+                  id: `${status2Id}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: status2Id,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    rootText: 'Ignored because inheritance was reset',
+                    content: 'Item 2 plain content',
+                    published: new Date().toISOString()
+                  }
+                }
+              ]
+            })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      const response = await getActorPosts({ database, person })
+      expect(response.statuses).toHaveLength(2)
+      expect(response.statuses[0].text).toBe('Item 1 inherits root context')
+      expect(response.statuses[1].text).toBe('Item 2 plain content')
+    })
+
+    it('preserves extension terms like quote and sensitive under inherited context', async () => {
+      const actorId = 'https://extension-terms.example/users/actor'
+      const statusId = `${actorId}/statuses/extension-1`
+      const quotedStatusId = 'https://other.example/statuses/quoted-1'
+      const person = MockActivityPubPerson({
+        id: actorId,
+        withContext: true
+      }) as Actor
+
+      fetchMock.resetMocks()
+      fetchMock.mockResponse(async (req) => {
+        if (req.url === `${actorId}/outbox`) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                {
+                  toot: 'http://joinmastodon.org/ns#'
+                }
+              ],
+              id: `${actorId}/outbox`,
+              type: 'OrderedCollection',
+              totalItems: 1,
+              orderedItems: [
+                {
+                  id: `${statusId}/activity`,
+                  type: 'Create',
+                  actor: actorId,
+                  published: new Date().toISOString(),
+                  object: {
+                    id: statusId,
+                    type: 'Note',
+                    attributedTo: actorId,
+                    to: [ACTIVITY_STREAM_PUBLIC],
+                    cc: [],
+                    content: 'Post with sensitive and quote',
+                    sensitive: true,
+                    quoteUrl: quotedStatusId,
+                    published: new Date().toISOString()
+                  }
+                }
+              ]
+            })
+          }
+        }
+        return { status: 404, body: 'Not Found' }
+      })
+
+      const response = await getActorPosts({ database, person })
+      expect(response.statuses).toHaveLength(1)
+      expect(response.statuses[0].text).toBe('Post with sensitive and quote')
+    })
+  })
 })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -35,11 +35,13 @@ import {
 import { logger } from '@/lib/utils/logger'
 import { toLoggableError } from '@/lib/utils/toLoggableError'
 import { withSpan } from '@/lib/utils/trace'
+import { isRecord } from '@/lib/utils/typeGuards'
 
 import { getActorCollections } from './getActorCollections'
 import { getActorPerson } from './getActorPerson'
 import { getActorPostsFromAtomFeed } from './getActorPostsFromAtomFeed'
 import { getPixelfedPosts } from './getPixelfedPosts'
+import { applyInheritedContext } from './inheritActivityPubContext'
 
 type GetActorPostsFunction = (params: {
   database: Database
@@ -127,6 +129,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
         }
       }
 
+      const pageContext = value.page?.['@context']
       const rawItems = value.page?.orderedItems
       const items = Array.isArray(rawItems) ? rawItems : []
       const statuses = await Promise.all(
@@ -135,10 +138,14 @@ export const getActorPosts: GetActorPostsFunction = async ({
             // This should be impossible for status api
             if (typeof item === 'string') return null
 
+            const itemToCompact = isRecord(item)
+              ? applyInheritedContext(pageContext, item)
+              : item
+
             // Canonicalise the activity (and any embedded object) via JSON-LD
             // compaction before validating, so dialect variations in `type`,
             // recipients and id references collapse to a predictable shape.
-            const activity = await compactActivityPub(item)
+            const activity = await compactActivityPub(itemToCompact)
 
             if (activity.type === AnnounceAction) {
               const announceResult = Announce.safeParse(

--- a/lib/activities/inheritActivityPubContext.test.ts
+++ b/lib/activities/inheritActivityPubContext.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyInheritedContext,
+  inheritActivityPubContext
+} from './inheritActivityPubContext'
+
+describe('inheritActivityPubContext', () => {
+  it('returns undefined when both parent and child context are undefined', () => {
+    expect(inheritActivityPubContext(undefined, undefined)).toBeUndefined()
+  })
+
+  it('inherits parent context when child context is undefined', () => {
+    expect(
+      inheritActivityPubContext(
+        'https://www.w3.org/ns/activitystreams',
+        undefined
+      )
+    ).toBe('https://www.w3.org/ns/activitystreams')
+
+    const parentObj = { toot: 'http://joinmastodon.org/ns#' }
+    expect(inheritActivityPubContext(parentObj, undefined)).toEqual(parentObj)
+
+    const parentArr = ['https://www.w3.org/ns/activitystreams', parentObj]
+    expect(inheritActivityPubContext(parentArr, undefined)).toEqual(parentArr)
+  })
+
+  it('returns child context directly when parent context is undefined or null', () => {
+    expect(
+      inheritActivityPubContext(
+        undefined,
+        'https://www.w3.org/ns/activitystreams'
+      )
+    ).toBe('https://www.w3.org/ns/activitystreams')
+
+    expect(
+      inheritActivityPubContext(null, 'https://www.w3.org/ns/activitystreams')
+    ).toBe('https://www.w3.org/ns/activitystreams')
+  })
+
+  it('resets inheritance when child context is explicitly null', () => {
+    expect(
+      inheritActivityPubContext('https://www.w3.org/ns/activitystreams', null)
+    ).toBeNull()
+
+    expect(
+      inheritActivityPubContext(
+        [
+          'https://www.w3.org/ns/activitystreams',
+          { rootTerm: 'https://example.com/ns#root' }
+        ],
+        null
+      )
+    ).toBeNull()
+  })
+
+  it('resets inheritance when child context array contains null', () => {
+    const parentContext = [
+      'https://www.w3.org/ns/activitystreams',
+      { rootTerm: 'https://example.com/ns#root' }
+    ]
+
+    // [null] resets everything
+    expect(inheritActivityPubContext(parentContext, [null])).toBeNull()
+
+    // [null, { childTerm: '...' }] discards parent context and keeps childTerm
+    expect(
+      inheritActivityPubContext(parentContext, [
+        null,
+        { childTerm: 'https://example.com/ns#child' }
+      ])
+    ).toEqual({ childTerm: 'https://example.com/ns#child' })
+
+    // [earlierChild, null, laterChild] discards parent context and earlier child definitions
+    expect(
+      inheritActivityPubContext(parentContext, [
+        { discardedChild: 'https://example.com/ns#discarded' },
+        null,
+        { activeChild: 'https://example.com/ns#active' }
+      ])
+    ).toEqual({ activeChild: 'https://example.com/ns#active' })
+
+    // Array ending in null resets everything
+    expect(
+      inheritActivityPubContext(parentContext, [
+        { activeChild: 'https://example.com/ns#active' },
+        null
+      ])
+    ).toBeNull()
+  })
+
+  it('preserves JSON-LD ordering where inherited definitions precede local definitions', () => {
+    const parent = 'https://www.w3.org/ns/activitystreams'
+    const child = { customTerm: 'https://example.com/ns#custom' }
+
+    expect(inheritActivityPubContext(parent, child)).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      { customTerm: 'https://example.com/ns#custom' }
+    ])
+  })
+
+  it('allows local definitions to override inherited definitions in array ordering', () => {
+    const parent = [
+      'https://www.w3.org/ns/activitystreams',
+      { sharedTerm: 'https://example.com/ns#v1' }
+    ]
+    const child = [{ sharedTerm: 'https://example.com/ns#v2' }]
+
+    const result = inheritActivityPubContext(parent, child)
+    expect(result).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      { sharedTerm: 'https://example.com/ns#v1' },
+      { sharedTerm: 'https://example.com/ns#v2' }
+    ])
+  })
+
+  it('handles nested context arrays', () => {
+    const parent = [['https://www.w3.org/ns/activitystreams']]
+    const child = [[null, [{ childTerm: 'https://example.com/ns#child' }]]]
+
+    expect(inheritActivityPubContext(parent, child)).toEqual({
+      childTerm: 'https://example.com/ns#child'
+    })
+  })
+
+  it('handles parent context with null reset', () => {
+    const parent = [
+      'https://discarded.example/ns',
+      null,
+      { rootTerm: 'https://example.com/root' }
+    ]
+    const child = { childTerm: 'https://example.com/child' }
+
+    expect(inheritActivityPubContext(parent, child)).toEqual([
+      { rootTerm: 'https://example.com/root' },
+      { childTerm: 'https://example.com/child' }
+    ])
+  })
+})
+
+describe('applyInheritedContext', () => {
+  it('attaches inherited context when child document omits @context', () => {
+    const doc = { id: 'https://example.com/status/1', type: 'Note' }
+    const parentContext = 'https://www.w3.org/ns/activitystreams'
+
+    expect(applyInheritedContext(parentContext, doc)).toEqual({
+      id: 'https://example.com/status/1',
+      type: 'Note',
+      '@context': 'https://www.w3.org/ns/activitystreams'
+    })
+  })
+
+  it('removes @context if effective context resolves to undefined', () => {
+    const doc = { id: 'https://example.com/status/1', type: 'Note' }
+    expect(applyInheritedContext(undefined, doc)).toEqual({
+      id: 'https://example.com/status/1',
+      type: 'Note'
+    })
+  })
+
+  it('sets @context to null when child explicitly resets inheritance', () => {
+    const doc = {
+      '@context': null,
+      id: 'https://example.com/status/1',
+      type: 'Note'
+    }
+    const parentContext = 'https://www.w3.org/ns/activitystreams'
+
+    expect(applyInheritedContext(parentContext, doc)).toEqual({
+      id: 'https://example.com/status/1',
+      type: 'Note',
+      '@context': null
+    })
+  })
+
+  it('combines parent and child context on the document', () => {
+    const doc = {
+      '@context': { local: 'https://example.com/local' },
+      id: 'https://example.com/status/1',
+      type: 'Note'
+    }
+    const parentContext = 'https://www.w3.org/ns/activitystreams'
+
+    expect(applyInheritedContext(parentContext, doc)).toEqual({
+      id: 'https://example.com/status/1',
+      type: 'Note',
+      '@context': [
+        'https://www.w3.org/ns/activitystreams',
+        { local: 'https://example.com/local' }
+      ]
+    })
+  })
+})

--- a/lib/activities/inheritActivityPubContext.ts
+++ b/lib/activities/inheritActivityPubContext.ts
@@ -1,0 +1,88 @@
+/**
+ * Inherit JSON-LD `@context` from a parent document (e.g. root collection or
+ * collection page) into a child document (e.g. fetched page or outbox item).
+ *
+ * Preserves JSON-LD context semantics:
+ * - Inherited parent definitions precede local child definitions in array ordering.
+ * - Local definitions may override inherited definitions.
+ * - An explicit null context in the child resets inheritance.
+ * - Slices after the last `null` if a child context array contains `null`.
+ */
+export const inheritActivityPubContext = (
+  parentContext: unknown,
+  childContext: unknown
+): unknown => {
+  if (childContext === null) {
+    return null
+  }
+
+  if (Array.isArray(childContext)) {
+    const flatChild = childContext.flat(Infinity)
+    const lastNullIndex = flatChild.lastIndexOf(null)
+    if (lastNullIndex !== -1) {
+      const remaining = flatChild.slice(lastNullIndex + 1)
+      if (remaining.length === 0) {
+        return null
+      }
+      return remaining.length === 1 ? remaining[0] : remaining
+    }
+  }
+
+  if (childContext === undefined) {
+    if (parentContext === undefined) return undefined
+    if (parentContext === null) return null
+    if (Array.isArray(parentContext)) {
+      const flatParent = parentContext.flat(Infinity)
+      const lastNullIndex = flatParent.lastIndexOf(null)
+      if (lastNullIndex !== -1) {
+        const remaining = flatParent.slice(lastNullIndex + 1)
+        if (remaining.length === 0) return null
+        return remaining.length === 1 ? remaining[0] : remaining
+      }
+      return parentContext
+    }
+    return parentContext
+  }
+
+  let resolvedParentEntries: unknown[] = []
+  if (parentContext !== undefined && parentContext !== null) {
+    const flatParent = Array.isArray(parentContext)
+      ? parentContext.flat(Infinity)
+      : [parentContext]
+    const lastNullIndex = flatParent.lastIndexOf(null)
+    resolvedParentEntries =
+      lastNullIndex !== -1 ? flatParent.slice(lastNullIndex + 1) : flatParent
+  }
+
+  if (resolvedParentEntries.length === 0) {
+    return childContext
+  }
+
+  const childEntries = Array.isArray(childContext)
+    ? childContext.flat(Infinity)
+    : [childContext]
+
+  return [...resolvedParentEntries, ...childEntries]
+}
+
+/**
+ * Applies the inherited context to an object document, attaching or updating
+ * `@context` if effective context exists, or removing `@context` if undefined.
+ */
+export const applyInheritedContext = <T extends Record<string, unknown>>(
+  parentContext: unknown,
+  document: T
+): T => {
+  const effectiveContext = inheritActivityPubContext(
+    parentContext,
+    document['@context']
+  )
+  if (effectiveContext === undefined) {
+    const { '@context': _context, ...rest } = document
+    return rest as T
+  }
+  return {
+    ...document,
+    '@context': effectiveContext
+  }
+}


### PR DESCRIPTION
Preserve inherited JSON-LD context across collection fetching and outbox items before compaction.

- Created `lib/activities/inheritActivityPubContext.ts` to combine parent and child contexts following JSON-LD semantics (inherited definitions precede local, local definitions override, explicit null context resets inheritance).
- Updated `lib/activities/getActorCollections.ts` to carry root collection context into fetched pages.
- Updated `lib/activities/getActorPosts.ts` to carry page context into individual outbox items before compaction.
- Added comprehensive unit and integration tests in `inheritActivityPubContext.test.ts`, `getActorCollections.test.ts`, and `getActorPosts.test.ts`.