### PR TITLE
refactor: share media-save coordination across storage drivers

### DIFF
--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -39,10 +39,8 @@ import {
   getImageOutputFormatDetail
 } from '@/lib/services/medias/imageOutputFormat'
 import { getMediaFileUrl } from '@/lib/services/medias/mediaFileUrl'
-import {
-  checkQuotaAvailable,
-  getUploadQuotaReservation
-} from '@/lib/services/medias/quota'
+import { checkQuotaAvailable } from '@/lib/services/medias/quota'
+import { saveMediaFile } from '@/lib/services/medias/saveMediaFile'
 import { readValidThumbnail } from '@/lib/services/medias/thumbnailInput'
 import {
   ImageRenditionOutput,
@@ -465,99 +463,24 @@ export class S3FileStorage implements MediaStorage {
   }
 
   async saveFile(actor: Actor, media: MediaSchema) {
-    const { file } = media
     const currentTime = Date.now()
-    if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
-      return null
-    }
-    // Read and validate the thumbnail before anything is uploaded, so unusable
-    // bytes cannot leave a stored original behind.
-    const thumbnailBuffer = media.thumbnail
-      ? await readValidThumbnail(media.thumbnail)
-      : null
-
-    // Check quota before saving; see `getUploadQuotaReservation` for why the
-    // thumbnail's share of it is an estimate.
-    const quotaCheck = await checkQuotaAvailable(
-      this._database,
+    return saveMediaFile({
+      database: this._database,
+      host: this._host,
       actor,
-      getUploadQuotaReservation(media)
-    )
-    if (!quotaCheck.available) {
-      throw new MediaValidationError(
-        `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
-      )
-    }
-
-    const { path, metaData, previewImage, blurhash, focus } =
-      file.type.startsWith('video')
-        ? await this._uploadVideoToS3(currentTime, file, {
-            manualFocus: media.focus
-          })
-        : await this._uploadImageToS3(currentTime, file, {
-            manualFocus: media.focus
-          })
-    // Same precedence as the local driver: a caller-supplied thumbnail wins, and
-    // a video otherwise falls back to the frame extracted from it. `previewImage`
-    // is null for an image upload — a video whose frame cannot be decoded
-    // rejects rather than resolving null.
-    const thumbnailSource = thumbnailBuffer ?? previewImage
-    let thumbnail
-    try {
-      thumbnail = thumbnailSource
-        ? await this._uploadImageBufferToS3(currentTime, thumbnailSource, {
+      media,
+      driver: {
+        saveVideoFile: (file, options) =>
+          this._uploadVideoToS3(currentTime, file, options),
+        saveImageFile: (file, options) =>
+          this._uploadImageToS3(currentTime, file, options),
+        saveThumbnailBuffer: (buffer) =>
+          this._uploadImageBufferToS3(currentTime, buffer, {
             isThumbnail: true
-          })
-        : null
-    } catch (error) {
-      // The thumbnail's bytes were validated above, so this is a storage fault
-      // of ours: keep the error — it has to stay a logged 500, not a 422 the
-      // client will not retry — but put the original back first.
-      await this._reclaimStored(path)
-      throw error
-    }
-
-    let storedMedia
-    try {
-      storedMedia = await this._database.createMedia({
-        actorId: actor.id,
-        original: {
-          path,
-          bytes: file.size,
-          mimeType: file.type,
-          metaData: {
-            width: metaData.width ?? 0,
-            height: metaData.height ?? 0
-          },
-          fileName: sanitizeStoredFileName(file.name)
-        },
-        ...(thumbnail
-          ? {
-              // Use the resized image's actual size/dimensions (outputInfo).
-              thumbnail: {
-                path: thumbnail.path,
-                bytes: thumbnail.outputInfo.size,
-                mimeType: thumbnail.contentType,
-                metaData: {
-                  width: thumbnail.outputInfo.width,
-                  height: thumbnail.outputInfo.height
-                }
-              }
-            }
-          : null),
-        ...(media.description ? { description: media.description } : null),
-        ...(focus ? { focus } : null),
-        ...(blurhash ? { blurhash } : null)
-      })
-    } catch (error) {
-      await this._reclaimStored(path, thumbnail?.path)
-      throw error
-    }
-    if (!storedMedia) {
-      await this._reclaimStored(path, thumbnail?.path)
-      throw new Error('Fail to store media')
-    }
-    return this._getSaveFileOutput(storedMedia)
+          }),
+        deleteFile: (filePath) => this.deleteFile(filePath)
+      }
+    })
   }
 
   async saveThumbnail(
@@ -637,16 +560,6 @@ export class S3FileStorage implements MediaStorage {
         height: outputInfo.height
       }
     }
-  }
-
-  // A stored path is reachable only through its `medias` row, so anything that
-  // fails before that row exists has to take the files back out.
-  private async _reclaimStored(originalPath: string, thumbnailPath?: string) {
-    await Promise.all(
-      [originalPath, thumbnailPath]
-        .filter((stored) => stored !== undefined)
-        .map((stored) => this.deleteFile(stored).catch(() => false))
-    )
   }
 
   private async _uploadImageToS3(

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -16,8 +16,7 @@ import { logger } from '@/lib/utils/logger'
 import { MAX_HEIGHT, MAX_WIDTH, STORED_IMAGE_RESIZE_OPTIONS } from './constants'
 import { MediaValidationError } from './errors'
 import { extractVideoMeta } from './extractVideoMeta'
-import { getStoredMediaExtension, sanitizeStoredFileName } from './fileName'
-import { getMediaAttachment } from './getMediaAttachment'
+import { getStoredMediaExtension } from './fileName'
 import {
   DEFAULT_IMAGE_OUTPUT_FORMAT,
   type ImageOutputFormat,
@@ -25,7 +24,8 @@ import {
   getImageOutputFormatDetail
 } from './imageOutputFormat'
 import { getMediaFileUrl } from './mediaFileUrl'
-import { checkQuotaAvailable, getUploadQuotaReservation } from './quota'
+import { checkQuotaAvailable } from './quota'
+import { saveMediaFile } from './saveMediaFile'
 import { assertStorageFilePath, resolveStorageFilePath } from './storagePath'
 import { readValidThumbnail } from './thumbnailInput'
 import {
@@ -130,92 +130,19 @@ export class LocalFileStorage implements MediaStorage {
   }
 
   async saveFile(actor: Actor, media: MediaSchema) {
-    const { file } = media
-    if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
-      return null
-    }
-    // Read and validate the thumbnail before anything is written, so unusable
-    // bytes cannot leave a stored original behind.
-    const thumbnailBuffer = media.thumbnail
-      ? await readValidThumbnail(media.thumbnail)
-      : null
-
-    // Check quota before saving; see `getUploadQuotaReservation` for why the
-    // thumbnail's share of it is an estimate.
-    const quotaCheck = await checkQuotaAvailable(
-      this._database,
+    return saveMediaFile({
+      database: this._database,
+      host: this._host,
       actor,
-      getUploadQuotaReservation(media)
-    )
-    if (!quotaCheck.available) {
-      throw new MediaValidationError(
-        `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
-      )
-    }
-
-    const { path, metaData, previewImage, blurhash, focus } =
-      file.type.startsWith('video')
-        ? await this._saveVideoFile(file, { manualFocus: media.focus })
-        : await this._saveImageFile(file, { manualFocus: media.focus })
-    // A caller-supplied thumbnail wins; a video otherwise falls back to the
-    // frame extracted from it.
-    const thumbnailSource = thumbnailBuffer ?? previewImage
-    let thumbnail
-    try {
-      thumbnail = thumbnailSource
-        ? await this._saveImageBuffer(thumbnailSource, { isThumbnail: true })
-        : null
-    } catch (error) {
-      // The thumbnail's bytes were validated above, so this is a storage fault
-      // of ours: keep the error — it has to stay a logged 500, not a 422 the
-      // client will not retry — but put the original back first.
-      await this._reclaimStored(path)
-      throw error
-    }
-    let storedMedia
-    try {
-      storedMedia = await this._database.createMedia({
-        actorId: actor.id,
-        original: {
-          path,
-          bytes: file.size,
-          mimeType: file.type,
-          metaData: {
-            width: metaData.width ?? 0,
-            height: metaData.height ?? 0
-          },
-          fileName: sanitizeStoredFileName(file.name)
-        },
-        ...(thumbnail
-          ? {
-              // Use the resized image's actual size/dimensions (outputInfo), not
-              // the input image's metadata.
-              thumbnail: {
-                path: thumbnail.path,
-                bytes: thumbnail.outputInfo.size,
-                mimeType: thumbnail.contentType,
-                metaData: {
-                  width: thumbnail.outputInfo.width,
-                  height: thumbnail.outputInfo.height
-                }
-              }
-            }
-          : null),
-        ...(media.description ? { description: media.description } : null),
-        ...(focus ? { focus } : null),
-        ...(blurhash ? { blurhash } : null)
-      })
-    } catch (error) {
-      await this._reclaimStored(path, thumbnail?.path)
-      throw error
-    }
-
-    if (!storedMedia) {
-      await this._reclaimStored(path, thumbnail?.path)
-      throw new Error('Fail to store media')
-    }
-
-    return getMediaAttachment(storedMedia, this._host)
+      media,
+      driver: {
+        saveVideoFile: (file, options) => this._saveVideoFile(file, options),
+        saveImageFile: (file, options) => this._saveImageFile(file, options),
+        saveThumbnailBuffer: (buffer) =>
+          this._saveImageBuffer(buffer, { isThumbnail: true }),
+        deleteFile: (filePath) => this.deleteFile(filePath)
+      }
+    })
   }
 
   async saveThumbnail(
@@ -291,16 +218,6 @@ export class LocalFileStorage implements MediaStorage {
         height: outputInfo.height
       }
     }
