### PR TITLE
refactor: apply status-array helpers to home, list, and hashtag timelines

### DIFF
--- a/app/(timeline)/MainPageTimeline.test.tsx
+++ b/app/(timeline)/MainPageTimeline.test.tsx
@@ -41,11 +41,19 @@ vi.mock('@/lib/components/posts/posts', () => ({
   Posts: ({
     statuses,
     currentTime,
-    onPostDeleted
+    onPostDeleted,
+    onPostUpdated,
+    onLikeChanged,
+    onBookmarkChanged,
+    onReactionsChanged
   }: {
     statuses: Status[]
     currentTime: number
     onPostDeleted?: (status: Status) => void
+    onPostUpdated?: (status: Status) => void
+    onLikeChanged?: (status: StatusNote, isLiked: boolean) => void
+    onBookmarkChanged?: (status: StatusNote, isBookmarked: boolean) => void
+    onReactionsChanged?: (status: StatusNote, reactions: any[]) => void
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
@@ -82,13 +90,27 @@ vi.mock('@/lib/components/posts/posts', () => ({
         delete unknown
       </button>
       {statuses.map((status) => {
-        const target =
+        const target = (
           status.type === StatusType.enum.Announce
             ? status.originalStatus
             : status
+        ) as StatusNote
         return (
           <div key={status.id} data-testid={`post-${status.id}`}>
             <span data-testid={`post-id-${status.id}`}>{status.id}</span>
+            <span data-testid={`post-text-${status.id}`}>{target.text}</span>
+            <span data-testid={`post-liked-${status.id}`}>
+              {String(target.isActorLiked)}
+            </span>
+            <span data-testid={`post-bookmarked-${status.id}`}>
+              {String(target.isActorBookmarked)}
+            </span>
+            <span data-testid={`post-likes-${status.id}`}>
+              {target.totalLikes}
+            </span>
+            <span data-testid={`post-reactions-${status.id}`}>
+              {target.reactions?.length ?? 0}
+            </span>
             <button
               type="button"
               data-testid={`trigger-delete-${status.id}`}
@@ -109,6 +131,54 @@ vi.mock('@/lib/components/posts/posts', () => ({
               onClick={() => onPostDeleted?.({ ...target })}
             >
               delete clone
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-update-${status.id}`}
+              onClick={() =>
+                onPostUpdated?.({ ...target, text: 'updated text' } as any)
+              }
+            >
+              update status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-like-${status.id}`}
+              onClick={() => onLikeChanged?.(target as any, true)}
+            >
+              like status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unlike-${status.id}`}
+              onClick={() => onLikeChanged?.(target as any, false)}
+            >
+              unlike status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-bookmark-${status.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, true)}
+            >
+              bookmark status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unbookmark-${status.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, false)}
+            >
+              unbookmark status
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-react-${status.id}`}
+              onClick={() =>
+                onReactionsChanged?.(target as any, [
+                  { name: '🎉', count: 1, me: true }
+                ])
+              }
+            >
+              react status
             </button>
           </div>
         )
@@ -766,6 +836,191 @@ describe('MainPageTimeline', () => {
 
       // Disconnect was called during unmount
       expect(disconnectMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('status updates and engagement sync', () => {
+    it('updates matching status in place on onPostUpdated', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+        />
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('https://activities.local/users/llun/s/1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-update-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('updated text')
+    })
+
+    it('updates announce wrapper when original post is updated', () => {
+      const original = createStatus('https://activities.local/users/other/s/1')
+      const announce = createAnnounceStatus(
+        'https://activities.local/users/llun/s/announce-1',
+        original
+      )
+
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[announce]}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-text-https://activities.local/users/llun/s/announce-1'
+        )
+      ).toHaveTextContent('https://activities.local/users/other/s/1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-update-https://activities.local/users/llun/s/announce-1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-text-https://activities.local/users/llun/s/announce-1'
+        )
+      ).toHaveTextContent('updated text')
+    })
+
+    it('updates like count and liked status when onLikeChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+        />
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-like-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('true')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-unlike-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('0')
+    })
+
+    it('updates bookmark status when onBookmarkChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('false')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-bookmark-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('true')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-unbookmark-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('false')
+    })
+
+    it('updates reactions when onReactionsChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[post1]}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-reactions-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-react-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-reactions-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('1')
     })
   })
 })

--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -8,17 +8,18 @@ import { AnnouncementBanner } from '@/lib/components/announcements/AnnouncementB
 import { PageHeader } from '@/lib/components/page-header'
 import { PostBox } from '@/lib/components/post-box/post-box'
 import { Posts } from '@/lib/components/posts/posts'
+import {
+  removeOriginalStatus,
+  updateMatchingStatus
+} from '@/lib/components/posts/statusArray'
 import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { Timeline } from '@/lib/services/timelines/types'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import {
-  Status,
-  StatusType,
-  getOriginalStatus
-} from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import { cn } from '@/lib/utils'
 
 interface MainPageTimelineProps {
@@ -58,36 +59,62 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
     setCurrentStatuses((previousValue) => [status, ...previousValue])
   }
 
-  const onPostUpdated = (updatedStatus: Status) => {
+  const onPostUpdated = useCallback((status: Status) => {
+    // Announce-aware (like onPostDeleted): also refreshes a boost row whose
+    // original was the edited post. An edited status is always a note/poll.
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.map((status) =>
-        status.id === updatedStatus.id ? updatedStatus : status
+      updateMatchingStatus(
+        previousStatuses,
+        status.id,
+        () => status as StatusNote | StatusPoll
       )
     )
-  }
+  }, [])
 
-  const onPostDeleted = (status: Status) => {
-    const deletedStatusId = status.id
-    setCurrentStatuses((previousStatuses) => {
-      const nextStatuses = previousStatuses.filter((item) => {
-        if (item.id === deletedStatusId) {
-          return false
-        }
-        if (
-          item.type === StatusType.enum.Announce &&
-          (item.originalStatus.id === deletedStatusId ||
-            getOriginalStatus(item).id === deletedStatusId)
-        ) {
-          return false
-        }
-        return true
-      })
-      if (nextStatuses.length === previousStatuses.length) {
-        return previousStatuses
-      }
-      return nextStatuses
-    })
-  }
+  const onPostDeleted = useCallback((status: Status) => {
+    setCurrentStatuses((previousStatuses) =>
+      removeOriginalStatus(previousStatuses, status.id)
+    )
+  }, [])
+
+  const onLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorLiked: isLiked,
+          totalLikes: isLiked
+            ? target.totalLikes + 1
+            : Math.max(0, target.totalLikes - 1)
+        }))
+      )
+    },
+    []
+  )
+
+  const onBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorBookmarked: isBookmarked
+        }))
+      )
+    },
+    []
+  )
+
+  const onReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     const lastStatusId = lastStatusIdRef.current
@@ -208,6 +235,9 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
             onStatusCreated={onStatusCreated}
             onPostUpdated={onPostUpdated}
             onPostDeleted={onPostDeleted}
