### PR TITLE
feat(maintenance): add importRemoteStatus script to recover federated posts

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -882,6 +882,30 @@ An attachment federated to this instance carries a URL its remote author chose, 
 
 A URL is treated as local storage only when its host is this instance's own — `ACTIVITIES_HOST` or one of `ACTIVITIES_TRUSTED_HOSTS`, wildcard entries such as `*.example.com` included, matched the same way a request's `Host` header is. Every other activities.next instance serves attachments under the same `/api/v1/files/` path, so the host is what tells the two apart. A path that walks upwards once decoded is refused rather than handed to storage.
 
+## Import Remote Status
+
+The `importRemoteStatus.ts` script fetches an arbitrary remote post (by its web URL or ActivityPub URI) and processes it through `createNoteJob`. This persists the status, populates tags and mentions, resolves author profiles, links reply threads, and fans out the post to timelines for local followers and recipients.
+
+### When to Use
+
+Use this script to recover federated statuses that were dropped due to federation downtime, delivery errors, or network outages (such as missed inbox deliveries).
+
+### Usage
+
+```bash
+# Preview what would be imported (dry-run mode)
+NODE_ENV=production node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts <statusUrl> --dry-run
+
+# Import and persist the status into the database
+NODE_ENV=production node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts <statusUrl>
+```
+
+### Examples
+
+```bash
+NODE_ENV=production node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts https://mastodon.in.th/@lluu/117228726176772772
+```
+
 ## Related Documentation
 
 - [Setup Guide](setup.md) — Initial setup and configuration

