### PR TITLE
refactor: apply status-array helpers to favorites and bookmarks

### DIFF
--- a/app/(timeline)/bookmarks/BookmarksTimeline.test.tsx
+++ b/app/(timeline)/bookmarks/BookmarksTimeline.test.tsx
@@ -5,7 +5,11 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { getBookmarks, undoBookmarkStatus } from '@/lib/client'
-import { StatusNote, StatusType } from '@/lib/types/domain/status'
+import {
+  StatusAnnounce,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 
 import { BookmarksTimeline } from './BookmarksTimeline'
 
@@ -74,6 +78,27 @@ const bookmarkedStatus: StatusNote = {
   totalShares: 0,
   attachments: [],
   tags: []
+}
+
+const boostActor = {
+  ...actor,
+  id: 'https://activities.local/users/booster',
+  username: 'booster',
+  name: 'Booster'
+}
+
+const boostedBookmarkedStatus: StatusAnnounce = {
+  id: 'https://activities.local/users/booster/statuses/boost-1',
+  actorId: boostActor.id,
+  actor: boostActor,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Announce,
+  originalStatus: bookmarkedStatus
 }
 
 describe('BookmarksTimeline', () => {
@@ -206,6 +231,87 @@ describe('BookmarksTimeline', () => {
     await screen.findByText('Bookmarked post')
     await waitFor(() => {
       expect(intersectionObserverDisconnect).toHaveBeenCalled()
+    })
+  })
+
+  it('removes a boosted post when unbookmarking it', async () => {
+    render(
+      <BookmarksTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[boostedBookmarkedStatus]}
+        initialNextMaxBookmarkId={null}
+      />
+    )
+
+    expect(screen.getByText('Bookmarked post')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove bookmark' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bookmarked post')).not.toBeInTheDocument()
+    })
+    expect(undoBookmarkStatus).toHaveBeenCalledWith({
+      statusId: bookmarkedStatus.id
+    })
+    expect(screen.getByText('No bookmarks yet')).toBeInTheDocument()
+  })
+
+  it('removes both direct and boosted representations when post is unbookmarked', async () => {
+    render(
+      <BookmarksTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[bookmarkedStatus, boostedBookmarkedStatus]}
+        initialNextMaxBookmarkId={null}
+      />
+    )
+
+    const unbookmarkButtons = screen.getAllByRole('button', {
+      name: 'Remove bookmark'
+    })
+    expect(unbookmarkButtons).toHaveLength(2)
+
+    fireEvent.click(unbookmarkButtons[0])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bookmarked post')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('No bookmarks yet')).toBeInTheDocument()
+  })
+
+  it('preserves server-provided cursor for next-page loading after a post is removed', async () => {
+    ;(getBookmarks as jest.Mock).mockResolvedValueOnce({
+      statuses: [
+        { ...bookmarkedStatus, id: 'next-bm-1', text: 'Second page post' }
+      ],
+      nextMaxBookmarkId: null,
+      prevMinBookmarkId: 'cursor-1'
+    })
+
+    render(
+      <BookmarksTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[bookmarkedStatus]}
+        initialNextMaxBookmarkId="cursor-1"
+      />
+    )
+
+    // Remove the post by unbookmarking
+    fireEvent.click(screen.getByRole('button', { name: 'Remove bookmark' }))
+    await waitFor(() => {
+      expect(screen.queryByText('Bookmarked post')).not.toBeInTheDocument()
+    })
+
+    // Click load more - must use cursor-1, not reconstructed status ID
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await screen.findByText('Second page post')
+    expect(getBookmarks).toHaveBeenCalledWith({
+      maxBookmarkId: 'cursor-1'
     })
   })
 })

--- a/app/(timeline)/bookmarks/BookmarksTimeline.tsx
+++ b/app/(timeline)/bookmarks/BookmarksTimeline.tsx
@@ -5,18 +5,17 @@ import { FC, useCallback, useRef, useState } from 'react'
 import { getBookmarks } from '@/lib/client'
 import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
+import {
+  removeOriginalStatus,
+  updateMatchingStatus
+} from '@/lib/components/posts/statusArray'
 import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import {
-  Status,
-  StatusNote,
-  StatusPoll,
-  StatusType,
-  getOriginalStatus
-} from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 const MAX_EMPTY_BOOKMARK_CONTINUATIONS = 5
 
@@ -48,33 +47,66 @@ export const BookmarksTimeline: FC<BookmarksTimelineProps> = ({
   const isLoadingRef = useRef<boolean>(false)
   const lastBookmarkIdRef = useRef<string | null>(initialNextMaxBookmarkId)
 
-  const removeStatus = (status: Status) => {
+  const onPostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.filter((item) => item.id !== status.id)
+      removeOriginalStatus(previousStatuses, status.id)
     )
-  }
+  }, [])
 