+            onLikeChanged={onLikeChanged}
+            onBookmarkChanged={onBookmarkChanged}
+            onReactionsChanged={onReactionsChanged}
           />
         ) : isLoadingMoreStatuses || isRefreshing ? (
           <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">

--- a/app/(timeline)/lists/[id]/ListTimeline.test.tsx
+++ b/app/(timeline)/lists/[id]/ListTimeline.test.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react'
 
 import { getListTimeline } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, StatusAnnounce, StatusType } from '@/lib/types/domain/status'
 import { ListEntity } from '@/lib/types/mastodon/list'
 
 import { ListTimeline } from './ListTimeline'
@@ -45,16 +45,102 @@ vi.mock('@/lib/components/page-header', () => ({
 vi.mock('@/lib/components/posts/posts', () => ({
   Posts: ({
     statuses,
-    currentTime
+    currentTime,
+    onPostDeleted,
+    onPostUpdated,
+    onLikeChanged,
+    onBookmarkChanged,
+    onReactionsChanged
   }: {
     statuses: Status[]
     currentTime: number
+    onPostDeleted?: (status: Status) => void
+    onPostUpdated?: (status: Status) => void
+    onLikeChanged?: (status: any, isLiked: boolean) => void
+    onBookmarkChanged?: (status: any, isBookmarked: boolean) => void
+    onReactionsChanged?: (status: any, reactions: any[]) => void
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
-      {statuses.map((status) => (
-        <div key={status.id}>{status.id}</div>
-      ))}
+      {statuses.map((status) => {
+        const target =
+          status.type === StatusType.enum.Announce
+            ? status.originalStatus
+            : status
+        return (
+          <div key={status.id} data-testid={`post-${status.id}`}>
+            <span data-testid={`post-id-${status.id}`}>id:{status.id}</span>
+            <span data-testid={`post-text-${status.id}`}>{target.text}</span>
+            <span data-testid={`post-liked-${status.id}`}>
+              {String(target.isActorLiked)}
+            </span>
+            <span data-testid={`post-bookmarked-${status.id}`}>
+              {String(target.isActorBookmarked)}
+            </span>
+            <span data-testid={`post-likes-${status.id}`}>
+              {target.totalLikes}
+            </span>
+            <span data-testid={`post-reactions-${status.id}`}>
+              {target.reactions?.length ?? 0}
+            </span>
+            <button
+              type="button"
+              data-testid={`trigger-delete-${status.id}`}
+              onClick={() => onPostDeleted?.(status)}
+            >
+              delete
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-update-${status.id}`}
+              onClick={() =>
+                onPostUpdated?.({ ...target, text: 'updated text' } as any)
+              }
+            >
+              update
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-like-${status.id}`}
+              onClick={() => onLikeChanged?.(target as any, true)}
+            >
+              like
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unlike-${status.id}`}
+              onClick={() => onLikeChanged?.(target as any, false)}
+            >
+              unlike
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-bookmark-${status.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, true)}
+            >
+              bookmark
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unbookmark-${status.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, false)}
+            >
+              unbookmark
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-react-${status.id}`}
+              onClick={() =>
+                onReactionsChanged?.(target as any, [
+                  { name: '🔥', count: 1, me: true }
+                ])
+              }
+            >
+              react
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }))
@@ -83,7 +169,7 @@ const list: ListEntity = {
   exclusive: false
 }
 
-const createStatus = (id: string): Status => ({
+const createStatus = (id: string, overrides: Partial<Status> = {}): Status => ({
   id,
   actorId: profile.id,
   actor: profile,
@@ -101,9 +187,28 @@ const createStatus = (id: string): Status => ({
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   attachments: [],
-  tags: []
+  tags: [],
+  ...overrides
+})
+
+const createAnnounceStatus = (
+  id: string,
+  originalStatus: Status
+): StatusAnnounce => ({
+  id,
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: FIXED_CURRENT_TIME,
+  updatedAt: FIXED_CURRENT_TIME,
+  type: StatusType.enum.Announce,
+  originalStatus
 })
 
 class MockIntersectionObserver {
@@ -196,6 +301,261 @@ describe('ListTimeline', () => {
     expect(getListTimeline).toHaveBeenCalledWith({
       listId: 'list-1',
       maxStatusId: 'https://activities.local/users/llun/s/1'
+    })
+  })
+
+  describe('status updates and engagement sync', () => {
+    it('updates matching status in place on onPostUpdated', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[post1]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('https://activities.local/users/llun/s/1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-update-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('updated text')
+    })
+
+    it('updates announce wrapper when original status is updated', () => {
+      const original = createStatus('https://activities.local/users/other/s/1')
+      const announce = createAnnounceStatus(
+        'https://activities.local/users/llun/s/announce-1',
+        original
+      )
+
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[announce]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-text-https://activities.local/users/llun/s/announce-1'
+        )
+      ).toHaveTextContent('https://activities.local/users/other/s/1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-update-https://activities.local/users/llun/s/announce-1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-text-https://activities.local/users/llun/s/announce-1'
+        )
+      ).toHaveTextContent('updated text')
+    })
+
+    it('removes matching status on onPostDeleted', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[post1]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId('post-https://activities.local/users/llun/s/1')
+      ).toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-delete-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.queryByTestId('post-https://activities.local/users/llun/s/1')
+      ).not.toBeInTheDocument()
+    })
+
+    it('removes announce wrapper when original status is deleted', () => {
+      const original = createStatus('https://activities.local/users/other/s/1')
+      const announce = createAnnounceStatus(
+        'https://activities.local/users/llun/s/announce-1',
+        original
+      )
+
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[announce]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-https://activities.local/users/llun/s/announce-1'
+        )
+      ).toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-delete-https://activities.local/users/llun/s/announce-1'
+        )
+      )
+
+      expect(
+        screen.queryByTestId(
+          'post-https://activities.local/users/llun/s/announce-1'
+        )
+      ).not.toBeInTheDocument()
+    })
+
+    it('updates like count and liked status when onLikeChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[post1]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-like-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('true')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('1')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-unlike-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/users/llun/s/1')
+      ).toHaveTextContent('0')
+    })
+
+    it('updates bookmark status when onBookmarkChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[post1]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('false')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-bookmark-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('true')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-unbookmark-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-bookmarked-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('false')
+    })
+
+    it('updates reactions when onReactionsChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/users/llun/s/1')
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={1}
+          statuses={[post1]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-reactions-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-react-https://activities.local/users/llun/s/1'
+        )
+      )
+
+      expect(
+        screen.getByTestId(
+          'post-reactions-https://activities.local/users/llun/s/1'
+        )
+      ).toHaveTextContent('1')
     })
   })
 })

