### PR TITLE
refactor: share follow-page server implementation

### DIFF
--- a/app/(timeline)/[actor]/FollowListPage.test.tsx
+++ b/app/(timeline)/[actor]/FollowListPage.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
+
+import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isLocalFederationDomain } from '@/lib/services/federation/domainPolicy'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { FollowListPage, generateFollowListMetadata } from './FollowListPage'
+
+const mockDatabase = {
+  getFollowers: vi.fn(),
+  getFollowing: vi.fn(),
+  getActorsFromIds: vi.fn(),
+  getActorFromId: vi.fn()
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.social',
+    mediaStorage: null
+  }),
+  getBaseURL: () => 'https://llun.social'
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/domainPolicy', () => ({
+  isLocalFederationDomain: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getProfileData', () => ({
+  getProfileData: vi.fn()
+}))
+
+vi.mock('@/app/(timeline)/[actor]/FollowList', () => ({
+  FollowList: ({
+    emptyMessage,
+    users
+  }: {
+    emptyMessage?: string
+    users?: { id: string; username: string }[]
+  }) => (
+    <div data-testid="follow-list" data-empty-message={emptyMessage}>
+      {users?.map((u) => (
+        <span key={u.id} data-testid={`user-${u.id}`}>
+          {u.username}
+        </span>
+      ))}
+    </div>
+  )
+}))
+
+vi.mock('@/app/(timeline)/[actor]/getFollowListBlockedActorIds', () => ({
+  getFollowListBlockedActorIds: vi.fn().mockResolvedValue([])
+}))
+
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockIsLocalFederationDomain = vi.mocked(isLocalFederationDomain)
+const mockGetProfileData = vi.mocked(getProfileData)
+const mockNotFound = vi.mocked(notFound)
+
+describe('FollowListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockIsLocalFederationDomain.mockResolvedValue(false)
+    mockGetProfileData.mockResolvedValue(null)
+  })
+
+  describe('redirect handling', () => {
+    it('renders ActorRedirectCard for non-local actor on followers direction', async () => {
+      const element = await FollowListPage({
+        params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' }),
+        direction: 'followers'
+      })
+      render(element)
+
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: 'You are leaving llun.social'
+        })
+      ).toBeInTheDocument()
+
+      const link = screen.getByRole('link', {
+        name: /continue to pouet\.chapril\.org/i
+      })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://pouet.chapril.org/@clairenony/followers'
+      )
+    })
+
+    it('renders ActorRedirectCard for non-local actor on following direction', async () => {
+      const element = await FollowListPage({
+        params: Promise.resolve({ actor: '@clairenony@pouet.chapril.org' }),
+        direction: 'following'
+      })
+      render(element)
+
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: 'You are leaving llun.social'
+        })
+      ).toBeInTheDocument()
+
+      const link = screen.getByRole('link', {
+        name: /continue to pouet\.chapril\.org/i
+      })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://pouet.chapril.org/@clairenony/following'
+      )
+    })
+  })
+
+  describe('missing actor / not-found handling', () => {
+    it('calls notFound when actor handle format is invalid', async () => {
+      await FollowListPage({
+        params: Promise.resolve({ actor: 'invalid' }),
+        direction: 'followers'
+      })
+      expect(mockNotFound).toHaveBeenCalled()
+    })
+
+    it('calls notFound when profile is not found', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+      mockGetProfileData.mockResolvedValue(null)
+
+      await FollowListPage({
+        params: Promise.resolve({ actor: '@someone@llun.social' }),
+        direction: 'followers'
+      })
+      expect(mockNotFound).toHaveBeenCalled()
+    })
+  })
+
+  describe('public and authenticated shell', () => {
+    const mockProfile = {
+      person: {
+        id: 'https://llun.social/users/someone',
+        preferredUsername: 'someone',
+        name: 'Someone'
+      },
+      followersCount: 10,
+      followingCount: 5
+    }
+
+    it('renders unauthenticated shell (no sticky PageHeader) for logged-out visitor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+      mockGetProfileData.mockResolvedValue(mockProfile as never)
+      mockDatabase.getFollowers.mockResolvedValue([])
+      mockDatabase.getActorsFromIds.mockResolvedValue([])
+
+      const element = await FollowListPage({
+        params: Promise.resolve({ actor: '@someone@llun.social' }),
+        direction: 'followers'
+      })
+      const { container } = render(element)
+
+      expect(container.querySelector('.sticky')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: 'Followers' })
+      ).toBeInTheDocument()
+      expect(screen.getByText('10 accounts')).toBeInTheDocument()
+      expect(screen.getByTestId('follow-list')).toHaveAttribute(
+        'data-empty-message',
+        'No followers yet'
+      )
+    })
+
+    it('renders authenticated PageHeader shell for logged-in user', async () => {
+      mockGetServerAuthSession.mockResolvedValue({
+        user: { email: 'viewer@llun.social' }
+      } as never)
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+      mockGetProfileData.mockResolvedValue(mockProfile as never)
+      mockDatabase.getFollowing.mockResolvedValue([])
+      mockDatabase.getActorsFromIds.mockResolvedValue([])
+
+      const element = await FollowListPage({
+        params: Promise.resolve({ actor: '@someone@llun.social' }),
+        direction: 'following'
+      })
+      const { container } = render(element)
+
+      expect(container.querySelector('.sticky')).toBeInTheDocument()
+      expect(screen.getByText('Following')).toBeInTheDocument()
+      expect(screen.getByText('5 accounts')).toBeInTheDocument()
+      expect(screen.getByTestId('follow-list')).toHaveAttribute(
+        'data-empty-message',
+        'Not following anyone yet'
+      )
+    })
+  })
+
+  describe('metadata generation', () => {
+    it('sets canonical link and robots for non-local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(false)
+      const meta = await generateFollowListMetadata({
+        params: Promise.resolve({ actor: '@user@remote.social' }),
+        direction: 'followers'
+      })
+      expect(meta).toEqual({
+        title: 'Activities.next: @user@remote.social Followers',
+        robots: { index: false, follow: false },
+        alternates: {
+          canonical: 'https://remote.social/@user/followers'
+        }
+      })
+    })
+
+    it('sets standard title for local actor', async () => {
+      mockIsLocalFederationDomain.mockResolvedValue(true)
+      const meta = await generateFollowListMetadata({
+        params: Promise.resolve({ actor: '@user@llun.social' }),
+        direction: 'following'
+      })
+      expect(meta).toEqual({
+        title: 'Activities.next: @user@llun.social Following'
+      })
+    })
+  })
+})

