### PR TITLE
refactor: migrate password recovery forms to lib/client.ts

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -233,9 +233,7 @@
           {
             "allowFiles": [
               "app/(timeline)/fitness/strava/StravaSettingsForm.tsx",
-              "app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx",
-              "app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.tsx",
-              "app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx"
+              "app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx"
             ]
           }
         ]

--- a/app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.test.tsx
+++ b/app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.test.tsx
@@ -2,15 +2,24 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import * as client from '@/lib/client'
 
 import { RequestPasswordResetForm } from './RequestPasswordResetForm'
 
+vi.mock('@/lib/client', () => ({
+  requestPasswordReset: vi.fn()
+}))
+
+const mockRequestPasswordReset = vi.mocked(client.requestPasswordReset)
+
 describe('RequestPasswordResetForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('renders the form with method="post" (defense-in-depth against a native GET submit)', () => {
-    // The email input is controlled and unnamed, so a native submit sends nothing
-    // today; method="post" guards against a `name` addition later,
-    // since a method-less <form> defaults to GET.
     render(<RequestPasswordResetForm />)
 
     const form = screen
@@ -18,5 +27,160 @@ describe('RequestPasswordResetForm', () => {
       .closest('form')
     expect(form).not.toBeNull()
     expect(form).toHaveAttribute('method', 'post')
+  })
+
+  it('submits email and displays generic success message without disclosing account existence', async () => {
+    mockRequestPasswordReset.mockResolvedValueOnce({
+      success: true,
+      message:
+        'If an account exists for that email, a password reset link has been sent.'
+    })
+
+    render(<RequestPasswordResetForm />)
+
+    const emailInput = screen.getByLabelText(/email/i)
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+        email: 'user@example.com'
+      })
+      expect(
+        screen.getByText(
+          'If an account exists for that email, a password reset link has been sent.'
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('displays API error and re-enables submit button on failure', async () => {
+    mockRequestPasswordReset.mockRejectedValueOnce(new Error('Bad Request'))
+
+    render(<RequestPasswordResetForm />)
+
+    const emailInput = screen.getByLabelText(/email/i)
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Bad Request')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /send reset link/i })
+    ).toBeEnabled()
+  })
+
+  it('handles network failure gracefully', async () => {
+    mockRequestPasswordReset.mockRejectedValueOnce(
+      new Error('Network error occurred')
+    )
+
+    render(<RequestPasswordResetForm />)
+
+    const emailInput = screen.getByLabelText(/email/i)
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error occurred')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /send reset link/i })
+    ).toBeEnabled()
+  })
+
+  it('handles non-Error rejection with fallback message', async () => {
+    mockRequestPasswordReset.mockRejectedValueOnce('unknown error')
+
+    render(<RequestPasswordResetForm />)
+
+    const emailInput = screen.getByLabelText(/email/i)
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('An unexpected error occurred. Please try again.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('handles repeated submissions: ignores duplicate submit while in flight and allows retrying afterwards', async () => {
+    let resolveRequest: (value: {
+      success: boolean
+      message: string
+    }) => void = () => {}
+    mockRequestPasswordReset.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+
+    render(<RequestPasswordResetForm />)
+
+    const emailInput = screen.getByLabelText(/email/i)
+    const submitButton = screen.getByRole('button', {
+      name: /send reset link/i
+    })
+
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+    fireEvent.click(submitButton)
+
+    // Button should now be disabled and text should change to 'Sending...'
+    expect(submitButton).toBeDisabled()
+    expect(screen.getByText('Sending...')).toBeInTheDocument()
+    expect(mockRequestPasswordReset).toHaveBeenCalledTimes(1)
+
+    // Attempting a second submit while in flight should not trigger additional calls
+    const form = submitButton.closest('form')
+    expect(form).not.toBeNull()
+    if (form) {
+      fireEvent.submit(form)
+    }
+    expect(mockRequestPasswordReset).toHaveBeenCalledTimes(1)
+
+    // Resolve the first request
+    resolveRequest({
+      success: true,
+      message:
+        'If an account exists for that email, a password reset link has been sent.'
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'If an account exists for that email, a password reset link has been sent.'
+        )
+      ).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /send reset link/i })
+    ).toBeEnabled()
+
+    // Second submission can be performed
+    mockRequestPasswordReset.mockResolvedValueOnce({
+      success: true,
+      message:
+        'If an account exists for that email, a password reset link has been sent.'
+    })
+
+    fireEvent.change(emailInput, { target: { value: 'another@example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledTimes(2)
+      expect(mockRequestPasswordReset).toHaveBeenLastCalledWith({
+        email: 'another@example.com'
+      })
+    })
   })
 })

