### PR TITLE
Bump version to v1.161.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.17",
+  "version": "1.161.18",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.18.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.17`
- Base main SHA: `9751a405b549cc62507a8ccee0b0380d1634d13e`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
