### PR TITLE
Bump version to v1.161.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.20",
+  "version": "1.161.21",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.21.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.20`
- Base main SHA: `320f5e72f12e52682076bd52bd17c838855c6816`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