--- a/app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.tsx
+++ b/app/(nosidebar)/auth/forgot-password/RequestPasswordResetForm.tsx
@@ -2,10 +2,10 @@
 
 import { FC, useState } from 'react'
 
+import { requestPasswordReset } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Label } from '@/lib/components/ui/label'
-import { parseFetchResponseData } from '@/lib/utils/parseFetchResponseData'
 
 export const RequestPasswordResetForm: FC = () => {
   const [email, setEmail] = useState('')
@@ -15,35 +15,26 @@ export const RequestPasswordResetForm: FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (isLoading) {
+      return
+    }
+
     setError('')
     setMessage('')
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/v1/accounts/password/reset/request', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ email })
-      })
-      const data = await parseFetchResponseData(response)
-      const responseError =
-        typeof data.error === 'string'
-          ? data.error
-          : 'Failed to request password reset'
-      const responseMessage =
-        typeof data.message === 'string'
-          ? data.message
-          : 'If an account exists for that email, a password reset link has been sent.'
-      if (!response.ok) {
-        setError(responseError)
-        return
-      }
-
-      setMessage(responseMessage)
-    } catch (_error) {
-      setError('An unexpected error occurred. Please try again.')
+      const data = await requestPasswordReset({ email })
+      setMessage(
+        data.message ||
+          'If an account exists for that email, a password reset link has been sent.'
+      )
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'An unexpected error occurred. Please try again.'
+      )
     } finally {
       setIsLoading(false)
     }

--- a/app/(nosidebar)/auth/reset-password/ResetPasswordForm.test.tsx
+++ b/app/(nosidebar)/auth/reset-password/ResetPasswordForm.test.tsx
@@ -2,15 +2,24 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import * as client from '@/lib/client'
 
 import { ResetPasswordForm } from './ResetPasswordForm'
 