-  }
-
-  // A stored path is reachable only through its `medias` row, so anything that
-  // fails before that row exists has to take the files back out.
-  private async _reclaimStored(originalPath: string, thumbnailPath?: string) {
-    await Promise.all(
-      [originalPath, thumbnailPath]
-        .filter((stored) => stored !== undefined)
-        .map((stored) => this.deleteFile(stored).catch(() => false))
-    )
   }
 
   private async _saveImageFile(

--- a/lib/services/medias/saveMediaFile.test.ts
+++ b/lib/services/medias/saveMediaFile.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Database } from '@/lib/database/types'
+import { MediaValidationError } from '@/lib/services/medias/errors'
+import {
+  MediaSaveDriver,
+  SavedOriginalMedia,
+  SavedThumbnail,
+  saveMediaFile
+} from '@/lib/services/medias/saveMediaFile'
+import { MediaSchema } from '@/lib/services/medias/types'
+import { Media } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+
+describe('saveMediaFile coordination', () => {
+  const actor = { id: 'actor-1' } as Actor
+  const host = 'activities.local'
+
+  const mockDatabase = (overrides?: Partial<Database>): Database =>
+    ({
+      getActorFromId: vi.fn().mockResolvedValue({
+        id: 'actor-1',
+        account: { id: 'account-1' }
+      }),
+      getStorageUsageForAccount: vi.fn().mockResolvedValue(0),
+      getFitnessStorageUsageForAccount: vi.fn().mockResolvedValue(0),
+      createMedia: vi.fn().mockResolvedValue({
+        id: '1',
+        actorId: 'actor-1',
+        original: {
+          path: 'original.png',
+          bytes: 1000,
+          mimeType: 'image/png',
+          metaData: { width: 100, height: 100 },
+          fileName: 'original.png'
+        }
+      } as Media),
+      ...overrides
+    }) as unknown as Database
+
+  const mockDriver = (
+    overrides?: Partial<MediaSaveDriver>
+  ): MediaSaveDriver => ({
+    saveVideoFile: vi.fn().mockResolvedValue({
+      path: 'video.mp4',
+      metaData: { width: 1920, height: 1080 },
+      previewImage: Buffer.from('video-preview'),
+      blurhash: 'video-blurhash',
+      focus: { x: 0, y: 0 }
+    } as SavedOriginalMedia),
+    saveImageFile: vi.fn().mockResolvedValue({
+      path: 'image.png',
+      metaData: { width: 800, height: 600 },
+      previewImage: null,
+      blurhash: 'image-blurhash',
+      focus: { x: 0.1, y: 0.2 }
+    } as SavedOriginalMedia),
+    saveThumbnailBuffer: vi.fn().mockResolvedValue({
+      path: 'thumb.webp',
+      outputInfo: { size: 500, width: 200, height: 150 },
+      contentType: 'image/webp'
+    } as SavedThumbnail),
+    deleteFile: vi.fn().mockResolvedValue(true),
+    ...overrides
+  })
+
+  it('returns null for unsupported file types without calling driver or checking quota', async () => {
+    const database = mockDatabase()
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['audio content'], 'test.mp3', { type: 'audio/mp3' })
+    }
+
+    const result = await saveMediaFile({
+      database,
+      host,
+      actor,
+      media,
+      driver
+    })
+
+    expect(result).toBeNull()
+    expect(driver.saveImageFile).not.toHaveBeenCalled()
+    expect(driver.saveVideoFile).not.toHaveBeenCalled()
+    expect(database.getActorFromId).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-image thumbnail before checking quota or saving file', async () => {
+    const database = mockDatabase()
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['image content'], 'test.png', { type: 'image/png' }),
+      thumbnail: new File(['audio content'], 'thumb.mp3', { type: 'audio/mp3' })
+    }
+
+    await expect(
+      saveMediaFile({
+        database,
+        host,
+        actor,
+        media,
+        driver
+      })
+    ).rejects.toThrow(MediaValidationError)
+
+    expect(driver.saveImageFile).not.toHaveBeenCalled()
+    expect(database.getActorFromId).not.toHaveBeenCalled()
+  })
+
+  it('rejects when quota is exceeded', async () => {
+    const database = mockDatabase({
+      getStorageUsageForAccount: vi.fn().mockResolvedValue(100_000_000_000)
+    })
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['image content'], 'test.png', { type: 'image/png' })
+    }
+
+    await expect(
+      saveMediaFile({
+        database,
+        host,
+        actor,
+        media,
+        driver
+      })
+    ).rejects.toThrow(MediaValidationError)
+
+    expect(driver.saveImageFile).not.toHaveBeenCalled()
+  })
+
+  it('saves an image and creates database media record', async () => {
+    const database = mockDatabase()
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['image content'], 'test.png', { type: 'image/png' }),
+      description: 'An image description',
+      focus: { x: 0.1, y: 0.2 }
+    }
+
+    const result = await saveMediaFile({
+      database,
+      host,
+      actor,
+      media,
+      driver
+    })
+
+    expect(driver.saveImageFile).toHaveBeenCalledWith(media.file, {
+      manualFocus: { x: 0.1, y: 0.2 }
+    })
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'actor-1',
+        description: 'An image description',
+        focus: { x: 0.1, y: 0.2 },
+        blurhash: 'image-blurhash',
+        original: expect.objectContaining({
+          path: 'image.png',
+          mimeType: 'image/png',
+          fileName: 'test.png'
+        })
+      })
+    )
+    expect(result).toBeDefined()
+    expect(result?.id).toBe('1')
+  })
+
+  it('saves a video and uses preview image for thumbnail', async () => {
+    const database = mockDatabase()
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['video content'], 'clip.mp4', { type: 'video/mp4' })
+    }
+
+    const result = await saveMediaFile({
+      database,
+      host,
+      actor,
+      media,
+      driver
+    })
+
+    expect(driver.saveVideoFile).toHaveBeenCalledWith(media.file, {
+      manualFocus: undefined
+    })
+    expect(driver.saveThumbnailBuffer).toHaveBeenCalledWith(
+      Buffer.from('video-preview')
+    )
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'actor-1',
+        original: expect.objectContaining({
+          path: 'video.mp4',
+          mimeType: 'video/mp4',
+          fileName: 'clip.mp4'
+        }),
+        thumbnail: expect.objectContaining({
+          path: 'thumb.webp',
+          bytes: 500,
+          mimeType: 'image/webp',
+          metaData: { width: 200, height: 150 }
+        })
+      })
+    )
+    expect(result).toBeDefined()
+  })
+
+  it('reclaims original when thumbnail saving throws and rethrows', async () => {
+    const database = mockDatabase()
+    const driver = mockDriver({
+      saveThumbnailBuffer: vi
+        .fn()
+        .mockRejectedValue(new Error('Storage disk full'))
+    })
+    const media: MediaSchema = {
+      file: new File(['video content'], 'clip.mp4', { type: 'video/mp4' })
+    }
+
+    await expect(
+      saveMediaFile({
+        database,
+        host,
+        actor,
+        media,
+        driver
+      })
+    ).rejects.toThrow('Storage disk full')
+
+    expect(driver.deleteFile).toHaveBeenCalledWith('video.mp4')
+    expect(database.createMedia).not.toHaveBeenCalled()
+  })
+
+  it('reclaims original and thumbnail when createMedia throws', async () => {
+    const database = mockDatabase({
+      createMedia: vi.fn().mockRejectedValue(new Error('DB connection lost'))
+    })
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['video content'], 'clip.mp4', { type: 'video/mp4' })
+    }
+
+    await expect(
+      saveMediaFile({
+        database,
+        host,
+        actor,
+        media,
+        driver
+      })
+    ).rejects.toThrow('DB connection lost')
+
+    expect(driver.deleteFile).toHaveBeenCalledWith('video.mp4')
+    expect(driver.deleteFile).toHaveBeenCalledWith('thumb.webp')
+  })
+
+  it('reclaims original and thumbnail when createMedia resolves null', async () => {
+    const database = mockDatabase({
+      createMedia: vi.fn().mockResolvedValue(null)
+    })
+    const driver = mockDriver()
+    const media: MediaSchema = {
+      file: new File(['video content'], 'clip.mp4', { type: 'video/mp4' })
+    }
+
+    await expect(
+      saveMediaFile({
+        database,
+        host,
+        actor,
+        media,
+        driver
+      })
+    ).rejects.toThrow('Fail to store media')
+
+    expect(driver.deleteFile).toHaveBeenCalledWith('video.mp4')
+    expect(driver.deleteFile).toHaveBeenCalledWith('thumb.webp')
+  })
+})

