### PR TITLE
feat: drain database queue worker on shutdown

### DIFF
--- a/lib/services/queue/databaseRunner.test.ts
+++ b/lib/services/queue/databaseRunner.test.ts
@@ -28,6 +28,11 @@ describe('databaseRunner', () => {
     await database.destroy()
   })
 
+  afterEach(async () => {
+    await knexDatabase('queue_jobs').delete()
+    await knexDatabase('dead_letter_jobs').delete()
+  })
+
   const sampleMessage: JobMessage = {
     id: 'test-runner-msg-1',
     name: 'deliverActivity',
@@ -325,11 +330,126 @@ describe('databaseRunner', () => {
 
     // Let it tick once
     await new Promise((resolve) => setTimeout(resolve, 60))
-    runner.stop()
+    await runner.stop()
 
     const countAfterStop = callCount
     await new Promise((resolve) => setTimeout(resolve, 100))
     expect(callCount).toBe(countAfterStop)
+  })
+
+  it('awaits currently running job and avoids claiming subsequent jobs on shutdown drain', async () => {
+    await database.createQueueJob({
+      id: 'job-drain-1',
+      name: 'deliverActivity',
+      payload: { ...sampleMessage, id: 'drain-msg-1' },
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+    await database.createQueueJob({
+      id: 'job-drain-2',
+      name: 'deliverActivity',
+      payload: { ...sampleMessage, id: 'drain-msg-2' },
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    let job1Started = false
+    let resolveJob1: () => void = () => {}
+    const job1Promise = new Promise<void>((resolve) => {
+      resolveJob1 = resolve
+    })
+    const executed: string[] = []
+
+    const handleJob = async (message: JobMessage) => {
+      executed.push(message.id)
+      if (message.id === 'drain-msg-1') {
+        job1Started = true
+        await job1Promise
+      }
+    }
+
+    const runner = startDatabaseQueueRunner(database, {
+      pollIntervalMs: 100,
+      batchSize: 5,
+      handleJob
+    })
+
+    // Wait until job 1 has started executing
+    while (!job1Started) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+
+    // Initiate stop while job 1 is in-flight
+    let stopResolved = false
+    const stopPromise = runner.stop().then(() => {
+      stopResolved = true
+    })
+
+    // Brief delay to ensure stop() didn't immediately resolve
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(stopResolved).toBe(false)
+
+    // Complete job 1
+    resolveJob1()
+    await stopPromise
+    expect(stopResolved).toBe(true)
+
+    // Job 1 should be completed
+    const job1 = await database.getQueueJobById('job-drain-1')
+    expect(job1?.status).toBe('completed')
+
+    // Job 2 should never have been claimed
+    const job2 = await database.getQueueJobById('job-drain-2')
+    expect(job2?.status).toBe('pending')
+    expect(executed).toEqual(['drain-msg-1'])
+  })
+
+  it('respects timeoutMs when draining if in-flight job takes too long', async () => {
+    await database.createQueueJob({
+      id: 'job-timeout-drain-1',
+      name: 'deliverActivity',
+      payload: { ...sampleMessage, id: 'timeout-msg-1' },
+      nextRunAt: new Date(Date.now() - 1000)
+    })
+
+    let jobStarted = false
+    let resolveJob: () => void = () => {}
+    const jobPromise = new Promise<void>((resolve) => {
+      resolveJob = resolve
+    })
+
+    const handleJob = async () => {
+      jobStarted = true
+      await jobPromise
+    }
+
+    const runner = startDatabaseQueueRunner(database, {
+      pollIntervalMs: 100,
+      batchSize: 5,
+      handleJob
+    })
+
+    while (!jobStarted) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+
+    const before = Date.now()
+    // Stop with 50ms timeout
+    await runner.stop(50)
+    const elapsed = Date.now() - before
+
+    expect(elapsed).toBeGreaterThanOrEqual(40)
+    expect(elapsed).toBeLessThan(500)
+
+    // Clean up hanging promise
+    resolveJob()
+  })
+
+  it('allows idempotent stop calls', async () => {
+    const runner = startDatabaseQueueRunner(database, {
+      pollIntervalMs: 50,
+      handleJob: async () => {}
+    })
+
+    await Promise.all([runner.stop(), runner.stop(), runner.stop()])
   })
 
   it('reclaims and processes orphaned jobs stuck in processing status past stalled timeout', async () => {

--- a/lib/services/queue/databaseRunner.ts
+++ b/lib/services/queue/databaseRunner.ts
@@ -15,6 +15,8 @@ export interface ProcessDueQueueJobsOptions {
   handleJob?: (message: JobMessage) => Promise<void>
   backoffOptions?: BackoffOptions
   stalledTimeoutMs?: number
+  signal?: AbortSignal
+  shouldStop?: () => boolean
 }
 
 export interface QueueRunnerOptions extends ProcessDueQueueJobsOptions {
@@ -47,6 +49,10 @@ export const processDueQueueJobs = async (
   let processedCount = 0
 
   for (const job of dueJobs) {
+    if (options.shouldStop?.() || options.signal?.aborted) {
+      break
+    }
+
     const claimedJob = await database.claimQueueJob({
       id: job.id,
       now,
@@ -205,7 +211,7 @@ export const processDueQueueJobs = async (
 }
 
 export interface DatabaseQueueRunnerHandle {
-  stop: () => void
+  stop: (timeoutMs?: number) => Promise<void>
 }
 
 export const startDatabaseQueueRunner = (
@@ -222,6 +228,7 @@ export const startDatabaseQueueRunner = (
 
   let running = true
   let timeoutId: NodeJS.Timeout | null = null
+  let activeTickPromise: Promise<void> | null = null
 
   const tick = async () => {
     if (!running) return
@@ -231,30 +238,52 @@ export const startDatabaseQueueRunner = (
         limit: batchSize,
         handleJob,
         backoffOptions,
-        stalledTimeoutMs
+        stalledTimeoutMs,
+        shouldStop: () => !running
       })
       // If we processed a batch that filled the limit, tick sooner to drain backlog
       const nextDelay = processed >= batchSize ? 50 : pollIntervalMs
       if (running) {
-        timeoutId = setTimeout(tick, nextDelay)
+        scheduleTick(nextDelay)
       }
     } catch (error) {
       const err = toLoggableError(error)
       logger.error({ err }, 'Unexpected error in database queue runner loop')
       if (running) {
-        timeoutId = setTimeout(tick, pollIntervalMs)
+        scheduleTick(pollIntervalMs)
       }
+    } finally {
+      activeTickPromise = null
     }
   }
 
-  timeoutId = setTimeout(tick, 0)
+  const scheduleTick = (delay: number) => {
+    if (!running) return
+    timeoutId = setTimeout(() => {
+      timeoutId = null
+      if (!running) return
+      activeTickPromise = tick()
+    }, delay)
+  }
+
+  scheduleTick(0)
 
   return {
-    stop: () => {
+    stop: async (timeoutMs?: number): Promise<void> => {
       running = false
       if (timeoutId) {
         clearTimeout(timeoutId)
         timeoutId = null
+      }
+      if (activeTickPromise) {
+        if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+          await Promise.race([
+            activeTickPromise,
+            new Promise((resolve) => setTimeout(resolve, timeoutMs))
+          ])
+        } else {
+          await activeTickPromise
+        }
       }
     }
   }

--- a/scripts/maintenance/runQueueWorker.ts
+++ b/scripts/maintenance/runQueueWorker.ts
@@ -27,14 +27,39 @@ async function runQueueWorker() {
     pollIntervalMs
   })
 
-  const shutdown = () => {
-    console.log('Shutting down queue worker gracefully...')
-    runner.stop()
-    process.exit(0)
+  let isShuttingDown = false
+  const shutdown = async (signal: string) => {
+    if (isShuttingDown) {
+      console.log(`Received ${signal} again, forcing immediate exit...`)
+      process.exit(1)
+    }
+    isShuttingDown = true
+    console.log(`Received ${signal}. Shutting down queue worker gracefully...`)
+
+    const forceExitTimer = setTimeout(() => {
+      console.error('Graceful shutdown timed out after 30s. Forcing exit.')
+      process.exit(1)
+    }, 30000)
+    forceExitTimer.unref()
+
+    try {
+      await runner.stop()
+      console.log('Queue worker drained and stopped successfully.')
+      clearTimeout(forceExitTimer)
+      process.exit(0)
+    } catch (error) {
+      console.error('Error while stopping queue worker:', error)
+      clearTimeout(forceExitTimer)
+      process.exit(1)
+    }
   }
 
-  process.on('SIGINT', shutdown)
-  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', () => {
+    void shutdown('SIGINT')
+  })
+  process.on('SIGTERM', () => {
+    void shutdown('SIGTERM')
+  })
 }
 
 runQueueWorker().catch((error) => {


### PR DESCRIPTION
## Summary
Drain the database queue runner on shutdown (Task A7).

- Updates `processDueQueueJobs` to accept `shouldStop` and `signal` options, avoiding claiming subsequent jobs in the current batch once shutdown is initiated.
- Updates `DatabaseQueueRunnerHandle.stop` to return `Promise<void>`, tracking active tick promises and awaiting in-flight jobs while supporting an optional graceful timeout (`timeoutMs`).
- Updates `scripts/maintenance/runQueueWorker.ts` to capture SIGINT and SIGTERM, gracefully await `runner.stop()` with a 30s forced exit fallback, and support immediate exit on repeated signals.
- Adds comprehensive unit tests in `lib/services/queue/databaseRunner.test.ts` for in-flight job completion during stop, avoidance of claiming subsequent jobs, timeout fallback, and idempotent stop calls.

## Verification
- `yarn run prettier --write .`
- `yarn lint` (0 errors)
- `yarn typecheck` (0 errors)
- `yarn build` (succeeded)
- `yarn test` (985 test files, 13,475 tests passed)
- Verified graceful shutdown via script execution with simulated SIGTERM.