+vi.mock('@/lib/client', () => ({
+  resetPassword: vi.fn()
+}))
+
+const mockResetPassword = vi.mocked(client.resetPassword)
+
 describe('ResetPasswordForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('renders the form with method="post" (defense-in-depth against a native GET submit)', () => {
-    // These inputs are controlled and unnamed, so a native submit sends nothing
-    // today; method="post" guards against a `name` addition later,
-    // since a method-less <form> defaults to GET.
     render(<ResetPasswordForm />)
 
     const form = screen
@@ -18,5 +27,238 @@ describe('ResetPasswordForm', () => {
       .closest('form')
     expect(form).not.toBeNull()
     expect(form).toHaveAttribute('method', 'post')
+  })
+
+  it('initializes code from initialCode prop', () => {
+    render(<ResetPasswordForm initialCode="preset-reset-code" />)
+
+    expect(screen.getByLabelText(/reset code/i)).toHaveValue(
+      'preset-reset-code'
+    )
+  })
+
+  it('validates reset code is required', async () => {
+    render(<ResetPasswordForm />)
+
+    fireEvent.change(screen.getByLabelText(/reset code/i), {
+      target: { value: '   ' }
+    })
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'password123' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'password123' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(screen.getByText('Reset code is required')).toBeInTheDocument()
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('validates passwords match before calling API', async () => {
+    render(<ResetPasswordForm initialCode="valid-code" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'password123' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'different-password' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('validates minimum password length before calling API', async () => {
+    render(<ResetPasswordForm initialCode="valid-code" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'short' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'short' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(
+      screen.getByText('Password must be at least 8 characters long')
+    ).toBeInTheDocument()
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('displays API error for invalid or expired codes and re-enables submit', async () => {
+    mockResetPassword.mockRejectedValueOnce(
+      new Error('Invalid or expired reset code')
+    )
+
+    render(<ResetPasswordForm initialCode="expired-code" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'password123' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'password123' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Invalid or expired reset code')
+      ).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /reset password/i })
+    ).toBeEnabled()
+  })
+
+  it('handles network failure gracefully', async () => {
+    mockResetPassword.mockRejectedValueOnce(
+      new Error('Network connection failed')
+    )
+
+    render(<ResetPasswordForm initialCode="valid-code" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'password123' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'password123' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network connection failed')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /reset password/i })
+    ).toBeEnabled()
+  })
+
+  it('handles non-Error failure with fallback error message', async () => {
+    mockResetPassword.mockRejectedValueOnce('unknown error')
+
+    render(<ResetPasswordForm initialCode="valid-code" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'password123' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'password123' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('An unexpected error occurred. Please try again.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('resets password successfully, disables inputs, and shows sign-in navigation link', async () => {
+    mockResetPassword.mockResolvedValueOnce({
+      success: true,
+      message: 'Password reset successfully'
+    })
+
+    render(<ResetPasswordForm initialCode="valid-code" />)
+
+    const codeInput = screen.getByLabelText(/reset code/i)
+    const newPasswordInput = screen.getByLabelText(/^new password/i)
+    const confirmPasswordInput = screen.getByLabelText(/confirm new password/i)
+
+    fireEvent.change(newPasswordInput, {
+      target: { value: 'new-secure-password' }
+    })
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'new-secure-password' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledWith({
+        code: 'valid-code',
+        newPassword: 'new-secure-password'
+      })
+      expect(
+        screen.getByText('Password reset successfully')
+      ).toBeInTheDocument()
+    })
+
+    expect(newPasswordInput).toHaveValue('')
+    expect(confirmPasswordInput).toHaveValue('')
+    expect(codeInput).toBeDisabled()
+    expect(newPasswordInput).toBeDisabled()
+    expect(confirmPasswordInput).toBeDisabled()
+
+    const continueLink = screen.getByRole('link', {
+      name: /continue to sign in/i
+    })
+    expect(continueLink).toBeInTheDocument()
+    expect(continueLink).toHaveAttribute('href', '/auth/signin')
+  })
+
+  it('handles repeated submissions: ignores duplicate submit while in flight and allows retrying after error', async () => {
+    let resolveReset: (value: {
+      success: boolean
+      message: string
+    }) => void = () => {}
+    mockResetPassword.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReset = resolve
+        })
+    )
+
+    render(<ResetPasswordForm initialCode="code-123" />)
+
+    fireEvent.change(screen.getByLabelText(/^new password/i), {
+      target: { value: 'valid-password' }
+    })
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'valid-password' }
+    })
+
+    const submitButton = screen.getByRole('button', { name: /reset password/i })
+    fireEvent.click(submitButton)
+
+    expect(submitButton).toBeDisabled()
+    expect(screen.getByText('Resetting...')).toBeInTheDocument()
+    expect(mockResetPassword).toHaveBeenCalledTimes(1)
+
+    // Attempt second submit while in flight
+    const form = submitButton.closest('form')
+    expect(form).not.toBeNull()
+    if (form) {
+      fireEvent.submit(form)
+    }
+    expect(mockResetPassword).toHaveBeenCalledTimes(1)
+
+    // Complete the first request
+    resolveReset({
+      success: true,
+      message: 'Password reset successfully'
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: /continue to sign in/i })
+      ).toBeInTheDocument()
+    })
+
+    // Submitting after success is ignored
+    if (form) {
+      fireEvent.submit(form)
+    }
+    expect(mockResetPassword).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx
+++ b/app/(nosidebar)/auth/reset-password/ResetPasswordForm.tsx
@@ -3,10 +3,10 @@
 import Link from 'next/link'
 import { FC, useState } from 'react'
 
