### PR TITLE
ci: add postgresql schema dump sync job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,9 @@ jobs:
   # This job replays all migrations against a fresh SQLite database, applies
   # the documented dump-and-strip pipeline (CONTRIBUTING.md → "SQLite —
   # migrations/schema.sqlite.sql"), and fails if the result differs from the
-  # committed file. The PostgreSQL dump (migrations/schema.sql) is still
-  # regenerated manually per the same guide.
+  # committed file.
   schema-dump-check:
-    name: Schema Dump Sync
+    name: SQLite Schema Dump Sync
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -202,6 +201,83 @@ jobs:
             exit 1
           fi
 
+  # Drift gate for the committed PostgreSQL reference schema dump. This job
+  # starts a PostgreSQL 17 service container, waits for readiness, replays all
+  # migrations against a fresh database, verifies that every migration file ran,
+  # generates a schema-only dump using PostgreSQL 17 tooling, applies the
+  # documented normalization (CONTRIBUTING.md → "PostgreSQL —
+  # migrations/schema.sql"), and fails if the result differs from the committed file.
+  schema-dump-check-pg:
+    name: PostgreSQL Schema Dump Sync
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: activities
+          POSTGRES_PASSWORD: activities
+          POSTGRES_DB: activities
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Enable corepack
+        run: corepack enable
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Wait for PostgreSQL readiness
+        run: |
+          until docker exec ${{ job.services.postgres.id }} pg_isready -U activities -d activities -q; do
+            sleep 1
+          done
+      - name: Run migrations against a fresh PostgreSQL database
+        run: |
+          ACTIVITIES_DATABASE_CLIENT=pg \
+          ACTIVITIES_DATABASE_PG_HOST=127.0.0.1 \
+          ACTIVITIES_DATABASE_PG_PORT=${{ job.services.postgres.ports['5432'] }} \
+          ACTIVITIES_DATABASE_PG_USER=activities \
+          ACTIVITIES_DATABASE_PG_PASSWORD=activities \
+          ACTIVITIES_DATABASE_PG_DATABASE=activities \
+            yarn migrate
+      - name: Verify every migration file ran
+        run: |
+          applied=$(docker exec ${{ job.services.postgres.id }} psql -U activities -d activities -tAc 'SELECT count(*) FROM knex_migrations;')
+          files=$(ls migrations/*.js | wc -l)
+          echo "applied=$applied files=$files"
+          if [ "$applied" -ne "$files" ]; then
+            echo "::error::knex_migrations has $applied rows but migrations/ has $files files"
+            exit 1
+          fi
+      - name: Diff regenerated dump against migrations/schema.sql
+        run: |
+          docker exec ${{ job.services.postgres.id }} \
+            pg_dump -U activities -d activities --schema-only --no-owner --no-privileges \
+            > /tmp/schema_raw.sql
+          awk '
+            /^SET statement_timeout/ { started = 1 }
+            !started { next }
+            /^--/ { next }
+            /^\\(un)?restrict/ { next }
+            /^SET default_tablespace/ { next }
+            /^SET default_table_access_method/ { next }
+            { print }
+          ' /tmp/schema_raw.sql | cat -s > /tmp/schema-regenerated.sql
+          if ! diff -u migrations/schema.sql /tmp/schema-regenerated.sql; then
+            echo "::error::migrations/schema.sql is out of sync with the migrations. Regenerate BOTH schema dumps in this PR — see AGENTS.md → 'Keeping the reference schema dumps in sync'."
+            exit 1
+          fi
+
   # Aggregate gate: this is the single check to mark required in branch
   # protection. It always runs (`if: always()`) and fails unless every upstream
   # job succeeded, so a failure in any one of the parallel jobs fails the overall
@@ -211,12 +287,20 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint-prettier, typecheck, build, test, schema-dump-check]
+    needs:
+      [
+        lint-prettier,
+        typecheck,
+        build,
+        test,
+        schema-dump-check,
+        schema-dump-check-pg
+      ]
     if: ${{ always() }}
     steps:
       - name: Verify all CI jobs succeeded
         env:
-          RESULTS: ${{ needs.lint-prettier.result }} ${{ needs.typecheck.result }} ${{ needs.build.result }} ${{ needs.test.result }} ${{ needs.schema-dump-check.result }}
+          RESULTS: ${{ needs.lint-prettier.result }} ${{ needs.typecheck.result }} ${{ needs.build.result }} ${{ needs.test.result }} ${{ needs.schema-dump-check.result }} ${{ needs.schema-dump-check-pg.result }}
         run: |
           echo "Upstream job results: $RESULTS"
           for result in $RESULTS; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2126,13 +2126,14 @@ preserving legacy and fitness attachments` pins the surviving-null behaviour.
   is unchanged.
 - CI (`.github/workflows/ci.yml`) runs lint + prettier-check, **type check**,
   build, four parallel test shards aggregated into an `All Tests` step, and
-  Schema Dump Sync (regenerates the SQLite schema dump from the migrations and
-  fails on drift) on every push and PR. Branch protection on `main` requires
+  schema dump sync jobs (regenerating SQLite and PostgreSQL schema dumps from
+  the migrations and failing on drift) on every push and PR. Branch protection on `main` requires
   four status checks — `All Tests`, `Lint and Prettier`, `Build`, and `CI Success`
   (strict: false). The `CI Success` aggregate job is fail-closed over all upstream
-  jobs (`Lint and Prettier`, `Type Check`, `Build`, `All Tests`, and
-  `Schema Dump Sync`), so failures in `Type Check` (the gate covering
-  `*.test.ts(x)`) or `Schema Dump Sync` block merging via `CI Success`.
+  jobs (`Lint and Prettier`, `Type Check`, `Build`, `All Tests`,
+  `SQLite Schema Dump Sync`, and `PostgreSQL Schema Dump Sync`), so failures in
+  `Type Check` (the gate covering `*.test.ts(x)`) or schema dump drift block
+  merging via `CI Success`.
   The test job pins `TEST_DATABASE_TYPE: sqlite`; `lib/database/testUtils.ts`
   also supports `TEST_DATABASE_TYPE=pg` (with `TEST_DATABASE_HOST` /
   `TEST_DATABASE_USERNAME` / `TEST_DATABASE_PASSWORD`, and optional
@@ -2343,7 +2344,7 @@ each ends with the Definition of Done gate.
 1. `yarn migrate:make <name>` — never hand-write the file (migrations are ESM `.js` with named `up`/`down` from `migration.stub`).
 2. Use the Knex query builder; the migration must work on SQLite and PostgreSQL and avoid breaking MySQL-compatible clients (see **Database Compatibility Guidelines**).
 3. Apply it locally against a throwaway SQLite file with inline env vars: `ACTIVITIES_DATABASE_CLIENT=better-sqlite3 ACTIVITIES_DATABASE_SQLITE_FILENAME=./throwaway.sqlite3 yarn migrate`.
-4. Regenerate BOTH reference schema dumps (see **Keeping the reference schema dumps in sync**). This is not optional: the Vitest suite builds its databases from the dumps, and CI's Schema Dump Sync job fails on SQLite-dump drift.
+4. Regenerate BOTH reference schema dumps (see **Keeping the reference schema dumps in sync**). This is not optional: the Vitest suite builds its databases from the dumps, and CI's SQLite and PostgreSQL Schema Dump Sync jobs fail on schema-dump drift.
 5. Update the affected `lib/database/` code and types, plus tests.
 6. Run the Definition of Done gate.
 
@@ -2583,7 +2584,7 @@ Use the one that matches the database you are reasoning about:
 
 The app (`yarn migrate`) runs Knex migrations, but the test suite does **not** — `lib/database/testUtils.ts` builds every test database directly from these dumps (see Testing Guidelines). If the dumps drift from the migrations, tests run against a stale schema, so keeping them in lockstep is load-bearing, not just hygiene. They are gitignored by the blanket `*.sql` rule and re-included by explicit `!` negations in `.gitignore`.
 
-- **Any PR that adds, edits, or removes a Knex migration in `migrations/` MUST regenerate BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` in the same PR.** Keep them in lockstep — they must always describe the same migration set. CI's **Schema Dump Sync** job regenerates the SQLite dump from the migrations on every push/PR and fails on drift; the PostgreSQL dump has no CI gate, so regenerating it stays on you.
+- **Any PR that adds, edits, or removes a Knex migration in `migrations/` MUST regenerate BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` in the same PR.** Keep them in lockstep — they must always describe the same migration set. CI's **SQLite Schema Dump Sync** and **PostgreSQL Schema Dump Sync** jobs regenerate both reference dumps from the migrations on every push/PR and fail on drift.
 - Regenerate them canonically rather than hand-editing — run every migration against a fresh database of each type and dump the result. In both cases verify `SELECT count(*) FROM knex_migrations` equals the number of `migrations/*.js` files first.
 
   Pass the DB settings **inline** on the `yarn migrate` line — do **not** write a `.env.local` (you'd clobber an existing one, and the cleanup would delete it). Because `knexfile.js` uses `dotenv-flow`, which never overrides variables already in the environment, inline values win over any `.env.local`; for the same reason, run in a shell with **no** other `ACTIVITIES_DATABASE*` vars exported (a stray one would be merged in and could target a remote DB — check `env | grep ACTIVITIES_DATABASE`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ Branch protection on `main` requires four status checks:
 - `Build`
 - `CI Success`
 
-`CI Success` is required and fail-closed over all upstream CI checks: lint (`Lint and Prettier`), typecheck (`Type Check`), build (`Build`), test shards (`All Tests`), and schema dump checks (`Schema Dump Sync`). If any upstream check fails, `CI Success` fails and blocks merging.
+`CI Success` is required and fail-closed over all upstream CI checks: lint (`Lint and Prettier`), typecheck (`Type Check`), build (`Build`), test shards (`All Tests`), and schema dump checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`). If any upstream check fails, `CI Success` fails and blocks merging.
 
 ### PR Checklist
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -194,8 +194,8 @@ change doesn't touch.
 - Any PR that adds/edits/removes a migration regenerates **both**
   `migrations/schema.sql` (PostgreSQL) and `migrations/schema.sqlite.sql` (SQLite)
   in the same PR, against fresh local DBs — never hand-edited. Commit a
-  schema-only regeneration as `none:`. (CI's Schema Dump Sync job catches
-  SQLite-dump drift; the PostgreSQL dump is not CI-checked.)
+  schema-only regeneration as `none:`. (CI's SQLite and PostgreSQL Schema Dump Sync
+  jobs catch schema-dump drift.)
 - The viewer's own follow row is read with `getViewerFollow`
   (`lib/services/getViewerFollow.ts`) on **read** paths — it is
   `cache()`d, so a profile render resolves it once instead of once per call site
@@ -1210,5 +1210,5 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
   `Lint and Prettier`, `Build`, and `CI Success`.
 - `CI Success` is required and fail-closed over lint (`Lint and Prettier`),
   typecheck (`Type Check`), build (`Build`), tests (`All Tests`), and schema dump
-  checks (`Schema Dump Sync`). A failure in any upstream check blocks merging via
+  checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`). A failure in any upstream check blocks merging via
   `CI Success`.


### PR DESCRIPTION
## Summary
- Implements Task G2: adds a PostgreSQL 17 service job (`PostgreSQL Schema Dump Sync`) in `.github/workflows/ci.yml` that:
  - Spins up a `postgres:17` service container and waits for database readiness (`pg_isready`).
  - Runs all migrations against a fresh PostgreSQL database.
  - Verifies that every migration file ran by matching the row count in `knex_migrations` against the count of migration files.
  - Generates a schema-only dump using PostgreSQL 17 tooling (`pg_dump`).
  - Applies the documented normalization pipeline (stripping noise while preserving all DDL statements).
  - Diffs the normalized dump against the committed `migrations/schema.sql` reference dump.
- Renames SQLite dump sync check to `SQLite Schema Dump Sync` while keeping SQLite drift detection intact.
- Includes `schema-dump-check-pg` in `ci-success`'s dependencies and fail-closed result checks.
- Updates schema guidance and CI check documentation in `AGENTS.md`, `CONTRIBUTING.md`, and `REVIEW.md`.

## Verification
- Verified against a disposable PostgreSQL 17 database that `migrations/schema.sql` matches the normalized dump without any existing drift.
- Verified that deliberate mismatches (added table, altered column type) are detected and fail the diff check.
- Passed full Definition of Done:
  - `yarn run prettier --write .`
  - `yarn lint`
  - `yarn typecheck`
  - `yarn build`
  - `yarn test`