### PR TITLE
fix(jobs): use getters in JOBS registry to avoid circular dependency TDZ

### DIFF
--- a/lib/jobs/index.test.ts
+++ b/lib/jobs/index.test.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process'
+
 import { JOBS } from '@/lib/jobs'
 import * as jobNames from '@/lib/jobs/names'
 
@@ -12,9 +14,17 @@ describe('JOBS registry', () => {
     }
   })
 
-  it('avoids TDZ when a job module that depends on queue is imported directly', async () => {
-    const { createNoteJob } = await import('./createNoteJob')
-    expect(createNoteJob).toBeDefined()
-    expect(typeof createNoteJob).toBe('function')
+  it('avoids TDZ when createNoteJob is the initial entry point in a fresh process', () => {
+    expect(() => {
+      execFileSync(
+        process.execPath,
+        ['-r', 'tsx/cjs', '-e', 'require("./lib/jobs/createNoteJob.ts")'],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf-8',
+          stdio: 'pipe'
+        }
+      )
+    }).not.toThrow()
   })
 })

--- a/lib/jobs/index.test.ts
+++ b/lib/jobs/index.test.ts
@@ -1,0 +1,20 @@
+import { JOBS } from '@/lib/jobs'
+import * as jobNames from '@/lib/jobs/names'
+
+describe('JOBS registry', () => {
+  it('registers all known job names as own property getters returning functions', () => {
+    const names = Object.values(jobNames)
+    expect(names.length).toBeGreaterThan(0)
+
+    for (const name of names) {
+      expect(Object.prototype.hasOwnProperty.call(JOBS, name)).toBe(true)
+      expect(typeof JOBS[name]).toBe('function')
+    }
+  })
+
+  it('avoids TDZ when a job module that depends on queue is imported directly', async () => {
+    const { createNoteJob } = await import('./createNoteJob')
+    expect(createNoteJob).toBeDefined()
+    expect(typeof createNoteJob).toBe('function')
+  })
+})

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -84,43 +84,121 @@ import { updatePollJob } from './updatePollJob'
 export type { JobHandle }
 
 export const JOBS: Record<string, JobHandle> = {
-  [CREATE_NOTE_JOB_NAME]: createNoteJob,
-  [UPDATE_NOTE_JOB_NAME]: updateNoteJob,
-  [CREATE_ANNOUNCE_JOB_NAME]: createAnnounceJob,
-  [RELAY_ANNOUNCE_JOB_NAME]: createRelayAnnounceJob,
-  [CREATE_POLL_JOB_NAME]: createPollJob,
-  [CREATE_POLL_VOTE_JOB_NAME]: createPollVoteJob,
-  [UPDATE_POLL_JOB_NAME]: updatePollJob,
-  [DELETE_OBJECT_JOB_NAME]: deleteObjectJob,
-  [DELETE_ACTOR_JOB_NAME]: deleteActorJob,
-  [SEND_ANNOUNCE_JOB_NAME]: sendAnnounceJob,
-  [SEND_BLOCK_JOB_NAME]: sendBlockJob,
-  [GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME]: generateFitnessRouteHeatmapJob,
-  [GENERATE_FITNESS_HEATMAP_JOB_NAME]: generateFitnessRouteHeatmapJob,
-  [PROCESS_FITNESS_FILE_JOB_NAME]: processFitnessFileJob,
-  [PROCESS_FORWARDED_ACTIVITY_JOB_NAME]: processForwardedActivityJob,
-  [REGENERATE_FITNESS_MAPS_JOB_NAME]: regenerateFitnessMapsJob,
-  [IMPORT_FITNESS_FILES_JOB_NAME]: importFitnessFilesJob,
-  [IMPORT_STRAVA_ACTIVITY_JOB_NAME]: importStravaActivityJob,
-  [IMPORT_STRAVA_ARCHIVE_JOB_NAME]: importStravaArchiveJob,
-  [SEND_NOTE_JOB_NAME]: sendNoteJob,
-  [SEND_QUOTE_REQUEST_JOB_NAME]: sendQuoteRequestJob,
-  [SEND_QUOTE_ACCEPT_JOB_NAME]: sendQuoteAcceptJob,
-  [SEND_QUOTE_REJECT_JOB_NAME]: sendQuoteRejectJob,
-  [SEND_QUOTE_REVOKE_JOB_NAME]: sendQuoteRevokeJob,
-  [HANDLE_QUOTE_REQUEST_JOB_NAME]: handleQuoteRequestJob,
-  [SEND_UPDATE_NOTE_JOB_NAME]: sendUpdateNoteJob,
-  [SEND_DELETE_NOTE_JOB_NAME]: sendDeleteNoteJob,
-  [SEND_UNDO_ANNOUNCE_JOB_NAME]: sendUndoAnnounceJob,
-  [SEND_UNDO_FOLLOW_JOB_NAME]: sendUndoFollowJob,
-  [SEND_UNBLOCK_JOB_NAME]: sendUnblockJob,
-  [SEND_FLAG_JOB_NAME]: sendFlagJob,
-  [FETCH_REMOTE_STATUS_JOB_NAME]: fetchRemoteStatusJob,
-  [FOLLOW_TIMELINE_BACKFILL_JOB_NAME]: followTimelineBackfillJob,
-  [PUBLISH_SCHEDULED_STATUS_JOB_NAME]: publishScheduledStatusJob,
-  [INGEST_COLLECTION_MEMBER_JOB_NAME]: ingestCollectionMemberJob,
-  [EMOJI_REACTION_JOB_NAME]: emojiReactionJob,
-  [FETCH_LINK_PREVIEW_JOB_NAME]: fetchLinkPreviewJob,
-  [FORWARD_ACTIVITY_JOB_NAME]: forwardActivityJob,
-  [DELIVER_ACTIVITY_JOB_NAME]: deliverActivityJob
+  get [CREATE_NOTE_JOB_NAME]() {
+    return createNoteJob
+  },
+  get [UPDATE_NOTE_JOB_NAME]() {
+    return updateNoteJob
+  },
+  get [CREATE_ANNOUNCE_JOB_NAME]() {
+    return createAnnounceJob
+  },
+  get [RELAY_ANNOUNCE_JOB_NAME]() {
+    return createRelayAnnounceJob
+  },
+  get [CREATE_POLL_JOB_NAME]() {
+    return createPollJob
+  },
+  get [CREATE_POLL_VOTE_JOB_NAME]() {
+    return createPollVoteJob
+  },
+  get [UPDATE_POLL_JOB_NAME]() {
+    return updatePollJob
+  },
+  get [DELETE_OBJECT_JOB_NAME]() {
+    return deleteObjectJob
+  },
+  get [DELETE_ACTOR_JOB_NAME]() {
+    return deleteActorJob
+  },
+  get [SEND_ANNOUNCE_JOB_NAME]() {
+    return sendAnnounceJob
+  },
+  get [SEND_BLOCK_JOB_NAME]() {
+    return sendBlockJob
+  },
+  get [GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME]() {
+    return generateFitnessRouteHeatmapJob
+  },
+  get [GENERATE_FITNESS_HEATMAP_JOB_NAME]() {
+    return generateFitnessRouteHeatmapJob
+  },
+  get [PROCESS_FITNESS_FILE_JOB_NAME]() {
+    return processFitnessFileJob
+  },
+  get [PROCESS_FORWARDED_ACTIVITY_JOB_NAME]() {
+    return processForwardedActivityJob
+  },
+  get [REGENERATE_FITNESS_MAPS_JOB_NAME]() {
+    return regenerateFitnessMapsJob
+  },
+  get [IMPORT_FITNESS_FILES_JOB_NAME]() {
+    return importFitnessFilesJob
+  },
+  get [IMPORT_STRAVA_ACTIVITY_JOB_NAME]() {
+    return importStravaActivityJob
+  },
+  get [IMPORT_STRAVA_ARCHIVE_JOB_NAME]() {
+    return importStravaArchiveJob
+  },
+  get [SEND_NOTE_JOB_NAME]() {
+    return sendNoteJob
+  },
+  get [SEND_QUOTE_REQUEST_JOB_NAME]() {
+    return sendQuoteRequestJob
+  },
+  get [SEND_QUOTE_ACCEPT_JOB_NAME]() {
+    return sendQuoteAcceptJob
+  },
+  get [SEND_QUOTE_REJECT_JOB_NAME]() {
+    return sendQuoteRejectJob
+  },
+  get [SEND_QUOTE_REVOKE_JOB_NAME]() {
+    return sendQuoteRevokeJob
+  },
+  get [HANDLE_QUOTE_REQUEST_JOB_NAME]() {
+    return handleQuoteRequestJob
+  },
+  get [SEND_UPDATE_NOTE_JOB_NAME]() {
+    return sendUpdateNoteJob
+  },
+  get [SEND_DELETE_NOTE_JOB_NAME]() {
+    return sendDeleteNoteJob
+  },
+  get [SEND_UNDO_ANNOUNCE_JOB_NAME]() {
+    return sendUndoAnnounceJob
+  },
+  get [SEND_UNDO_FOLLOW_JOB_NAME]() {
+    return sendUndoFollowJob
+  },
+  get [SEND_UNBLOCK_JOB_NAME]() {
+    return sendUnblockJob
+  },
+  get [SEND_FLAG_JOB_NAME]() {
+    return sendFlagJob
+  },
+  get [FETCH_REMOTE_STATUS_JOB_NAME]() {
+    return fetchRemoteStatusJob
+  },
+  get [FOLLOW_TIMELINE_BACKFILL_JOB_NAME]() {
+    return followTimelineBackfillJob
+  },
+  get [PUBLISH_SCHEDULED_STATUS_JOB_NAME]() {
+    return publishScheduledStatusJob
+  },
+  get [INGEST_COLLECTION_MEMBER_JOB_NAME]() {
+    return ingestCollectionMemberJob
+  },
+  get [EMOJI_REACTION_JOB_NAME]() {
+    return emojiReactionJob
+  },
+  get [FETCH_LINK_PREVIEW_JOB_NAME]() {
+    return fetchLinkPreviewJob
+  },
+  get [FORWARD_ACTIVITY_JOB_NAME]() {
+    return forwardActivityJob
+  },
+  get [DELIVER_ACTIVITY_JOB_NAME]() {
+    return deliverActivityJob
+  }
 }


