### PR TITLE
refactor: extract fitness chart calculations to pure module

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -1029,6 +1029,40 @@ describe('FitnessStatusDetail', () => {
       )
     })
 
+    it('renders a flat series without dividing by zero and scrubs accurately', async () => {
+      mockGetFitnessRouteData.mockResolvedValue({
+        ...routeData,
+        altitudeSeries: [50, 50, 50, 50]
+      })
+
+      const panel = await openAnalysis()
+      expect(within(panel).getByText(/^Scale 50 m - 50 m$/)).toBeInTheDocument()
+
+      const [elevationPath] = Array.from(panel.querySelectorAll('path'))
+      const pathData = elevationPath.getAttribute('d') ?? ''
+      expect(pathData).not.toContain('NaN')
+      expect(pathData).not.toContain('Infinity')
+
+      hoverChart(panel, 200)
+      expect(screen.getAllByTestId('chart-hover-value')[0]).toHaveTextContent(
+        /^50m$/
+      )
+    })
+
+    it('renders a single-point series without error', async () => {
+      mockGetFitnessRouteData.mockResolvedValue({
+        ...routeData,
+        altitudeSeries: [42]
+      })
+
+      const panel = await openAnalysis()
+      expect(within(panel).getByText(/^Scale 42 m - 42 m$/)).toBeInTheDocument()
+
+      const [elevationPath] = Array.from(panel.querySelectorAll('path'))
+      const pathData = elevationPath.getAttribute('d') ?? ''
+      expect(pathData).toBe('M 0.00 250.00')
+    })
+
     it('scrubs on touch as well as on hover', async () => {
       const panel = await openAnalysis()
       const [elevationChart] = Array.from(panel.querySelectorAll('svg'))

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -92,7 +92,6 @@ import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 import {
-  formatFitnessDuration,
   getFitnessPaceOrSpeed,
   getFitnessSourceLabel,
   normalizeFitnessSourceUrl
@@ -109,60 +108,29 @@ import {
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-const clampNumber = (value: number, min: number, max: number) => {
-  return Math.max(min, Math.min(max, value))
-}
-
-// How densely a chart series is plotted, as samples-per-drawn-point.
-//
-// The series used to be flattened to a fixed 120 points, which is what made
-// every graph on this page read as a smoothed cartoon of the activity beside
-// the same ride on Strava: a 1h44 recording arrives as 6,123 one-second
-// samples, so each of those 120 bins averaged ~51 seconds — roughly 370 m of a
-// 44 km ride — and every short climb, descent and sprint inside a bin was
-// averaged flat.
-//
-// 8 is Strava's own ratio, read off two of its activity Analysis pages rather
-// than guessed: it ships the whole stream to the browser and draws exactly one
-// point per 8 of them (5,913 samples -> 740 drawn; 5,272 -> 659). A fixed point
-// COUNT would not reproduce that — it is a density, so a longer recording gets
-// proportionally more points rather than being squeezed into the same budget.
-const ANALYSIS_SAMPLES_PER_POINT = 8
-// Floors and ceilings on that ratio. The floor keeps a short activity at least
-// as detailed as it was before this change (a 10-minute 1 Hz recording is 600
-// samples, which Strava's ratio alone would draw as 75 points); the ceiling
-// bounds the path strings — memoized, so a hover never rebuilds them — for a
-// recording long enough that the ratio would otherwise run away.
-const ANALYSIS_SERIES_MIN_POINTS = 120
-const ANALYSIS_SERIES_MAX_POINTS = 1_200
-
-const downsampleSeries = (series: number[], targetCount: number) => {
-  if (series.length <= targetCount) return series
-  const ratio = series.length / targetCount
-  const result: number[] = []
-  for (let i = 0; i < targetCount; i++) {
-    const start = Math.floor(i * ratio)
-    const end = Math.floor((i + 1) * ratio)
-    const chunk = series.slice(start, end)
-    const sum = chunk.reduce((a, b) => a + b, 0)
-    result.push(sum / chunk.length)
-  }
-  return result
-}
-
-// Reduce one raw series to the point count Strava would draw it at. An empty
-// series stays empty — a chart with no data is not rendered at all.
-const plotAtStravaDensity = (series: number[]) => {
-  if (series.length === 0) return []
-  return downsampleSeries(
-    series,
-    clampNumber(
-      Math.round(series.length / ANALYSIS_SAMPLES_PER_POINT),
-      ANALYSIS_SERIES_MIN_POINTS,
-      ANALYSIS_SERIES_MAX_POINTS
-    )
-  )
-}
+import {
+  GRAPH_VIEW_HEIGHT,
+  type HeartRateZone,
+  OVERVIEW_TICK_COUNT,
+  buildChartAreaPath,
+  buildChartPath,
+  buildXAxisLabels,
+  clampNumber,
+  computeChartHighlight,
+  computeCombinedChartHighlights,
+  computeHeartRateStats,
+  computeHeartRateZones,
+  computeHighlightedIndex,
+  computePowerHistogramMinutes,
+  fillHeartRateDropouts,
+  filterPositiveHeartRateSeries,
+  formatChartValue,
+  formatDuration,
+  getSeriesMinMax,
+  plotAtStravaDensity,
+  scaleCombinedChartSeries,
+  shouldFlipChartReadout
+} from './fitnessChartData'
 
 interface Props {
   host: string
@@ -329,15 +297,6 @@ const ANALYSIS_GRAPH_STYLES: Record<
   }
 }
 
-// `toFixed` keeps the sign of a value that rounds to zero, so an elevation bin
-// straddling sea level reads "-0 m". Round first, then add zero — `-0 + 0` is
-// `+0` — so a chart can only ever show a plain "0". EVERY number a chart prints
-// goes through this, not just the hover readout: the scale labels are derived
-// from the same downsampled bins, so fixing one and not the others left a chart
-// reading "Scale -0 m - 55 m" beside a readout saying "0 m".
-const formatChartValue = (value: number, fractionDigits: number) =>
-  (Number(value.toFixed(fractionDigits)) + 0).toFixed(fractionDigits)
-
 const VISIBILITY_META: Record<
   MastodonVisibility,
   { label: string; icon: LucideIcon }
@@ -347,74 +306,6 @@ const VISIBILITY_META: Record<
   private: { label: 'Followers only', icon: Lock },
   direct: { label: 'Direct', icon: Mail }
 }
-
-interface HeartRateZoneDefinition {
-  name: string
-  label: string
-  lo: number
-  hi: number | null
-  color: string
-}
-
-// Fixed heart-rate zone boundaries (bpm), mirroring the design system's
-// five-zone model. Real activity files carry a heart-rate sample series but no
-// personalised zones, so we bucket the samples against these shared cut-offs.
-const HEART_RATE_ZONES: HeartRateZoneDefinition[] = [
-  { name: 'Z1', label: 'Recovery', lo: 0, hi: 122, color: 'hsl(205 45% 62%)' },
-  {
-    name: 'Z2',
-    label: 'Endurance',
-    lo: 122,
-    hi: 142,
-    color: 'hsl(142 60% 45%)'
-  },
-  { name: 'Z3', label: 'Tempo', lo: 142, hi: 158, color: 'hsl(45 92% 50%)' },
-  {
-    name: 'Z4',
-    label: 'Threshold',
-    lo: 158,
-    hi: 172,
-    color: 'hsl(24 95% 50%)'
-  },
-  { name: 'Z5', label: 'Anaerobic', lo: 172, hi: null, color: 'hsl(2 78% 55%)' }
-]
-
-interface HeartRateZone extends HeartRateZoneDefinition {
-  seconds: number
-  // Rounded percentage for display; rawPct (unrounded) drives bar widths so
-  // the stacked segments don't under/overflow from rounding.
-  pct: number
-  rawPct: number
-}
-
-const computeHeartRateZones = (
-  series: number[],
-  durationSeconds: number
-): HeartRateZone[] => {
-  const counts = HEART_RATE_ZONES.map(() => 0)
-  for (const bpm of series) {
-    // Heart-rate monitors report 0 (or negative) bpm during sensor dropouts;
-    // skip those so they don't inflate the Z1 (Recovery) bucket.
-    if (bpm <= 0) continue
-    const index = HEART_RATE_ZONES.findIndex(
-      (zone) => bpm >= zone.lo && (zone.hi === null || bpm < zone.hi)
-    )
-    if (index >= 0) counts[index] += 1
-  }
-  const totalSamples = counts.reduce((sum, value) => sum + value, 0)
-  return HEART_RATE_ZONES.map((zone, index) => {
-    const fraction = totalSamples > 0 ? counts[index] / totalSamples : 0
-    return {
-      ...zone,
-      pct: Math.round(fraction * 100),
-      rawPct: fraction * 100,
-      seconds: Math.round(fraction * durationSeconds)
-    }
-  })
-}
-
-const formatDuration = (durationSeconds?: number) =>
-  formatFitnessDuration(durationSeconds, { fallback: '0:00' }) ?? '0:00'
 
 const formatUtcDate = (timestamp: number, pattern: string) => {
   return format(new UTCDate(timestamp), pattern)
@@ -467,7 +358,6 @@ const getActivityLabel = (activityType?: string) => {
   return `${activityType[0].toUpperCase()}${activityType.slice(1)}`
 }
 
-const GRAPH_VIEW_HEIGHT = 250
 const GRAPH_HEIGHT_CLASSNAME = 'h-[190px] lg:h-[250px]'
 const MAP_ROUTE_SOURCE_ID = 'activity-route'
 const MAP_ROUTE_HIDDEN_HIT_LAYER_ID = 'activity-route-line-hidden-hit'
@@ -522,53 +412,12 @@ const normalizeRouteSegments = ({
   return []
 }
 
-// The one projection from (sample index, sample value) to plot coordinates.
-// `buildChartPath` draws the line with it and the hover crosshair places the
-// dot and the readout with it, and those two have to agree to the pixel or the
-// dot floats off the line it is supposed to sit on. That used to be two copies
-// of the same arithmetic kept in step by hand, which was survivable while both
-// lived in the same SVG — the dot is now an HTML element positioned from these
-// same numbers as a percentage, so the agreement now spans two rendering
-// systems. Change the scale here and everything follows.
-const getChartXPosition = (index: number, count: number, width: number) => {
-  return (index / Math.max(1, count - 1)) * width
-}
-
-const getChartYPosition = (
-  value: number,
-  height: number,
-  minValue: number,
-  maxValue: number
-) => {
-  const range = Math.max(1, maxValue - minValue)
-  return height - ((value - minValue) / range) * height
-}
-
 const clampLongitude = (value: number) => {
   return clampNumber(value, -180, 180)
 }
 
 const clampLatitude = (value: number) => {
   return clampNumber(value, -85, 85)
-}
-
-const getSeriesMinMax = (values: number[]) => {
-  if (values.length === 0) {
-    return { minValue: 0, maxValue: 0 }
-  }
-
-  let minValue = values[0]
-  let maxValue = values[0]
-
-  for (let index = 1; index < values.length; index += 1) {
-    if (values[index] < minValue) {
-      minValue = values[index]
-    } else if (values[index] > maxValue) {
-      maxValue = values[index]
-    }
-  }
-
-  return { minValue, maxValue }
 }
 
 const getRouteBoundsCoordinates = (samples: FitnessRouteSample[]) => {
@@ -591,41 +440,6 @@ const getRouteBoundsCoordinates = (samples: FitnessRouteSample[]) => {
     south,
     north
   }
-}
-
-const buildChartPath = (
-  values: number[],
-  width: number,
-  height: number,
-  minValue?: number,
-  maxValue?: number
-) => {
-  if (values.length === 0) return ''
-
-  const defaultMinMax = getSeriesMinMax(values)
-  const min = typeof minValue === 'number' ? minValue : defaultMinMax.minValue
-  const max = typeof maxValue === 'number' ? maxValue : defaultMinMax.maxValue
-
-  return values
-    .map((value, index) => {
-      const x = getChartXPosition(index, values.length, width)
-      const y = getChartYPosition(value, height, min, max)
-      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
-    })
-    .join(' ')
-}
-
-// Ticks are evenly spaced over the duration, so the sample count has no say in
-// them — it used to be the first parameter and was never read, which made the
-// labels look series-dependent when they are not.
-const buildXAxisLabels = (durationSeconds: number, tickCount = 6) => {
-  const labels: string[] = []
-  for (let i = 0; i < tickCount; i++) {
-    const ratio = i / (tickCount - 1)
-    const seconds = Math.round(ratio * durationSeconds)
-    labels.push(formatDuration(seconds))
-  }
-  return labels
 }
 
 interface ChartScrubOptions {
@@ -668,29 +482,21 @@ const useChartScrub = ({
   // `isHighlighted` boolean: a boolean beside them narrows nothing, so every
   // consumer had to re-assert that x, y and value were numbers before it could
   // pass them anywhere typed.
-  const highlightedIndex =
-    canScrub && typeof highlightedElapsedSeconds === 'number'
-      ? clampNumber(
-          Math.round(
-            (highlightedElapsedSeconds / durationSeconds) * (values.length - 1)
-          ),
-          0,
-          values.length - 1
-        )
-      : null
-  const highlight =
-    highlightedIndex === null
-      ? null
-      : {
-          value: values[highlightedIndex],
-          x: getChartXPosition(highlightedIndex, values.length, width),
-          y: getChartYPosition(
-            values[highlightedIndex],
-            height,
-            minValue,
-            maxValue
-          )
-        }
+  const highlightedIndex = canScrub
+    ? computeHighlightedIndex(
+        highlightedElapsedSeconds,
+        durationSeconds,
+        values.length
+      )
+    : null
+  const highlight = computeChartHighlight(
+    values,
+    highlightedIndex,
+    width,
+    height,
+    minValue,
+    maxValue
+  )
 
   // One scrub for pointer and touch alike: both report a viewport x, and the
   // instant it lands on is the same either way.
@@ -791,7 +597,7 @@ const ChartHoverMarker: FC<{
   // is also smaller ("1234 m" is ~67px against that 77px), so the right edge
   // lands at 0.62 x 212 + 12 + 67 = 210px — inside the 212px plot, before
   // touching the card's 20px padding. Re-derive BOTH if this moves.
-  const shouldFlipReadout = x / width > 0.62
+  const shouldFlipReadout = shouldFlipChartReadout(x, width)
 
   return (
     <>
@@ -1045,8 +851,8 @@ const ElevationProfileChart: FC<{
     [values, height, minValue, maxValue]
   )
   const area = useMemo(
-    () => `${line} L ${width.toFixed(2)} ${height} L 0 ${height} Z`,
-    [line, height]
+    () => buildChartAreaPath(line, width, height),
+    [line, height, width]
   )
   // Four ticks, not the helper's default six. This card is narrower than the
   // Analysis panel (a `p-5` Card inside the same column, so 212px of content at
@@ -1065,7 +871,10 @@ const ElevationProfileChart: FC<{
   // at six ticks, a still-comfortable 157px at four. Pinned by a test, since
   // the failure is silent — nothing errors, the labels just merge.
   const xLabels = useMemo(
-    () => (durationSeconds ? buildXAxisLabels(durationSeconds, 4) : null),
+    () =>
+      durationSeconds
+        ? buildXAxisLabels(durationSeconds, OVERVIEW_TICK_COUNT)
+        : null,
     [durationSeconds]
   )
   const scrub = useChartScrub({
@@ -1379,16 +1188,7 @@ const CombinedChartPanel: FC<{
   // run to Strava's density (up to 1,200 points each) and must not rebuild on a
   // pointer move.
   const plotted = useMemo(
-    () =>
-      series.map((entry) => {
-        const { minValue, maxValue } = getSeriesMinMax(entry.values)
-        return {
-          ...entry,
-          minValue,
-          maxValue,
-          path: buildChartPath(entry.values, width, height, minValue, maxValue)
-        }
-      }),
+    () => scaleCombinedChartSeries(series, width, height),
     [series]
   )
 
@@ -1422,32 +1222,10 @@ const CombinedChartPanel: FC<{
   // The crosshair marks the shared time; each dot sits on its own line, at that
   // series' own sample for the instant.
   const crosshairX = ratio === null ? null : ratio * width
-  const highlights =
-    ratio === null
-      ? []
-      : plotted
-          .map((entry) => {
-            if (entry.values.length === 0) return null
-            const index = clampNumber(
-              Math.round(ratio * (entry.values.length - 1)),
-              0,
-              entry.values.length - 1
-            )
-            return {
-              key: entry.key,
-              unit: entry.unit,
-              fractionDigits: entry.fractionDigits,
-              value: entry.values[index],
-              x: getChartXPosition(index, entry.values.length, width),
-              y: getChartYPosition(
-                entry.values[index],
-                height,
-                entry.minValue,
-                entry.maxValue
-              )
-            }
-          })
-          .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+  const highlights = useMemo(
+    () => computeCombinedChartHighlights(plotted, ratio, width, height),
+    [plotted, ratio]
+  )
 
   const xLabels = useMemo(
     () => (durationSeconds ? buildXAxisLabels(durationSeconds) : null),
@@ -1456,7 +1234,8 @@ const CombinedChartPanel: FC<{
 
   // Flip the readout to the left of the crosshair near the right edge, on the
   // same fraction the single-series `ChartHoverMarker` uses so both charts agree.
-  const shouldFlipReadout = crosshairX !== null && crosshairX / width > 0.62
+  const shouldFlipReadout =
+    crosshairX !== null && shouldFlipChartReadout(crosshairX, width)
 
   return (
     <div className="bg-background p-4">
@@ -2686,7 +2465,7 @@ export const FitnessStatusDetail: FC<Props> = ({
   // the avg/max and the zone buckets, which are order-free tallies (unlike
   // power, 0 bpm is never a real reading). Mirrors computeHeartRateZones.
   const positiveHeartRateSeries = useMemo(
-    () => heartRateSeries.filter((bpm) => bpm > 0),
+    () => filterPositiveHeartRateSeries(heartRateSeries),
     [heartRateSeries]
   )
 
@@ -2698,26 +2477,15 @@ export const FitnessStatusDetail: FC<Props> = ({
   // beside it correctly on 15:00 and nothing on screen to say so. Hold the last
   // good reading across a gap instead (back-filling a leading one), which keeps
   // the length and still keeps 0 bpm off the plot.
-  const heartRateChartSeries = useMemo(() => {
-    const firstReading = heartRateSeries.find((bpm) => bpm > 0)
-    if (firstReading === undefined) return []
+  const heartRateChartSeries = useMemo(
+    () => fillHeartRateDropouts(heartRateSeries),
+    [heartRateSeries]
+  )
 
-    let lastReading = firstReading
-    return heartRateSeries.map((bpm) => {
-      if (bpm > 0) lastReading = bpm
-      return lastReading
-    })
-  }, [heartRateSeries])
-
-  const heartRateStats = useMemo(() => {
-    if (positiveHeartRateSeries.length === 0) return null
-    const { maxValue } = getSeriesMinMax(positiveHeartRateSeries)
-    const avg = Math.round(
-      positiveHeartRateSeries.reduce((a, b) => a + b, 0) /
-        positiveHeartRateSeries.length
-    )
-    return { avg, max: Math.round(maxValue) }
-  }, [positiveHeartRateSeries])
+  const heartRateStats = useMemo(
+    () => computeHeartRateStats(positiveHeartRateSeries),
+    [positiveHeartRateSeries]
+  )
 
   const heartRateZones = useMemo(
     () => computeHeartRateZones(positiveHeartRateSeries, durationSeconds),
@@ -2846,28 +2614,10 @@ export const FitnessStatusDetail: FC<Props> = ({
     [visibleAnalysisCharts]
   )
 
-  const histogramMinutes = useMemo(() => {
-    if (powerSeries.length === 0) return []
-
-    // Use the stack-safe helper rather than spreading a long series into
-    // Math.max, which can overflow the call stack on large arrays.
-    const computedMaxPower = Math.max(
-      getSeriesMinMax(powerSeries).maxValue,
-      100
-    )
-    const bucketCount = Math.ceil((computedMaxPower + 25) / 25)
-
-    const buckets = new Array(bucketCount).fill(0)
-    // Actual power data represents samples (usually 1 per second)
-    for (const p of powerSeries) {
-      const bucketIndex = Math.floor(p / 25)
-      if (bucketIndex >= 0 && bucketIndex < bucketCount) {
-        buckets[bucketIndex] += 1
-      }
-    }
-    // Convert samples (seconds) to minutes
-    return buckets.map((seconds) => seconds / 60)
-  }, [powerSeries])
+  const histogramMinutes = useMemo(
+    () => computePowerHistogramMinutes(powerSeries),
+    [powerSeries]
+  )
 
   const histogramLayout = useMemo(() => {
     const histogramViewHeight = GRAPH_VIEW_HEIGHT

--- a/app/(timeline)/[actor]/[status]/fitnessChartData.test.ts
+++ b/app/(timeline)/[actor]/[status]/fitnessChartData.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ANALYSIS_SAMPLES_PER_POINT,
+  ANALYSIS_SERIES_MAX_POINTS,
+  ANALYSIS_SERIES_MIN_POINTS,
+  CHART_READOUT_FLIP_THRESHOLD,
+  DEFAULT_TICK_COUNT,
+  GRAPH_VIEW_HEIGHT,
+  HEART_RATE_ZONES,
+  OVERVIEW_GRAPH_VIEW_HEIGHT,
+  OVERVIEW_TICK_COUNT,
+  buildChartAreaPath,
+  buildChartPath,
+  buildXAxisLabels,
+  clampNumber,
+  computeChartHighlight,
+  computeCombinedChartHighlights,
+  computeHeartRateStats,
+  computeHeartRateZones,
+  computeHighlightedIndex,
+  computePowerHistogramMinutes,
+  downsampleSeries,
+  fillHeartRateDropouts,
+  filterPositiveHeartRateSeries,
+  formatChartValue,
+  formatDuration,
+  getChartXPosition,
+  getChartYPosition,
+  getSeriesMinMax,
+  plotAtStravaDensity,
+  scaleCombinedChartSeries,
+  shouldFlipChartReadout
+} from './fitnessChartData'
+
+describe('fitnessChartData', () => {
+  describe('constants', () => {
+    it('defines standard density and sample limits matching Strava', () => {
+      expect(ANALYSIS_SAMPLES_PER_POINT).toBe(8)
+      expect(ANALYSIS_SERIES_MIN_POINTS).toBe(120)
+      expect(ANALYSIS_SERIES_MAX_POINTS).toBe(1200)
+      expect(DEFAULT_TICK_COUNT).toBe(6)
+      expect(OVERVIEW_TICK_COUNT).toBe(4)
+      expect(GRAPH_VIEW_HEIGHT).toBe(250)
+      expect(OVERVIEW_GRAPH_VIEW_HEIGHT).toBe(130)
+      expect(CHART_READOUT_FLIP_THRESHOLD).toBe(0.62)
+    })
+  })
+
+  describe('clampNumber', () => {
+    it('clamps values below min or above max', () => {
+      expect(clampNumber(-5, 0, 10)).toBe(0)
+      expect(clampNumber(15, 0, 10)).toBe(10)
+      expect(clampNumber(7, 0, 10)).toBe(7)
+    })
+  })
+
+  describe('downsampling', () => {
+    it('handles empty and single-point series', () => {
+      expect(downsampleSeries([], 10)).toEqual([])
+      expect(downsampleSeries([42], 5)).toEqual([42])
+      expect(downsampleSeries([42], 1)).toEqual([42])
+      expect(downsampleSeries([1, 2, 3], 0)).toEqual([])
+    })
+
+    it('leaves series shorter than targetCount untouched', () => {
+      const series = [10, 20, 30]
+      expect(downsampleSeries(series, 5)).toBe(series)
+    })
+
+    it('averages chunks evenly when downsampling', () => {
+      const series = [10, 20, 30, 40]
+      expect(downsampleSeries(series, 2)).toEqual([15, 35])
+    })
+
+    it('plots at Strava density for empty and single-point series', () => {
+      expect(plotAtStravaDensity([])).toEqual([])
+      expect(plotAtStravaDensity([100])).toEqual([100])
+    })
+
+    it('plots at Strava density with 8:1 ratio', () => {
+      // 1000 samples / 8 = 125 points
+      const ramp = Array.from({ length: 1000 }, (_, i) => i)
+      const plotted = plotAtStravaDensity(ramp)
+      expect(plotted).toHaveLength(125)
+    })
+
+    it('enforces floor of 120 points on short recordings', () => {
+      // 600 samples / 8 = 75 points -> floored to 120
+      const ramp = Array.from({ length: 600 }, (_, i) => i)
+      const plotted = plotAtStravaDensity(ramp)
+      expect(plotted).toHaveLength(120)
+    })
+
+    it('enforces ceiling of 1200 points on very long recordings (large datasets)', () => {
+      // 40,000 samples / 8 = 5,000 -> capped at 1200
+      const ramp = Array.from({ length: 40_000 }, (_, i) => i)
+      const plotted = plotAtStravaDensity(ramp)
+      expect(plotted).toHaveLength(1200)
+    })
+
+    it('leaves series shorter than the 120-point floor at its own resolution', () => {
+      const short = [10, 20, 30, 40, 50]
+      expect(plotAtStravaDensity(short)).toHaveLength(5)
+    })
+  })
+
+  describe('getSeriesMinMax', () => {
+    it('handles empty and single-point series', () => {
+      expect(getSeriesMinMax([])).toEqual({ minValue: 0, maxValue: 0 })
+      expect(getSeriesMinMax([42])).toEqual({ minValue: 42, maxValue: 42 })
+    })
+
+    it('handles flat ranges', () => {
+      expect(getSeriesMinMax([50, 50, 50, 50])).toEqual({
+        minValue: 50,
+        maxValue: 50
+      })
+    })
+
+    it('computes min and max on large datasets safely without stack overflow', () => {
+      const count = 50_000
+      const large = Array.from({ length: count }, (_, i) => i - 25_000)
+      const { minValue, maxValue } = getSeriesMinMax(large)
+      expect(minValue).toBe(-25_000)
+      expect(maxValue).toBe(24_999)
+    })
+  })
+
+  describe('coordinate projection', () => {
+    it('projects X position across count and width', () => {
+      expect(getChartXPosition(0, 1, 800)).toBe(0)
+      expect(getChartXPosition(0, 5, 800)).toBe(0)
+      expect(getChartXPosition(2, 5, 800)).toBe(400)
+      expect(getChartXPosition(4, 5, 800)).toBe(800)
+    })
+
+    it('projects Y position safely on flat ranges', () => {
+      // Range is max(1, 50 - 50) = 1, so y = height - (0/1)*height = height
+      expect(getChartYPosition(50, 200, 50, 50)).toBe(200)
+      expect(getChartYPosition(100, 200, 0, 100)).toBe(0)
+      expect(getChartYPosition(0, 200, 0, 100)).toBe(200)
+      expect(getChartYPosition(50, 200, 0, 100)).toBe(100)
+    })
+  })
+
+  describe('buildChartPath and buildChartAreaPath', () => {
+    it('handles empty series', () => {
+      expect(buildChartPath([], 800, 200)).toBe('')
+      expect(buildChartAreaPath('', 800, 200)).toBe('')
+    })
+
+    it('handles single-point series', () => {
+      const path = buildChartPath([50], 800, 200)
+      expect(path).toBe('M 0.00 200.00')
+      const area = buildChartAreaPath(path, 800, 200)
+      expect(area).toBe('M 0.00 200.00 L 800.00 200 L 0 200 Z')
+    })
+
+    it('handles flat ranges without NaN or Infinity', () => {
+      const path = buildChartPath([50, 50, 50], 800, 200)
+      expect(path).toBe('M 0.00 200.00 L 400.00 200.00 L 800.00 200.00')
+      const area = buildChartAreaPath(path, 800, 200)
+      expect(area).toBe(
+        'M 0.00 200.00 L 400.00 200.00 L 800.00 200.00 L 800.00 200 L 0 200 Z'
+      )
+    })
+
+    it('builds valid SVG path for varying series with custom min/max', () => {
+      const path = buildChartPath([0, 50, 100], 800, 200, 0, 100)
+      expect(path).toBe('M 0.00 200.00 L 400.00 100.00 L 800.00 0.00')
+    })
+  })
+
+  describe('formatChartValue (negative-zero formatting)', () => {
+    it('formats numbers and suppresses negative zero', () => {
+      expect(formatChartValue(-0.3, 0)).toBe('0')
+      expect(formatChartValue(-0.0001, 2)).toBe('0.00')
+      expect(formatChartValue(-0, 0)).toBe('0')
+      expect(formatChartValue(-0, 1)).toBe('0.0')
+      expect(formatChartValue(0, 0)).toBe('0')
+    })
+
+    it('formats positive and negative non-zero values accurately', () => {
+      expect(formatChartValue(15.42, 1)).toBe('15.4')
+      expect(formatChartValue(15.46, 1)).toBe('15.5')
+      expect(formatChartValue(-12.4, 0)).toBe('-12')
+      expect(formatChartValue(1234.567, 2)).toBe('1234.57')
+    })
+  })
+
+  describe('formatDuration (boundary durations)', () => {
+    it('handles boundary and edge durations', () => {
+      expect(formatDuration(undefined)).toBe('0:00')
+      expect(formatDuration(0)).toBe('0:00')
+      expect(formatDuration(-10)).toBe('0:00')
+      expect(formatDuration(59)).toBe('0:59')
+      expect(formatDuration(60)).toBe('1:00')
+      expect(formatDuration(3599)).toBe('59:59')
+      expect(formatDuration(3600)).toBe('1:00:00')
+      expect(formatDuration(3661)).toBe('1:01:01')
+      expect(formatDuration(86400)).toBe('24:00:00')
+    })
+  })
+
+  describe('buildXAxisLabels', () => {
+    it('generates ticks for boundary tick counts', () => {
+      expect(buildXAxisLabels(1800, 0)).toEqual([])
+      expect(buildXAxisLabels(1800, 1)).toEqual(['0:00'])
+      expect(buildXAxisLabels(0, 4)).toEqual(['0:00', '0:00', '0:00', '0:00'])
+    })
+
+    it('generates four ticks for overview cards', () => {
+      expect(buildXAxisLabels(1800, OVERVIEW_TICK_COUNT)).toEqual([
+        '0:00',
+        '10:00',
+        '20:00',
+        '30:00'
+      ])
+    })
+
+    it('generates six ticks for default analysis charts', () => {
+      expect(buildXAxisLabels(1800, DEFAULT_TICK_COUNT)).toEqual([
+        '0:00',
+        '6:00',
+        '12:00',
+        '18:00',
+        '24:00',
+        '30:00'
+      ])
+    })
+  })
+
+  describe('combined-chart scaling', () => {
+    it('scales each series independently to its own range', () => {
+      const elevation = { key: 'elevation', values: [0, 25, 50] }
+      const heartRate = { key: 'heart-rate', values: [100, 150, 200] }
+      const width = 800
+      const height = 200
+
+      const [scaledElevation, scaledHeartRate] = scaleCombinedChartSeries(
+        [elevation, heartRate],
+        width,
+        height
+      )
+
+      expect(scaledElevation.minValue).toBe(0)
+      expect(scaledElevation.maxValue).toBe(50)
+      // Both highest values map to SVG y = 0
+      expect(scaledElevation.path).toBe(
+        'M 0.00 200.00 L 400.00 100.00 L 800.00 0.00'
+      )
+
+      expect(scaledHeartRate.minValue).toBe(100)
+      expect(scaledHeartRate.maxValue).toBe(200)
+      expect(scaledHeartRate.path).toBe(
+        'M 0.00 200.00 L 400.00 100.00 L 800.00 0.00'
+      )
+    })
+
+    it('computes combined chart highlights at given ratio', () => {
+      const width = 800
+      const height = 200
+      const plotted = [
+        {
+          key: 'elevation' as const,
+          label: 'Elevation',
+          unit: 'm',
+          fractionDigits: 0,
+          values: [10, 20, 30],
+          minValue: 10,
+          maxValue: 30,
+          path: ''
+        },
+        {
+          key: 'speed' as const,
+          label: 'Speed',
+          unit: 'km/h',
+          fractionDigits: 1,
+          values: [20, 25, 30],
+          minValue: 20,
+          maxValue: 30,
+          path: ''
+        }
+      ]
+
+      expect(
+        computeCombinedChartHighlights(plotted, null, width, height)
+      ).toEqual([])
+
+      const highlights = computeCombinedChartHighlights(
+        plotted,
+        0.5,
+        width,
+        height
+      )
+      expect(highlights).toEqual([
+        {
+          key: 'elevation',
+          unit: 'm',
+          fractionDigits: 0,
+          value: 20,
+          x: 400,
+          y: 100
+        },
+        {
+          key: 'speed',
+          unit: 'km/h',
+          fractionDigits: 1,
+          value: 25,
+          x: 400,
+          y: 100
+        }
+      ])
+    })
+  })
+
+  describe('scrub highlight helpers', () => {
+    it('computes highlighted index from elapsed time and duration', () => {
+      expect(computeHighlightedIndex(null, 1800, 100)).toBeNull()
+      expect(computeHighlightedIndex(0, 1800, 100)).toBe(0)
+      expect(computeHighlightedIndex(900, 1800, 100)).toBe(50)
+      expect(computeHighlightedIndex(1800, 1800, 100)).toBe(99)
+      expect(computeHighlightedIndex(-50, 1800, 100)).toBe(0)
+      expect(computeHighlightedIndex(2500, 1800, 100)).toBe(99)
+      expect(computeHighlightedIndex(100, 0, 100)).toBeNull()
+    })
+
+    it('computes single chart highlight', () => {
+      const values = [10, 20, 30]
+      expect(computeChartHighlight(values, null, 800, 200, 10, 30)).toBeNull()
+      expect(computeChartHighlight(values, 1, 800, 200, 10, 30)).toEqual({
+        value: 20,
+        x: 400,
+        y: 100
+      })
+    })
+
+    it('determines when hover readout should flip', () => {
+      expect(shouldFlipChartReadout(400, 800)).toBe(false)
+      expect(shouldFlipChartReadout(500, 800)).toBe(true) // 500 / 800 = 0.625 > 0.62
+      expect(shouldFlipChartReadout(100, 0)).toBe(false)
+    })
+  })
+
+  describe('heart rate calculations and dropout treatment', () => {
+    it('computes heart rate training zones for empty and normal series', () => {
+      expect(HEART_RATE_ZONES).toHaveLength(5)
+      const emptyZones = computeHeartRateZones([], 1800)
+      expect(emptyZones).toHaveLength(5)
+      expect(emptyZones.every((z) => z.seconds === 0 && z.pct === 0)).toBe(true)
+
+      // 100 bpm is Z1 (Recovery, lo: 0, hi: 122)
+      // 130 bpm is Z2 (Endurance, lo: 122, hi: 142)
+      const zones = computeHeartRateZones([100, 130], 1800)
+      expect(zones[0].name).toBe('Z1')
+      expect(zones[0].seconds).toBe(900)
+      expect(zones[0].pct).toBe(50)
+      expect(zones[1].name).toBe('Z2')
+      expect(zones[1].seconds).toBe(900)
+      expect(zones[1].pct).toBe(50)
+    })
+
+    it('excludes 0 bpm sensor dropouts from heart rate zones', () => {
+      // 0 bpm readings must be ignored so they don't inflate Z1
+      const zones = computeHeartRateZones([0, 130, 0, 130], 1800)
+      expect(zones[0].seconds).toBe(0)
+      expect(zones[0].pct).toBe(0)
+      expect(zones[1].seconds).toBe(1800)
+      expect(zones[1].pct).toBe(100)
+    })
+
+    it('filters positive heart rate series', () => {
+      expect(filterPositiveHeartRateSeries([0, 120, -5, 140, 0])).toEqual([
+        120, 140
+      ])
+    })
+
+    it('treats heart-rate gaps and dropouts by holding last reading and backfilling leading dropouts', () => {
+      expect(fillHeartRateDropouts([])).toEqual([])
+      expect(fillHeartRateDropouts([0, 0, 0])).toEqual([])
+      // Single reading
+      expect(fillHeartRateDropouts([140])).toEqual([140])
+      // Leading dropouts: back-fill with first positive reading
+      expect(fillHeartRateDropouts([0, 0, 140, 150])).toEqual([
+        140, 140, 140, 150
+      ])
+      // Middle dropouts: hold last reading across gap
+      expect(fillHeartRateDropouts([130, 0, 0, 150])).toEqual([
+        130, 130, 130, 150
+      ])
+      // Trailing dropouts: hold last reading across gap
+      expect(fillHeartRateDropouts([130, 140, 0, 0])).toEqual([
+        130, 140, 140, 140
+      ])
+    })
+
+    it('computes heart rate stats ignoring dropouts', () => {
+      expect(computeHeartRateStats([])).toBeNull()
+      expect(computeHeartRateStats([0, 0])).toBeNull()
+      expect(computeHeartRateStats([0, 150, 0, 150, 150])).toEqual({
+        avg: 150,
+        max: 150
+      })
+      expect(computeHeartRateStats([120, 140, 160])).toEqual({
+        avg: 140,
+        max: 160
+      })
+    })
+  })
+
+  describe('computePowerHistogramMinutes', () => {
+    it('handles empty and small series', () => {
+      expect(computePowerHistogramMinutes([])).toEqual([])
+      // 50W falls in bucket 2 (50 / 25 = 2). 60 samples at 50W = 1 minute
+      const series = new Array(60).fill(50)
+      const histogram = computePowerHistogramMinutes(series)
+      expect(histogram[2]).toBe(1)
+    })
+
+    it('computes power histogram on large datasets safely without stack overflow', () => {
+      const large = new Array(50_000).fill(200)
+      const histogram = computePowerHistogramMinutes(large)
+      expect(histogram.length).toBeGreaterThan(0)
+      expect(histogram[8]).toBe(50_000 / 60)
+    })
+  })
+})

--- a/app/(timeline)/[actor]/[status]/fitnessChartData.ts
+++ b/app/(timeline)/[actor]/[status]/fitnessChartData.ts
@@ -1,0 +1,485 @@
+import { formatFitnessDuration } from '@/lib/utils/fitness'
+
+/**
+ * How densely a chart series is plotted, as samples-per-drawn-point.
+ * Matches Strava's 8:1 ratio (e.g. 5,913 samples -> 740 drawn; 5,272 -> 659).
+ */
+export const ANALYSIS_SAMPLES_PER_POINT = 8
+
+/**
+ * Floors and ceilings on drawn point count.
+ * The floor keeps a short activity at least as detailed as it was before (120 points).
+ * The ceiling bounds the path strings for long recordings (1,200 points).
+ */
+export const ANALYSIS_SERIES_MIN_POINTS = 120
+export const ANALYSIS_SERIES_MAX_POINTS = 1_200
+
+/**
+ * Default tick counts for time axes across charts.
+ * 6 ticks for full analysis panels; 4 ticks for the narrower overview elevation card.
+ */
+export const DEFAULT_TICK_COUNT = 6
+export const OVERVIEW_TICK_COUNT = 4
+
+/**
+ * Common graph view heights.
+ */
+export const GRAPH_VIEW_HEIGHT = 250
+export const OVERVIEW_GRAPH_VIEW_HEIGHT = 130
+
+/**
+ * Fraction of plot width beyond which the hover value chip flips to the left
+ * of the cursor to avoid overflowing container padding.
+ */
+export const CHART_READOUT_FLIP_THRESHOLD = 0.62
+
+export const clampNumber = (
+  value: number,
+  min: number,
+  max: number
+): number => {
+  return Math.max(min, Math.min(max, value))
+}
+
+/**
+ * Downsample an array of numbers to `targetCount` points using bin averaging.
+ */
+export const downsampleSeries = (
+  series: number[],
+  targetCount: number
+): number[] => {
+  if (series.length <= targetCount) return series
+  if (targetCount <= 0) return []
+  const ratio = series.length / targetCount
+  const result: number[] = []
+  for (let i = 0; i < targetCount; i++) {
+    const start = Math.floor(i * ratio)
+    const end = Math.floor((i + 1) * ratio)
+    const chunk = series.slice(start, end)
+    const sum = chunk.reduce((a, b) => a + b, 0)
+    result.push(chunk.length > 0 ? sum / chunk.length : 0)
+  }
+  return result
+}
+
+/**
+ * Reduce one raw series to the point count Strava would draw it at.
+ * An empty series stays empty.
+ */
+export const plotAtStravaDensity = (series: number[]): number[] => {
+  if (series.length === 0) return []
+  return downsampleSeries(
+    series,
+    clampNumber(
+      Math.round(series.length / ANALYSIS_SAMPLES_PER_POINT),
+      ANALYSIS_SERIES_MIN_POINTS,
+      ANALYSIS_SERIES_MAX_POINTS
+    )
+  )
+}
+
+export interface SeriesMinMax {
+  minValue: number
+  maxValue: number
+}
+
+/**
+ * Stack-safe computation of min and max across an array of numbers.
+ * Avoids spreading large arrays into Math.min/Math.max.
+ */
+export const getSeriesMinMax = (values: number[]): SeriesMinMax => {
+  if (values.length === 0) {
+    return { minValue: 0, maxValue: 0 }
+  }
+
+  let minValue = values[0]
+  let maxValue = values[0]
+
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index] < minValue) {
+      minValue = values[index]
+    } else if (values[index] > maxValue) {
+      maxValue = values[index]
+    }
+  }
+
+  return { minValue, maxValue }
+}
+
+/**
+ * Projects sample index to SVG coordinate x.
+ */
+export const getChartXPosition = (
+  index: number,
+  count: number,
+  width: number
+): number => {
+  return (index / Math.max(1, count - 1)) * width
+}
+
+/**
+ * Projects sample value to SVG coordinate y.
+ * Clamps flat ranges (maxValue === minValue) to avoid division by zero.
+ */
+export const getChartYPosition = (
+  value: number,
+  height: number,
+  minValue: number,
+  maxValue: number
+): number => {
+  const range = Math.max(1, maxValue - minValue)
+  return height - ((value - minValue) / range) * height
+}
+
+/**
+ * Builds SVG line path (`M x y L x y ...`) for a series of values.
+ */
+export const buildChartPath = (
+  values: number[],
+  width: number,
+  height: number,
+  minValue?: number,
+  maxValue?: number
+): string => {
+  if (values.length === 0) return ''
+
+  const defaultMinMax = getSeriesMinMax(values)
+  const min = typeof minValue === 'number' ? minValue : defaultMinMax.minValue
+  const max = typeof maxValue === 'number' ? maxValue : defaultMinMax.maxValue
+
+  return values
+    .map((value, index) => {
+      const x = getChartXPosition(index, values.length, width)
+      const y = getChartYPosition(value, height, min, max)
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
+    })
+    .join(' ')
+}
+
+/**
+ * Closes an SVG line path into an area path spanning down to the bottom (height).
+ */
+export const buildChartAreaPath = (
+  linePath: string,
+  width: number,
+  height: number
+): string => {
+  if (!linePath) return ''
+  return `${linePath} L ${width.toFixed(2)} ${height} L 0 ${height} Z`
+}
+
+/**
+ * Value formatting helper that suppresses negative zero (`-0` or `-0.0`).
+ * Adding 0 to `-0` evaluates to `+0`.
+ */
+export const formatChartValue = (
+  value: number,
+  fractionDigits: number
+): string => {
+  const formatted = value.toFixed(fractionDigits)
+  return (Number(formatted) + 0).toFixed(fractionDigits)
+}
+
+/**
+ * Format duration in seconds to M:SS or H:MM:SS, defaulting to '0:00'.
+ */
+export const formatDuration = (durationSeconds?: number): string =>
+  formatFitnessDuration(durationSeconds, { fallback: '0:00' }) ?? '0:00'
+
+/**
+ * Generates evenly spaced time-axis tick labels across durationSeconds.
+ */
+export const buildXAxisLabels = (
+  durationSeconds: number,
+  tickCount = DEFAULT_TICK_COUNT
+): string[] => {
+  if (tickCount <= 0) return []
+  if (tickCount === 1) return [formatDuration(0)]
+  const labels: string[] = []
+  for (let i = 0; i < tickCount; i++) {
+    const ratio = i / (tickCount - 1)
+    const seconds = Math.round(ratio * durationSeconds)
+    labels.push(formatDuration(seconds))
+  }
+  return labels
+}
+
+export interface ScaledSeriesInput<TKey extends string = string> {
+  key: TKey
+  label?: string
+  unit?: string
+  values: number[]
+  fractionDigits?: number
+}
+
+export interface PlottedCombinedSeries<TKey extends string = string> {
+  key: TKey
+  label: string
+  unit: string
+  values: number[]
+  fractionDigits: number
+  minValue: number
+  maxValue: number
+  path: string
+}
+
+/**
+ * Scales multiple series independently to their own min and max values,
+ * generating SVG path data for each.
+ */
+export const scaleCombinedChartSeries = <T extends { values: number[] }>(
+  seriesList: T[],
+  width: number,
+  height: number
+): Array<T & { minValue: number; maxValue: number; path: string }> => {
+  return seriesList.map((entry) => {
+    const { minValue, maxValue } = getSeriesMinMax(entry.values)
+    return {
+      ...entry,
+      minValue,
+      maxValue,
+      path: buildChartPath(entry.values, width, height, minValue, maxValue)
+    }
+  })
+}
+
+export interface CombinedChartHighlight<TKey extends string = string> {
+  key: TKey
+  unit: string
+  fractionDigits: number
+  value: number
+  x: number
+  y: number
+}
+
+/**
+ * Computes hover coordinates and values across multiple combined series for a given scrub ratio.
+ */
+export const computeCombinedChartHighlights = <TKey extends string = string>(
+  plottedSeries: Array<{
+    key: TKey
+    unit: string
+    fractionDigits: number
+    values: number[]
+    minValue: number
+    maxValue: number
+  }>,
+  ratio: number | null,
+  width: number,
+  height: number
+): Array<CombinedChartHighlight<TKey>> => {
+  if (ratio === null) return []
+  return plottedSeries
+    .map((entry) => {
+      if (entry.values.length === 0) return null
+      const index = clampNumber(
+        Math.round(ratio * (entry.values.length - 1)),
+        0,
+        entry.values.length - 1
+      )
+      return {
+        key: entry.key,
+        unit: entry.unit,
+        fractionDigits: entry.fractionDigits,
+        value: entry.values[index],
+        x: getChartXPosition(index, entry.values.length, width),
+        y: getChartYPosition(
+          entry.values[index],
+          height,
+          entry.minValue,
+          entry.maxValue
+        )
+      }
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+}
+
+export interface ChartHighlight {
+  value: number
+  x: number
+  y: number
+}
+
+/**
+ * Computes sample index from highlighted elapsed seconds and total duration.
+ */
+export const computeHighlightedIndex = (
+  highlightedElapsedSeconds: number | null | undefined,
+  durationSeconds: number | undefined,
+  pointCount: number
+): number | null => {
+  if (
+    typeof highlightedElapsedSeconds !== 'number' ||
+    typeof durationSeconds !== 'number' ||
+    durationSeconds <= 0 ||
+    pointCount <= 0
+  ) {
+    return null
+  }
+  return clampNumber(
+    Math.round(
+      (highlightedElapsedSeconds / durationSeconds) * (pointCount - 1)
+    ),
+    0,
+    pointCount - 1
+  )
+}
+
+/**
+ * Computes plot highlight coordinates (x, y, value) for a single series.
+ */
+export const computeChartHighlight = (
+  values: number[],
+  highlightedIndex: number | null,
+  width: number,
+  height: number,
+  minValue: number,
+  maxValue: number
+): ChartHighlight | null => {
+  if (
+    highlightedIndex === null ||
+    highlightedIndex < 0 ||
+    highlightedIndex >= values.length
+  ) {
+    return null
+  }
+  return {
+    value: values[highlightedIndex],
+    x: getChartXPosition(highlightedIndex, values.length, width),
+    y: getChartYPosition(values[highlightedIndex], height, minValue, maxValue)
+  }
+}
+
+/**
+ * Checks whether the hover readout chip should flip to the left of the cursor.
+ */
+export const shouldFlipChartReadout = (
+  x: number,
+  width: number,
+  threshold = CHART_READOUT_FLIP_THRESHOLD
+): boolean => {
+  if (width <= 0) return false
+  return x / width > threshold
+}
+
+export interface HeartRateZoneDefinition {
+  name: string
+  label: string
+  lo: number
+  hi: number | null
+  color: string
+}
+
+export const HEART_RATE_ZONES: HeartRateZoneDefinition[] = [
+  { name: 'Z1', label: 'Recovery', lo: 0, hi: 122, color: 'hsl(205 45% 62%)' },
+  {
+    name: 'Z2',
+    label: 'Endurance',
+    lo: 122,
+    hi: 142,
+    color: 'hsl(142 60% 45%)'
+  },
+  { name: 'Z3', label: 'Tempo', lo: 142, hi: 158, color: 'hsl(45 92% 50%)' },
+  {
+    name: 'Z4',
+    label: 'Threshold',
+    lo: 158,
+    hi: 172,
+    color: 'hsl(24 95% 50%)'
+  },
+  { name: 'Z5', label: 'Anaerobic', lo: 172, hi: null, color: 'hsl(2 78% 55%)' }
+]
+
+export interface HeartRateZone extends HeartRateZoneDefinition {
+  seconds: number
+  pct: number
+  rawPct: number
+}
+
+/**
+ * Buckets heart-rate samples into 5 standard training zones.
+ * Excludes 0 bpm sensor dropouts from inflating Zone 1.
+ */
+export const computeHeartRateZones = (
+  series: number[],
+  durationSeconds: number
+): HeartRateZone[] => {
+  const counts = HEART_RATE_ZONES.map(() => 0)
+  for (const bpm of series) {
+    if (bpm <= 0) continue
+    const index = HEART_RATE_ZONES.findIndex(
+      (zone) => bpm >= zone.lo && (zone.hi === null || bpm < zone.hi)
+    )
+    if (index >= 0) counts[index] += 1
+  }
+  const totalSamples = counts.reduce((sum, value) => sum + value, 0)
+  return HEART_RATE_ZONES.map((zone, index) => {
+    const fraction = totalSamples > 0 ? counts[index] / totalSamples : 0
+    return {
+      ...zone,
+      pct: Math.round(fraction * 100),
+      rawPct: fraction * 100,
+      seconds: Math.round(fraction * durationSeconds)
+    }
+  })
+}
+
+/**
+ * Filter out sensor dropouts (<= 0 bpm) for tallies like avg, max, and zone buckets.
+ */
+export const filterPositiveHeartRateSeries = (series: number[]): number[] => {
+  return series.filter((bpm) => bpm > 0)
+}
+
+/**
+ * Hold the last good reading across a gap and back-fill leading dropouts.
+ * Keeps series length and sample-index alignment with elapsed time,
+ * while preventing 0 bpm dropouts from dipping the plotted line.
+ */
+export const fillHeartRateDropouts = (series: number[]): number[] => {
+  const firstReading = series.find((bpm) => bpm > 0)
+  if (firstReading === undefined) return []
+
+  let lastReading = firstReading
+  return series.map((bpm) => {
+    if (bpm > 0) lastReading = bpm
+    return lastReading
+  })
+}
+
+export interface HeartRateStats {
+  avg: number
+  max: number
+}
+
+/**
+ * Computes average and max heart rate, ignoring sensor dropouts (<= 0 bpm).
+ */
+export const computeHeartRateStats = (
+  series: number[]
+): HeartRateStats | null => {
+  const positive = series.filter((bpm) => bpm > 0)
+  if (positive.length === 0) return null
+  const { maxValue } = getSeriesMinMax(positive)
+  const avg = Math.round(positive.reduce((a, b) => a + b, 0) / positive.length)
+  return { avg, max: Math.round(maxValue) }
+}
+
+/**
+ * Computes 25-watt distribution histogram buckets in minutes.
+ */
+export const computePowerHistogramMinutes = (
+  powerSeries: number[]
+): number[] => {
+  if (powerSeries.length === 0) return []
+  const computedMaxPower = Math.max(getSeriesMinMax(powerSeries).maxValue, 100)
+  const bucketCount = Math.ceil((computedMaxPower + 25) / 25)
+  const buckets = new Array(bucketCount).fill(0)
+  for (const p of powerSeries) {
+    const bucketIndex = Math.floor(p / 25)
+    if (bucketIndex >= 0 && bucketIndex < bucketCount) {
+      buckets[bucketIndex] += 1
+    }
+  }
+  return buckets.map((seconds) => seconds / 60)
+}


### PR DESCRIPTION
### Summary
- Extracted pure chart sampling constants, downsampling algorithms, SVG chart-coordinate and path calculations, axis-label generation, value formatting, and heart-rate-zone computations from `FitnessStatusDetail` into a route-local pure module `fitnessChartData.ts`.
- Preserved existing numerical behavior, sample-density limits (8:1 Strava density, 120-point floor, 1200-point ceiling), 4-tick overview time axis labels, independent combined-chart range scaling, duration formatting, and sensor dropout treatment.
- Added comprehensive unit tests in `fitnessChartData.test.ts` covering empty and single-point series, flat ranges, large datasets, negative-zero formatting, heart-rate gaps/dropouts, and boundary durations.
- Verified that rendered charts in `FitnessStatusDetail.test.tsx` remain visually equivalent.