### PR TITLE
Bump version to v1.161.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.14",
+  "version": "1.161.15",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.15.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.14`
- Base main SHA: `6625bae6d778659502fd7e14c73aec6eb1d7aaed`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
