### PR TITLE
Bump version to v1.161.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.9",
+  "version": "1.161.10",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.10.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.9`
- Base main SHA: `9f7dbb05bb6ffd672935265873276f5387dc6574`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
