### PR TITLE
fix: restrict admin POST proxy exemption to exact path segment

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -423,7 +423,11 @@ describe('proxy', () => {
       '/notifications',
       '/inbox-invalid',
       '/inbox/invalid',
-      '/users'
+      '/users',
+      '/administrator',
+      '/administrator/callback',
+      '/admin-invalid/callback',
+      '/admin123'
     ]) {
       const request = new NextRequest(`https://llun.social${path}`, {
         method: 'POST'
@@ -432,6 +436,9 @@ describe('proxy', () => {
       const response = await proxy(request)
 
       expect(response?.status).toBe(404)
+      expect(response?.headers.get('Content-Security-Policy')).toContain(
+        "default-src 'none'"
+      )
     }
   })
 
@@ -448,11 +455,25 @@ describe('proxy', () => {
     const oauthResponse = await proxy(oauthRequest)
     expect(oauthResponse?.status).toBe(200)
 
-    const adminRequest = new NextRequest('https://llun.social/admin/queues', {
-      method: 'POST'
-    })
-    const adminResponse = await proxy(adminRequest)
-    expect(adminResponse?.status).toBe(200)
+    for (const adminPath of ['/admin', '/admin/queues', '/admin/relays']) {
+      const adminRequest = new NextRequest(`https://llun.social${adminPath}`, {
+        method: 'POST'
+      })
+      const adminResponse = await proxy(adminRequest)
+      expect(adminResponse?.status).toBe(200)
+    }
+
+    const formData = new FormData()
+    formData.append('inboxUrl', 'https://relay.example/inbox')
+    const adminFormRequest = new NextRequest(
+      'https://llun.social/admin/relays',
+      {
+        method: 'POST',
+        body: formData
+      }
+    )
+    const adminFormResponse = await proxy(adminFormRequest)
+    expect(adminFormResponse?.status).toBe(200)
 
     const actionRequest = new NextRequest('https://llun.social/custom-action', {
       method: 'POST',
@@ -462,6 +483,18 @@ describe('proxy', () => {
     })
     const actionResponse = await proxy(actionRequest)
     expect(actionResponse?.status).toBe(200)
+
+    const lookalikeActionRequest = new NextRequest(
+      'https://llun.social/administrator/callback',
+      {
+        method: 'POST',
+        headers: {
+          'next-action': 'action-id-123'
+        }
+      }
+    )
+    const lookalikeActionResponse = await proxy(lookalikeActionRequest)
+    expect(lookalikeActionResponse?.status).toBe(200)
   })
 
   it('allows POST requests to rewritten API routes', async () => {

--- a/proxy.ts
+++ b/proxy.ts
@@ -81,18 +81,21 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // Next.js App Router treats ANY POST request to a page route as a Server Action invocation.
-  // If the page does not define Server Actions and no action ID is provided, Next.js throws
-  // "Failed to find Server Action" and produces a 500 error.
+  // Next.js App Router inspects incoming requests to determine if they are Server
+  // Action invocations based on request method (POST), headers (e.g. Next-Action /
+  // ACTION_HEADER), and content type (multipart/form-data or urlencoded). If a request
+  // resembles an action or targets an action route but cannot be resolved, Next.js can
+  // reject or fail the request.
   // In activities.next, POST requests are only valid on API route handlers (/api/*), OAuth
-  // route handlers (/oauth/*), admin Server Actions (/admin/* or with Next-Action header),
+  // route handlers (/oauth/*), admin Server Actions (/admin, /admin/*, or with Next-Action header),
   // and rewritten API routes (/inbox, /users/*).
   // All other page POSTs are rejected cleanly here.
   if (
     request.method === 'POST' &&
     !pathname.startsWith('/api/') &&
     !pathname.startsWith('/oauth/') &&
-    !pathname.startsWith('/admin') &&
+    pathname !== '/admin' &&
+    !pathname.startsWith('/admin/') &&
     !isRewrittenApiRoute(pathname) &&
     !request.headers.has('next-action')
   ) {


### PR DESCRIPTION
## Summary

Following PRs #1850 and #1882, this PR fixes the remaining boundary issue in `proxy.ts` where the POST exemption for admin routes used `!pathname.startsWith('/admin')`.

- **Boundary Check**: Replaced `!pathname.startsWith('/admin')` with `pathname !== '/admin' && !pathname.startsWith('/admin/')`, ensuring lookalike paths like `/administrator`, `/administrator/callback`, `/admin-invalid/callback`, and `/admin123` are rejected cleanly with a 404 and CSP headers attached when no `next-action` header is present.
- **Comment Correction**: Clarified the nearby comment regarding Next.js App Router Server Action detection behavior (method, headers, content type).
- **Regression Tests**: Extended `proxy.test.ts` to assert that lookalike admin paths return 404 with CSP, while legitimate admin paths (`/admin`, `/admin/queues`, `/admin/relays` including `multipart/form-data`) and lookalike paths with `next-action` pass through.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)