### PR TITLE
Bump version to v1.161.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.23",
+  "version": "1.161.24",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.24.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.23`
- Base main SHA: `0649eae08f26ab1a0ffeede3934837288eef0712`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
