### PR TITLE
fix(proxy): allow POST to rewritten inbox routes

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -416,7 +416,15 @@ describe('proxy', () => {
   })
 
   it('rejects non-action POST requests to page routes with 404', async () => {
-    for (const path of ['/', '/settings', '/explore', '/notifications']) {
+    for (const path of [
+      '/',
+      '/settings',
+      '/explore',
+      '/notifications',
+      '/inbox-invalid',
+      '/inbox/invalid',
+      '/users'
+    ]) {
       const request = new NextRequest(`https://llun.social${path}`, {
         method: 'POST'
       })
@@ -456,7 +464,7 @@ describe('proxy', () => {
     expect(actionResponse?.status).toBe(200)
   })
 
-  it('allows POST requests to rewritten inbox routes', async () => {
+  it('allows POST requests to rewritten API routes', async () => {
     for (const path of ['/inbox', '/users/alice/inbox']) {
       const request = new NextRequest(`https://llun.social${path}`, {
         method: 'POST'

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -456,6 +456,32 @@ describe('proxy', () => {
     expect(actionResponse?.status).toBe(200)
   })
 
+  it('allows POST requests to rewritten inbox routes', async () => {
+    for (const path of ['/inbox', '/users/alice/inbox']) {
+      const request = new NextRequest(`https://llun.social${path}`, {
+        method: 'POST'
+      })
+
+      const response = await proxy(request)
+
+      expect(response?.status).toBe(200)
+    }
+  })
+
+  it('allows mutating methods on rewritten routes', async () => {
+    for (const method of ['PUT', 'DELETE', 'PATCH']) {
+      for (const path of ['/inbox', '/users/alice']) {
+        const request = new NextRequest(`https://llun.social${path}`, {
+          method
+        })
+
+        const response = await proxy(request)
+
+        expect(response?.status).toBe(200)
+      }
+    }
+  })
+
   it('rewrites actor handles on HEAD requests', async () => {
     const request = new NextRequest('https://internal.example.com/@alice', {
       method: 'HEAD',

--- a/proxy.ts
+++ b/proxy.ts
@@ -47,6 +47,10 @@ const VALID_AUTH_PAGES = new Set([
   '/auth/two-factor'
 ])
 
+const isRewrittenApiRoute = (pathname: string): boolean => {
+  return pathname === '/inbox' || pathname.startsWith('/users/')
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
@@ -81,13 +85,15 @@ export async function proxy(request: NextRequest) {
   // If the page does not define Server Actions and no action ID is provided, Next.js throws
   // "Failed to find Server Action" and produces a 500 error.
   // In activities.next, POST requests are only valid on API route handlers (/api/*), OAuth
-  // route handlers (/oauth/*), and admin Server Actions (/admin/* or with Next-Action header).
+  // route handlers (/oauth/*), admin Server Actions (/admin/* or with Next-Action header),
+  // and rewritten API routes (/inbox, /users/*).
   // All other page POSTs are rejected cleanly here.
   if (
     request.method === 'POST' &&
     !pathname.startsWith('/api/') &&
     !pathname.startsWith('/oauth/') &&
     !pathname.startsWith('/admin') &&
+    !isRewrittenApiRoute(pathname) &&
     !request.headers.has('next-action')
   ) {
     return withContentSecurityPolicy(
@@ -102,7 +108,8 @@ export async function proxy(request: NextRequest) {
       request.method === 'DELETE' ||
       request.method === 'PATCH') &&
     !pathname.startsWith('/api/') &&
-    !pathname.startsWith('/oauth/')
+    !pathname.startsWith('/oauth/') &&
+    !isRewrittenApiRoute(pathname)
   ) {
     return withContentSecurityPolicy(
       new NextResponse(null, {


### PR DESCRIPTION
## Summary

PR #1850 added a check in `proxy.ts` to reject mutating/POST requests to page routes to prevent Next.js from treating them as missing Server Actions (producing 500 errors). However, Next.js middleware executes before `next.config.ts` rewrites run.

Because of this, incoming ActivityPub POST requests to rewritten endpoints:
- `/inbox` (rewritten to `/api/inbox`)
- `/users/:username/inbox` (rewritten to `/api/users/:username/inbox`)

were intercepted by `proxy.ts` and returned as HTTP 404, breaking incoming federation.

This PR:
- Adds `isRewrittenApiRoute` in `proxy.ts` to allow `/inbox` and `/users/*` requests to bypass the POST Server Action rejection guard and mutating method checks.
- Adds test cases in `proxy.test.ts` verifying that `POST /inbox` and `POST /users/alice/inbox` pass through (HTTP 200), mutating methods on rewritten routes pass through, and non-action page POSTs (`/`, `/settings`, etc.) still return 404.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)