--- a/scripts/maintenance/importRemoteStatus.test.ts
+++ b/scripts/maintenance/importRemoteStatus.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getNote } from '@/lib/activities'
+import { Database } from '@/lib/database/types'
+import { createNoteJob } from '@/lib/jobs/createNoteJob'
+import { CREATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { StatusType } from '@/lib/types/domain/status'
+
+import { importRemoteStatus, parseArgs } from './importRemoteStatus'
+
+vi.mock('@/lib/activities', () => ({
+  getNote: vi.fn()
+}))
+
+vi.mock('@/lib/jobs/createNoteJob', () => ({
+  createNoteJob: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: vi.fn().mockResolvedValue(undefined)
+}))
+
+describe('importRemoteStatus parseArgs', () => {
+  it('parses statusUrl correctly', () => {
+    expect(
+      parseArgs(['https://mastodon.in.th/@lluu/117228726176772772'])
+    ).toEqual({
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772',
+      dryRun: false
+    })
+  })
+
+  it('parses --dry-run flag', () => {
+    expect(
+      parseArgs([
+        'https://mastodon.in.th/@lluu/117228726176772772',
+        '--dry-run'
+      ])
+    ).toEqual({
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772',
+      dryRun: true
+    })
+    expect(
+      parseArgs([
+        '--dry-run=true',
+        'https://mastodon.in.th/@lluu/117228726176772772'
+      ])
+    ).toEqual({
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772',
+      dryRun: true
+    })
+    expect(
+      parseArgs([
+        'https://mastodon.in.th/@lluu/117228726176772772',
+        '--dry-run=false'
+      ])
+    ).toEqual({
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772',
+      dryRun: false
+    })
+  })
+
+  it('throws on missing statusUrl', () => {
+    expect(() => parseArgs([])).toThrow('Missing required statusUrl argument')
+    expect(() => parseArgs(['--dry-run'])).toThrow(
+      'Missing required statusUrl argument'
+    )
+  })
+
+  it('throws on unexpected arguments', () => {
+    expect(() =>
+      parseArgs([
+        'https://mastodon.in.th/@lluu/117228726176772772',
+        '--unknown'
+      ])
+    ).toThrow('Unexpected argument: --unknown')
+    expect(() =>
+      parseArgs([
+        'https://mastodon.in.th/@lluu/117228726176772772',
+        'https://example.com'
+      ])
+    ).toThrow('Unexpected extra argument: https://example.com')
+  })
+})
+
+describe('importRemoteStatus', () => {
+  const mockNote = {
+    id: 'https://mastodon.in.th/users/lluu/statuses/117228726176772772',
+    type: 'Note',
+    attributedTo: 'https://mastodon.in.th/users/lluu',
+    inReplyTo:
+      'https://llun.dev/users/null/statuses/01a07ae4-85cd-73fb-a153-4384565ae994',
+    published: '2026-09-07T08:06:44Z',
+    url: 'https://mastodon.in.th/@lluu/117228726176772772',
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [
+      'https://mastodon.in.th/users/lluu/followers',
+      'https://llun.dev/users/null'
+    ],
+    content: 'Hello fediverse'
+  }
+
+  it('returns preview in dry-run mode without calling createNoteJob', async () => {
+    vi.mocked(getNote).mockResolvedValueOnce(mockNote as any)
+    const mockDatabase = {} as Database
+
+    const result = await importRemoteStatus(mockDatabase, {
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772',
+      dryRun: true
+    })
+
+    expect(result).toEqual({
+      statusId: mockNote.id,
+      publicId: '(dry-run)',
+      actorId: mockNote.attributedTo,
+      reply: mockNote.inReplyTo,
+      url: mockNote.url,
+      createdAt: '2026-09-07T08:06:44.000Z'
+    })
+    expect(createNoteJob).not.toHaveBeenCalled()
+  })
+
+  it('calls createNoteJob and returns stored status details', async () => {
+    vi.mocked(getNote).mockResolvedValueOnce(mockNote as any)
+    const mockStoredStatus = {
+      id: mockNote.id,
+      publicId: '01991234-5678-7abc-8def-0123456789ab',
+      actorId: mockNote.attributedTo,
+      type: StatusType.enum.Note,
+      reply: mockNote.inReplyTo,
+      url: mockNote.url,
+      createdAt: new Date(mockNote.published).getTime()
+    }
+
+    const mockDatabase = {
+      getStatus: vi.fn().mockResolvedValue(mockStoredStatus)
+    } as unknown as Database
+
+    const result = await importRemoteStatus(mockDatabase, {
+      statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772'
+    })
+
+    expect(createNoteJob).toHaveBeenCalledWith(mockDatabase, {
+      id: mockNote.id,
+      name: CREATE_NOTE_JOB_NAME,
+      data: mockNote,
+      verifiedSenderActorId: mockNote.attributedTo
+    })
+
+    expect(result).toEqual({
+      statusId: mockNote.id,
+      publicId: '01991234-5678-7abc-8def-0123456789ab',
+      actorId: mockNote.attributedTo,
+      reply: mockNote.inReplyTo,
+      url: mockNote.url,
+      createdAt: '2026-09-07T08:06:44.000Z'
+    })
+  })
+
+  it('throws if getNote returns null', async () => {
+    vi.mocked(getNote).mockResolvedValueOnce(null)
+    const mockDatabase = {} as Database
+
+    await expect(
+      importRemoteStatus(mockDatabase, {
+        statusUrl: 'https://mastodon.in.th/@lluu/117228726176772772'
+      })
+    ).rejects.toThrow(
+      'Failed to fetch remote status from https://mastodon.in.th/@lluu/117228726176772772'
+    )
+  })
+})

--- a/scripts/maintenance/importRemoteStatus.ts
+++ b/scripts/maintenance/importRemoteStatus.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Imports a remote status into the database using createNoteJob, which
+ * persists the status, populates tags/mentions, links reply threads,
+ * and fans out to timelines for local followers and recipients.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/maintenance/importRemoteStatus.ts <statusUrl> [--dry-run]
+ *
+ * Examples:
+ *   NODE_ENV=production node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts https://mastodon.in.th/@lluu/117228726176772772
+ *   NODE_ENV=production node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts https://mastodon.in.th/users/lluu/statuses/117228726176772772 --dry-run
+ */
+import { loadEnvConfig } from '@next/env'
+
+import { getNote } from '@/lib/activities'
+import { BaseNote } from '@/lib/activities/note'
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { createNoteJob } from '@/lib/jobs/createNoteJob'
+import { CREATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { StatusType } from '@/lib/types/domain/status'
+import { getClientStatusId } from '@/lib/utils/publicId'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+export interface ImportRemoteStatusOptions {
+  statusUrl: string
+  dryRun?: boolean
+}
+
+export interface ImportRemoteStatusResult {
+  statusId: string
+  publicId: string
+  actorId: string
+  reply: string
+  url: string
+  createdAt: string
+}
+
+export const parseArgs = (args: string[]): ImportRemoteStatusOptions => {
+  let statusUrl: string | undefined
+  let dryRun = false
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--dry-run' || argument === '--dry-run=true') {
+      dryRun = true
+      continue
+    }
+    if (argument === '--dry-run=false') {
+      dryRun = false
+      continue
+    }
+    if (argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+    if (!statusUrl) {
+      statusUrl = argument
+    } else {
+      throw new Error(`Unexpected extra argument: ${argument}`)
+    }
+  }
+
+  if (!statusUrl) {
+    throw new Error('Missing required statusUrl argument')
+  }
+
+  return { statusUrl, dryRun }
+}
+
+export const importRemoteStatus = async (
+  database: Database,
+  options: ImportRemoteStatusOptions
+): Promise<ImportRemoteStatusResult | null> => {
+  const { statusUrl, dryRun = false } = options
+
+  const signingActor = await getFederationSigningActor(database).catch(
+    () => undefined
+  )
+  const note = await getNote({ statusId: statusUrl, signingActor })
+
+  if (!note) {
+    throw new Error(`Failed to fetch remote status from ${statusUrl}`)
+  }
+
+  let objectNote: BaseNote = note
+  if (
+    typeof note === 'object' &&
+    note !== null &&
+    'type' in note &&
+    (note as { type: string }).type === 'Create' &&
+    'object' in note &&
+    typeof (note as { object: unknown }).object === 'object' &&
+    (note as { object: unknown }).object !== null
+  ) {
+    objectNote = (note as { object: BaseNote }).object
+  }
+
+  if (dryRun) {
+    return {
+      statusId: objectNote.id,
+      publicId: '(dry-run)',
+      actorId: objectNote.attributedTo,
+      reply: objectNote.inReplyTo || '',
+      url: typeof objectNote.url === 'string' ? objectNote.url : objectNote.id,
+      createdAt: objectNote.published
+        ? new Date(objectNote.published).toISOString()
+        : new Date().toISOString()
+    }
+  }
+
+  await createNoteJob(database, {
+    id: objectNote.id,
+    name: CREATE_NOTE_JOB_NAME,
+    data: objectNote,
+    verifiedSenderActorId: objectNote.attributedTo
+  })
+
+  const storedStatus = await database.getStatus({ statusId: objectNote.id })
+  if (!storedStatus) {
+    throw new Error(
+      `Status ${objectNote.id} was not found in database after running createNoteJob`
+    )
+  }
+
+  const reply =
+    storedStatus.type === StatusType.enum.Note ? storedStatus.reply : ''
+  const importedUrl =
+    storedStatus.type === StatusType.enum.Note ? storedStatus.url : ''
+
+  return {
+    statusId: storedStatus.id,
+    publicId: getClientStatusId(storedStatus),
+    actorId: storedStatus.actorId,
+    reply,
+    url: importedUrl,
+    createdAt: new Date(storedStatus.createdAt).toISOString()
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const database = getDatabase()
+  if (!database) {
+    console.error('importRemoteStatus: Database is not available')
+    process.exit(1)
+  }
+
+  console.log(`Fetching remote status from ${options.statusUrl}...`)
+  if (options.dryRun) {
+    console.log('Running in dry-run mode (no database writes)')
+  }
+
+  try {
+    const result = await importRemoteStatus(database, options)
+    if (result) {
+      console.log('Successfully imported status:')
+      console.log(`  ID:        ${result.statusId}`)
+      console.log(`  Public ID: ${result.publicId}`)
+      console.log(`  Actor:     ${result.actorId}`)
+      console.log(`  Reply To:  ${result.reply || '(none)'}`)
+      console.log(`  URL:       ${result.url}`)
+      console.log(`  Created:   ${result.createdAt}`)
+    }
+  } catch (error) {
+    console.error(
+      'Import failed:',
+      error instanceof Error ? error.message : error
+    )
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('importRemoteStatus.ts')) {
+  main().catch((error) => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Adds a maintenance script `scripts/maintenance/importRemoteStatus.ts` to fetch an arbitrary remote post (by its web URL or ActivityPub URI) and import it via `createNoteJob`.

### Context & Motivation
When incoming federation deliveries fail or are dropped before persisting (such as during transient proxy/routing issues), visiting the remote post's web URL in the browser only triggers ephemeral on-the-fly fetching or `fetchRemoteStatusJob` (which only stores the post to `statuses` for thread viewing and does not fan out to home timelines or create notification rows).

This script feeds the remote Note payload into `createNoteJob` to execute the full federation intake:
- Records author actor profile.
- Persists attachments and tags.
- Attaches the status into reply threads.
- Fans out to `timelines` for local followers and recipients.
- Creates notifications and search documents.
- Includes `--dry-run` support for safely previewing remote note metadata.

### Verification
- Tested unit tests in `scripts/maintenance/importRemoteStatus.test.ts`.
- Passed full verification sequence: `yarn run prettier --write .` -> `yarn lint` -> `yarn typecheck` -> `yarn build` -> `yarn test`.
- Updated `docs/maintenance.md`.