--- a/app/(timeline)/lists/[id]/ListTimeline.tsx
+++ b/app/(timeline)/lists/[id]/ListTimeline.tsx
@@ -7,13 +7,18 @@ import { FC, useCallback, useRef, useState } from 'react'
 import { getListTimeline } from '@/lib/client'
 import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
+import {
+  removeOriginalStatus,
+  updateMatchingStatus
+} from '@/lib/components/posts/statusArray'
 import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { ListEntity } from '@/lib/types/mastodon/list'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 interface ListTimelineProps {
   host: string
@@ -52,17 +57,60 @@ export const ListTimeline: FC<ListTimelineProps> = ({
     statuses.length > 0 ? statuses[statuses.length - 1].id : null
   )
 
-  const removeStatus = (status: Status) => {
+  const onPostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.filter((item) => item.id !== status.id)
+      removeOriginalStatus(previousStatuses, status.id)
     )
-  }
+  }, [])
 
-  const updateStatus = (status: Status) => {
+  const onPostUpdated = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.map((item) => (item.id === status.id ? status : item))
+      updateMatchingStatus(
+        previousStatuses,
+        status.id,
+        () => status as StatusNote | StatusPoll
+      )
     )
-  }
+  }, [])
+
+  const onLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorLiked: isLiked,
+          totalLikes: isLiked
+            ? target.totalLikes + 1
+            : Math.max(0, target.totalLikes - 1)
+        }))
+      )
+    },
+    []
+  )
+
+  const onBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorBookmarked: isBookmarked
+        }))
+      )
+    },
+    []
+  )
+
+  const onReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     const maxStatusId = lastStatusIdRef.current
@@ -136,8 +184,11 @@ export const ListTimeline: FC<ListTimelineProps> = ({
           showActions
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
-          onPostDeleted={removeStatus}
-          onPostUpdated={updateStatus}
+          onPostDeleted={onPostDeleted}
+          onPostUpdated={onPostUpdated}
+          onLikeChanged={onLikeChanged}
+          onBookmarkChanged={onBookmarkChanged}
+          onReactionsChanged={onReactionsChanged}
         />
       ) : (
         <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
@@ -2,10 +2,10 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusAnnounce, StatusType } from '@/lib/types/domain/status'
 
 import { HashtagTimeline } from './HashtagTimeline'
 
@@ -20,18 +20,106 @@ vi.mock('@/lib/components/posts/posts', () => ({
   Posts: ({
     statuses,
     showActions,
-    showReadOnlyStats
+    showReadOnlyStats,
+    onPostDeleted,
+    onPostUpdated,
+    onLikeChanged,
+    onBookmarkChanged,
+    onReactionsChanged
   }: {
     statuses: Status[]
     showActions?: boolean
     showReadOnlyStats?: boolean
+    onPostDeleted?: (status: Status) => void
+    onPostUpdated?: (status: Status) => void
+    onLikeChanged?: (status: any, isLiked: boolean) => void
+    onBookmarkChanged?: (status: any, isBookmarked: boolean) => void
+    onReactionsChanged?: (status: any, reactions: any[]) => void
   }) => (
     <div
       data-testid="posts"
       data-show-actions={String(Boolean(showActions))}
       data-read-only-stats={String(Boolean(showReadOnlyStats))}
     >
-      {statuses.map((s) => s.id).join(',')}
+      {statuses.map((s) => {
+        const target =
+          s.type === StatusType.enum.Announce ? s.originalStatus : s
+        return (
+          <div key={s.id} data-testid={`post-${s.id}`}>
+            <span data-testid={`post-id-${s.id}`}>id:{s.id}</span>
+            <span data-testid={`post-text-${s.id}`}>
+              {(target as any).text}
+            </span>
+            <span data-testid={`post-liked-${s.id}`}>
+              {String((target as any).isActorLiked)}
+            </span>
+            <span data-testid={`post-bookmarked-${s.id}`}>
+              {String((target as any).isActorBookmarked)}
+            </span>
+            <span data-testid={`post-likes-${s.id}`}>
+              {(target as any).totalLikes ?? 0}
+            </span>
+            <span data-testid={`post-reactions-${s.id}`}>
+              {(target as any).reactions?.length ?? 0}
+            </span>
+            <button
+              type="button"
+              data-testid={`trigger-delete-${s.id}`}
+              onClick={() => onPostDeleted?.(s)}
+            >
+              delete
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-update-${s.id}`}
+              onClick={() =>
+                onPostUpdated?.({ ...target, text: 'updated text' } as any)
+              }
+            >
+              update
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-like-${s.id}`}
+              onClick={() => onLikeChanged?.(target as any, true)}
+            >
+              like
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unlike-${s.id}`}
+              onClick={() => onLikeChanged?.(target as any, false)}
+            >
+              unlike
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-bookmark-${s.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, true)}
+            >
+              bookmark
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-unbookmark-${s.id}`}
+              onClick={() => onBookmarkChanged?.(target as any, false)}
+            >
+              unbookmark
+            </button>
+            <button
+              type="button"
+              data-testid={`trigger-react-${s.id}`}
+              onClick={() =>
+                onReactionsChanged?.(target as any, [
+                  { name: '✨', count: 1, me: true }
+                ])
+              }
+            >
+              react
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }))
@@ -47,7 +135,31 @@ vi.mock('@/lib/components/posts/useLoadMoreOnVisible', () => ({
   })
 }))
 
-const statuses = [{ id: 'status-1' }] as unknown as Status[]
+const createStatus = (
+  id: string,
+  overrides: Record<string, any> = {}
+): Status =>
+  ({
+    id,
+    type: StatusType.enum.Note,
+    text: id,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    totalLikes: 0,
+    ...overrides
+  }) as unknown as Status
+
+const createAnnounceStatus = (
+  id: string,
+  originalStatus: Status
+): StatusAnnounce =>
+  ({
+    id,
+    type: StatusType.enum.Announce,
+    originalStatus
+  }) as unknown as StatusAnnounce
+
+const statuses = [createStatus('status-1')]
 
 const baseProps = {
   tag: 'fediverse',
@@ -78,5 +190,165 @@ describe('HashtagTimeline', () => {
     const feed = screen.getByTestId('posts')
     expect(feed).toHaveAttribute('data-show-actions', showActions)
     expect(feed).toHaveAttribute('data-read-only-stats', readOnlyStats)
+  })
+
+  describe('status updates and engagement sync', () => {
+    it('updates matching status in place on onPostUpdated', () => {
+      const post1 = createStatus('https://activities.local/s/1')
+      render(<HashtagTimeline {...baseProps} statuses={[post1]} />)
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/s/1')
+      ).toHaveTextContent('https://activities.local/s/1')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-update-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/s/1')
+      ).toHaveTextContent('updated text')
+    })
+
+    it('updates announce wrapper when original status is updated', () => {
+      const original = createStatus('https://activities.local/s/original')
+      const announce = createAnnounceStatus(
+        'https://activities.local/s/announce-1',
+        original
+      )
+
+      render(<HashtagTimeline {...baseProps} statuses={[announce]} />)
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/s/announce-1')
+      ).toHaveTextContent('https://activities.local/s/original')
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-update-https://activities.local/s/announce-1'
+        )
+      )
+
+      expect(
+        screen.getByTestId('post-text-https://activities.local/s/announce-1')
+      ).toHaveTextContent('updated text')
+    })
+
+    it('removes matching status on onPostDeleted', () => {
+      const post1 = createStatus('https://activities.local/s/1')
+      render(<HashtagTimeline {...baseProps} statuses={[post1]} />)
+
+      expect(
+        screen.getByTestId('post-https://activities.local/s/1')
+      ).toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByTestId('trigger-delete-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.queryByTestId('post-https://activities.local/s/1')
+      ).not.toBeInTheDocument()
+    })
+
+    it('removes announce wrapper when original status is deleted', () => {
+      const original = createStatus('https://activities.local/s/original')
+      const announce = createAnnounceStatus(
+        'https://activities.local/s/announce-1',
+        original
+      )
+
+      render(<HashtagTimeline {...baseProps} statuses={[announce]} />)
+
+      expect(
+        screen.getByTestId('post-https://activities.local/s/announce-1')
+      ).toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByTestId(
+          'trigger-delete-https://activities.local/s/announce-1'
+        )
+      )
+
+      expect(
+        screen.queryByTestId('post-https://activities.local/s/announce-1')
+      ).not.toBeInTheDocument()
+    })
+
+    it('updates like count and liked status when onLikeChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/s/1')
+      render(<HashtagTimeline {...baseProps} statuses={[post1]} />)
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/s/1')
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-like-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/s/1')
+      ).toHaveTextContent('true')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/s/1')
+      ).toHaveTextContent('1')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-unlike-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-liked-https://activities.local/s/1')
+      ).toHaveTextContent('false')
+      expect(
+        screen.getByTestId('post-likes-https://activities.local/s/1')
+      ).toHaveTextContent('0')
+    })
+
+    it('updates bookmark status when onBookmarkChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/s/1')
+      render(<HashtagTimeline {...baseProps} statuses={[post1]} />)
+
+      expect(
+        screen.getByTestId('post-bookmarked-https://activities.local/s/1')
+      ).toHaveTextContent('false')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-bookmark-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-bookmarked-https://activities.local/s/1')
+      ).toHaveTextContent('true')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-unbookmark-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-bookmarked-https://activities.local/s/1')
+      ).toHaveTextContent('false')
+    })
+
+    it('updates reactions when onReactionsChanged is triggered', () => {
+      const post1 = createStatus('https://activities.local/s/1')
+      render(<HashtagTimeline {...baseProps} statuses={[post1]} />)
+
+      expect(
+        screen.getByTestId('post-reactions-https://activities.local/s/1')
+      ).toHaveTextContent('0')
+
+      fireEvent.click(
+        screen.getByTestId('trigger-react-https://activities.local/s/1')
+      )
+
+      expect(
+        screen.getByTestId('post-reactions-https://activities.local/s/1')
+      ).toHaveTextContent('1')
+    })
   })
 })

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
@@ -5,12 +5,17 @@ import { FC, useCallback, useRef, useState } from 'react'
 
 import { getHashtagTimeline } from '@/lib/client'
 import { Posts } from '@/lib/components/posts/posts'