--- a/app/(timeline)/[actor]/FollowListPage.tsx
+++ b/app/(timeline)/[actor]/FollowListPage.tsx
@@ -1,0 +1,216 @@
+import { ArrowLeft } from 'lucide-react'
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { FC } from 'react'
+
+import { ActorRedirectCard } from '@/app/(timeline)/[actor]/ActorRedirectCard'
+import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
+import { getFollowListBlockedActorIds } from '@/app/(timeline)/[actor]/getFollowListBlockedActorIds'
+import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
+import { getNonLocalActorRedirectTarget } from '@/app/(timeline)/[actor]/resolveActorRedirect'
+import { PageHeader } from '@/lib/components/page-header'
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { Actor, ActorProfile } from '@/lib/types/domain/actor'
+import { Follow } from '@/lib/types/domain/follow'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+type ProfileData = NonNullable<Awaited<ReturnType<typeof getProfileData>>>
+
+export type FollowListDirection = 'followers' | 'following'
+
+interface DirectionConfig {
+  label: string
+  subpath: '/followers' | '/following'
+  emptyMessage: string
+  getCount: (profile: ProfileData) => number | null | undefined
+  getFollows: (
+    database: NonNullable<ReturnType<typeof getDatabase>>,
+    targetActorId: string
+  ) => Promise<Follow[]>
+  extractActorIds: (follows: Follow[]) => string[]
+}
+
+const DIRECTION_CONFIGS: Record<FollowListDirection, DirectionConfig> = {
+  followers: {
+    label: 'Followers',
+    subpath: '/followers',
+    emptyMessage: 'No followers yet',
+    getCount: (profile) => profile.followersCount,
+    getFollows: (database, targetActorId) =>
+      database.getFollowers({ targetActorId, limit: 100 }),
+    extractActorIds: (follows) => follows.map((f) => f.actorId)
+  },
+  following: {
+    label: 'Following',
+    subpath: '/following',
+    emptyMessage: 'Not following anyone yet',
+    getCount: (profile) => profile.followingCount,
+    getFollows: (database, actorId) =>
+      database.getFollowing({ actorId, limit: 100 }),
+    extractActorIds: (follows) => follows.map((f) => f.targetActorId)
+  }
+}
+
+export interface FollowListPageProps {
+  params: Promise<{ actor: string }>
+  direction: FollowListDirection
+}
+
+export const generateFollowListMetadata = async ({
+  params,
+  direction
+}: FollowListPageProps): Promise<Metadata> => {
+  const config = DIRECTION_CONFIGS[direction]
+  const { actor } = await params
+  const decodedActorHandle = decodeURIComponent(actor)
+  const parts = decodedActorHandle.split('@').slice(1)
+  if (parts.length === 2) {
+    const [username, domain] = parts
+    const database = getDatabase()
+    if (database) {
+      const targetUrl = await getNonLocalActorRedirectTarget(
+        database,
+        username,
+        domain,
+        config.subpath
+      )
+      if (targetUrl) {
+        return {
+          title: `Activities.next: ${decodedActorHandle} ${config.label}`,
+          robots: { index: false, follow: false },
+          alternates: {
+            canonical: targetUrl
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    title: `Activities.next: ${decodedActorHandle} ${config.label}`
+  }
+}
+
+export const FollowListPage: FC<FollowListPageProps> = async ({
+  params,
+  direction
+}) => {
+  const config = DIRECTION_CONFIGS[direction]
+  const { host } = getConfig()
+  const database = getDatabase()
+  if (!database) throw new Error('Database is not available')
+
+  const session = await getServerAuthSession()
+  const isLoggedIn = Boolean(session?.user?.email)
+  const currentActor = await getActorFromSession(database, session)
+  const { actor } = await params
+  const decodedActorHandle = decodeURIComponent(actor)
+  const parts = decodedActorHandle.split('@').slice(1)
+  if (parts.length !== 2) {
+    return notFound()
+  }
+  const [actorUsername, actorDomain] = parts
+
+  const targetUrl = await getNonLocalActorRedirectTarget(
+    database,
+    actorUsername,
+    actorDomain,
+    config.subpath
+  )
+  if (targetUrl) {
+    const bareHost = host.includes('://') ? new URL(host).host : host
+    return (
+      <ActorRedirectCard
+        host={bareHost}
+        targetUrl={targetUrl}
+        domain={actorDomain}
+        username={actorUsername}
+      />
+    )
+  }
+
+  const actorProfile = await getProfileData(
+    database,
+    decodedActorHandle,
+    isLoggedIn,
+    { currentActor }
+  )
+  if (!actorProfile) {
+    return notFound()
+  }
+
+  const follows = await config.getFollows(database, actorProfile.person.id)
+  const actorIds = config.extractActorIds(follows)
+  const rawActors = await database.getActorsFromIds({ ids: actorIds })
+  const actorById = new Map(rawActors.map((a) => [a.id, a]))
+  const users = actorIds
+    .map((id) => actorById.get(id))
+    .filter((item): item is Actor => Boolean(item))
+    .map((item) => ActorProfile.parse(item))
+
+  const blockedActorIds = await getFollowListBlockedActorIds(
+    database,
+    currentActor?.id,
+    users
+  )
+
+  const count = config.getCount(actorProfile)
+  const countDescription =
+    typeof count === 'number' ? `${count.toLocaleString()} accounts` : undefined
+
+  return (
+    <div className="space-y-6">
+      {isLoggedIn ? (
+        <PageHeader
+          title={
+            <span className="flex items-center gap-2">
+              <Link
+                href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+                prefetch={false}
+                aria-label="Back to profile"
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+              <span className="truncate">{config.label}</span>
+            </span>
+          }
+          description={countDescription}
+        />
+      ) : (
+        <div className="flex items-start gap-2">
+          <Link
+            href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
+            prefetch={false}
+            aria-label="Back to profile"
+            className="mt-0.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">
+              {config.label}
+            </h1>
+            {countDescription && (
+              <p className="text-sm text-muted-foreground">
+                {countDescription}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+        <FollowList
+          users={users}
+          isLoggedIn={isLoggedIn}
+          blockedActorIds={blockedActorIds}
+          emptyMessage={config.emptyMessage}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(timeline)/[actor]/followers/page.tsx
+++ b/app/(timeline)/[actor]/followers/page.tsx
@@ -1,176 +1,20 @@
-import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
-import Link from 'next/link'
-import { notFound } from 'next/navigation'
-import { FC } from 'react'
 
-import { ActorRedirectCard } from '@/app/(timeline)/[actor]/ActorRedirectCard'
-import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
-import { getFollowListBlockedActorIds } from '@/app/(timeline)/[actor]/getFollowListBlockedActorIds'
-import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
-import { getNonLocalActorRedirectTarget } from '@/app/(timeline)/[actor]/resolveActorRedirect'
-import { PageHeader } from '@/lib/components/page-header'
-import { getConfig } from '@/lib/config'
-import { getDatabase } from '@/lib/database'
-import { getServerAuthSession } from '@/lib/services/auth/getSession'
-import { Actor, ActorProfile } from '@/lib/types/domain/actor'
-import { Follow } from '@/lib/types/domain/follow'
-import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import {
+  FollowListPage,
+  generateFollowListMetadata
+} from '@/app/(timeline)/[actor]/FollowListPage'
 
 interface Props {
   params: Promise<{ actor: string }>
 }
 
-export const generateMetadata = async ({
-  params
-}: Props): Promise<Metadata> => {
-  const { actor } = await params
-  const decodedActorHandle = decodeURIComponent(actor)
-  const parts = decodedActorHandle.split('@').slice(1)
-  if (parts.length === 2) {
-    const [username, domain] = parts
-    const database = getDatabase()
-    if (database) {
-      const targetUrl = await getNonLocalActorRedirectTarget(
-        database,
-        username,
-        domain,
-        '/followers'
-      )
-      if (targetUrl) {
-        return {
-          title: `Activities.next: ${decodedActorHandle} Followers`,
-          robots: { index: false, follow: false },
-          alternates: {
-            canonical: targetUrl
-          }
-        }
-      }
-    }
-  }
-
-  return {
-    title: `Activities.next: ${decodedActorHandle} Followers`
-  }
+export const generateMetadata = async (props: Props): Promise<Metadata> => {
+  return generateFollowListMetadata({ ...props, direction: 'followers' })
 }
 
-const Page: FC<Props> = async ({ params }) => {
-  const { host } = getConfig()
-  const database = getDatabase()
-  if (!database) throw new Error('Database is not available')
-
-  const session = await getServerAuthSession()
-  const isLoggedIn = Boolean(session?.user?.email)
-  const currentActor = await getActorFromSession(database, session)
-  const { actor } = await params
-  const decodedActorHandle = decodeURIComponent(actor)
-  const parts = decodedActorHandle.split('@').slice(1)
-  if (parts.length !== 2) {
-    return notFound()
-  }
-  const [actorUsername, actorDomain] = parts
-
-  const targetUrl = await getNonLocalActorRedirectTarget(
-    database,
-    actorUsername,
-    actorDomain,
-    '/followers'
-  )
-  if (targetUrl) {
-    const bareHost = host.includes('://') ? new URL(host).host : host
-    return (
-      <ActorRedirectCard
-        host={bareHost}
-        targetUrl={targetUrl}
-        domain={actorDomain}
-        username={actorUsername}
-      />
-    )
-  }
-
-  const actorProfile = await getProfileData(
-    database,
-    decodedActorHandle,
-    isLoggedIn,
-    { currentActor }
-  )
-  if (!actorProfile) {
-    return notFound()
-  }
-
-  const follows = await database.getFollowers({
-    targetActorId: actorProfile.person.id,
-    limit: 100
-  })
-
-  const rawActors = await database.getActorsFromIds({
-    ids: follows.map((follow: Follow) => follow.actorId)
-  })
-  const actorById = new Map(rawActors.map((actor) => [actor.id, actor]))
-  const followers = follows
-    .map((follow) => actorById.get(follow.actorId))
-    .filter((item): item is Actor => Boolean(item))
-    .map((actor) => ActorProfile.parse(actor))
-  const blockedActorIds = await getFollowListBlockedActorIds(
-    database,
-    currentActor?.id,
-    followers
-  )
-
-  return (
-    <div className="space-y-6">
-      {isLoggedIn ? (
-        <PageHeader
-          title={
-            <span className="flex items-center gap-2">
-              <Link
-                href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-                prefetch={false}
-                aria-label="Back to profile"
-                className="text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <ArrowLeft className="h-5 w-5" />
-              </Link>
-              <span className="truncate">Followers</span>
-            </span>
-          }
-          description={
-            typeof actorProfile.followersCount === 'number'
-              ? `${actorProfile.followersCount.toLocaleString()} accounts`
-              : undefined
-          }
-        />
-      ) : (
-        <div className="flex items-start gap-2">
-          <Link
-            href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-            prefetch={false}
-            aria-label="Back to profile"
-            className="mt-0.5 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </Link>
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight">Followers</h1>
-            {typeof actorProfile.followersCount === 'number' && (
-              <p className="text-sm text-muted-foreground">
-                {actorProfile.followersCount.toLocaleString()} accounts
-              </p>
-            )}
-          </div>
-        </div>
-      )}
-
-      <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <FollowList
-          users={followers}
-          isLoggedIn={isLoggedIn}
-          blockedActorIds={blockedActorIds}
-          emptyMessage="No followers yet"
-        />
-      </div>
-    </div>
-  )
+const Page = async (props: Props) => {
+  return FollowListPage({ ...props, direction: 'followers' })
 }
 
 export default Page

--- a/app/(timeline)/[actor]/following/page.tsx
+++ b/app/(timeline)/[actor]/following/page.tsx
@@ -1,176 +1,20 @@
-import { ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
-import Link from 'next/link'
-import { notFound } from 'next/navigation'
-import { FC } from 'react'
 
-import { ActorRedirectCard } from '@/app/(timeline)/[actor]/ActorRedirectCard'
-import { FollowList } from '@/app/(timeline)/[actor]/FollowList'
-import { getFollowListBlockedActorIds } from '@/app/(timeline)/[actor]/getFollowListBlockedActorIds'
-import { getProfileData } from '@/app/(timeline)/[actor]/getProfileData'
-import { getNonLocalActorRedirectTarget } from '@/app/(timeline)/[actor]/resolveActorRedirect'
-import { PageHeader } from '@/lib/components/page-header'
-import { getConfig } from '@/lib/config'
-import { getDatabase } from '@/lib/database'
-import { getServerAuthSession } from '@/lib/services/auth/getSession'
-import { Actor, ActorProfile } from '@/lib/types/domain/actor'
-import { Follow } from '@/lib/types/domain/follow'
-import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import {
+  FollowListPage,
+  generateFollowListMetadata
+} from '@/app/(timeline)/[actor]/FollowListPage'
 
 interface Props {
   params: Promise<{ actor: string }>
 }
 
-export const generateMetadata = async ({
-  params
-}: Props): Promise<Metadata> => {
-  const { actor } = await params
-  const decodedActorHandle = decodeURIComponent(actor)
-  const parts = decodedActorHandle.split('@').slice(1)
-  if (parts.length === 2) {
-    const [username, domain] = parts
-    const database = getDatabase()
-    if (database) {
-      const targetUrl = await getNonLocalActorRedirectTarget(
-        database,
-        username,
-        domain,
-        '/following'
-      )
-      if (targetUrl) {
-        return {
-          title: `Activities.next: ${decodedActorHandle} Following`,
-          robots: { index: false, follow: false },
-          alternates: {
-            canonical: targetUrl
-          }
-        }
-      }
-    }
-  }
-
-  return {
-    title: `Activities.next: ${decodedActorHandle} Following`
-  }
+export const generateMetadata = async (props: Props): Promise<Metadata> => {
+  return generateFollowListMetadata({ ...props, direction: 'following' })
 }
 
-const Page: FC<Props> = async ({ params }) => {
-  const { host } = getConfig()
-  const database = getDatabase()
-  if (!database) throw new Error('Database is not available')
-
-  const session = await getServerAuthSession()
-  const isLoggedIn = Boolean(session?.user?.email)
-  const currentActor = await getActorFromSession(database, session)
-  const { actor } = await params
-  const decodedActorHandle = decodeURIComponent(actor)
-  const parts = decodedActorHandle.split('@').slice(1)
-  if (parts.length !== 2) {
-    return notFound()
-  }
-  const [actorUsername, actorDomain] = parts
-
-  const targetUrl = await getNonLocalActorRedirectTarget(
-    database,
-    actorUsername,
-    actorDomain,
-    '/following'
-  )
-  if (targetUrl) {
-    const bareHost = host.includes('://') ? new URL(host).host : host
-    return (
-      <ActorRedirectCard
-        host={bareHost}
-        targetUrl={targetUrl}
-        domain={actorDomain}
-        username={actorUsername}
-      />
-    )
-  }
-
-  const actorProfile = await getProfileData(
-    database,
-    decodedActorHandle,
-    isLoggedIn,
-    { currentActor }
-  )
-  if (!actorProfile) {
-    return notFound()
-  }
-
-  const follows = await database.getFollowing({
-    actorId: actorProfile.person.id,
-    limit: 100
-  })
-
-  const rawActors = await database.getActorsFromIds({
-    ids: follows.map((follow: Follow) => follow.targetActorId)
-  })
-  const actorById = new Map(rawActors.map((actor) => [actor.id, actor]))
-  const followings = follows
-    .map((follow) => actorById.get(follow.targetActorId))
-    .filter((item): item is Actor => Boolean(item))
-    .map((actor) => ActorProfile.parse(actor))
-  const blockedActorIds = await getFollowListBlockedActorIds(
-    database,
-    currentActor?.id,
-    followings
-  )
-
-  return (
-    <div className="space-y-6">
-      {isLoggedIn ? (
-        <PageHeader
-          title={
-            <span className="flex items-center gap-2">
-              <Link
-                href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-                prefetch={false}
-                aria-label="Back to profile"
-                className="text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <ArrowLeft className="h-5 w-5" />
-              </Link>
-              <span className="truncate">Following</span>
-            </span>
-          }
-          description={
-            typeof actorProfile.followingCount === 'number'
-              ? `${actorProfile.followingCount.toLocaleString()} accounts`
-              : undefined
-          }
-        />
-      ) : (
-        <div className="flex items-start gap-2">
-          <Link
-            href={`/@${actorProfile.person.preferredUsername}@${actorDomain}`}
-            prefetch={false}
-            aria-label="Back to profile"
-            className="mt-0.5 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </Link>
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight">Following</h1>
-            {typeof actorProfile.followingCount === 'number' && (
-              <p className="text-sm text-muted-foreground">
-                {actorProfile.followingCount.toLocaleString()} accounts
-              </p>
-            )}
-          </div>
-        </div>
-      )}
-
-      <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <FollowList
-          users={followings}
-          isLoggedIn={isLoggedIn}
-          blockedActorIds={blockedActorIds}
-          emptyMessage="Not following anyone yet"
-        />
-      </div>
-    </div>
-  )
+const Page = async (props: Props) => {
+  return FollowListPage({ ...props, direction: 'following' })
 }
 
 export default Page


### PR DESCRIPTION
## Summary
Extracts the shared server-side follow-page data loading, redirect handling, profile preparation, and metadata construction into  and companion tests in .

- Keeps `app/(timeline)/[actor]/followers/page.tsx` and `app/(timeline)/[actor]/following/page.tsx` as thin async wrappers.
- Preserves all remote redirect behavior, not-found logic, logged in / anonymous header shells, and batch actor hydration.
- Adds comprehensive unit tests covering both directions, redirects, missing actors, and metadata generation.

Closes task C8.