### PR TITLE
refactor: align follow-page loading headers with loaded pages

### DIFF
--- a/app/(timeline)/[actor]/FollowListLoadingSkeleton.test.tsx
+++ b/app/(timeline)/[actor]/FollowListLoadingSkeleton.test.tsx
@@ -19,12 +19,12 @@ describe('FollowListLoadingSkeleton', () => {
   )
 
   it('renders every placeholder with the shimmer skeleton utility', () => {
-    // jsdom paints no CSS so classes are the observable; every leaf <div> in
-    // this skeleton is a placeholder (containers always hold further divs).
+    // jsdom paints no CSS so classes are the observable; every leaf in
+    // this skeleton is a placeholder (containers always hold further elements).
     const { container } = render(
       <FollowListLoadingSkeleton label="Loading followers" />
     )
-    const leaves = Array.from(container.querySelectorAll('div')).filter(
+    const leaves = Array.from(container.querySelectorAll('div, span')).filter(
       (el) => el.children.length === 0
     )
     expect(leaves.length).toBeGreaterThan(0)
@@ -46,5 +46,74 @@ describe('FollowListLoadingSkeleton', () => {
     )
     expect(anonHeader).toBeInTheDocument()
     expect(anonHeader).toHaveClass('hidden')
+  })
+
+  it('composes PageHeader with matching font, icon, and padding metrics for signed-in shell', () => {
+    const { container } = render(
+      <FollowListLoadingSkeleton label="Loading followers" route="followers" />
+    )
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+
+    // PageHeader container properties
+    const innerContainer = stickyHeader?.querySelector('.max-w-content')
+    expect(innerContainer).toBeInTheDocument()
+    expect(innerContainer).toHaveClass('px-4', 'py-4')
+
+    // Title row mirrors loaded PageHeader: h1 text-xl with flex items-center gap-2
+    const h1 = stickyHeader?.querySelector('h1')
+    expect(h1).toHaveClass('text-xl', 'font-semibold', 'tracking-tight')
+
+    const titleFlex = h1?.querySelector('.flex')
+    expect(titleFlex).toHaveClass('items-center', 'gap-2')
+
+    // Back button skeleton in title flex matches ArrowLeft (size-5)
+    const backButtonSkeleton = titleFlex?.querySelector('.size-5')
+    expect(backButtonSkeleton).toBeInTheDocument()
+    expect(backButtonSkeleton).toHaveClass('skeleton', 'rounded-md')
+
+    // Title text skeleton matches h1 line height (28px -> h-7)
+    const titleTextSkeleton = titleFlex?.querySelector('.h-7')
+    expect(titleTextSkeleton).toBeInTheDocument()
+    expect(titleTextSkeleton).toHaveClass('skeleton', 'w-28', 'rounded-md')
+
+    // Description skeleton under h1 matches text-xs line height (16px -> h-4)
+    const descWrapper = stickyHeader?.querySelector('.mt-0\\.5')
+    expect(descWrapper).toHaveClass('text-xs', 'text-muted-foreground')
+    const descSkeleton = descWrapper?.querySelector('.skeleton')
+    expect(descSkeleton).toHaveClass('h-4', 'w-24', 'rounded')
+
+    // Root element preserves data-route
+    expect(screen.getByLabelText('Loading followers')).toHaveAttribute(
+      'data-route',
+      'followers'
+    )
+  })
+
+  it('renders public shell header matching loaded non-sticky geometry', () => {
+    const { container } = render(
+      <FollowListLoadingSkeleton label="Loading following" route="following" />
+    )
+    const anonHeader = container.querySelector(
+      '.group-data-\\[shell\\=public\\]\\/shell\\:flex'
+    )
+    expect(anonHeader).toBeInTheDocument()
+    expect(anonHeader).toHaveClass('items-start', 'gap-2')
+
+    // Back icon skeleton matches ArrowLeft with mt-0.5 and size-5
+    const backIcon = anonHeader?.querySelector('.size-5')
+    expect(backIcon).toHaveClass('skeleton', 'mt-0.5', 'shrink-0', 'rounded-md')
+
+    // Text column contains h-7 title and h-4 description inside space-y-1
+    const titleSkeleton = anonHeader?.querySelector('.h-7')
+    expect(titleSkeleton).toHaveClass('skeleton', 'w-28', 'rounded-md')
+
+    const descSkeleton = anonHeader?.querySelector('.h-4')
+    expect(descSkeleton).toHaveClass('skeleton', 'w-24', 'rounded')
+
+    expect(screen.getByLabelText('Loading following')).toHaveAttribute(
+      'data-route',
+      'following'
+    )
   })
 })

--- a/app/(timeline)/[actor]/FollowListLoadingSkeleton.tsx
+++ b/app/(timeline)/[actor]/FollowListLoadingSkeleton.tsx
@@ -1,12 +1,10 @@
-import { CSSProperties, FC } from 'react'
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
 
 interface FollowListLoadingSkeletonProps {
   label: string
-}
-
-const breakoutStyle: CSSProperties = {
-  marginLeft: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)',
-  marginRight: 'calc(-50vw + 50% + var(--sidebar-w, 0px) / 2)'
+  route?: 'followers' | 'following'
 }
 
 /**
@@ -19,32 +17,34 @@ const breakoutStyle: CSSProperties = {
  * loading state.
  */
 export const FollowListLoadingSkeleton: FC<FollowListLoadingSkeletonProps> = ({
-  label
+  label,
+  route
 }) => {
   return (
-    <div aria-busy="true" aria-label={label} className="space-y-6">
-      {/* Signed-in header: mirrors PageHeader (sticky top-0, breakout, py-4) */}
-      <div
-        className="sticky top-0 z-20 border-b bg-background/85 backdrop-blur group-data-[shell=public]/shell:hidden"
-        style={breakoutStyle}
-      >
-        <div className="mx-auto max-w-content px-4 py-4">
-          <div className="flex items-start gap-2">
-            <div className="skeleton mt-0.5 size-5 shrink-0 rounded-md" />
-            <div className="space-y-1">
-              <div className="skeleton h-6 w-28 rounded-md" />
-              <div className="skeleton h-3.5 w-24 rounded" />
-            </div>
-          </div>
-        </div>
-      </div>
+    <div
+      aria-busy="true"
+      aria-label={label}
+      data-route={route}
+      className="space-y-6"
+    >
+      {/* Signed-in header: reuses PageHeader directly for pixel-exact alignment */}
+      <PageHeader
+        className="group-data-[shell=public]/shell:hidden"
+        title={
+          <span className="flex items-center gap-2">
+            <span className="skeleton size-5 shrink-0 rounded-md" />
+            <span className="skeleton block h-7 w-28 rounded-md" />
+          </span>
+        }
+        description={<span className="skeleton block h-4 w-24 rounded" />}
+      />
 
       {/* Anonymous header: mirrors the non-sticky header inside PublicShell */}
       <div className="hidden items-start gap-2 group-data-[shell=public]/shell:flex">
         <div className="skeleton mt-0.5 size-5 shrink-0 rounded-md" />
         <div className="space-y-1">
-          <div className="skeleton h-6 w-28 rounded-md" />
-          <div className="skeleton h-3.5 w-24 rounded" />
+          <div className="skeleton h-7 w-28 rounded-md" />
+          <div className="skeleton h-4 w-24 rounded" />
         </div>
       </div>
 

--- a/app/(timeline)/[actor]/followers/loading.test.tsx
+++ b/app/(timeline)/[actor]/followers/loading.test.tsx
@@ -22,17 +22,45 @@ describe('[actor]/followers loading', () => {
   })
 
   it('renders every placeholder with the shimmer skeleton utility', () => {
-    // jsdom paints no CSS so classes are the observable; every leaf <div> in
-    // this skeleton is a placeholder (containers always hold further divs),
+    // jsdom paints no CSS so classes are the observable; every leaf in
+    // this skeleton is a placeholder (containers always hold further elements),
     // and a bare `length > 0` missed both a partial strip and a future
     // unstyled row; the `.skeleton` definition itself is guarded by
     // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-    const leaves = Array.from(container.querySelectorAll('div')).filter(
+    const leaves = Array.from(container.querySelectorAll('div, span')).filter(
       (el) => el.children.length === 0
     )
     expect(leaves.length).toBeGreaterThan(0)
     leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('reuses PageHeader with matching header metrics', () => {
+    const { container } = render(<Loading />)
+
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader).toHaveClass('group-data-[shell=public]/shell:hidden')
+    expect(stickyHeader?.querySelector('.max-w-content')).toBeInTheDocument()
+
+    // Title row mirrors loaded PageHeader font metrics (h1 text-xl 28px -> h-7, back icon -> size-5)
+    expect(stickyHeader?.querySelector('h1 .size-5')).toHaveClass('skeleton')
+    expect(stickyHeader?.querySelector('h1 .h-7')).toHaveClass('skeleton')
+    expect(stickyHeader?.querySelector('.mt-0\\.5 .skeleton')).toHaveClass(
+      'h-4'
+    )
+
+    // Public shell alternative header exists
+    expect(
+      container.querySelector('.group-data-\\[shell\\=public\\]\\/shell\\:flex')
+    ).toBeInTheDocument()
+
+    // Has route metadata
+    expect(screen.getByLabelText('Loading followers')).toHaveAttribute(
+      'data-route',
+      'followers'
+    )
   })
 })

--- a/app/(timeline)/[actor]/followers/loading.tsx
+++ b/app/(timeline)/[actor]/followers/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { FollowListLoadingSkeleton } from '@/app/(timeline)/[actor]/FollowListLoadingSkeleton'
 
 export const FollowersLoading: FC = () => (
-  <FollowListLoadingSkeleton label="Loading followers" />
+  <FollowListLoadingSkeleton label="Loading followers" route="followers" />
 )
 
 export default FollowersLoading

--- a/app/(timeline)/[actor]/following/loading.test.tsx
+++ b/app/(timeline)/[actor]/following/loading.test.tsx
@@ -22,17 +22,45 @@ describe('[actor]/following loading', () => {
   })
 
   it('renders every placeholder with the shimmer skeleton utility', () => {
-    // jsdom paints no CSS so classes are the observable; every leaf <div> in
-    // this skeleton is a placeholder (containers always hold further divs),
+    // jsdom paints no CSS so classes are the observable; every leaf in
+    // this skeleton is a placeholder (containers always hold further elements),
     // and a bare `length > 0` missed both a partial strip and a future
     // unstyled row; the `.skeleton` definition itself is guarded by
     // app/globals.skeleton.test.ts.
     const { container } = render(<Loading />)
-    const leaves = Array.from(container.querySelectorAll('div')).filter(
+    const leaves = Array.from(container.querySelectorAll('div, span')).filter(
       (el) => el.children.length === 0
     )
     expect(leaves.length).toBeGreaterThan(0)
     leaves.forEach((el) => expect(el).toHaveClass('skeleton'))
     expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('reuses PageHeader with matching header metrics', () => {
+    const { container } = render(<Loading />)
+
+    const stickyHeader = container.querySelector('.sticky')
+    expect(stickyHeader).toBeInTheDocument()
+    expect(stickyHeader).toHaveClass('top-0')
+    expect(stickyHeader).toHaveClass('group-data-[shell=public]/shell:hidden')
+    expect(stickyHeader?.querySelector('.max-w-content')).toBeInTheDocument()
+
+    // Title row mirrors loaded PageHeader font metrics (h1 text-xl 28px -> h-7, back icon -> size-5)
+    expect(stickyHeader?.querySelector('h1 .size-5')).toHaveClass('skeleton')
+    expect(stickyHeader?.querySelector('h1 .h-7')).toHaveClass('skeleton')
+    expect(stickyHeader?.querySelector('.mt-0\\.5 .skeleton')).toHaveClass(
+      'h-4'
+    )
+
+    // Public shell alternative header exists
+    expect(
+      container.querySelector('.group-data-\\[shell\\=public\\]\\/shell\\:flex')
+    ).toBeInTheDocument()
+
+    // Has route metadata
+    expect(screen.getByLabelText('Loading following')).toHaveAttribute(
+      'data-route',
+      'following'
+    )
   })
 })

--- a/app/(timeline)/[actor]/following/loading.tsx
+++ b/app/(timeline)/[actor]/following/loading.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { FollowListLoadingSkeleton } from '@/app/(timeline)/[actor]/FollowListLoadingSkeleton'
 
 export const FollowingLoading: FC = () => (
-  <FollowListLoadingSkeleton label="Loading following" />
+  <FollowListLoadingSkeleton label="Loading following" route="following" />
 )
 
 export default FollowingLoading


### PR DESCRIPTION
Reuse `PageHeader` in `FollowListLoadingSkeleton` to eliminate duplicated header geometry and align follow-page loading states pixel-for-pixel with loaded pages.

- Replaces hand-rolled sticky header div in `FollowListLoadingSkeleton` with `PageHeader` composition
- Matches font height (`h-7` for 28px text-xl line height), icon size (`size-5`), and description (`h-4` for 16px text-xs)
- Preserves the public-shell loading variant and its visibility rules (`group-data-[shell=public]/shell:hidden` vs `group-data-[shell=public]/shell:flex`)
- Enhances companion tests across `FollowListLoadingSkeleton.test.tsx`, `followers/loading.test.tsx`, and `following/loading.test.tsx`