### PR TITLE
Bump version to v1.161.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.12",
+  "version": "1.161.13",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.13.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.12`
- Base main SHA: `9f573cea3402d7220d895c971c7be962fef1707f`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
