### PR TITLE
Bump version to v1.161.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.19",
+  "version": "1.161.20",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.20.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.19`
- Base main SHA: `8a43efd05ad2b9c48ac0529836cc8fddafe2b6a9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
