### PR TITLE
Bump version to v1.161.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.16",
+  "version": "1.161.17",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.17.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.16`
- Base main SHA: `1c80cf41734ed12562249b8fdc4d0339a95ae8d2`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