-  const updateStatus = (status: Status) => {
+  const onPostUpdated = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.map((item) => (item.id === status.id ? status : item))
+      updateMatchingStatus(
+        previousStatuses,
+        status.id,
+        () => status as StatusNote | StatusPoll
+      )
     )
-  }
+  }, [])
 
-  const onBookmarkChanged = (
-    status: StatusNote | StatusPoll,
-    isBookmarked: boolean
-  ) => {
-    if (isBookmarked) return
-    setCurrentStatuses((previousStatuses) =>
-      previousStatuses.filter((item) => {
-        const actualStatus =
-          item.type === StatusType.enum.Announce
-            ? getOriginalStatus(item)
-            : item
-        return actualStatus.id !== status.id
-      })
-    )
-  }
+  const onBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      if (!isBookmarked) {
+        setCurrentStatuses((previousStatuses) =>
+          removeOriginalStatus(previousStatuses, status.id)
+        )
+      } else {
+        setCurrentStatuses((previousStatuses) =>
+          updateMatchingStatus(previousStatuses, status.id, (target) => ({
+            ...target,
+            isActorBookmarked: isBookmarked
+          }))
+        )
+      }
+    },
+    []
+  )
+
+  const onLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorLiked: isLiked,
+          totalLikes: isLiked
+            ? target.totalLikes + 1
+            : Math.max(0, target.totalLikes - 1)
+        }))
+      )
+    },
+    []
+  )
+
+  const onReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     let nextBookmarkId = lastBookmarkIdRef.current
@@ -146,9 +178,11 @@ export const BookmarksTimeline: FC<BookmarksTimelineProps> = ({
           showActions
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
-          onPostDeleted={removeStatus}
-          onPostUpdated={updateStatus}
+          onPostDeleted={onPostDeleted}
+          onPostUpdated={onPostUpdated}
           onBookmarkChanged={onBookmarkChanged}
+          onLikeChanged={onLikeChanged}
+          onReactionsChanged={onReactionsChanged}
         />
       ) : (
         <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">

--- a/app/(timeline)/favorites/FavoritesTimeline.test.tsx
+++ b/app/(timeline)/favorites/FavoritesTimeline.test.tsx
@@ -5,7 +5,11 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { getFavourites, undoLikeStatus } from '@/lib/client'
-import { StatusNote, StatusType } from '@/lib/types/domain/status'
+import {
+  StatusAnnounce,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 
 import { FavoritesTimeline } from './FavoritesTimeline'
 
@@ -74,6 +78,27 @@ const favouritedStatus: StatusNote = {
   totalShares: 0,
   attachments: [],
   tags: []
+}
+
+const boostActor = {
+  ...actor,
+  id: 'https://activities.local/users/booster',
+  username: 'booster',
+  name: 'Booster'
+}
+
+const boostedFavouritedStatus: StatusAnnounce = {
+  id: 'https://activities.local/users/booster/statuses/boost-1',
+  actorId: boostActor.id,
+  actor: boostActor,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Announce,
+  originalStatus: favouritedStatus
 }
 
 describe('FavoritesTimeline', () => {
@@ -206,6 +231,85 @@ describe('FavoritesTimeline', () => {
     await screen.findByText('Favourited post')
     await waitFor(() => {
       expect(intersectionObserverDisconnect).toHaveBeenCalled()
+    })
+  })
+
+  it('removes a boosted post when unliking it', async () => {
+    render(
+      <FavoritesTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[boostedFavouritedStatus]}
+        initialNextMaxFavouriteId={null}
+      />
+    )
+
+    expect(screen.getByText('Favourited post')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Unlike/ }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Favourited post')).not.toBeInTheDocument()
+    })
+    expect(undoLikeStatus).toHaveBeenCalledWith({
+      statusId: favouritedStatus.id
+    })
+    expect(screen.getByText('No favorites yet')).toBeInTheDocument()
+  })
+
+  it('removes both direct and boosted representations when post is unfavourited', async () => {
+    render(
+      <FavoritesTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[favouritedStatus, boostedFavouritedStatus]}
+        initialNextMaxFavouriteId={null}
+      />
+    )
+
+    const unlikeButtons = screen.getAllByRole('button', { name: /Unlike/ })
+    expect(unlikeButtons).toHaveLength(2)
+
+    fireEvent.click(unlikeButtons[0])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Favourited post')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('No favorites yet')).toBeInTheDocument()
+  })
+
+  it('preserves server-provided cursor for next-page loading after a post is removed', async () => {
+    ;(getFavourites as jest.Mock).mockResolvedValueOnce({
+      statuses: [
+        { ...favouritedStatus, id: 'next-fav-1', text: 'Second page post' }
+      ],
+      nextMaxFavouriteId: null,
+      prevMinFavouriteId: 'cursor-1'
+    })
+
+    render(
+      <FavoritesTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[favouritedStatus]}
+        initialNextMaxFavouriteId="cursor-1"
+      />
+    )
+
+    // Remove the post by unliking
+    fireEvent.click(screen.getByRole('button', { name: /Unlike/ }))
+    await waitFor(() => {
+      expect(screen.queryByText('Favourited post')).not.toBeInTheDocument()
+    })
+
+    // Click load more - must use cursor-1, not reconstructed status ID
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await screen.findByText('Second page post')
+    expect(getFavourites).toHaveBeenCalledWith({
+      maxFavouriteId: 'cursor-1'
     })
   })
 })