### PR DESCRIPTION
## Summary
When importing `createNoteJob` directly (such as in `scripts/maintenance/importRemoteStatus.ts`), a circular dependency chain occurred during module loading:
`importRemoteStatus.ts` -> `createNoteJob.ts` -> `syncStatusLinkPreview.ts` -> `lib/services/queue` -> `lib/services/queue/base.ts` -> `lib/jobs/index.ts` -> `createNoteJob.ts`.

Because `createNoteJob.ts` was mid-evaluation when `lib/jobs/index.ts` was evaluated, constructing the `JOBS` dictionary with eager property values (`[CREATE_NOTE_JOB_NAME]: createNoteJob`) threw `ReferenceError: Cannot access 'createNoteJob' before initialization` due to the temporal dead zone (TDZ).

This PR converts the properties in `JOBS` to property getters (`get [JOB_NAME]() { return job }`). This defers accessing the job handlers until runtime lookup rather than module evaluation time, safely eliminating circular initialization TDZ errors while preserving own property enumerability and `hasOwnProperty` semantics.

## Testing
- `yarn run prettier --write .` passed.
- `yarn lint` passed with 0 errors.
- `yarn typecheck` passed.
- `yarn build` passed.
- `yarn test` passed (990 test files, 13,576 tests).
- Verified `node scripts/run.cjs scripts/maintenance/importRemoteStatus.ts` loads successfully without TDZ ReferenceError.