--- a/lib/services/medias/saveMediaFile.ts
+++ b/lib/services/medias/saveMediaFile.ts
@@ -1,0 +1,177 @@
+import { Database } from '@/lib/database/types'
+import { MediaValidationError } from '@/lib/services/medias/errors'
+import { sanitizeStoredFileName } from '@/lib/services/medias/fileName'
+import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
+import {
+  checkQuotaAvailable,
+  getUploadQuotaReservation
+} from '@/lib/services/medias/quota'
+import { readValidThumbnail } from '@/lib/services/medias/thumbnailInput'
+import {
+  MediaSchema,
+  MediaStorageSaveFileOutput
+} from '@/lib/services/medias/types'
+import { Actor } from '@/lib/types/domain/actor'
+
+export interface SavedOriginalMedia {
+  path: string
+  metaData: {
+    width?: number
+    height?: number
+  }
+  previewImage?: Buffer | null
+  blurhash?: string | null
+  focus?: { x: number; y: number } | null
+}
+
+export interface SavedThumbnail {
+  path: string
+  outputInfo: {
+    size: number
+    width?: number
+    height?: number
+  }
+  contentType: string
+}
+
+export interface MediaSaveDriver {
+  saveVideoFile(
+    file: File,
+    options: { manualFocus?: { x: number; y: number } | null }
+  ): Promise<SavedOriginalMedia>
+  saveImageFile(
+    file: File,
+    options: { manualFocus?: { x: number; y: number } | null }
+  ): Promise<SavedOriginalMedia>
+  saveThumbnailBuffer(buffer: Buffer): Promise<SavedThumbnail>
+  deleteFile(path: string): Promise<boolean>
+  reclaimStored?(originalPath: string, thumbnailPath?: string): Promise<void>
+}
+
+export interface SaveMediaFileParams {
+  database: Database
+  host: string
+  actor: Actor
+  media: MediaSchema
+  driver: MediaSaveDriver
+}
+
+export const reclaimStoredMedia = async (
+  deleteFile: (filePath: string) => Promise<boolean>,
+  originalPath: string,
+  thumbnailPath?: string
+): Promise<void> => {
+  await Promise.all(
+    [originalPath, thumbnailPath]
+      .filter((stored): stored is string => stored !== undefined)
+      .map((stored) => deleteFile(stored).catch(() => false))
+  )
+}
+
+export const saveMediaFile = async ({
+  database,
+  host,
+  actor,
+  media,
+  driver
+}: SaveMediaFileParams): Promise<MediaStorageSaveFileOutput | null> => {
+  const { file } = media
+  if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
+    return null
+  }
+
+  // Read and validate the thumbnail before anything is written, so unusable
+  // bytes cannot leave a stored original behind.
+  const thumbnailBuffer = media.thumbnail
+    ? await readValidThumbnail(media.thumbnail)
+    : null
+
+  // Check quota before saving; see `getUploadQuotaReservation` for why the
+  // thumbnail's share of it is an estimate.
+  const quotaCheck = await checkQuotaAvailable(
+    database,
+    actor,
+    getUploadQuotaReservation(media)
+  )
+  if (!quotaCheck.available) {
+    throw new MediaValidationError(
+      `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
+    )
+  }
+
+  const { path, metaData, previewImage, blurhash, focus } =
+    file.type.startsWith('video')
+      ? await driver.saveVideoFile(file, { manualFocus: media.focus })
+      : await driver.saveImageFile(file, { manualFocus: media.focus })
+
+  const reclaim = (originalPath: string, thumbnailPath?: string) =>
+    driver.reclaimStored
+      ? driver.reclaimStored(originalPath, thumbnailPath)
+      : reclaimStoredMedia(
+          driver.deleteFile.bind(driver),
+          originalPath,
+          thumbnailPath
+        )
+
+  // A caller-supplied thumbnail wins; a video otherwise falls back to the
+  // frame extracted from it. `previewImage` is null for an image upload — a video
+  // whose frame cannot be decoded rejects rather than resolving null.
+  const thumbnailSource = thumbnailBuffer ?? previewImage
+  let thumbnail: SavedThumbnail | null
+  try {
+    thumbnail = thumbnailSource
+      ? await driver.saveThumbnailBuffer(thumbnailSource)
+      : null
+  } catch (error) {
+    // The thumbnail's bytes were validated above, so this is a storage fault
+    // of ours: keep the error — it has to stay a logged 500, not a 422 the
+    // client will not retry — but put the original back first.
+    await reclaim(path)
+    throw error
+  }
+
+  let storedMedia
+  try {
+    storedMedia = await database.createMedia({
+      actorId: actor.id,
+      original: {
+        path,
+        bytes: file.size,
+        mimeType: file.type,
+        metaData: {
+          width: metaData.width ?? 0,
+          height: metaData.height ?? 0
+        },
+        fileName: sanitizeStoredFileName(file.name)
+      },
+      ...(thumbnail
+        ? {
+            // Use the resized image's actual size/dimensions (outputInfo), not
+            // the input image's metadata.
+            thumbnail: {
+              path: thumbnail.path,
+              bytes: thumbnail.outputInfo.size,
+              mimeType: thumbnail.contentType,
+              metaData: {
+                width: thumbnail.outputInfo.width ?? 0,
+                height: thumbnail.outputInfo.height ?? 0
+              }
+            }
+          }
+        : null),
+      ...(media.description ? { description: media.description } : null),
+      ...(focus ? { focus } : null),
+      ...(blurhash ? { blurhash } : null)
+    })
+  } catch (error) {
+    await reclaim(path, thumbnail?.path)
+    throw error
+  }
+
+  if (!storedMedia) {
+    await reclaim(path, thumbnail?.path)
+    throw new Error('Fail to store media')
+  }
+
+  return getMediaAttachment(storedMedia, host)
+}


### PR DESCRIPTION
Share media-save coordination logic across storage drivers without merging the drivers themselves (Task D6).

- Extracts shared upload coordination into `lib/services/medias/saveMediaFile.ts`
- Centralizes thumbnail validation, quota reservation enforcement, video vs image routing, error recovery and file reclamation
- Refactors `LocalFileStorage.saveFile` and `S3FileStorage.saveFile` to delegate to `saveMediaFile` with driver-specific operations
- Eliminates duplicated `_reclaimStored` implementation from both classes
- Adds dedicated unit tests in `lib/services/medias/saveMediaFile.test.ts` verifying quota refusal, thumbnail validation, error reclamation, and database media creation