### PR TITLE
feat: atomically enqueue database deletion job during status deletion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,6 +261,22 @@ the synchronous backend has no scheduler and **drops** any delayed message. Code
 that wants a delay must therefore check `getQueue().runsInline` and skip the
 delay rather than losing the job (see `syncStatusLinkPreview`).
 
+#### Status Deletion & Transactional Outbox Semantics
+
+Status deletion (`deleteStatusFromUserInput`) adapts its federation queue dispatching to the configured queue backend:
+
+- **Database Queue (`ACTIVITIES_QUEUE_TYPE=database`)**:
+  - Employs the transactional outbox pattern via `deleteStatusWithQueueJob`.
+  - The status deletion (including cascading deletions of replies, tags, likes, and counter updates) and the insertion of `SendDeleteNoteJob` into `queue_jobs` occur atomically in the exact same database transaction.
+  - Recipient addresses (`to` and `cc`), actor ID, and status ID are snapshotted before deleting the status record and embedded into the job payload.
+  - Job configuration matches `DatabaseQueue` defaults (`attempts: 0`, `status: 'pending'`, `maxRetries` from `ACTIVITIES_QUEUE_DATABASE_MAX_RETRIES` or default 16, `nextRunAt` set to immediate).
+  - No secondary publish step is executed after transaction commit.
+  - If the database transaction fails, the entire operation rolls back (the status and dependent rows are preserved, and no queue job is persisted), propagating the transaction failure to the caller.
+- **External & Synchronous Queues (QStash, CloudTasks, inline NoQueue)**:
+  - Preserves a two-phase delete-then-publish workflow: `database.deleteStatus` commits the local deletion first so the status disappears immediately from author and local timelines.
+  - The `SendDeleteNoteJob` is then published to the queue with the pre-deletion recipient snapshot.
+  - If publishing to the external queue fails, the error is logged without masking the committed local deletion, ensuring the user is not falsely told their post remains when it has already been removed.
+
 ### Link Preview Cards
 
 When a status contains a link, `FetchLinkPreviewJob` fetches that page once,

--- a/lib/actions/deleteStatus.test.ts
+++ b/lib/actions/deleteStatus.test.ts
@@ -1,15 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
 import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import { CloudTasksQueue } from '@/lib/services/queue/cloudtasks'
+import { DatabaseQueue } from '@/lib/services/queue/database'
+import { NoQueue } from '@/lib/services/queue/noqueue'
+import { QStashQueue } from '@/lib/services/queue/qstash'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
+
+let currentMockConfig: { queue?: any } = { queue: undefined }
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => currentMockConfig)
+}))
 
 vi.mock('@/lib/services/queue', () => ({
-  getQueue: vi.fn().mockReturnValue({
-    publish: vi.fn().mockResolvedValue(undefined)
-  })
+  getQueue: vi.fn()
 }))
 
 const CURRENT_ACTOR = { id: 'https://llun.test/users/me' } as Actor
@@ -17,116 +30,580 @@ const CURRENT_ACTOR = { id: 'https://llun.test/users/me' } as Actor
 const createDatabase = (status: Status | null) =>
   ({
     getStatus: vi.fn().mockResolvedValue(status),
-    deleteStatus: vi.fn().mockResolvedValue(undefined)
+    deleteStatus: vi.fn().mockResolvedValue(undefined),
+    deleteStatusWithQueueJob: vi.fn().mockResolvedValue(true)
   }) as unknown as Database
 
 describe('deleteStatusFromUserInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    currentMockConfig = { queue: undefined }
   })
 
