### PR TITLE
Bump version to v1.161.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.15",
+  "version": "1.161.16",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.16.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.15`
- Base main SHA: `32f20ffcc2fe3d46d9482a80f5edb46dd1e3a801`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
