### PR TITLE
Bump version to v1.161.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.21",
+  "version": "1.161.22",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.22.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.21`
- Base main SHA: `aebb8fe55ee92656a960238a9cff3630a3030e29`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