-  // vi.clearAllMocks() drops call history but keeps queued one-shot behaviour,
-  // so an unconsumed mockRejectedValueOnce would fire inside a later test's
-  // action and be swallowed by its catch.
-  afterEach(() => {
-    vi.mocked(getQueue().publish).mockReset().mockResolvedValue(undefined)
-  })
-
-  it('deletes the status locally before queueing the federation job', async () => {
-    const status = {
-      id: 'https://llun.test/users/me/statuses/direct-delete',
-      actorId: CURRENT_ACTOR.id,
-      to: ['https://remote.test/users/primary'],
-      cc: ['https://remote.test/users/copied']
-    } as Status
-    const database = createDatabase(status)
-    const publish = vi.mocked(getQueue().publish)
-
-    await deleteStatusFromUserInput({
-      currentActor: CURRENT_ACTOR,
-      statusId: status.id,
-      database
-    })
-
-    expect(database.deleteStatus).toHaveBeenCalledWith({
-      statusId: status.id,
-      actorId: CURRENT_ACTOR.id
-    })
-    expect(publish).toHaveBeenCalledWith({
-      id: getHashFromString(`${status.id}#delete`),
-      name: SEND_DELETE_NOTE_JOB_NAME,
-      data: {
-        actorId: CURRENT_ACTOR.id,
-        statusId: status.id,
-        to: status.to,
-        cc: status.cc
+  describe('Database queue backend', () => {
+    beforeEach(() => {
+      currentMockConfig = {
+        queue: { type: 'database', maxRetries: 16 }
       }
+      const dbQueue = new DatabaseQueue(currentMockConfig.queue)
+      vi.spyOn(dbQueue, 'publish')
+      vi.mocked(getQueue).mockReturnValue(dbQueue)
     })
 
-    // The local delete has to win the race: the job resolves its delivery
-    // targets from the payload precisely because the row is already gone.
-    const deleteOrder = vi.mocked(database.deleteStatus).mock
-      .invocationCallOrder[0]
-    const publishOrder = publish.mock.invocationCallOrder[0]
-    expect(deleteOrder).toBeLessThan(publishOrder)
-  })
+    it('atomically deletes status and enqueues deletion job via deleteStatusWithQueueJob', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/db-delete-1',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: ['https://llun.test/users/me/followers']
+      } as Status
+      const database = createDatabase(status)
 
-  it('does not delete or federate statuses owned by a different actor', async () => {
-    const status = {
-      id: 'https://llun.test/users/other/statuses/delete-attempt',
-      actorId: 'https://llun.test/users/other',
-      to: ['https://www.w3.org/ns/activitystreams#Public'],
-      cc: []
-    } as Status
-    const database = createDatabase(status)
-
-    await deleteStatusFromUserInput({
-      currentActor: CURRENT_ACTOR,
-      statusId: status.id,
-      database
-    })
-
-    expect(database.deleteStatus).not.toHaveBeenCalled()
-    expect(getQueue().publish).not.toHaveBeenCalled()
-  })
-
-  it('does nothing when the status does not exist', async () => {
-    const database = createDatabase(null)
-
-    await deleteStatusFromUserInput({
-      currentActor: CURRENT_ACTOR,
-      statusId: 'https://llun.test/users/me/statuses/missing',
-      database
-    })
-
-    expect(database.deleteStatus).not.toHaveBeenCalled()
-    expect(getQueue().publish).not.toHaveBeenCalled()
-  })
-
-  it('keeps the local delete when queueing the federation job fails', async () => {
-    const status = {
-      id: 'https://llun.test/users/me/statuses/queue-failure',
-      actorId: CURRENT_ACTOR.id,
-      to: ['https://www.w3.org/ns/activitystreams#Public'],
-      cc: []
-    } as Status
-    const database = createDatabase(status)
-    vi.mocked(getQueue().publish).mockRejectedValueOnce(
-      new Error('Queue unavailable')
-    )
-
-    await expect(
-      deleteStatusFromUserInput({
+      await deleteStatusFromUserInput({
         currentActor: CURRENT_ACTOR,
         statusId: status.id,
         database
       })
-    ).resolves.toBeUndefined()
 
-    expect(vi.mocked(getQueue().publish)).toHaveBeenCalledTimes(1)
-    expect(database.deleteStatus).toHaveBeenCalledWith({
-      statusId: status.id,
-      actorId: CURRENT_ACTOR.id
+      const expectedJobId = getHashFromString(`${status.id}#delete`)
+      expect(database.deleteStatusWithQueueJob).toHaveBeenCalledTimes(1)
+      expect(database.deleteStatusWithQueueJob).toHaveBeenCalledWith({
+        actorId: CURRENT_ACTOR.id,
+        statusId: status.id,
+        queueJob: {
+          id: expectedJobId,
+          name: SEND_DELETE_NOTE_JOB_NAME,
+          payload: {
+            id: expectedJobId,
+            name: SEND_DELETE_NOTE_JOB_NAME,
+            data: {
+              actorId: CURRENT_ACTOR.id,
+              statusId: status.id,
+              to: status.to,
+              cc: status.cc
+            }
+          },
+          attempts: 0,
+          maxRetries: 16,
+          nextRunAt: expect.any(Date),
+          status: 'pending'
+        }
+      })
+
+      // Must not separately delete or publish
+      expect(database.deleteStatus).not.toHaveBeenCalled()
+      expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
+    it('respects custom maxRetries from DatabaseQueueConfig', async () => {
+      currentMockConfig = {
+        queue: { type: 'database', maxRetries: 5 }
+      }
+      const dbQueue = new DatabaseQueue(currentMockConfig.queue)
+      vi.mocked(getQueue).mockReturnValue(dbQueue)
+
+      const status = {
+        id: 'https://llun.test/users/me/statuses/db-custom-retries',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatusWithQueueJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queueJob: expect.objectContaining({
+            maxRetries: 5
+          })
+        })
+      )
+    })
+
+    it('snapshots recipient addresses (to, cc) in the job payload', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/snapshot-test',
+        actorId: CURRENT_ACTOR.id,
+        to: ['https://remote.example/users/alice', ACTIVITY_STREAM_PUBLIC],
+        cc: ['https://remote.example/users/bob']
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      const callArgs = vi.mocked(database.deleteStatusWithQueueJob).mock
+        .calls[0][0]
+      expect(callArgs.queueJob.payload).toEqual({
+        id: getHashFromString(`${status.id}#delete`),
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        data: {
+          actorId: CURRENT_ACTOR.id,
+          statusId: status.id,
+          to: ['https://remote.example/users/alice', ACTIVITY_STREAM_PUBLIC],
+          cc: ['https://remote.example/users/bob']
+        }
+      })
+    })
+
+    it('propagates transaction failure when deleteStatusWithQueueJob rejects', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/db-tx-fail',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      const txError = new Error('Database transaction rolled back')
+      vi.mocked(database.deleteStatusWithQueueJob).mockRejectedValueOnce(
+        txError
+      )
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).rejects.toThrow('Database transaction rolled back')
+    })
+
+    it('rejects deletion when status is owned by another actor', async () => {
+      const status = {
+        id: 'https://llun.test/users/other/statuses/unauthorized',
+        actorId: 'https://llun.test/users/other',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatusWithQueueJob).not.toHaveBeenCalled()
+      expect(database.deleteStatus).not.toHaveBeenCalled()
+      expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
+    it('handles repeated deletion gracefully when status is already deleted', async () => {
+      const database = createDatabase(null)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: 'https://llun.test/users/me/statuses/already-deleted',
+        database
+      })
+
+      expect(database.deleteStatusWithQueueJob).not.toHaveBeenCalled()
+      expect(database.deleteStatus).not.toHaveBeenCalled()
+    })
+
+    it('handles repeated deletion gracefully when deleteStatusWithQueueJob returns false', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/race-condition',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      vi.mocked(database.deleteStatusWithQueueJob).mockResolvedValueOnce(false)
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('QStash queue backend', () => {
+    let qstashQueue: QStashQueue
+
+    beforeEach(() => {
+      currentMockConfig = {
+        queue: {
+          type: 'qstash',
+          url: 'https://qstash.example.com',
+          token: 'token',
+          currentSigningKey: 'sig1',
+          nextSigningKey: 'sig2'
+        }
+      }
+      qstashQueue = new QStashQueue(currentMockConfig.queue)
+      vi.spyOn(qstashQueue, 'publish').mockResolvedValue(undefined)
+      vi.mocked(getQueue).mockReturnValue(qstashQueue)
+    })
+
+    it('deletes locally before publishing to QStash', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/qstash-delete',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: ['https://remote.example/users/bob']
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatus).toHaveBeenCalledWith({
+        statusId: status.id,
+        actorId: CURRENT_ACTOR.id
+      })
+      expect(database.deleteStatusWithQueueJob).not.toHaveBeenCalled()
+
+      expect(qstashQueue.publish).toHaveBeenCalledWith({
+        id: getHashFromString(`${status.id}#delete`),
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        data: {
+          actorId: CURRENT_ACTOR.id,
+          statusId: status.id,
+          to: status.to,
+          cc: status.cc
+        }
+      })
+
+      const deleteOrder = vi.mocked(database.deleteStatus).mock
+        .invocationCallOrder[0]
+      const publishOrder = vi.mocked(qstashQueue.publish).mock
+        .invocationCallOrder[0]
+      expect(deleteOrder).toBeLessThan(publishOrder)
+    })
+
+    it('swallows and logs QStash enqueue error without failing the deletion', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/qstash-fail',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      vi.spyOn(qstashQueue, 'publish').mockRejectedValueOnce(
+        new Error('QStash network error')
+      )
+      const loggerSpy = vi
+        .spyOn(logger, 'error')
+        .mockImplementation(() => logger)
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).resolves.toBeUndefined()
+
+      expect(database.deleteStatus).toHaveBeenCalledTimes(1)
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusId: status.id,
+          actorId: CURRENT_ACTOR.id
+        }),
+        'Failed to queue status delete federation'
+      )
+      loggerSpy.mockRestore()
+    })
+
+    it('rejects deletion when status is owned by another actor', async () => {
+      const status = {
+        id: 'https://llun.test/users/other/statuses/qstash-unauthorized',
+        actorId: 'https://llun.test/users/other',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatus).not.toHaveBeenCalled()
+      expect(qstashQueue.publish).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('CloudTasks queue backend', () => {
+    let cloudTasksQueue: CloudTasksQueue
+
+    beforeEach(() => {
+      currentMockConfig = {
+        queue: {
+          type: 'cloudtasks',
+          location: 'us-central1',
+          project: 'test-project'
+        }
+      }
+      cloudTasksQueue = new CloudTasksQueue(currentMockConfig.queue)
+      vi.spyOn(cloudTasksQueue, 'publish').mockResolvedValue(undefined)
+      vi.mocked(getQueue).mockReturnValue(cloudTasksQueue)
+    })
+
+    it('deletes locally before publishing to CloudTasks', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/cloudtasks-delete',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatus).toHaveBeenCalledWith({
+        statusId: status.id,
+        actorId: CURRENT_ACTOR.id
+      })
+      expect(cloudTasksQueue.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: getHashFromString(`${status.id}#delete`),
+          name: SEND_DELETE_NOTE_JOB_NAME
+        })
+      )
+    })
+
+    it('swallows and logs CloudTasks publish failure', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/cloudtasks-fail',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      vi.spyOn(cloudTasksQueue, 'publish').mockRejectedValueOnce(
+        new Error('CloudTasks quota exceeded')
+      )
+      const loggerSpy = vi
+        .spyOn(logger, 'error')
+        .mockImplementation(() => logger)
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).resolves.toBeUndefined()
+
+      expect(loggerSpy).toHaveBeenCalled()
+      loggerSpy.mockRestore()
+    })
+  })
+
+  describe('Inline / NoQueue backend', () => {
+    let noQueue: NoQueue
+
+    beforeEach(() => {
+      currentMockConfig = { queue: undefined }
+      noQueue = new NoQueue()
+      vi.spyOn(noQueue, 'publish').mockResolvedValue(undefined)
+      vi.mocked(getQueue).mockReturnValue(noQueue)
+    })
+
+    it('deletes locally before publishing to inline queue', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/inline-delete',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+
+      await deleteStatusFromUserInput({
+        currentActor: CURRENT_ACTOR,
+        statusId: status.id,
+        database
+      })
+
+      expect(database.deleteStatus).toHaveBeenCalledWith({
+        statusId: status.id,
+        actorId: CURRENT_ACTOR.id
+      })
+      expect(noQueue.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: getHashFromString(`${status.id}#delete`),
+          name: SEND_DELETE_NOTE_JOB_NAME
+        })
+      )
+    })
+
+    it('swallows inline publish failure after local deletion committed', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/inline-fail',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      vi.spyOn(noQueue, 'publish').mockRejectedValueOnce(
+        new Error('Inline handler failure')
+      )
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).resolves.toBeUndefined()
+
+      expect(database.deleteStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates error when local database.deleteStatus fails', async () => {
+      const status = {
+        id: 'https://llun.test/users/me/statuses/local-db-fail',
+        actorId: CURRENT_ACTOR.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as Status
+      const database = createDatabase(status)
+      vi.mocked(database.deleteStatus).mockRejectedValueOnce(
+        new Error('Disk I/O error')
+      )
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: CURRENT_ACTOR,
+          statusId: status.id,
+          database
+        })
+      ).rejects.toThrow('Disk I/O error')
+
+      expect(noQueue.publish).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Immediate local disappearance (Integration with SQL Database)', () => {
+    let database: Database
+    let actor: Actor
+
+    beforeEach(async () => {
+      database = await getTestSQLDatabase()
+      await database.migrate()
+      currentMockConfig = {
+        queue: { type: 'database', maxRetries: 16 }
+      }
+      const dbQueue = new DatabaseQueue(currentMockConfig.queue, database)
+      vi.mocked(getQueue).mockReturnValue(dbQueue)
+
+      await database.createAccount({
+        email: 'integration-author@test.local',
+        username: 'integration_author',
+        passwordHash: 'hash',
+        domain: 'test.local',
+        privateKey: 'key',
+        publicKey: 'pub'
+      })
+      const found = await database.getActorFromEmail({
+        email: 'integration-author@test.local'
+      })
+      if (!found) throw new Error('Actor creation failed')
+      actor = found
+    })
+
+    afterEach(async () => {
+      await database.destroy()
+    })
+
+    it('immediately deletes status and persists pending queue job in SQLite', async () => {
+      const statusId = `${actor.id}/statuses/integration-delete-test`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: actor.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${actor.id}/followers`],
+        text: 'Integration status deletion test note'
+      })
+
+      // Verify status exists before
+      const beforeStatus = await database.getStatus({ statusId })
+      expect(beforeStatus).not.toBeNull()
+
+      await deleteStatusFromUserInput({
+        currentActor: actor,
+        statusId,
+        database
+      })
+
+      // Status must disappear immediately
+      const afterStatus = await database.getStatus({ statusId })
+      expect(afterStatus).toBeNull()
+
+      // Queue job must exist in database in pending status
+      const expectedJobId = getHashFromString(`${statusId}#delete`)
+      const persistedJob = await database.getQueueJobById(expectedJobId)
+      expect(persistedJob).not.toBeNull()
+      expect(persistedJob?.name).toBe(SEND_DELETE_NOTE_JOB_NAME)
+      expect(persistedJob?.status).toBe('pending')
+      expect(persistedJob?.attempts).toBe(0)
+      expect(persistedJob?.payload).toMatchObject({
+        id: expectedJobId,
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          statusId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [`${actor.id}/followers`]
+        }
+      })
+    })
+
+    it('rolls back status deletion and leaves no queue job when transaction fails midway', async () => {
+      const statusId = `${actor.id}/statuses/integration-rollback-test`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: actor.id,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${actor.id}/followers`],
+        text: 'Integration rollback test note'
+      })
+
+      const expectedJobId = getHashFromString(`${statusId}#delete`)
+      vi.spyOn(database, 'deleteStatusWithQueueJob').mockImplementationOnce(
+        async () => {
+          throw new Error('Forced transaction failure')
+        }
+      )
+
+      await expect(
+        deleteStatusFromUserInput({
+          currentActor: actor,
+          statusId,
+          database
+        })
+      ).rejects.toThrow('Forced transaction failure')
+
+      // Status still exists because transaction rolled back
+      const afterStatus = await database.getStatus({ statusId })
+      expect(afterStatus).not.toBeNull()
+
+      // Queue job was not persisted
+      const persistedJob = await database.getQueueJobById(expectedJobId)
+      expect(persistedJob).toBeNull()
     })
   })
 })

