### PR TITLE
Bump version to v1.161.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.22",
+  "version": "1.161.23",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.23.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.22`
- Base main SHA: `50e16f8f9ec9614f3fbbcb28746468d35d75e95c`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