--- a/app/(timeline)/favorites/FavoritesTimeline.tsx
+++ b/app/(timeline)/favorites/FavoritesTimeline.tsx
@@ -5,18 +5,16 @@ import { FC, useCallback, useRef, useState } from 'react'
 import { getFavourites } from '@/lib/client'
 import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
+import {
+  removeOriginalStatus,
+  updateMatchingStatus
+} from '@/lib/components/posts/statusArray'
 import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import {
-  Status,
-  StatusNote,
-  StatusPoll,
-  StatusType,
-  getOriginalStatus
-} from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 const MAX_EMPTY_FAVOURITE_CONTINUATIONS = 5
@@ -49,46 +47,69 @@ export const FavoritesTimeline: FC<FavoritesTimelineProps> = ({
   const isLoadingRef = useRef<boolean>(false)
   const lastFavouriteIdRef = useRef<string | null>(initialNextMaxFavouriteId)
 
-  const removeStatus = (status: Status) => {
+  const onPostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.filter((item) => {
-        const actualStatus =
-          item.type === StatusType.enum.Announce
-            ? getOriginalStatus(item)
-            : item
-        return actualStatus.id !== status.id
-      })
+      removeOriginalStatus(previousStatuses, status.id)
     )
-  }
+  }, [])
 
-  const updateStatus = (status: Status) => {
-    // Announce-aware (like removeStatus): also refreshes a boost row whose
+  const onPostUpdated = useCallback((status: Status) => {
+    // Announce-aware (like onPostDeleted): also refreshes a boost row whose
     // original was the edited post. An edited status is always a note/poll.
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.map((item) => {
-        if (item.type === StatusType.enum.Announce) {
-          return item.originalStatus.id === status.id
-            ? { ...item, originalStatus: status as StatusNote | StatusPoll }
-            : item
-        }
-        return item.id === status.id ? status : item
-      })
+      updateMatchingStatus(
+        previousStatuses,
+        status.id,
+        () => status as StatusNote | StatusPoll
+      )
     )
-  }
+  }, [])
 
-  const onLikeChanged = (status: StatusNote | StatusPoll, isLiked: boolean) => {
-    if (!isLiked) removeStatus(status)
-  }
+  const onLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      if (!isLiked) {
+        setCurrentStatuses((previousStatuses) =>
+          removeOriginalStatus(previousStatuses, status.id)
+        )
+      } else {
+        setCurrentStatuses((previousStatuses) =>
+          updateMatchingStatus(previousStatuses, status.id, (target) => ({
+            ...target,
+            isActorLiked: isLiked,
+            totalLikes: target.totalLikes + 1
+          }))
+        )
+      }
+    },
+    []
+  )
+
+  const onBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorBookmarked: isBookmarked
+        }))
+      )
+    },
+    []
+  )
 
   // Keep this page's copy in step with a reaction the viewer just added, so a
   // later edit (which replaces the status object) doesn't re-render the reaction
   // row from a stale `reactions` prop and drop the chip.
-  const onReactionsChanged = (
-    status: StatusNote | StatusPoll,
-    reactions: StatusReaction[]
-  ) => {
-    updateStatus({ ...status, reactions })
-  }
+  const onReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     let nextFavouriteId = lastFavouriteIdRef.current
@@ -157,9 +178,10 @@ export const FavoritesTimeline: FC<FavoritesTimelineProps> = ({
           showActions
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
-          onPostDeleted={removeStatus}
-          onPostUpdated={updateStatus}
+          onPostDeleted={onPostDeleted}
+          onPostUpdated={onPostUpdated}
           onLikeChanged={onLikeChanged}
+          onBookmarkChanged={onBookmarkChanged}
           onReactionsChanged={onReactionsChanged}
         />
       ) : (


### PR DESCRIPTION
Apply `removeOriginalStatus` and `updateMatchingStatus` from `@/lib/components/posts/statusArray` to `FavoritesTimeline.tsx` and `BookmarksTimeline.tsx`.

- Ensures announce-aware status deletion and mutation consistency across timelines
- Handles likes, bookmarks, and emoji reactions updates properly in both timelines
- Preserves server-provided cursor for cursor-based pagination even if statuses are removed
- Adds full interaction handler tests to `FavoritesTimeline.test.tsx` and `BookmarksTimeline.test.tsx`