--- a/lib/actions/deleteStatus.ts
+++ b/lib/actions/deleteStatus.ts
@@ -1,6 +1,9 @@
+import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import { DatabaseQueue } from '@/lib/services/queue/database'
+import { CreateQueueJobParams } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
@@ -36,6 +39,44 @@ export const deleteStatusFromUserInput = async ({
       return
     }
 
+    const queue = getQueue()
+    const config = getConfig()
+    const isDatabaseQueue =
+      queue instanceof DatabaseQueue || config.queue?.type === 'database'
+
+    const queueJobId = getHashFromString(`${statusId}#delete`)
+
+    if (isDatabaseQueue) {
+      const maxRetries =
+        config.queue?.type === 'database' ? (config.queue.maxRetries ?? 16) : 16
+
+      const queueJob: CreateQueueJobParams = {
+        id: queueJobId,
+        name: SEND_DELETE_NOTE_JOB_NAME,
+        payload: {
+          id: queueJobId,
+          name: SEND_DELETE_NOTE_JOB_NAME,
+          data: {
+            actorId: currentActor.id,
+            statusId,
+            to: originalStatus.to,
+            cc: originalStatus.cc
+          }
+        },
+        attempts: 0,
+        maxRetries,
+        nextRunAt: new Date(),
+        status: 'pending'
+      }
+
+      await database.deleteStatusWithQueueJob({
+        actorId: currentActor.id,
+        statusId,
+        queueJob
+      })
+      return
+    }
+
     // Delete locally first so the status leaves the author's timelines
     // immediately, then federate the Tombstone in the background. Delivery used
     // to run inline ahead of this, so the response waited on every remote inbox
@@ -45,12 +86,12 @@ export const deleteStatusFromUserInput = async ({
     await database.deleteStatus({ statusId, actorId: currentActor.id })
 
     try {
-      await getQueue().publish({
+      await queue.publish({
         // Suffixed because the queue deduplicates on this id across job names
         // and the create/update jobs already publish under the bare status id.
         // Without it, deleting a status posted or edited within the dedup
         // window would be dropped and never federate.
-        id: getHashFromString(`${statusId}#delete`),
+        id: queueJobId,
         name: SEND_DELETE_NOTE_JOB_NAME,
         data: {
           actorId: currentActor.id,


### PR DESCRIPTION
## Summary
Implements Task I2 from the cleanup plan.

- Updates `deleteStatusFromUserInput` (`lib/actions/deleteStatus.ts`) to use the transactional outbox method `deleteStatusWithQueueJob` when the database queue backend is active.
- For the database queue backend:
  - Deletes status row, cascading relations, and enqueues `SendDeleteNoteJob` within the exact same database transaction.
  - Snapshots recipient addresses (`to`, `cc`), actor ID, and status ID prior to row deletion.
  - Matches `DatabaseQueue`'s retry defaults (`attempts: 0`, `maxRetries` from config / default 16) and pending schedule (`status: 'pending'`, `nextRunAt: new Date()`).
  - Does not separately publish after transaction commit.
  - Propagates transaction failures directly if `deleteStatusWithQueueJob` fails, ensuring deletion rollback is not falsely reported as successful.
- Preserves two-phase delete-then-publish behavior for QStash, CloudTasks, and inline/synchronous queues, swallowing queue publish failures so already-committed local deletions are not reported as failed.
- Documents status deletion transactional outbox semantics in `docs/architecture.md`.
- Comprehensive test coverage in `lib/actions/deleteStatus.test.ts` testing all queue backends (database, QStash, CloudTasks, inline), ownership checks, repeated deletion, transaction failure propagation, payload snapshotting, and SQLite integration.