+import {
+  removeOriginalStatus,
+  updateMatchingStatus
+} from '@/lib/components/posts/statusArray'
 import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 interface HashtagTimelineProps {
   tag: string
@@ -47,25 +52,60 @@ export const HashtagTimeline: FC<HashtagTimelineProps> = ({
       (statuses.length > 0 ? statuses[statuses.length - 1].id : null)
   )
 
-  const onPostDeleted = (status: Status) => {
-    const statusIndex = currentStatuses.findIndex(
-      (item) => item.id === status.id
-    )
-    if (statusIndex === -1) return
-    const newStatuses = [
-      ...currentStatuses.slice(0, statusIndex),
-      ...currentStatuses.slice(statusIndex + 1)
-    ]
-    setCurrentStatuses(newStatuses)
-    lastStatusIdRef.current =
-      newStatuses.length > 0 ? newStatuses[newStatuses.length - 1].id : null
-  }
-
-  const updateStatus = (status: Status) => {
+  const onPostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.map((item) => (item.id === status.id ? status : item))
+      removeOriginalStatus(previousStatuses, status.id)
     )
-  }
+  }, [])
+
+  const onPostUpdated = useCallback((status: Status) => {
+    setCurrentStatuses((previousStatuses) =>
+      updateMatchingStatus(
+        previousStatuses,
+        status.id,
+        () => status as StatusNote | StatusPoll
+      )
+    )
+  }, [])
+
+  const onLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorLiked: isLiked,
+          totalLikes: isLiked
+            ? target.totalLikes + 1
+            : Math.max(0, target.totalLikes - 1)
+        }))
+      )
+    },
+    []
+  )
+
+  const onBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorBookmarked: isBookmarked
+        }))
+      )
+    },
+    []
+  )
+
+  const onReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     const lastStatusId = lastStatusIdRef.current
@@ -127,7 +167,10 @@ export const HashtagTimeline: FC<HashtagTimelineProps> = ({
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
           onPostDeleted={onPostDeleted}
-          onPostUpdated={updateStatus}
+          onPostUpdated={onPostUpdated}
+          onLikeChanged={onLikeChanged}
+          onBookmarkChanged={onBookmarkChanged}
+          onReactionsChanged={onReactionsChanged}
         />
       ) : (
         <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">


### PR DESCRIPTION
Apply shared status-array helpers to home, list, and hashtag timelines (Task C5).

- Use `removeOriginalStatus` and `updateMatchingStatus` from `@/lib/components/posts/statusArray`.
- Connect `onLikeChanged`, `onBookmarkChanged`, and `onReactionsChanged` in `MainPageTimeline`, `ListTimeline`, and `HashtagTimeline`.
- Preserve nested original statuses and boost wrapper updates across edits/deletions/reactions/likes/bookmarks.
- Add comprehensive unit tests covering status array transformations and interaction callbacks.