### PR TITLE
Bump version to v1.161.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.18",
+  "version": "1.161.19",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.19.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.18`
- Base main SHA: `ffd0f513ec5b1bd373b10f9ef1205c9258d27fa3`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
