### PR TITLE
ci: add postgresql database integration tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Runs on every commit (push to any branch + pull requests). The lint/prettier,
-# typecheck, build, test, and schema-dump-sync jobs run in parallel (no `needs:` chain
+# typecheck, build, test, postgresql database test, and schema-dump-sync jobs run in parallel (no `needs:` chain
 # between them) so the check finishes as fast as the slowest single job instead
 # of the sum of all of them. If any one of them fails, the run is reported as failed: the
 # `CI / CI Success` job aggregates every job's result and fails unless all
@@ -153,6 +153,59 @@ jobs:
           fi
           echo "All test shards succeeded."
 
+  # Bounded PostgreSQL integration test job covering database access layers:
+  # media, fitness files, gear, component periods, and heatmap tiles.
+  # Vitest worker concurrency is bounded (--maxWorkers=2) to avoid exhausting
+  # database connections or overloading disposable service containers.
+  test-pg:
+    name: PostgreSQL Database Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: activities
+          POSTGRES_PASSWORD: activities
+          POSTGRES_DB: postgres
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Enable corepack
+        run: corepack enable
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Wait for PostgreSQL readiness
+        run: |
+          until docker exec ${{ job.services.postgres.id }} pg_isready -U activities -d postgres -q; do
+            sleep 1
+          done
+      - name: Run PostgreSQL database integration tests
+        run: |
+          yarn test --maxWorkers=2 \
+            lib/database/sql/media.test.ts \
+            lib/database/sql/fitnessFile.test.ts \
+            lib/database/sql/fitnessGear.test.ts \
+            lib/database/sql/fitnessGearComponentPeriods.test.ts \
+            lib/database/sql/fitnessRouteHeatmapTile.test.ts
+        env:
+          TEST_DATABASE_TYPE: pg
+          TEST_DATABASE_HOST: 127.0.0.1
+          TEST_DATABASE_PORT: ${{ job.services.postgres.ports['5432'] }}
+          TEST_DATABASE_USERNAME: activities
+          TEST_DATABASE_PASSWORD: activities
+
   # Drift gate for the committed SQLite reference schema dump. The Vitest
   # suite builds every test database from migrations/schema.sqlite.sql (via
   # lib/database/testUtils.ts) instead of running the Knex migration chain, so
@@ -293,6 +346,7 @@ jobs:
         typecheck,
         build,
         test,
+        test-pg,
         schema-dump-check,
         schema-dump-check-pg
       ]
@@ -300,7 +354,7 @@ jobs:
     steps:
       - name: Verify all CI jobs succeeded
         env:
-          RESULTS: ${{ needs.lint-prettier.result }} ${{ needs.typecheck.result }} ${{ needs.build.result }} ${{ needs.test.result }} ${{ needs.schema-dump-check.result }} ${{ needs.schema-dump-check-pg.result }}
+          RESULTS: ${{ needs.lint-prettier.result }} ${{ needs.typecheck.result }} ${{ needs.build.result }} ${{ needs.test.result }} ${{ needs.test-pg.result }} ${{ needs.schema-dump-check.result }} ${{ needs.schema-dump-check-pg.result }}
         run: |
           echo "Upstream job results: $RESULTS"
           for result in $RESULTS; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2131,8 +2131,8 @@ preserving legacy and fitness attachments` pins the surviving-null behaviour.
   four status checks — `All Tests`, `Lint and Prettier`, `Build`, and `CI Success`
   (strict: false). The `CI Success` aggregate job is fail-closed over all upstream
   jobs (`Lint and Prettier`, `Type Check`, `Build`, `All Tests`,
-  `SQLite Schema Dump Sync`, and `PostgreSQL Schema Dump Sync`), so failures in
-  `Type Check` (the gate covering `*.test.ts(x)`) or schema dump drift block
+  `PostgreSQL Database Tests`, `SQLite Schema Dump Sync`, and `PostgreSQL Schema Dump Sync`), so failures in
+  `Type Check` (the gate covering `*.test.ts(x)`), database portability, or schema dump drift block
   merging via `CI Success`.
   The test job pins `TEST_DATABASE_TYPE: sqlite`; `lib/database/testUtils.ts`
   also supports `TEST_DATABASE_TYPE=pg` (with `TEST_DATABASE_HOST` /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,6 +255,44 @@ yarn test
 
 The suite runs on [Vitest](https://vitest.dev/) (native ESM; use the `vi.*` API, e.g. `vi.fn()` / `vi.mock()` / `vi.importMock()` — there is no `jest` global). All tests run in parallel using isolated SQLite in-memory databases for fast execution.
 
+### Running PostgreSQL Database Integration Tests
+
+While the full test suite runs with SQLite in-memory databases for fast execution, database integration test suites can be executed against a local PostgreSQL 17 instance to verify cross-backend portability.
+
+The backend-aware database test harness (`lib/database/testUtils.ts`) configures per-worker databases (`test_<VITEST_POOL_ID>`) dropped and migrated from `migrations/schema.sql`.
+
+1. Start a local disposable PostgreSQL 17 container:
+
+```bash
+docker run --rm -d --name test-postgres -p 5432:5432 \
+  -e POSTGRES_USER=activities \
+  -e POSTGRES_PASSWORD=activities \
+  -e POSTGRES_DB=postgres \
+  postgres:17
+```
+
+2. Run the PostgreSQL database test suites with bounded worker concurrency (e.g. `--maxWorkers=2` to avoid connection exhaustion):
+
+```bash
+TEST_DATABASE_TYPE=pg \
+TEST_DATABASE_HOST=127.0.0.1 \
+TEST_DATABASE_PORT=5432 \
+TEST_DATABASE_USERNAME=activities \
+TEST_DATABASE_PASSWORD=activities \
+yarn test --maxWorkers=2 \
+  lib/database/sql/media.test.ts \
+  lib/database/sql/fitnessFile.test.ts \
+  lib/database/sql/fitnessGear.test.ts \
+  lib/database/sql/fitnessGearComponentPeriods.test.ts \
+  lib/database/sql/fitnessRouteHeatmapTile.test.ts
+```
+
+3. When finished, stop the container:
+
+```bash
+docker stop test-postgres
+```
+
 ### Writing Tests
 
 - **Co-locate tests** with the code being tested
@@ -333,7 +371,7 @@ Branch protection on `main` requires four status checks:
 - `Build`
 - `CI Success`
 
-`CI Success` is required and fail-closed over all upstream CI checks: lint (`Lint and Prettier`), typecheck (`Type Check`), build (`Build`), test shards (`All Tests`), and schema dump checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`). If any upstream check fails, `CI Success` fails and blocks merging.
+`CI Success` is required and fail-closed over all upstream CI checks: lint (`Lint and Prettier`), typecheck (`Type Check`), build (`Build`), test shards (`All Tests`), PostgreSQL database tests (`PostgreSQL Database Tests`), and schema dump checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`). If any upstream check fails, `CI Success` fails and blocks merging.
 
 ### PR Checklist
 
@@ -344,7 +382,7 @@ Branch protection on `main` requires four status checks:
 - [ ] TypeScript types are proper (no `any`)
 - [ ] Commit messages follow convention
 - [ ] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` pass
-- [ ] All CI status checks pass (including required check `CI Success`, fail-closed over lint, typecheck, build, tests, and schema dump checks)
+- [ ] All CI status checks pass (including required check `CI Success`, fail-closed over lint, typecheck, build, tests, PostgreSQL database tests, and schema dump checks)
 
 ## Project Structure
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1209,6 +1209,6 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
 - Branch protection on `main` requires four status checks: `All Tests`,
   `Lint and Prettier`, `Build`, and `CI Success`.
 - `CI Success` is required and fail-closed over lint (`Lint and Prettier`),
-  typecheck (`Type Check`), build (`Build`), tests (`All Tests`), and schema dump
-  checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`). A failure in any upstream check blocks merging via
-  `CI Success`.
+  typecheck (`Type Check`), build (`Build`), tests (`All Tests`), PostgreSQL database tests
+  (`PostgreSQL Database Tests`), and schema dump checks (`SQLite Schema Dump Sync` and `PostgreSQL Schema Dump Sync`).
+  A failure in any upstream check blocks merging via `CI Success`.


### PR DESCRIPTION
## Description

Implements Task G3:
- Adds a bounded PostgreSQL integration test job (`test-pg` / `PostgreSQL Database Tests`) to `.github/workflows/ci.yml` running against a disposable PostgreSQL 17 service container on explicitly local connection settings.
- Covers media (`lib/database/sql/media.test.ts`), fitness files (`lib/database/sql/fitnessFile.test.ts`), gear (`lib/database/sql/fitnessGear.test.ts`), component periods (`lib/database/sql/fitnessGearComponentPeriods.test.ts`), and heatmap tiles (`lib/database/sql/fitnessRouteHeatmapTile.test.ts`).
- Bounds worker concurrency with `--maxWorkers=2` to avoid exhausting database connections or overloading service containers.
- Adds `test-pg` to `CI Success` required aggregation gate.
- Adds contributor testing guidance in `CONTRIBUTING.md` on running PostgreSQL integration tests with disposable containers, and updates CI checklists in `AGENTS.md` and `REVIEW.md`.