### PR TITLE
refactor: migrate remaining settings fetch callers to lib/client.ts

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -238,10 +238,7 @@
               "app/(timeline)/account/security/ChangePasswordForm.tsx",
               "app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx",
               "app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.tsx",
-              "app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx",
-              "lib/components/settings/DeleteActorDialog.tsx",
-              "lib/components/settings/MediaManagement.tsx",
-              "lib/components/settings/ActorsSection.tsx"
+              "app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx"
             ]
           }
         ]

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -17,6 +17,8 @@ import {
   createDirectMessage,
   createPoll,
   createReport,
+  deleteAccountMedia,
+  deleteActor,
   deleteCollection,
   deleteFitnessRouteHeatmap,
   deleteStatus,
@@ -38,6 +40,7 @@ import {
   removeCollectionAccounts,
   revokeCollectionMembership,
   search,
+  setDefaultActor,
   startStravaArchiveImport,
   switchActor,
   triggerFitnessRouteHeatmap,
@@ -1762,6 +1765,211 @@ describe('client actor management helpers', () => {
 
       await expect(switchActor({ actorId: 'actor-2' })).rejects.toThrow(
         'Network disconnected'
+      )
+    })
+  })
+
+  describe('setDefaultActor', () => {
+    it('sends POST with actorId to set default actor', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          defaultActorId: 'actor-1',
+          id: 'actor-1',
+          username: 'alice',
+          domain: 'activities.local'
+        }),
+        { status: 200 }
+      )
+
+      const result = await setDefaultActor({ actorId: 'actor-1' })
+
+      expect(result).toEqual({
+        defaultActorId: 'actor-1',
+        id: 'actor-1',
+        username: 'alice',
+        domain: 'activities.local'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/default',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1' })
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'Actor not found or not owned by account'
+        }),
+        { status: 404 }
+      )
+
+      await expect(
+        setDefaultActor({ actorId: 'actor-missing' })
+      ).rejects.toThrow('Actor not found or not owned by account')
+    })
+
+    it('falls back to default error message on failure', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(setDefaultActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to update default actor'
+      )
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      await expect(setDefaultActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Network error'
+      )
+    })
+  })
+
+  describe('deleteActor', () => {
+    it('sends POST with actorId and delayDays', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          actorId: 'actor-1',
+          status: 'scheduled',
+          scheduledAt: '2026-09-10T00:00:00.000Z',
+          immediate: false
+        }),
+        { status: 200 }
+      )
+
+      const result = await deleteActor({ actorId: 'actor-1', delayDays: 3 })
+
+      expect(result).toEqual({
+        actorId: 'actor-1',
+        status: 'scheduled',
+        scheduledAt: '2026-09-10T00:00:00.000Z',
+        immediate: false
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/delete',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1', delayDays: 3 })
+        })
+      )
+    })
+
+    it('defaults delayDays to 0 when omitted', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          actorId: 'actor-1',
+          status: 'scheduled',
+          scheduledAt: null,
+          immediate: true
+        }),
+        { status: 200 }
+      )
+
+      await deleteActor({ actorId: 'actor-1' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/delete',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1', delayDays: 0 })
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'Cannot delete the default actor'
+        }),
+        { status: 400 }
+      )
+
+      await expect(deleteActor({ actorId: 'actor-default' })).rejects.toThrow(
+        'Cannot delete the default actor'
+      )
+    })
+
+    it('falls back to default error message on failure', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(deleteActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to delete actor'
+      )
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      await expect(deleteActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Network error'
+      )
+    })
+  })
+
+  describe('deleteAccountMedia', () => {
+    it('sends DELETE to account media route and returns true', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      const result = await deleteAccountMedia({ mediaId: 'media-123' })
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/media/media-123',
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      )
+    })
+
+    it('encodes mediaId in path', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      await deleteAccountMedia({ mediaId: 'path/with/slash' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/media/path%2Fwith%2Fslash',
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'Media not found or not owned by account'
+        }),
+        { status: 404 }
+      )
+
+      await expect(
+        deleteAccountMedia({ mediaId: 'media-missing' })
+      ).rejects.toThrow('Media not found or not owned by account')
+    })
+
+    it('falls back to default error message on failure', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(deleteAccountMedia({ mediaId: 'media-1' })).rejects.toThrow(
+        'Failed to delete media'
+      )
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      await expect(deleteAccountMedia({ mediaId: 'media-1' })).rejects.toThrow(
+        'Network error'
       )
     })
   })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -941,6 +941,96 @@ export const cancelActorDeletion = async ({
   return (await response.json()) as CancelActorDeletionResult
 }
 
+export interface SetDefaultActorParams {
+  actorId: string
+}
+
+export interface SetDefaultActorResult {
+  defaultActorId: string
+  id: string
+  username: string
+  domain: string
+}
+
+/**
+ * Sets the default actor for the current account
+ */
+export const setDefaultActor = async ({
+  actorId
+}: SetDefaultActorParams): Promise<SetDefaultActorResult> => {
+  const response = await fetch('/api/v1/actors/default', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to update default actor')
+  }
+
+  return (await response.json()) as SetDefaultActorResult
+}
+
+export interface DeleteActorParams {
+  actorId: string
+  delayDays?: number
+}
+
+export interface DeleteActorResult {
+  actorId: string
+  status: string
+  scheduledAt: string | null
+  immediate: boolean
+}
+
+/**
+ * Schedules or immediately executes deletion of an actor
+ */
+export const deleteActor = async ({
+  actorId,
+  delayDays = 0
+}: DeleteActorParams): Promise<DeleteActorResult> => {
+  const response = await fetch('/api/v1/actors/delete', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId, delayDays })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to delete actor')
+  }
+
+  return (await response.json()) as DeleteActorResult
+}
+
+export interface DeleteAccountMediaParams {
+  mediaId: string
+}
+
+/**
+ * Deletes a media item owned by the current account
+ */
+export const deleteAccountMedia = async ({
+  mediaId
+}: DeleteAccountMediaParams): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/accounts/media/${encodeURIComponent(mediaId)}`,
+    {
+      method: 'DELETE'
+    }
+  )
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to delete media')
+  }
+
+  return true
+}
+
 interface MarkNotificationsReadParams {
   notificationIds: string[]
 }

--- a/lib/components/settings/ActorsSection.test.tsx
+++ b/lib/components/settings/ActorsSection.test.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-import { cancelActorDeletion, switchActor } from '@/lib/client'
+import { cancelActorDeletion, setDefaultActor, switchActor } from '@/lib/client'
 
 import { ActorsSection } from './ActorsSection'
 
@@ -21,6 +21,7 @@ vi.mock('@/lib/components/actor-switcher', () => ({
 
 vi.mock('@/lib/client', () => ({
   cancelActorDeletion: vi.fn(),
+  setDefaultActor: vi.fn(),
   switchActor: vi.fn()
 }))
 
@@ -346,5 +347,76 @@ describe('ActorsSection', () => {
     expect(deletingItem).toBeDefined()
     expect(deletingItem).toHaveAttribute('data-disabled')
     expect(deletingItem).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('updates default actor via setDefaultActor and refreshes', async () => {
+    vi.mocked(setDefaultActor).mockResolvedValue({
+      defaultActorId: 'actor-2',
+      id: 'actor-2',
+      username: 'bob',
+      domain: 'activities.local'
+    })
+
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={actors}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    // Select Bob from dropdown
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const bobItem = screen.getByText('Bob')
+    fireEvent.click(bobItem)
+
+    const saveDefaultButton = screen.getByRole('button', {
+      name: 'Set as default'
+    })
+    expect(saveDefaultButton).not.toBeDisabled()
+    fireEvent.click(saveDefaultButton)
+
+    expect(setDefaultActor).toHaveBeenCalledWith({ actorId: 'actor-2' })
+    await waitFor(() => {
+      expect(screen.getByText('Default actor updated')).toBeInTheDocument()
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('displays error message when setDefaultActor fails', async () => {
+    vi.mocked(setDefaultActor).mockRejectedValueOnce(
+      new Error('Failed to update')
+    )
+
+    render(
+      <ActorsSection
+        currentActor={actors[0]}
+        actors={actors}
+        currentDefault={actors[0].id}
+      />
+    )
+
+    // Select Bob from dropdown
+    const trigger = screen.getByRole('button', { name: /alice/i })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await screen.findByRole('menu')
+
+    const bobItem = screen.getByText('Bob')
+    fireEvent.click(bobItem)
+
+    const saveDefaultButton = screen.getByRole('button', {
+      name: 'Set as default'
+    })
+    fireEvent.click(saveDefaultButton)
+
+    expect(setDefaultActor).toHaveBeenCalledWith({ actorId: 'actor-2' })
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to update default actor')
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/lib/components/settings/ActorsSection.tsx
+++ b/lib/components/settings/ActorsSection.tsx
@@ -4,7 +4,7 @@ import { Check, ChevronDown, Clock, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 
-import { cancelActorDeletion, switchActor } from '@/lib/client'
+import { cancelActorDeletion, setDefaultActor, switchActor } from '@/lib/client'
 import { ActorInfo, AddActorDialog } from '@/lib/components/actor-switcher'
 import { ActorDisplayName } from '@/lib/components/actors/ActorDisplayName'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
@@ -91,20 +91,11 @@ export function ActorsSection({
     setMessage(null)
 
     try {
-      const response = await fetch('/api/v1/actors/default', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actorId: selectedActorId })
-      })
-
-      if (response.ok) {
-        setMessage({ type: 'success', text: 'Default actor updated' })
-        router.refresh()
-      } else {
-        setMessage({ type: 'error', text: 'Failed to update default actor' })
-      }
+      await setDefaultActor({ actorId: selectedActorId })
+      setMessage({ type: 'success', text: 'Default actor updated' })
+      router.refresh()
     } catch {
-      setMessage({ type: 'error', text: 'An error occurred' })
+      setMessage({ type: 'error', text: 'Failed to update default actor' })
     } finally {
       setIsSavingDefault(false)
     }

--- a/lib/components/settings/DeleteActorDialog.test.tsx
+++ b/lib/components/settings/DeleteActorDialog.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { deleteActor } from '@/lib/client'
+
+import { DeleteActorDialog } from './DeleteActorDialog'
+
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    refresh: mockRefresh
+  }))
+}))
+
+vi.mock('@/lib/client', () => ({
+  deleteActor: vi.fn()
+}))
+
+describe('DeleteActorDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders dialog with actor username and domain', () => {
+    render(
+      <DeleteActorDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        actorId="actor-1"
+        actorUsername="alice"
+        actorDomain="activities.local"
+      />
+    )
+
+    expect(screen.getByText('@alice@activities.local')).toBeInTheDocument()
+    expect(screen.getByText('Delete Actor')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Schedule Deletion' })
+    ).toBeInTheDocument()
+  })
+
+  it('schedules delayed deletion by default and refreshes', async () => {
+    const onOpenChange = vi.fn()
+    vi.mocked(deleteActor).mockResolvedValueOnce({
+      actorId: 'actor-1',
+      status: 'scheduled',
+      scheduledAt: '2026-09-10T00:00:00.000Z',
+      immediate: false
+    })
+
+    render(
+      <DeleteActorDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        actorId="actor-1"
+        actorUsername="alice"
+        actorDomain="activities.local"
+      />
+    )
+
+    const scheduleButton = screen.getByRole('button', {
+      name: 'Schedule Deletion'
+    })
+    fireEvent.click(scheduleButton)
+
+    expect(deleteActor).toHaveBeenCalledWith({
+      actorId: 'actor-1',
+      delayDays: 3
+    })
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('deletes immediately when immediate option is selected', async () => {
+    const onOpenChange = vi.fn()
+    vi.mocked(deleteActor).mockResolvedValueOnce({
+      actorId: 'actor-1',
+      status: 'scheduled',
+      scheduledAt: null,
+      immediate: true
+    })
+
+    render(
+      <DeleteActorDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        actorId="actor-1"
+        actorUsername="alice"
+        actorDomain="activities.local"
+      />
+    )
+
+    const immediateRadio = screen.getByLabelText('Delete immediately')
+    fireEvent.click(immediateRadio)
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete Now'
+    })
+    fireEvent.click(deleteButton)
+
+    expect(deleteActor).toHaveBeenCalledWith({
+      actorId: 'actor-1',
+      delayDays: 0
+    })
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  it('displays error message when deleteActor fails', async () => {
+    vi.mocked(deleteActor).mockRejectedValueOnce(
+      new Error('Cannot delete the default actor')
+    )
+
+    render(
+      <DeleteActorDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        actorId="actor-1"
+        actorUsername="alice"
+        actorDomain="activities.local"
+      />
+    )
+
+    const scheduleButton = screen.getByRole('button', {
+      name: 'Schedule Deletion'
+    })
+    fireEvent.click(scheduleButton)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Cannot delete the default actor')
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/lib/components/settings/DeleteActorDialog.tsx
+++ b/lib/components/settings/DeleteActorDialog.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
+import { deleteActor } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import {
   Dialog,
@@ -43,26 +44,19 @@ export function DeleteActorDialog({
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/v1/actors/delete', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          actorId,
-          delayDays: delayOption === 'delayed' ? 3 : 0
-        })
+      await deleteActor({
+        actorId,
+        delayDays: delayOption === 'delayed' ? 3 : 0
       })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        setError(data.error || 'Failed to delete actor')
-        return
-      }
 
       onOpenChange(false)
       router.refresh()
-    } catch {
-      setError('An error occurred while deleting the actor')
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'An error occurred while deleting the actor'
+      )
     } finally {
       setIsLoading(false)
     }

--- a/lib/components/settings/MediaManagement.test.tsx
+++ b/lib/components/settings/MediaManagement.test.tsx
@@ -2,7 +2,9 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { deleteAccountMedia } from '@/lib/client'
 
 import { MediaManagement } from './MediaManagement'
 
@@ -11,6 +13,10 @@ vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
     push: vi.fn()
   }))
+}))
+
+vi.mock('@/lib/client', () => ({
+  deleteAccountMedia: vi.fn()
 }))
 
 describe('MediaManagement', () => {
@@ -163,6 +169,59 @@ describe('MediaManagement', () => {
 
       const link = screen.queryByText('View in post →')
       expect(link).not.toBeInTheDocument()
+    })
+  })
+
+  describe('media deletion', () => {
+    it('calls deleteAccountMedia and removes item from list on confirm', async () => {
+      const medias = [
+        {
+          id: 'media-to-delete',
+          actorId: 'https://example.com/users/alice',
+          bytes: 1024,
+          mimeType: 'image/png',
+          width: 800,
+          height: 600,
+          url: '/api/v1/files/test.png'
+        }
+      ]
+
+      vi.mocked(deleteAccountMedia).mockResolvedValueOnce(true)
+
+      render(
+        <MediaManagement
+          used={1024}
+          limit={10485760}
+          medias={medias}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      expect(screen.getByText('ID: media-to-delete')).toBeInTheDocument()
+
+      const deleteTrigger = screen.getByRole('button', { name: 'Delete' })
+      fireEvent.click(deleteTrigger)
+
+      // Dialog opens
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+
+      const confirmButton = screen.getByRole('button', {
+        name: 'Delete'
+      })
+      fireEvent.click(confirmButton)
+
+      expect(deleteAccountMedia).toHaveBeenCalledWith({
+        mediaId: 'media-to-delete'
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('ID: media-to-delete')
+        ).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/lib/components/settings/MediaManagement.tsx
+++ b/lib/components/settings/MediaManagement.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
+import { deleteAccountMedia } from '@/lib/client'
 import { PageHeader } from '@/lib/components/page-header'
 import {
   FileListPagination,
@@ -80,20 +81,13 @@ export function MediaManagement({
 
     setDeleting(true)
     try {
-      const response = await fetch(
-        `/api/v1/accounts/media/${mediaToDelete.id}`,
-        {
-          method: 'DELETE'
-        }
-      )
+      await deleteAccountMedia({ mediaId: mediaToDelete.id })
 
-      if (response.ok) {
-        // Update local state
-        setMedias(medias.filter((m) => m.id !== mediaToDelete.id))
-        setCurrentUsed(currentUsed - mediaToDelete.bytes)
-        setDeleteDialogOpen(false)
-        setMediaToDelete(null)
-      }
+      // Update local state
+      setMedias(medias.filter((m) => m.id !== mediaToDelete.id))
+      setCurrentUsed(currentUsed - mediaToDelete.bytes)
+      setDeleteDialogOpen(false)
+      setMediaToDelete(null)
     } catch {
       // Silently fail on network errors or API failures - user will see media is still present
     } finally {


### PR DESCRIPTION
Migrate direct `fetch` calls in `ActorsSection.tsx`, `DeleteActorDialog.tsx`, and `MediaManagement.tsx` to `lib/client.ts` helpers (`setDefaultActor`, `deleteActor`, `deleteAccountMedia`), removing them from `allowFiles` in `.oxlintrc.json`.