### PR TITLE
Bump version to v1.161.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.11",
+  "version": "1.161.12",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.12.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.11`
- Base main SHA: `91903397865fcef808e359ab676d83d4eb03ad15`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