+import { resetPassword } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Label } from '@/lib/components/ui/label'
-import { parseFetchResponseData } from '@/lib/utils/parseFetchResponseData'
 
 type Props = {
   initialCode?: string
@@ -23,6 +23,10 @@ export const ResetPasswordForm: FC<Props> = ({ initialCode }) => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (isLoading || isSuccess) {
+      return
+    }
+
     setError('')
     setMessage('')
 
@@ -44,33 +48,18 @@ export const ResetPasswordForm: FC<Props> = ({ initialCode }) => {
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/v1/accounts/password/reset', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ code, newPassword })
-      })
-
-      const data = await parseFetchResponseData(response)
-      const responseError =
-        typeof data.error === 'string' ? data.error : 'Failed to reset password'
-      const responseMessage =
-        typeof data.message === 'string'
-          ? data.message
-          : 'Password reset successfully'
-
-      if (!response.ok) {
-        setError(responseError)
-        return
-      }
+      const data = await resetPassword({ code, newPassword })
 
       setIsSuccess(true)
-      setMessage(responseMessage)
+      setMessage(data.message || 'Password reset successfully')
       setNewPassword('')
       setConfirmPassword('')
-    } catch (_error) {
-      setError('An unexpected error occurred. Please try again.')
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'An unexpected error occurred. Please try again.'
+      )
     } finally {
       setIsLoading(false)
     }

--- a/app/api/v1/accounts/password/reset/route.test.ts
+++ b/app/api/v1/accounts/password/reset/route.test.ts
@@ -65,4 +65,110 @@ describe('POST /api/v1/accounts/password/reset', () => {
     expect(mockDb.validatePasswordResetCode).not.toHaveBeenCalled()
     expect(mockDb.resetPasswordWithCode).not.toHaveBeenCalled()
   })
+
+  it('resets password successfully with valid code and password', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          code: 'valid-code-123',
+          newPassword: 'new-password-123'
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://client.llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      success: true,
+      message: 'Password reset successfully'
+    })
+    expect(mockDb.validatePasswordResetCode).toHaveBeenCalledTimes(1)
+    expect(mockBcryptHash).toHaveBeenCalledWith('new-password-123', 10)
+    expect(mockDb.resetPasswordWithCode).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      passwordResetCode: expect.any(String),
+      newPasswordHash: 'new-password-hash'
+    })
+  })
+
+  it('returns 400 when reset code is invalid or expired', async () => {
+    mockDb.validatePasswordResetCode.mockResolvedValueOnce(null)
+
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          code: 'invalid-or-expired-code',
+          newPassword: 'new-password-123'
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://client.llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'Invalid or expired reset code' })
+    expect(mockBcryptHash).not.toHaveBeenCalled()
+    expect(mockDb.resetPasswordWithCode).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when resetPasswordWithCode fails', async () => {
+    mockDb.resetPasswordWithCode.mockResolvedValueOnce(null)
+
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          code: 'valid-code',
+          newPassword: 'new-password-123'
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://client.llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'Invalid or expired reset code' })
+  })
+
+  it('returns 422 when password is less than 8 characters', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          code: 'valid-code',
+          newPassword: 'short'
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://client.llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    expect(response.status).toBe(422)
+    expect(mockDb.validatePasswordResetCode).not.toHaveBeenCalled()
+  })
 })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -40,6 +40,8 @@ import {
   likeStatus,
   removeCollectionAccounts,
   requestEmailChange,
+  requestPasswordReset,
+  resetPassword,
   revokeCollectionMembership,
   search,
   setDefaultActor,
@@ -2137,6 +2139,132 @@ describe('client actor management helpers', () => {
           newPassword: 'new-password'
         })
       ).rejects.toThrow('Network timeout')
