### PR TITLE
feat: bound fan-out and make delivery child IDs deterministic

### DIFF
--- a/lib/jobs/sendNoteJob.test.ts
+++ b/lib/jobs/sendNoteJob.test.ts
@@ -2,7 +2,11 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { DELIVER_ACTIVITY_JOB_NAME, SEND_NOTE_JOB_NAME } from '@/lib/jobs/names'
-import { sendNoteJob } from '@/lib/jobs/sendNoteJob'
+import {
+  MAX_CONCURRENT_DELIVERY_PUBLICATIONS,
+  getDeliveryJobId,
+  sendNoteJob
+} from '@/lib/jobs/sendNoteJob'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
@@ -15,22 +19,41 @@ const hoisted = vi.hoisted(() => ({
   database: null as unknown,
   publishSpy: vi.fn(),
   runsInline: true,
-  failInbox: null as string | null
+  failInbox: null as string | null,
+  activePublishes: 0,
+  maxConcurrentPublishes: 0,
+  publishDelayMs: 0
 }))
 
 vi.mock('@/lib/services/queue', () => ({
   getQueue: () => ({
     runsInline: hoisted.runsInline,
     publish: async (message: { name: string; data: { inbox?: string } }) => {
+      hoisted.activePublishes++
+      hoisted.maxConcurrentPublishes = Math.max(
+        hoisted.maxConcurrentPublishes,
+        hoisted.activePublishes
+      )
       hoisted.publishSpy(message)
-      if (hoisted.failInbox && message.data?.inbox === hoisted.failInbox) {
-        throw new Error('Simulated inbox delivery rejection')
-      }
-      const { JOBS } = await import('@/lib/jobs')
-      const job = (JOBS as Record<string, unknown>)[message.name] as
-        ((db: unknown, msg: unknown) => Promise<void>) | undefined
-      if (job && hoisted.database) {
-        await job(hoisted.database, message)
+      try {
+        if (hoisted.publishDelayMs > 0) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, hoisted.publishDelayMs)
+          )
+        }
+        if (hoisted.failInbox && message.data?.inbox === hoisted.failInbox) {
+          throw new Error('Simulated inbox delivery rejection')
+        }
+        if (hoisted.runsInline) {
+          const { JOBS } = await import('@/lib/jobs')
+          const job = (JOBS as Record<string, unknown>)[message.name] as
+            ((db: unknown, msg: unknown) => Promise<void>) | undefined
+          if (job && hoisted.database) {
+            await job(hoisted.database, message)
+          }
+        }
+      } finally {
+        hoisted.activePublishes--
       }
     }
   })
@@ -60,6 +83,10 @@ describe('sendNoteJob', () => {
     mockRequests(fetchMock)
     hoisted.publishSpy.mockClear()
     hoisted.failInbox = null
+    hoisted.runsInline = true
+    hoisted.activePublishes = 0
+    hoisted.maxConcurrentPublishes = 0
+    hoisted.publishDelayMs = 0
   })
 
   it('does nothing when status is not found', async () => {
@@ -280,5 +307,240 @@ describe('sendNoteJob', () => {
         (call) => call[0] === 'https://friend2.test/inbox'
       )
     ).toBe(true)
+  })
+
+  it('enqueues a DeliverActivityJob with deterministic child ID derived from parent message id and inbox', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const statusId = `${actor1.id}/statuses/deterministic-id-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Deterministic ID note',
+      createdAt: Date.now()
+    })
+
+    const parentId = 'job-deterministic-fanout'
+    await sendNoteJob(database, {
+      id: parentId,
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+
+    const expectedId = getDeliveryJobId(parentId, 'https://friend2.test/inbox')
+    expect(hoisted.publishSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expectedId,
+        name: DELIVER_ACTIVITY_JOB_NAME,
+        data: expect.objectContaining({
+          inbox: 'https://friend2.test/inbox',
+          actorId: actor1.id
+        })
+      })
+    )
+  })
+
+  it('produces stable child delivery IDs on parent retry and distinct IDs across parent generations', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const statusId = `${actor1.id}/statuses/stable-id-test-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Note content for stable ID test',
+      createdAt: Date.now()
+    })
+
+    // Generation 1 run 1
+    await sendNoteJob(database, {
+      id: 'parent-gen-1',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+    const gen1Calls = [...hoisted.publishSpy.mock.calls]
+    const gen1JobIds = gen1Calls.map((call) => (call[0] as { id: string }).id)
+
+    // Generation 1 run 2 (retry with same parent message ID)
+    hoisted.publishSpy.mockClear()
+    await sendNoteJob(database, {
+      id: 'parent-gen-1',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+    const retryCalls = [...hoisted.publishSpy.mock.calls]
+    const retryJobIds = retryCalls.map((call) => (call[0] as { id: string }).id)
+    expect(retryJobIds).toEqual(gen1JobIds)
+
+    // Generation 2 run (different parent message ID)
+    hoisted.publishSpy.mockClear()
+    await sendNoteJob(database, {
+      id: 'parent-gen-2',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+    const gen2Calls = [...hoisted.publishSpy.mock.calls]
+    const gen2JobIds = gen2Calls.map((call) => (call[0] as { id: string }).id)
+    expect(gen2JobIds).not.toEqual(gen1JobIds)
+    const firstInbox = (gen2Calls[0][0] as { data: { inbox: string } }).data
+      .inbox
+    expect(gen2JobIds[0]).toBe(getDeliveryJobId('parent-gen-2', firstInbox))
+  })
+
+  it('deduplicates identical inbox URLs across multiple followers', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const sharedInboxUrl = 'https://shared-instance.test/inbox'
+    await database.createFollow({
+      actorId: 'https://shared-instance.test/actors/alice',
+      targetActorId: actor1.id,
+      inbox: 'https://shared-instance.test/actors/alice/inbox',
+      sharedInbox: sharedInboxUrl,
+      status: FollowStatus.enum.Accepted
+    })
+
+    await database.createFollow({
+      actorId: 'https://shared-instance.test/actors/bob',
+      targetActorId: actor1.id,
+      inbox: 'https://shared-instance.test/actors/bob/inbox',
+      sharedInbox: sharedInboxUrl,
+      status: FollowStatus.enum.Accepted
+    })
+
+    const statusId = `${actor1.id}/statuses/dedup-inbox-test-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Note for dedup inbox test',
+      createdAt: Date.now()
+    })
+
+    await sendNoteJob(database, {
+      id: 'parent-dedup-test',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+
+    const callsToSharedInbox = hoisted.publishSpy.mock.calls.filter(
+      (call) =>
+        (call[0] as { data?: { inbox?: string } }).data?.inbox ===
+        sharedInboxUrl
+    )
+    expect(callsToSharedInbox).toHaveLength(1)
+  })
+
+  it('awaits all attempted publications and propagates error when queue is asynchronous', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    hoisted.runsInline = false
+
+    await database.createFollow({
+      actorId: 'https://async-target-1.test/actors/user1',
+      targetActorId: actor1.id,
+      inbox: 'https://async-target-1.test/inbox',
+      status: FollowStatus.enum.Accepted
+    })
+
+    await database.createFollow({
+      actorId: 'https://async-target-2.test/actors/user2',
+      targetActorId: actor1.id,
+      inbox: 'https://async-target-2.test/inbox',
+      status: FollowStatus.enum.Accepted
+    })
+
+    hoisted.failInbox = 'https://async-target-1.test/inbox'
+
+    const statusId = `${actor1.id}/statuses/async-failure-test-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Note for async failure propagation',
+      createdAt: Date.now()
+    })
+
+    await expect(
+      sendNoteJob(database, {
+        id: 'parent-async-fail',
+        name: SEND_NOTE_JOB_NAME,
+        data: {
+          actorId: actor1.id,
+          statusId
+        }
+      })
+    ).rejects.toThrow('Simulated inbox delivery rejection')
+
+    const inboxesPublished = hoisted.publishSpy.mock.calls.map(
+      (call) => (call[0] as { data?: { inbox?: string } }).data?.inbox
+    )
+    expect(inboxesPublished).toContain('https://async-target-1.test/inbox')
+    expect(inboxesPublished).toContain('https://async-target-2.test/inbox')
+  })
+
+  it('limits concurrent publications to at most 10 without exceeding the limit', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    hoisted.runsInline = false
+    hoisted.publishDelayMs = 20
+
+    for (let i = 1; i <= 15; i++) {
+      await database.createFollow({
+        actorId: `https://concurrency-${i}.test/actors/user`,
+        targetActorId: actor1.id,
+        inbox: `https://concurrency-${i}.test/inbox`,
+        status: FollowStatus.enum.Accepted
+      })
+    }
+
+    const statusId = `${actor1.id}/statuses/concurrency-limit-test-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Note for concurrency test',
+      createdAt: Date.now()
+    })
+
+    await sendNoteJob(database, {
+      id: 'parent-concurrency-test',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+
+    expect(hoisted.maxConcurrentPublishes).toBeLessThanOrEqual(
+      MAX_CONCURRENT_DELIVERY_PUBLICATIONS
+    )
+    expect(hoisted.maxConcurrentPublishes).toBeGreaterThan(1)
+    expect(hoisted.publishSpy.mock.calls.length).toBeGreaterThanOrEqual(15)
   })
 })

--- a/lib/jobs/sendNoteJob.ts
+++ b/lib/jobs/sendNoteJob.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 
 import { CreateStatus } from '@/lib/activities/createStatus'
@@ -11,13 +10,52 @@ import { getQueue } from '@/lib/services/queue'
 import { JobHandle } from '@/lib/services/queue/type'
 import { CreateAction } from '@/lib/types/activitypub/activities'
 import { StatusType } from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { withSpan } from '@/lib/utils/trace'
+
+export const MAX_CONCURRENT_DELIVERY_PUBLICATIONS = 10
+
+export const getDeliveryJobId = (
+  parentMessageId: string,
+  inbox: string
+): string => {
+  return getHashFromString(
+    `${DELIVER_ACTIVITY_JOB_NAME}:${parentMessageId}:${inbox}`
+  )
+}
 
 export const JobData = z.object({
   actorId: z.string(),
   statusId: z.string()
 })
+
+async function runWithConcurrencyLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length)
+  if (items.length === 0) return results
+
+  let nextIndex = 0
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      try {
+        const val = await fn(items[index])
+        results[index] = { status: 'fulfilled', value: val }
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason }
+      }
+    }
+  }
+
+  const workerCount = Math.min(limit, items.length)
+  const workers = Array.from({ length: workerCount }, () => worker())
+  await Promise.all(workers)
+  return results
+}
 
 export const sendNoteJob: JobHandle = createJobHandle(
   SEND_NOTE_JOB_NAME,
@@ -50,6 +88,8 @@ export const sendNoteJob: JobHandle = createJobHandle(
         status
       })
 
+      const inboxes = Array.from(new Set(federatedInboxes))
+
       const activity: CreateStatus = {
         '@context': NOTE_ACTIVITY_CONTEXT,
         id: note.id,
@@ -64,27 +104,28 @@ export const sendNoteJob: JobHandle = createJobHandle(
       const queue = getQueue()
 
       span.addEvent('fanout_started', {
-        'fanout.inbox_count': federatedInboxes.length,
+        'fanout.inbox_count': inboxes.length,
         'fanout.actor_id': actor.id,
         'fanout.status_id': status.id,
         'queue.runs_inline': queue.runsInline
       })
 
-      if (queue.runsInline) {
-        const results = await Promise.allSettled(
-          federatedInboxes.map((inbox) =>
-            queue.publish({
-              id: randomUUID(),
-              name: DELIVER_ACTIVITY_JOB_NAME,
-              data: {
-                inbox,
-                actorId: actor.id,
-                activity: activity as unknown as Record<string, unknown>
-              }
-            })
-          )
-        )
+      const results = await runWithConcurrencyLimit(
+        inboxes,
+        MAX_CONCURRENT_DELIVERY_PUBLICATIONS,
+        (inbox) =>
+          queue.publish({
+            id: getDeliveryJobId(message.id, inbox),
+            name: DELIVER_ACTIVITY_JOB_NAME,
+            data: {
+              inbox,
+              actorId: actor.id,
+              activity: activity as unknown as Record<string, unknown>
+            }
+          })
+      )
 
+      if (queue.runsInline) {
         let failureCount = 0
         for (let i = 0; i < results.length; i++) {
           const result = results[i]
@@ -95,34 +136,44 @@ export const sendNoteJob: JobHandle = createJobHandle(
                 ? result.reason
                 : new Error(String(result.reason))
             span.addEvent('inbox_delivery_inline_error', {
-              'delivery.inbox': federatedInboxes[i],
+              'delivery.inbox': inboxes[i],
               'error.message': err.message
             })
           }
         }
 
         span.addEvent('fanout_completed', {
-          'fanout.inbox_count': federatedInboxes.length,
+          'fanout.inbox_count': inboxes.length,
           'fanout.failure_count': failureCount,
           'queue.runs_inline': true
         })
       } else {
-        await Promise.all(
-          federatedInboxes.map((inbox) =>
-            queue.publish({
-              id: randomUUID(),
-              name: DELIVER_ACTIVITY_JOB_NAME,
-              data: {
-                inbox,
-                actorId: actor.id,
-                activity: activity as unknown as Record<string, unknown>
-              }
-            })
-          )
+        const failures = results.filter(
+          (r): r is PromiseRejectedResult => r.status === 'rejected'
         )
 
+        if (failures.length > 0) {
+          const firstError =
+            failures[0].reason instanceof Error
+              ? failures[0].reason
+              : new Error(String(failures[0].reason))
+          span.recordException(firstError)
+          span.addEvent('fanout_failed', {
+            'fanout.inbox_count': inboxes.length,
+            'fanout.failure_count': failures.length,
+            'queue.runs_inline': false
+          })
+          if (failures.length === 1) {
+            throw firstError
+          }
+          throw new AggregateError(
+            failures.map((f) => f.reason),
+            `Failed to publish ${failures.length} delivery jobs: ${firstError.message}`
+          )
+        }
+
         span.addEvent('fanout_completed', {
-          'fanout.inbox_count': federatedInboxes.length,
+          'fanout.inbox_count': inboxes.length,
           'fanout.failure_count': 0,
           'queue.runs_inline': false
         })


### PR DESCRIPTION
Bound fan-out and make delivery child IDs deterministic in sendNoteJob (Task A6).

- Replaces random delivery job UUIDs with deterministic child job IDs hashed from `DeliverActivityJob`, parent message ID, and the recipient inbox URL (`getDeliveryJobId`).
- Deduplicates federated inbox URLs before fan-out so duplicate inboxes receive at most one delivery job.
- Limits concurrent queue publication to at most 10 (`MAX_CONCURRENT_DELIVERY_PUBLICATIONS`) without external dependencies via an in-memory worker pool.
- Preserves inline delivery's existing best-effort behavior (logs inline delivery errors without aborting).
- For asynchronous queues, awaits all attempted publications and propagates publication failures so the parent retries; completed child publications retain identical IDs on that retry.
- Adds comprehensive test coverage in `lib/jobs/sendNoteJob.test.ts` for deduplication, deterministic child IDs, stable retry identities across attempts, distinct IDs across generations, concurrency limits, and async failure propagation.