### PR TITLE
Bump version to v1.161.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.10",
+  "version": "1.161.11",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.11.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.10`
- Base main SHA: `be111d36681766716c7cc6642249fbe7e6cf1e41`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
