### PR TITLE
feat: make normal queue enqueue idempotent and replay explicit

### DIFF
--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -412,13 +412,8 @@ describe('QueueJobDatabase', () => {
       expect(initialDlq?.errorMessage).toBe('First failure')
       expect(initialDlq?.attempts).toBe(1)
 
-      // Re-enqueue with the same ID and claim again
-      await database.createQueueJob({
-        id: 'fail-dlq-dup-1',
-        name: 'deliverActivity',
-        payload: samplePayload,
-        status: 'pending'
-      })
+      // Replay the failed job with explicit replay and claim again
+      await database.replayQueueJob({ id: 'fail-dlq-dup-1' })
 
       const claim2 = await database.claimQueueJob({ id: 'fail-dlq-dup-1' })
       expect(claim2).not.toBeNull()
@@ -607,39 +602,205 @@ describe('QueueJobDatabase', () => {
     expect(notFound).toBeNull()
   })
 
-  it('re-enqueues or upserts an existing job on duplicate id without primary key collision', async () => {
-    // Create a job that eventually failed
-    await database.createQueueJob({
-      id: 'retry-upsert-1',
+  it('preserves payload, attempts, schedule, state, and claim token on duplicate enqueue across all states', async () => {
+    // 1. Pending state
+    const originalPending = await database.createQueueJob({
+      id: 'dup-pending-1',
       name: 'deliverActivity',
-      payload: samplePayload,
-      attempts: 16,
-      status: 'failed',
-      lastErrorMessage: 'Original terminal failure'
+      payload: {
+        id: 'dup-pending-1',
+        name: 'deliverActivity',
+        data: { version: 1 }
+      },
+      attempts: 2,
+      maxRetries: 10,
+      nextRunAt: new Date(Date.now() + 50000),
+      status: 'pending'
     })
 
-    const failedJob = await database.getQueueJobById('retry-upsert-1')
-    expect(failedJob?.status).toBe('failed')
-    expect(failedJob?.attempts).toBe(16)
+    const duplicatePending = await database.createQueueJob({
+      id: 'dup-pending-1',
+      name: 'deliverActivityOverwritten',
+      payload: {
+        id: 'dup-pending-1',
+        name: 'deliverActivityOverwritten',
+        data: { version: 2 }
+      },
+      attempts: 0,
+      maxRetries: 5,
+      nextRunAt: new Date(Date.now() + 100000),
+      status: 'failed'
+    })
 
-    // Re-enqueue with the same ID (e.g. from DLQ retry)
-    const reEnqueued = await database.createQueueJob({
-      id: 'retry-upsert-1',
+    expect(duplicatePending.payload).toEqual(originalPending.payload)
+    expect(duplicatePending.attempts).toBe(originalPending.attempts)
+    expect(duplicatePending.maxRetries).toBe(originalPending.maxRetries)
+    expect(duplicatePending.nextRunAt).toBe(originalPending.nextRunAt)
+    expect(duplicatePending.status).toBe('pending')
+
+    // 2. Processing state (with claimToken)
+    await database.createQueueJob({
+      id: 'dup-processing-1',
       name: 'deliverActivity',
-      payload: samplePayload,
+      payload: samplePayload
+    })
+    const claimed = await database.claimQueueJob({ id: 'dup-processing-1' })
+    expect(claimed).not.toBeNull()
+    expect(claimed?.claimToken).toBeDefined()
+
+    const duplicateProcessing = await database.createQueueJob({
+      id: 'dup-processing-1',
+      name: 'deliverActivityOverwritten',
+      payload: { ...samplePayload, data: { overwritten: true } },
       attempts: 0,
       status: 'pending'
     })
 
-    expect(reEnqueued.id).toBe('retry-upsert-1')
-    expect(reEnqueued.status).toBe('pending')
-    expect(reEnqueued.attempts).toBe(0)
-    expect(reEnqueued.claimToken).toBeNull()
+    expect(duplicateProcessing.status).toBe('processing')
+    expect(duplicateProcessing.claimToken).toBe(claimed?.claimToken)
+    expect(duplicateProcessing.payload).toEqual(samplePayload)
 
-    const fetched = await database.getQueueJobById('retry-upsert-1')
-    expect(fetched?.status).toBe('pending')
-    expect(fetched?.attempts).toBe(0)
-    expect(fetched?.claimToken).toBeNull()
+    // 3. Completed state
+    await database.completeQueueJob({
+      id: 'dup-processing-1',
+      claimToken: claimed!.claimToken
+    })
+    const duplicateCompleted = await database.createQueueJob({
+      id: 'dup-processing-1',
+      name: 'deliverActivityOverwritten',
+      payload: { ...samplePayload, data: { overwritten: true } },
+      status: 'pending'
+    })
+    expect(duplicateCompleted.status).toBe('completed')
+    expect(duplicateCompleted.claimToken).toBeNull()
+
+    // 4. Failed state
+    await database.createQueueJob({
+      id: 'dup-failed-1',
+      name: 'deliverActivity',
+      payload: samplePayload
+    })
+    const claimedFailed = await database.claimQueueJob({ id: 'dup-failed-1' })
+    await database.failQueueJob({
+      id: 'dup-failed-1',
+      claimToken: claimedFailed!.claimToken,
+      attempts: 16,
+      error: new Error('Original terminal failure')
+    })
+    const duplicateFailed = await database.createQueueJob({
+      id: 'dup-failed-1',
+      name: 'deliverActivityOverwritten',
+      payload: { ...samplePayload, data: { overwritten: true } },
+      attempts: 0,
+      status: 'pending'
+    })
+    expect(duplicateFailed.status).toBe('failed')
+    expect(duplicateFailed.attempts).toBe(16)
+    expect(duplicateFailed.lastErrorMessage).toBe('Original terminal failure')
+  })
+
+  it('explicitly replays failed database jobs transactionally, resetting attempts, errors, and claim ownership', async () => {
+    const jobPayload: JobMessage = {
+      id: 'replay-test-1',
+      name: 'deliverActivity',
+      data: { replay: true }
+    }
+
+    await database.createQueueJob({
+      id: 'replay-test-1',
+      name: 'deliverActivity',
+      payload: jobPayload
+    })
+    const claimed = await database.claimQueueJob({ id: 'replay-test-1' })
+    expect(claimed).not.toBeNull()
+
+    await database.failQueueJobWithDeadLetter({
+      id: 'replay-test-1',
+      claimToken: claimed!.claimToken,
+      attempts: 16,
+      error: new Error('Terminal crash')
+    })
+
+    const failedJob = await database.getQueueJobById('replay-test-1')
+    expect(failedJob?.status).toBe('failed')
+    expect(failedJob?.attempts).toBe(16)
+    expect(failedJob?.lastErrorMessage).toBe('Terminal crash')
+
+    const dlqJob = await knexDatabase('dead_letter_jobs')
+      .where({ id: 'replay-test-1' })
+      .first()
+    expect(dlqJob?.status).toBe('failed')
+
+    // Replay job
+    const success = await database.replayQueueJob({ id: 'replay-test-1' })
+    expect(success).toBe(true)
+
+    const replayedJob = await database.getQueueJobById('replay-test-1')
+    expect(replayedJob?.status).toBe('pending')
+    expect(replayedJob?.attempts).toBe(0)
+    expect(replayedJob?.claimToken).toBeNull()
+    expect(replayedJob?.lastErrorMessage).toBeNull()
+    expect(replayedJob?.lastErrorStack).toBeNull()
+
+    const replayedDlq = await knexDatabase('dead_letter_jobs')
+      .where({ id: 'replay-test-1' })
+      .first()
+    expect(replayedDlq?.status).toBe('retried')
+  })
+
+  it('rolls back DLQ status update if queue job replay fails', async () => {
+    // Insert a dead letter job without a corresponding queue_jobs row
+    await knexDatabase('dead_letter_jobs').insert({
+      id: 'missing-queue-job-1',
+      job_name: 'deliverActivity',
+      payload: JSON.stringify(samplePayload),
+      error_message: 'Some error',
+      attempts: 16,
+      status: 'failed',
+      created_at: new Date(),
+      updated_at: new Date()
+    })
+
+    const success = await database.replayQueueJob({ id: 'missing-queue-job-1' })
+    expect(success).toBe(false)
+
+    // Verify DLQ status was NOT changed to retried because transaction rolled back
+    const dlqRecord = await knexDatabase('dead_letter_jobs')
+      .where({ id: 'missing-queue-job-1' })
+      .first()
+    expect(dlqRecord?.status).toBe('failed')
+  })
+
+  it('handles concurrent replay safely so only one replay commits', async () => {
+    await database.createQueueJob({
+      id: 'concurrent-replay-1',
+      name: 'deliverActivity',
+      payload: samplePayload
+    })
+    const claimed = await database.claimQueueJob({ id: 'concurrent-replay-1' })
+    await database.failQueueJobWithDeadLetter({
+      id: 'concurrent-replay-1',
+      claimToken: claimed!.claimToken,
+      attempts: 16,
+      error: new Error('Fail once')
+    })
+
+    const results = await Promise.all([
+      database.replayQueueJob({ id: 'concurrent-replay-1' }),
+      database.replayQueueJob({ id: 'concurrent-replay-1' })
+    ])
+
+    expect(results.filter(Boolean)).toHaveLength(1)
+    expect(results.filter((r) => !r)).toHaveLength(1)
+
+    const job = await database.getQueueJobById('concurrent-replay-1')
+    expect(job?.status).toBe('pending')
+    expect(job?.attempts).toBe(0)
+
+    const dlqRecord = await knexDatabase('dead_letter_jobs')
+      .where({ id: 'concurrent-replay-1' })
+      .first()
+    expect(dlqRecord?.status).toBe('retried')
   })
 
   it('recovers stalled processing jobs when stalledTimeoutMs is passed', async () => {

--- a/lib/database/sql/queueJob.ts
+++ b/lib/database/sql/queueJob.ts
@@ -12,8 +12,11 @@ import {
   GetDueQueueJobsParams,
   QueueJob,
   QueueJobDatabase,
-  QueueJobStatus
+  QueueJobStatus,
+  ReplayQueueJobParams
 } from '@/lib/types/database/operations'
+import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 export interface SQLQueueJob {
   id: string
@@ -73,35 +76,17 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
       updated_at: currentTime
     }
 
-    await database('queue_jobs')
-      .insert(row)
-      .onConflict('id')
-      .merge({
-        name,
-        payload: JSON.stringify(params.payload),
-        attempts,
-        max_retries: maxRetries,
-        next_run_at: nextRunAt,
-        status,
-        last_error_message: lastErrorMessage,
-        last_error_stack: lastErrorStack,
-        updated_at: currentTime
-      })
+    await database('queue_jobs').insert(row).onConflict('id').ignore()
 
-    return {
-      id,
-      name,
-      payload: params.payload,
-      attempts,
-      maxRetries,
-      nextRunAt: nextRunAt.getTime(),
-      status,
-      claimToken: null,
-      lastErrorMessage,
-      lastErrorStack,
-      createdAt: currentTime.getTime(),
-      updatedAt: currentTime.getTime()
+    const persisted = await database<SQLQueueJob>('queue_jobs')
+      .where({ id })
+      .first()
+
+    if (!persisted) {
+      throw new Error(`Failed to persist or fetch queue job: ${id}`)
     }
+
+    return toQueueJob(persisted)
   },
 
   async getDueQueueJobs(params: GetDueQueueJobsParams = {}) {
@@ -366,6 +351,50 @@ export const QueueJobSQLDatabaseMixin = (database: Knex): QueueJobDatabase => ({
 
       return true
     })
+  },
+
+  async replayQueueJob({ id }: ReplayQueueJobParams): Promise<boolean> {
+    try {
+      return await database.transaction(async (trx) => {
+        const updatedDlq = await trx('dead_letter_jobs')
+          .where({ id, status: 'failed' })
+          .update({
+            status: 'retried',
+            updated_at: new Date()
+          })
+
+        if (updatedDlq === 0) {
+          return false
+        }
+
+        const updatedJob = await trx('queue_jobs')
+          .where({ id, status: 'failed' })
+          .update({
+            status: 'pending',
+            attempts: 0,
+            next_run_at: new Date(),
+            claim_token: null,
+            last_error_message: null,
+            last_error_stack: null,
+            updated_at: new Date()
+          })
+
+        if (updatedJob === 0) {
+          throw new Error(
+            `Cannot replay queue job ${id}: job not found or not in failed state in queue_jobs`
+          )
+        }
+
+        return true
+      })
+    } catch (error) {
+      logger.error({
+        err: toLoggableError(error),
+        jobId: id,
+        message: 'Failed to replay queue job'
+      })
+      return false
+    }
   },
 
   async getQueueJobById(id: string) {

--- a/lib/services/queue/database.test.ts
+++ b/lib/services/queue/database.test.ts
@@ -83,35 +83,49 @@ describe('DatabaseQueue', () => {
     expect(job?.nextRunAt).toBeGreaterThanOrEqual(before + 115 * 1000)
   })
 
-  it('re-publishes job with same ID cleanly without constraint violation (DLQ retry)', async () => {
+  it('preserves existing job state on duplicate publish and resets attempts only on explicit replay', async () => {
     const queue = new DatabaseQueue(undefined, database)
     const message: JobMessage = {
-      id: 'db-queue-dlq-retry-1',
+      id: 'db-queue-idempotent-1',
       name: 'deliverActivity',
       data: { original: true }
     }
 
     await queue.publish(message)
 
-    // Simulate job failing terminally in database
+    // Simulate job failing terminally in database with dead letter
     const claimed = await database.claimQueueJob({
-      id: 'db-queue-dlq-retry-1'
+      id: 'db-queue-idempotent-1'
     })
     expect(claimed).not.toBeNull()
-    await database.failQueueJob({
-      id: 'db-queue-dlq-retry-1',
+    await database.failQueueJobWithDeadLetter({
+      id: 'db-queue-idempotent-1',
       claimToken: claimed!.claimToken,
       attempts: 16,
       error: new Error('Terminal failure')
     })
-    const failed = await database.getQueueJobById('db-queue-dlq-retry-1')
+    const failed = await database.getQueueJobById('db-queue-idempotent-1')
     expect(failed?.status).toBe('failed')
     expect(failed?.attempts).toBe(16)
 
-    // Re-publish from DLQ retry
-    await expect(queue.publish(message)).resolves.toBeUndefined()
+    // Re-publish with duplicate ID must preserve existing failed status and attempts (idempotent enqueue)
+    await expect(
+      queue.publish({
+        ...message,
+        data: { modified: true }
+      })
+    ).resolves.toBeUndefined()
 
-    const retried = await database.getQueueJobById('db-queue-dlq-retry-1')
+    const stillFailed = await database.getQueueJobById('db-queue-idempotent-1')
+    expect(stillFailed?.status).toBe('failed')
+    expect(stillFailed?.attempts).toBe(16)
+    expect(stillFailed?.payload).toEqual(message)
+
+    // Explicit replay resets attempts and status to pending
+    const replaySuccess = await queue.replay('db-queue-idempotent-1')
+    expect(replaySuccess).toBe(true)
+
+    const retried = await database.getQueueJobById('db-queue-idempotent-1')
     expect(retried?.status).toBe('pending')
     expect(retried?.attempts).toBe(0)
   })

--- a/lib/services/queue/database.ts
+++ b/lib/services/queue/database.ts
@@ -64,4 +64,12 @@ export class DatabaseQueue implements Queue {
   async handle(message: JobMessage): Promise<void> {
     return defaultJobHandle('database')(message)
   }
+
+  async replay(id: string): Promise<boolean> {
+    const database = this.database ?? getDatabase()
+    if (!database) {
+      throw new Error('Database is not available for DatabaseQueue')
+    }
+    return database.replayQueueJob({ id })
+  }
 }

--- a/lib/services/queue/dlq/database.test.ts
+++ b/lib/services/queue/dlq/database.test.ts
@@ -1,0 +1,274 @@
+import knex, { Knex } from 'knex'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { Database } from '@/lib/database/types'
+import { DatabaseQueue } from '@/lib/services/queue/database'
+import { DatabaseDLQProvider } from '@/lib/services/queue/dlq/database'
+import { JobMessage, Queue } from '@/lib/services/queue/type'
+
+describe('DatabaseDLQProvider', () => {
+  let knexDatabase: Knex
+  let database: Database
+  let dbQueue: DatabaseQueue
+
+  beforeAll(async () => {
+    knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    database = getSQLDatabase(knexDatabase)
+    await database.migrate()
+    dbQueue = new DatabaseQueue(undefined, database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(async () => {
+    await knexDatabase('dead_letter_jobs').delete()
+    await knexDatabase('queue_jobs').delete()
+  })
+
+  const samplePayload: JobMessage = {
+    id: 'dlq-job-1',
+    name: 'deliverActivity',
+    data: { inbox: 'https://example.com/inbox' }
+  }
+
+  describe('DatabaseQueue replay routing', () => {
+    it('routes retryJob through transactional database replay', async () => {
+      const provider = new DatabaseDLQProvider(database, dbQueue)
+
+      await dbQueue.publish(samplePayload)
+      const claimed = await database.claimQueueJob({ id: 'dlq-job-1' })
+      await database.failQueueJobWithDeadLetter({
+        id: 'dlq-job-1',
+        claimToken: claimed!.claimToken,
+        attempts: 16,
+        error: new Error('Database job failed')
+      })
+
+      const dlqBefore = await database.getDeadLetterJobById('dlq-job-1')
+      expect(dlqBefore?.status).toBe('failed')
+
+      const result = await provider.retryJob('dlq-job-1')
+      expect(result.success).toBe(true)
+
+      const dlqAfter = await database.getDeadLetterJobById('dlq-job-1')
+      expect(dlqAfter?.status).toBe('retried')
+
+      const queueJobAfter = await database.getQueueJobById('dlq-job-1')
+      expect(queueJobAfter?.status).toBe('pending')
+      expect(queueJobAfter?.attempts).toBe(0)
+    })
+
+    it('returns error when retryJob is called for nonexistent or unfailed job', async () => {
+      const provider = new DatabaseDLQProvider(database, dbQueue)
+
+      const notFoundResult = await provider.retryJob('nonexistent-id')
+      expect(notFoundResult.success).toBe(false)
+      expect(notFoundResult.error).toBe('Job not found')
+    })
+
+    it('routes retryJobs through transactional database replay in batch', async () => {
+      const provider = new DatabaseDLQProvider(database, dbQueue)
+
+      for (const id of ['batch-1', 'batch-2']) {
+        const payload: JobMessage = { ...samplePayload, id }
+        await dbQueue.publish(payload)
+        const claimed = await database.claimQueueJob({ id })
+        await database.failQueueJobWithDeadLetter({
+          id,
+          claimToken: claimed!.claimToken,
+          attempts: 16,
+          error: new Error('Batch failure')
+        })
+      }
+
+      const result = await provider.retryJobs([
+        'batch-1',
+        'batch-2',
+        'nonexistent'
+      ])
+      expect(result.success).toBe(true)
+      expect(result.count).toBe(2)
+
+      const job1 = await database.getQueueJobById('batch-1')
+      const job2 = await database.getQueueJobById('batch-2')
+      expect(job1?.status).toBe('pending')
+      expect(job1?.attempts).toBe(0)
+      expect(job2?.status).toBe('pending')
+      expect(job2?.attempts).toBe(0)
+    })
+
+    it('routes retryAll through transactional database replay for all failed jobs', async () => {
+      const provider = new DatabaseDLQProvider(database, dbQueue)
+
+      for (const id of ['all-1', 'all-2', 'all-3']) {
+        const payload: JobMessage = { ...samplePayload, id }
+        await dbQueue.publish(payload)
+        const claimed = await database.claimQueueJob({ id })
+        await database.failQueueJobWithDeadLetter({
+          id,
+          claimToken: claimed!.claimToken,
+          attempts: 16,
+          error: new Error('All failure')
+        })
+      }
+
+      const result = await provider.retryAll()
+      expect(result.success).toBe(true)
+      expect(result.count).toBe(3)
+
+      for (const id of ['all-1', 'all-2', 'all-3']) {
+        const job = await database.getQueueJobById(id)
+        expect(job?.status).toBe('pending')
+        expect(job?.attempts).toBe(0)
+        const dlq = await database.getDeadLetterJobById(id)
+        expect(dlq?.status).toBe('retried')
+      }
+    })
+  })
+
+  describe('CloudTasks / broker queue replay', () => {
+    it('preserves broker republishing for non-database queues without requiring queue_jobs rows', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(undefined)
+      const mockQueue: Queue = {
+        runsInline: false,
+        publish: mockPublish,
+        handle: vi.fn()
+      }
+
+      const provider = new DatabaseDLQProvider(database, mockQueue)
+
+      // Insert directly into dead_letter_jobs (as CloudTasks DLQ does without queue_jobs table)
+      await knexDatabase('dead_letter_jobs').insert({
+        id: 'cloudtasks-job-1',
+        job_name: 'deliverActivity',
+        payload: JSON.stringify(samplePayload),
+        error_message: 'CloudTasks task deadline exceeded',
+        attempts: 5,
+        status: 'failed',
+        created_at: new Date(),
+        updated_at: new Date()
+      })
+
+      // Ensure no queue_jobs row exists
+      const queueJob = await database.getQueueJobById('cloudtasks-job-1')
+      expect(queueJob).toBeNull()
+
+      const result = await provider.retryJob('cloudtasks-job-1')
+      expect(result.success).toBe(true)
+      expect(mockPublish).toHaveBeenCalledTimes(1)
+      expect(mockPublish).toHaveBeenCalledWith(samplePayload)
+
+      const dlqAfter = await database.getDeadLetterJobById('cloudtasks-job-1')
+      expect(dlqAfter?.status).toBe('retried')
+    })
+
+    it('handles broker retryJobs in batch', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(undefined)
+      const mockQueue: Queue = {
+        runsInline: false,
+        publish: mockPublish,
+        handle: vi.fn()
+      }
+
+      const provider = new DatabaseDLQProvider(database, mockQueue)
+
+      for (const id of ['ct-batch-1', 'ct-batch-2']) {
+        await knexDatabase('dead_letter_jobs').insert({
+          id,
+          job_name: 'deliverActivity',
+          payload: JSON.stringify({ ...samplePayload, id }),
+          error_message: 'Failure',
+          attempts: 5,
+          status: 'failed',
+          created_at: new Date(),
+          updated_at: new Date()
+        })
+      }
+
+      const result = await provider.retryJobs(['ct-batch-1', 'ct-batch-2'])
+      expect(result.success).toBe(true)
+      expect(result.count).toBe(2)
+      expect(mockPublish).toHaveBeenCalledTimes(2)
+    })
+
+    it('handles broker retryAll', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(undefined)
+      const mockQueue: Queue = {
+        runsInline: false,
+        publish: mockPublish,
+        handle: vi.fn()
+      }
+
+      const provider = new DatabaseDLQProvider(database, mockQueue)
+
+      for (const id of ['ct-all-1', 'ct-all-2']) {
+        await knexDatabase('dead_letter_jobs').insert({
+          id,
+          job_name: 'deliverActivity',
+          payload: JSON.stringify({ ...samplePayload, id }),
+          error_message: 'Failure',
+          attempts: 5,
+          status: 'failed',
+          created_at: new Date(),
+          updated_at: new Date()
+        })
+      }
+
+      const result = await provider.retryAll()
+      expect(result.success).toBe(true)
+      expect(result.count).toBe(2)
+      expect(mockPublish).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Management actions', () => {
+    it('discards, deletes, and counts dead letter jobs', async () => {
+      const provider = new DatabaseDLQProvider(database, dbQueue)
+
+      await knexDatabase('dead_letter_jobs').insert({
+        id: 'manage-1',
+        job_name: 'deliverActivity',
+        payload: JSON.stringify(samplePayload),
+        error_message: 'Err',
+        attempts: 1,
+        status: 'failed',
+        created_at: new Date(),
+        updated_at: new Date()
+      })
+
+      const listBefore = await provider.getJobs()
+      expect(listBefore.total).toBe(1)
+      expect(listBefore.counts.failed).toBe(1)
+
+      const discardResult = await provider.discardJob('manage-1')
+      expect(discardResult.success).toBe(true)
+
+      const listAfterDiscard = await provider.getJobs()
+      expect(listAfterDiscard.counts.discarded).toBe(1)
+
+      const clearResult = await provider.clearDiscarded()
+      expect(clearResult.success).toBe(true)
+      expect(clearResult.count).toBe(1)
+
+      const listAfterClear = await provider.getJobs()
+      expect(listAfterClear.total).toBe(0)
+    })
+  })
+})

--- a/lib/services/queue/dlq/database.ts
+++ b/lib/services/queue/dlq/database.ts
@@ -1,6 +1,10 @@
 import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
 import { getQueue } from '@/lib/services/queue'
+import { DatabaseQueue } from '@/lib/services/queue/database'
+import { Queue } from '@/lib/services/queue/type'
 import { logger } from '@/lib/utils/logger'
+import { toLoggableError } from '@/lib/utils/toLoggableError'
 
 import {
   DLQActionResult,
@@ -13,12 +17,24 @@ import {
 export class DatabaseDLQProvider implements DLQProvider {
   readonly type = 'database' as const
 
+  private database?: Database
+  private queue?: Queue
+
+  constructor(database?: Database, queue?: Queue) {
+    this.database = database
+    this.queue = queue
+  }
+
   private getDatabase() {
-    const database = getDatabase()
+    const database = this.database ?? getDatabase()
     if (!database) {
       throw new Error('Database is not initialized')
     }
     return database
+  }
+
+  private getQueue(): Queue {
+    return this.queue ?? getQueue()
   }
 
   async getJobs(params?: GetDLQJobsParams): Promise<GetDLQJobsResult> {
@@ -63,6 +79,20 @@ export class DatabaseDLQProvider implements DLQProvider {
 
   async retryJob(id: string): Promise<DLQActionResult> {
     const database = this.getDatabase()
+    const queue = this.getQueue()
+
+    if (queue instanceof DatabaseQueue) {
+      const success = await database.replayQueueJob({ id })
+      if (!success) {
+        logger.warn(
+          { id },
+          'Cannot replay dead letter job: not found in database or not failed'
+        )
+        return { success: false, error: 'Job not found' }
+      }
+      return { success: true }
+    }
+
     const job = await database.getDeadLetterJobById(id)
     if (!job) {
       logger.warn({ id }, 'Cannot retry dead letter job: not found in database')
@@ -70,12 +100,12 @@ export class DatabaseDLQProvider implements DLQProvider {
     }
 
     try {
-      await getQueue().publish(job.payload)
+      await queue.publish(job.payload)
       await database.updateDeadLetterJobStatus(id, 'retried')
       return { success: true }
     } catch (error) {
       logger.error({
-        err: error,
+        err: toLoggableError(error),
         id,
         message: 'Failed to re-dispatch dead letter job'
       })
@@ -91,12 +121,23 @@ export class DatabaseDLQProvider implements DLQProvider {
 
   async retryAll(): Promise<DLQActionResult> {
     const database = this.getDatabase()
+    const queue = this.getQueue()
     const failedJobs = await database.getDeadLetterJobs({
       status: 'failed',
       limit: 1000
     })
 
-    const queue = getQueue()
+    if (queue instanceof DatabaseQueue) {
+      let retriedCount = 0
+      for (const job of failedJobs) {
+        const success = await database.replayQueueJob({ id: job.id })
+        if (success) {
+          retriedCount++
+        }
+      }
+      return { success: true, count: retriedCount }
+    }
+
     let retriedCount = 0
     for (const job of failedJobs) {
       try {
@@ -105,7 +146,7 @@ export class DatabaseDLQProvider implements DLQProvider {
         retriedCount++
       } catch (error) {
         logger.error({
-          err: error,
+          err: toLoggableError(error),
           jobId: job.id,
           message: 'Failed to retry dead letter job in batch'
         })
@@ -129,9 +170,20 @@ export class DatabaseDLQProvider implements DLQProvider {
 
   async retryJobs(ids: string[]): Promise<DLQActionResult> {
     const database = this.getDatabase()
-    const queue = getQueue()
-    let retriedCount = 0
+    const queue = this.getQueue()
 
+    if (queue instanceof DatabaseQueue) {
+      let retriedCount = 0
+      for (const id of ids) {
+        const success = await database.replayQueueJob({ id })
+        if (success) {
+          retriedCount++
+        }
+      }
+      return { success: true, count: retriedCount }
+    }
+
+    let retriedCount = 0
     for (const id of ids) {
       const job = await database.getDeadLetterJobById(id)
       if (!job) continue
@@ -142,7 +194,7 @@ export class DatabaseDLQProvider implements DLQProvider {
         retriedCount++
       } catch (error) {
         logger.error({
-          err: error,
+          err: toLoggableError(error),
           jobId: id,
           message: 'Failed to retry dead letter job'
         })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -4329,6 +4329,10 @@ export interface FailQueueJobWithDeadLetterParams {
   error?: Error | unknown
 }
 
+export interface ReplayQueueJobParams {
+  id: string
+}
+
 export interface QueueJobDatabase {
   createQueueJob(params: CreateQueueJobParams): Promise<QueueJob>
   getDueQueueJobs(params?: GetDueQueueJobsParams): Promise<QueueJob[]>
@@ -4350,6 +4354,7 @@ export interface QueueJobDatabase {
   failQueueJobWithDeadLetter(
     params: FailQueueJobWithDeadLetterParams
   ): Promise<boolean>
+  replayQueueJob(params: ReplayQueueJobParams): Promise<boolean>
   getQueueJobById(id: string): Promise<QueueJob | null>
   deleteQueueJob(id: string): Promise<boolean>
   countQueueJobs(params?: { status?: QueueJobStatus }): Promise<number>


### PR DESCRIPTION
Make normal queue enqueue idempotent with insert-if-absent and make failed database job replay explicit.

- Updated `createQueueJob` in `lib/database/sql/queueJob.ts` to use `.onConflict('id').ignore()` and return the actual persisted row, preserving payload, attempts, schedule, state, and claimToken across all job states on duplicate enqueue.
- Added transactional `replayQueueJob` operation to `QueueJobSQLDatabaseMixin` and `QueueJobDatabase` interface that resets attempts, schedule, errors, and claim ownership in `queue_jobs` while atomically marking the dead-letter record as `retried` only when that reset commits.
- Added `replay(id)` method to `DatabaseQueue`.
- Updated `DatabaseDLQProvider` in `lib/services/queue/dlq/database.ts` to route single and batch DLQ retries (`retryJob`, `retryJobs`, `retryAll`) through transactional database replay for `DatabaseQueue`, while preserving broker republishing for non-database queues (e.g. CloudTasks).
- Added comprehensive companion tests covering duplicate publication in all states, transactional replay, rollback on failure, concurrent replay, and CloudTasks broker republishing.