+    })
+  })
+
+  describe('requestPasswordReset', () => {
+    it('requests password reset with email payload', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          success: true,
+          message:
+            'If an account exists for that email, a password reset link has been sent.'
+        }),
+        { status: 200 }
+      )
+
+      const result = await requestPasswordReset({
+        email: 'test@example.com'
+      })
+
+      expect(result).toEqual({
+        success: true,
+        message:
+          'If an account exists for that email, a password reset link has been sent.'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/password/reset/request',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'test@example.com' })
+        })
+      )
+    })
+
+    it('decodes API error message on failure', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Bad Request' }), {
+        status: 400
+      })
+
+      await expect(
+        requestPasswordReset({ email: 'invalid-email' })
+      ).rejects.toThrow('Bad Request')
+    })
+
+    it('falls back to default error message on non-JSON failure', async () => {
+      fetchMock.mockResponseOnce('Server Error', { status: 500 })
+
+      await expect(
+        requestPasswordReset({ email: 'test@example.com' })
+      ).rejects.toThrow('Failed to request password reset')
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network connection failed'))
+
+      await expect(
+        requestPasswordReset({ email: 'test@example.com' })
+      ).rejects.toThrow('Network connection failed')
+    })
+  })
+
+  describe('resetPassword', () => {
+    it('resets password with code and newPassword payload', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          success: true,
+          message: 'Password reset successfully'
+        }),
+        { status: 200 }
+      )
+
+      const result = await resetPassword({
+        code: 'valid-reset-code',
+        newPassword: 'new-password-123'
+      })
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Password reset successfully'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/password/reset',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            code: 'valid-reset-code',
+            newPassword: 'new-password-123'
+          })
+        })
+      )
+    })
+
+    it('decodes API error when reset code is invalid or expired', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Invalid or expired reset code' }),
+        { status: 400 }
+      )
+
+      await expect(
+        resetPassword({
+          code: 'expired-code',
+          newPassword: 'new-password-123'
+        })
+      ).rejects.toThrow('Invalid or expired reset code')
+    })
+
+    it('falls back to default error on non-JSON failure', async () => {
+      fetchMock.mockResponseOnce('Internal Server Error', { status: 500 })
+
+      await expect(
+        resetPassword({
+          code: 'any-code',
+          newPassword: 'new-password-123'
+        })
+      ).rejects.toThrow('Failed to reset password')
+    })
+
+    it('propagates network failure', async () => {
+      fetchMock.mockRejectOnce(new Error('Network offline'))
+
+      await expect(
+        resetPassword({
+          code: 'any-code',
+          newPassword: 'new-password-123'
+        })
+      ).rejects.toThrow('Network offline')
     })
   })
 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -5192,3 +5192,41 @@ export const changeAccountPassword = async ({
   }
   return response.json()
 }
+
+export const requestPasswordReset = async ({
+  email
+}: {
+  email: string
+}): Promise<{ success: boolean; message: string }> => {
+  const response = await fetch('/api/v1/accounts/password/reset/request', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ email })
+  })
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to request password reset')
+  }
+  return response.json()
+}
+
+export const resetPassword = async ({
+  code,
+  newPassword
+}: {
+  code: string
+  newPassword: string
+}): Promise<{ success: boolean; message: string }> => {
+  const response = await fetch('/api/v1/accounts/password/reset', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ code, newPassword })
+  })
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to reset password')
+  }
+  return response.json()
+}


### PR DESCRIPTION
## Summary
Migrates password recovery forms (`RequestPasswordResetForm` and `ResetPasswordForm`) away from component-level `fetch` calls to typed client helpers in `lib/client.ts`:
- Added `requestPasswordReset` and `resetPassword` to `lib/client.ts`, preserving the POST endpoints `/api/v1/accounts/password/reset/request` and `/api/v1/accounts/password/reset` and payloads `{ email }` and `{ code, newPassword }`.
- Handled error propagation via `throwApiError` while preserving forms' validation, completion screens, navigation, and generic account-recovery messaging without disclosing account existence.
- Guarded both forms against repeated submissions (preventing concurrent in-flight submissions and post-completion re-submits).
- Removed both allowlist entries from `.oxlintrc.json`.
- Added comprehensive unit tests in `lib/client.test.ts`, `RequestPasswordResetForm.test.tsx`, `ResetPasswordForm.test.tsx`, and `route.test.ts` covering invalid/expired codes, password validation, generic request success, network failures, and repeated submissions.

Closes task E2b.