### PR TITLE
refactor: migrate StravaSettingsForm to lib/client.ts and empty component-fetch allowlist

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -231,13 +231,12 @@
         "agents/no-component-fetch": [
           "error",
           {
-            "allowFiles": [
-              "app/(timeline)/fitness/strava/StravaSettingsForm.tsx"
-            ]
+            "allowFiles": []
           }
         ]
       }
     },
+
     {
       "files": [
         "**/*.test.js",

--- a/app/(timeline)/fitness/strava/StravaSettingsForm.test.tsx
+++ b/app/(timeline)/fitness/strava/StravaSettingsForm.test.tsx
@@ -2,37 +2,36 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as client from '@/lib/client'
 
 import { StravaSettingsForm } from './StravaSettingsForm'
 
-// The form calls `fetch` directly rather than going through `lib/client`, so
-// the global is what has to be stubbed here.
-const stubSettingsResponse = (defaultVisibility?: string) => {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        configured: true,
-        connected: true,
-        clientId: '12345',
-        webhookUrl: 'https://llun.test/api/v1/webhooks/strava/token',
-        ...(defaultVisibility ? { defaultVisibility } : {})
-      })
-    })
+vi.mock('@/lib/client', () => ({
+  getStravaSettings: vi.fn(),
+  saveStravaSettings: vi.fn(),
+  deleteStravaSettings: vi.fn()
+}))
+
+vi.mock('./StravaArchiveImportSection', () => ({
+  StravaArchiveImportSection: ({ actorHandle }: { actorHandle?: string }) => (
+    <div data-testid="archive-import-section" data-actor-handle={actorHandle} />
   )
-}
+}))
 
-const renderForm = async (defaultVisibility?: string) => {
-  stubSettingsResponse(defaultVisibility)
-  render(<StravaSettingsForm />)
-  await waitFor(() => expect(fetch).toHaveBeenCalled())
-}
+const mockGetStravaSettings = vi.mocked(client.getStravaSettings)
+const mockSaveStravaSettings = vi.mocked(client.saveStravaSettings)
+const mockDeleteStravaSettings = vi.mocked(client.deleteStravaSettings)
 
-describe('StravaSettingsForm import visibility', () => {
+describe('StravaSettingsForm', () => {
+  const originalLocation = window.location
+  let locationHref = 'http://localhost/fitness/strava'
+  let locationSearch = ''
+
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.stubGlobal(
       'ResizeObserver',
       class {
@@ -41,62 +40,580 @@ describe('StravaSettingsForm import visibility', () => {
         disconnect() {}
       }
     )
+
+    locationHref = 'http://localhost/fitness/strava'
+    locationSearch = ''
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        get href() {
+          return locationHref
+        },
+        set href(val: string) {
+          locationHref = val
+        },
+        get search() {
+          return locationSearch
+        },
+        set search(val: string) {
+          locationSearch = val
+        },
+        pathname: '/fitness/strava',
+        hash: ''
+      }
+    })
   })
 
   afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation
+    })
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
-  // The whole point of the disclosure: before it, the only user-facing copy
-  // said imports "will use this visibility" and never mentioned that Strava's
-  // own per-activity privacy is discarded.
-  it('says that an activity marked Only you on Strava is posted at this visibility', async () => {
-    await renderForm('private')
+  describe('loading', () => {
+    it('loads unconfigured settings into form', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: false,
+        defaultVisibility: 'private'
+      })
 
-    const helper = await screen.findByText(
-      /Every activity imported from Strava/
+      render(<StravaSettingsForm serverActorHandle="@server@example.com" />)
+
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      const clientIdInput = screen.getByLabelText(
+        /^client id/i
+      ) as HTMLInputElement
+      const clientSecretInput = screen.getByLabelText(
+        /^client secret/i
+      ) as HTMLInputElement
+
+      expect(clientIdInput.value).toBe('')
+      expect(clientIdInput).not.toBeDisabled()
+      expect(clientSecretInput.value).toBe('')
+      expect(clientSecretInput).not.toBeDisabled()
+
+      expect(
+        screen.getByRole('button', { name: /save and connect/i })
+      ).toBeDisabled()
+      expect(screen.queryByLabelText(/webhook url/i)).toBeNull()
+      expect(screen.queryByText(/connected to strava/i)).toBeNull()
+
+      const archiveSection = screen.getByTestId('archive-import-section')
+      expect(archiveSection).toHaveAttribute(
+        'data-actor-handle',
+        '@server@example.com'
+      )
+    })
+
+    it('loads configured and connected settings, preserving masked secret', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '998877',
+        webhookUrl: 'https://llun.test/api/v1/webhooks/strava/tok123',
+        defaultVisibility: 'private',
+        actorHandle: '@alice@example.com'
+      })
+
+      render(<StravaSettingsForm serverActorHandle="@server@example.com" />)
+
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      const clientIdInput = screen.getByLabelText(
+        /^client id/i
+      ) as HTMLInputElement
+      const clientSecretInput = screen.getByLabelText(
+        /^client secret/i
+      ) as HTMLInputElement
+      const webhookUrlInput = screen.getByLabelText(
+        /^webhook url/i
+      ) as HTMLInputElement
+
+      expect(clientIdInput.value).toBe('998877')
+      expect(clientIdInput).toBeDisabled()
+      expect(clientSecretInput.value).toBe('••••••••')
+      expect(clientSecretInput).toBeDisabled()
+      expect(webhookUrlInput.value).toBe(
+        'https://llun.test/api/v1/webhooks/strava/tok123'
+      )
+      expect(webhookUrlInput).toHaveAttribute('readonly')
+
+      expect(screen.getByText('✓ Connected to Strava')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /save visibility/i })
+      ).toBeInTheDocument()
+
+      const archiveSection = screen.getByTestId('archive-import-section')
+      expect(archiveSection).toHaveAttribute(
+        'data-actor-handle',
+        '@alice@example.com'
+      )
+    })
+
+    it('displays warning when credentials are saved but not connected', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: false,
+        clientId: '998877',
+        defaultVisibility: 'private'
+      })
+
+      render(<StravaSettingsForm />)
+
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      expect(
+        screen.getByText(
+          'Credentials saved but not connected. Please reconnect.'
+        )
+      ).toBeInTheDocument()
+      expect(screen.queryByText('✓ Connected to Strava')).toBeNull()
+    })
+
+    it('shows success message from URL search params and cleans up URL', async () => {
+      locationSearch = '?success=true'
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '12345',
+        defaultVisibility: 'private'
+      })
+      const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+
+      render(<StravaSettingsForm />)
+
+      expect(
+        await screen.findByText('Successfully connected to Strava!')
+      ).toBeInTheDocument()
+      expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/fitness/strava')
+    })
+
+    it.each([
+      {
+        param: 'authorization_failed',
+        expected: 'Authorization was denied or failed'
+      },
+      {
+        param: 'webhook_subscription_failed',
+        expected: 'Failed to create webhook subscription. Please try again.'
+      },
+      {
+        param: 'other_reason',
+        expected: 'Failed to connect to Strava'
+      }
+    ])(
+      'shows error message for URL error param "$param"',
+      async ({ param, expected }) => {
+        locationSearch = `?error=${param}`
+        mockGetStravaSettings.mockResolvedValueOnce({
+          configured: false,
+          defaultVisibility: 'private'
+        })
+        const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+
+        render(<StravaSettingsForm />)
+
+        expect(await screen.findByText(expected)).toBeInTheDocument()
+        expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/fitness/strava')
+      }
     )
-    expect(helper).toHaveTextContent('Only you')
-    expect(helper).toHaveTextContent(/never carried over|is never carried over/)
   })
 
-  it('says the setting covers retries and repairs, not just the webhook', async () => {
-    await renderForm('private')
+  describe('cancellation', () => {
+    it('treats aborts as cancellation rather than visible failure', async () => {
+      mockGetStravaSettings.mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            const abortError = new Error('The user aborted a request.')
+            abortError.name = 'AbortError'
+            reject(abortError)
+          })
+      )
 
-    const helper = await screen.findByText(
-      /Every activity imported from Strava/
-    )
-    expect(helper).toHaveTextContent(/retry or repair/)
+      render(<StravaSettingsForm />)
+
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      expect(screen.queryByText('Failed to load settings')).toBeNull()
+    })
   })
 
-  // "Webhook Activity Visibility" understated the scope — the same stored
-  // value is what a retry and the repair scripts post at.
-  it('does not label the control as webhook-only', async () => {
-    await renderForm('private')
+  describe('loading failure', () => {
+    it('displays error message when settings request rejects', async () => {
+      mockGetStravaSettings.mockRejectedValueOnce(
+        new Error('Network error loading settings')
+      )
 
-    expect(await screen.findByText('Automatic import visibility')).toBeVisible()
-    expect(screen.queryByText('Webhook Activity Visibility')).toBeNull()
+      render(<StravaSettingsForm />)
+
+      expect(
+        await screen.findByText('Failed to load settings')
+      ).toBeInTheDocument()
+    })
   })
 
-  it.each([
-    { description: 'warns when imports are public', visibility: 'public' },
-    { description: 'warns when imports are unlisted', visibility: 'unlisted' }
-  ])('$description', async ({ visibility }) => {
-    await renderForm(visibility)
+  describe('saving', () => {
+    it('submits clientId, clientSecret, and defaultVisibility when not configured', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: false,
+        defaultVisibility: 'private'
+      })
+      mockSaveStravaSettings.mockResolvedValueOnce({
+        success: true,
+        message: 'Strava settings saved successfully!'
+      })
 
-    const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent('Anyone on the fediverse can read')
-    expect(alert).toHaveTextContent('Only you')
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      const clientIdInput = screen.getByLabelText(/^client id/i)
+      const clientSecretInput = screen.getByLabelText(/^client secret/i)
+
+      fireEvent.change(clientIdInput, { target: { value: '123456' } })
+      fireEvent.change(clientSecretInput, { target: { value: 'my-secret' } })
+
+      const submitButton = screen.getByRole('button', {
+        name: /save and connect/i
+      })
+      expect(submitButton).not.toBeDisabled()
+      fireEvent.click(submitButton)
+
+      await waitFor(() =>
+        expect(mockSaveStravaSettings).toHaveBeenCalledWith({
+          clientId: '123456',
+          clientSecret: 'my-secret',
+          defaultVisibility: 'private'
+        })
+      )
+
+      expect(
+        await screen.findByText('Strava settings saved successfully!')
+      ).toBeInTheDocument()
+      expect(
+        (screen.getByLabelText(/^client secret/i) as HTMLInputElement).value
+      ).toBe('••••••••')
+      expect(screen.getByLabelText(/^client id/i)).toBeDisabled()
+    })
+
+    it('submits only defaultVisibility when already configured', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '123456',
+        defaultVisibility: 'private'
+      })
+      mockSaveStravaSettings.mockResolvedValueOnce({
+        success: true,
+        message: 'Strava import visibility saved successfully'
+      })
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      // Change visibility using dropdown
+      fireEvent.keyDown(
+        screen.getByRole('button', { name: /set visibility/i }),
+        { key: 'ArrowDown' }
+      )
+      const unlistedOption = await screen.findByRole('menuitemradio', {
+        name: /unlisted/i
+      })
+      fireEvent.click(unlistedOption)
+
+      const saveButton = screen.getByRole('button', {
+        name: /save visibility/i
+      })
+      fireEvent.click(saveButton)
+
+      await waitFor(() =>
+        expect(mockSaveStravaSettings).toHaveBeenCalledWith({
+          defaultVisibility: 'unlisted'
+        })
+      )
+
+      expect(
+        await screen.findByText('Strava import visibility saved successfully')
+      ).toBeInTheDocument()
+    })
+
+    it('shows loading state while saving is in progress', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: false,
+        defaultVisibility: 'private'
+      })
+      let resolveSave: (value: { success: boolean; message: string }) => void
+      mockSaveStravaSettings.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSave = resolve
+          })
+      )
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.change(screen.getByLabelText(/^client id/i), {
+        target: { value: '123456' }
+      })
+      fireEvent.change(screen.getByLabelText(/^client secret/i), {
+        target: { value: 'secret' }
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /save and connect/i }))
+
+      expect(
+        screen.getByRole('button', { name: /saving\.\.\./i })
+      ).toBeDisabled()
+
+      resolveSave!({ success: true, message: 'Saved!' })
+
+      expect(await screen.findByText('Saved!')).toBeInTheDocument()
+    })
   })
 
-  it.each([
-    { description: 'stays quiet for followers-only', visibility: 'private' },
-    { description: 'stays quiet for direct', visibility: 'direct' }
-  ])('$description', async ({ visibility }) => {
-    await renderForm(visibility)
+  describe('redirect responses', () => {
+    it('redirects to Strava authorization URL when returned from save', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: false,
+        defaultVisibility: 'private'
+      })
+      mockSaveStravaSettings.mockResolvedValueOnce({
+        success: true,
+        message: 'Strava settings saved successfully',
+        authorizeUrl: '/api/v1/fitness/strava/authorize'
+      })
 
-    await screen.findByText(/Every activity imported from Strava/)
-    expect(screen.queryByRole('alert')).toBeNull()
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.change(screen.getByLabelText(/^client id/i), {
+        target: { value: '123456' }
+      })
+      fireEvent.change(screen.getByLabelText(/^client secret/i), {
+        target: { value: 'secret' }
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /save and connect/i }))
+
+      expect(
+        await screen.findByText('Redirecting to Strava for authorization...')
+      ).toBeInTheDocument()
+      expect(locationHref).toBe('/api/v1/fitness/strava/authorize')
+    })
+  })
+
+  describe('saving failure', () => {
+    it('displays error message when saving fails', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: false,
+        defaultVisibility: 'private'
+      })
+      mockSaveStravaSettings.mockRejectedValueOnce(
+        new Error('Client ID must be numeric')
+      )
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.change(screen.getByLabelText(/^client id/i), {
+        target: { value: '123456' }
+      })
+      fireEvent.change(screen.getByLabelText(/^client secret/i), {
+        target: { value: 'secret' }
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /save and connect/i }))
+
+      expect(
+        await screen.findByText('Client ID must be numeric')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /save and connect/i })
+      ).not.toBeDisabled()
+    })
+  })
+
+  describe('unlinking', () => {
+    it('opens confirmation dialog and cancels without calling API', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '123456',
+        defaultVisibility: 'private'
+      })
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByRole('button', { name: /^unlink$/i }))
+
+      expect(
+        await screen.findByText('Unlink Strava Integration')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          /are you sure you want to remove your strava integration\?/i
+        )
+      ).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Unlink Strava Integration')
+        ).not.toBeInTheDocument()
+      })
+      expect(mockDeleteStravaSettings).not.toHaveBeenCalled()
+    })
+
+    it('unlinks integration, resets form state, and provides feedback', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '123456',
+        webhookUrl: 'https://llun.test/webhook',
+        defaultVisibility: 'unlisted'
+      })
+      mockDeleteStravaSettings.mockResolvedValueOnce({
+        success: true,
+        message: 'Strava settings removed successfully'
+      })
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByRole('button', { name: /^unlink$/i }))
+
+      expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+      // The confirm button in DialogFooter is the second Unlink button
+      const allUnlinkButtons = screen.getAllByRole('button', {
+        name: /^unlink$/i
+      })
+      const dialogUnlinkButton = allUnlinkButtons[allUnlinkButtons.length - 1]
+      fireEvent.click(dialogUnlinkButton)
+
+      await waitFor(() => expect(mockDeleteStravaSettings).toHaveBeenCalled())
+
+      expect(
+        await screen.findByText('Strava settings removed successfully')
+      ).toBeInTheDocument()
+
+      const clientIdInput = screen.getByLabelText(
+        /^client id/i
+      ) as HTMLInputElement
+      const clientSecretInput = screen.getByLabelText(
+        /^client secret/i
+      ) as HTMLInputElement
+
+      expect(clientIdInput.value).toBe('')
+      expect(clientIdInput).not.toBeDisabled()
+      expect(clientSecretInput.value).toBe('')
+      expect(clientSecretInput).not.toBeDisabled()
+      expect(screen.queryByLabelText(/webhook url/i)).toBeNull()
+      expect(screen.queryByText(/connected to strava/i)).toBeNull()
+      expect(
+        screen.getByRole('button', { name: /save and connect/i })
+      ).toBeInTheDocument()
+    })
+
+    it('displays error message when unlinking fails', async () => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '123456',
+        defaultVisibility: 'private'
+      })
+      mockDeleteStravaSettings.mockRejectedValueOnce(
+        new Error('Failed to remove settings')
+      )
+
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByRole('button', { name: /^unlink$/i }))
+
+      const allUnlinkButtons = screen.getAllByRole('button', {
+        name: /^unlink$/i
+      })
+      fireEvent.click(allUnlinkButtons[allUnlinkButtons.length - 1])
+
+      expect(
+        await screen.findByText('Failed to remove settings')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('import visibility disclosure', () => {
+    const renderFormWithVisibility = async (visibility?: string) => {
+      mockGetStravaSettings.mockResolvedValueOnce({
+        configured: true,
+        connected: true,
+        clientId: '12345',
+        webhookUrl: 'https://llun.test/api/v1/webhooks/strava/token',
+        ...(visibility
+          ? { defaultVisibility: visibility as any }
+          : { defaultVisibility: 'private' })
+      })
+      render(<StravaSettingsForm />)
+      await waitFor(() => expect(mockGetStravaSettings).toHaveBeenCalled())
+    }
+
+    it('says that an activity marked Only you on Strava is posted at this visibility', async () => {
+      await renderFormWithVisibility('private')
+
+      const helper = await screen.findByText(
+        /Every activity imported from Strava/
+      )
+      expect(helper).toHaveTextContent('Only you')
+      expect(helper).toHaveTextContent(
+        /never carried over|is never carried over/
+      )
+    })
+
+    it('says the setting covers retries and repairs, not just the webhook', async () => {
+      await renderFormWithVisibility('private')
+
+      const helper = await screen.findByText(
+        /Every activity imported from Strava/
+      )
+      expect(helper).toHaveTextContent(/retry or repair/)
+    })
+
+    it('does not label the control as webhook-only', async () => {
+      await renderFormWithVisibility('private')
+
+      expect(
+        await screen.findByText('Automatic import visibility')
+      ).toBeVisible()
+      expect(screen.queryByText('Webhook Activity Visibility')).toBeNull()
+    })
+
+    it.each([
+      { description: 'warns when imports are public', visibility: 'public' },
+      { description: 'warns when imports are unlisted', visibility: 'unlisted' }
+    ])('$description', async ({ visibility }) => {
+      await renderFormWithVisibility(visibility)
+
+      const alert = await screen.findByRole('alert')
+      expect(alert).toHaveTextContent('Anyone on the fediverse can read')
+      expect(alert).toHaveTextContent('Only you')
+    })
+
+    it.each([
+      { description: 'stays quiet for followers-only', visibility: 'private' },
+      { description: 'stays quiet for direct', visibility: 'direct' }
+    ])('$description', async ({ visibility }) => {
+      await renderFormWithVisibility(visibility)
+
+      await screen.findByText(/Every activity imported from Strava/)
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
   })
 })

--- a/app/(timeline)/fitness/strava/StravaSettingsForm.tsx
+++ b/app/(timeline)/fitness/strava/StravaSettingsForm.tsx
@@ -2,6 +2,11 @@
 
 import { FC, useEffect, useState } from 'react'
 
+import {
+  deleteStravaSettings,
+  getStravaSettings,
+  saveStravaSettings
+} from '@/lib/client'
 import { VisibilitySelector } from '@/lib/components/post-box/visibility-selector'
 import { Button } from '@/lib/components/ui/button'
 import {
@@ -29,10 +34,19 @@ const isMastodonVisibility = (value: unknown): value is MastodonVisibility => {
   return MastodonVisibilitySchema.safeParse(value).success
 }
 
+const isAbortError = (err: unknown) =>
+  Boolean(
+    (err instanceof Error && err.name === 'AbortError') ||
+    (typeof DOMException !== 'undefined' &&
+      err instanceof DOMException &&
+      err.name === 'AbortError')
+  )
+
 export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
   serverActorHandle
 }) => {
   const [clientId, setClientId] = useState('')
+
   const [clientSecret, setClientSecret] = useState('')
   const [isConfigured, setIsConfigured] = useState(false)
   const [isConnected, setIsConnected] = useState(false)
@@ -49,15 +63,12 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
     const controller = new AbortController()
     const fetchSettings = async () => {
       try {
-        const response = await fetch('/api/v1/fitness/strava', {
-          signal: controller.signal
-        })
-        const data = await response.json()
+        const data = await getStravaSettings({ signal: controller.signal })
 
         if (data.configured) {
           setIsConfigured(true)
           setIsConnected(data.connected || false)
-          setClientId(data.clientId)
+          setClientId(data.clientId || '')
           setClientSecret('••••••••')
           setWebhookUrl(data.webhookUrl || '')
         }
@@ -73,7 +84,7 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
           setArchiveActorHandle(serverActorHandle)
         }
       } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
+        if (isAbortError(err) || controller.signal.aborted) {
           return
         }
         setError('Failed to load settings')
@@ -117,7 +128,7 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
     return () => {
       controller.abort()
     }
-  }, [])
+  }, [serverActorHandle])
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -126,24 +137,11 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/v1/fitness/strava', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(
-          isConfigured
-            ? { defaultVisibility }
-            : { clientId, clientSecret, defaultVisibility }
-        )
-      })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        setError(data.error || 'Failed to save settings')
-        return
-      }
+      const data = await saveStravaSettings(
+        isConfigured
+          ? { defaultVisibility }
+          : { clientId, clientSecret, defaultVisibility }
+      )
 
       setIsConfigured(true)
       if (!isConfigured) {
@@ -157,8 +155,12 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
       }
 
       setMessage(data.message || 'Strava settings saved successfully!')
-    } catch (_err) {
-      setError('An error occurred. Please try again.')
+    } catch (err) {
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'An error occurred. Please try again.'
+      )
     } finally {
       setIsLoading(false)
     }
@@ -170,18 +172,9 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/v1/fitness/strava', {
-        method: 'DELETE'
-      })
+      const data = await deleteStravaSettings()
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        setError(data.error || 'Failed to remove settings')
-        return
-      }
-
-      setMessage('Settings removed successfully!')
+      setMessage(data.message || 'Settings removed successfully!')
       setIsConfigured(false)
       setIsConnected(false)
       setClientId('')
@@ -189,8 +182,12 @@ export const StravaSettingsForm: FC<StravaSettingsFormProps> = ({
       setWebhookUrl('')
       setDefaultVisibility(DEFAULT_STRAVA_VISIBILITY)
       setShowUnlinkDialog(false)
-    } catch (_err) {
-      setError('An error occurred. Please try again.')
+    } catch (err) {
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Failed to remove settings'
+      )
     } finally {
       setIsLoading(false)
     }

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -23,6 +23,7 @@ import {
   deleteCollection,
   deleteFitnessRouteHeatmap,
   deleteStatus,
+  deleteStravaSettings,
   follow,
   getActorDomains,
   getActorStatuses,
@@ -34,6 +35,7 @@ import {
   getFitnessRouteHeatmaps,
   getFollowStatus,
   getPublicHeatmapTiles,
+  getStravaSettings,
   getTrendingLinks,
   getTrendingStatuses,
   getTrendingTags,
@@ -43,6 +45,7 @@ import {
   requestPasswordReset,
   resetPassword,
   revokeCollectionMembership,
+  saveStravaSettings,
   search,
   setDefaultActor,
   startStravaArchiveImport,
@@ -2375,6 +2378,297 @@ describe('client actor management helpers', () => {
           oauth_query: 'client_id=flow-test-client'
         })
       ).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('Strava settings helpers', () => {
+    beforeEach(() => {
+      fetchMock.resetMocks()
+    })
+
+    describe('getStravaSettings', () => {
+      it('fetches Strava settings with Accept header', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            configured: true,
+            actorId: 'https://local.example/users/alice',
+            actorHandle: '@alice@local.example',
+            clientId: '12345',
+            connected: true,
+            webhookUrl: 'https://local.example/api/v1/webhooks/strava/tok123',
+            defaultVisibility: 'private'
+          }),
+          { status: 200 }
+        )
+
+        const result = await getStravaSettings()
+
+        expect(result).toEqual({
+          configured: true,
+          actorId: 'https://local.example/users/alice',
+          actorHandle: '@alice@local.example',
+          clientId: '12345',
+          connected: true,
+          webhookUrl: 'https://local.example/api/v1/webhooks/strava/tok123',
+          defaultVisibility: 'private'
+        })
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            method: 'GET',
+            headers: {
+              Accept: 'application/json'
+            }
+          })
+        )
+      })
+
+      it('supports passing AbortSignal directly or via options object', async () => {
+        fetchMock.mockResponse(
+          JSON.stringify({
+            configured: false,
+            defaultVisibility: 'private'
+          }),
+          { status: 200 }
+        )
+
+        const controller1 = new AbortController()
+        await getStravaSettings(controller1.signal)
+        expect(fetchMock).toHaveBeenNthCalledWith(
+          1,
+          '/api/v1/fitness/strava',
+          expect.objectContaining({ signal: controller1.signal })
+        )
+
+        const controller2 = new AbortController()
+        await getStravaSettings({ signal: controller2.signal })
+        expect(fetchMock).toHaveBeenNthCalledWith(
+          2,
+          '/api/v1/fitness/strava',
+          expect.objectContaining({ signal: controller2.signal })
+        )
+      })
+
+      it('throws server error message on non-ok response', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({ error: 'Session expired' }),
+          { status: 401 }
+        )
+
+        await expect(getStravaSettings()).rejects.toThrow('Session expired')
+      })
+
+      it('falls back to default error on non-JSON failure', async () => {
+        fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+        await expect(getStravaSettings()).rejects.toThrow(
+          'Failed to load settings'
+        )
+      })
+
+      it('propagates cancellation / abort errors', async () => {
+        const abortError = new Error('The user aborted a request.')
+        abortError.name = 'AbortError'
+        fetchMock.mockRejectOnce(abortError)
+
+        await expect(getStravaSettings()).rejects.toThrow(
+          'The user aborted a request.'
+        )
+      })
+    })
+
+    describe('saveStravaSettings', () => {
+      it('posts credentials and visibility, returning authorizeUrl', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            success: true,
+            message: 'Strava settings saved successfully',
+            authorizeUrl: '/api/v1/fitness/strava/authorize'
+          }),
+          { status: 200 }
+        )
+
+        const result = await saveStravaSettings({
+          clientId: '12345',
+          clientSecret: 'my-strava-secret',
+          defaultVisibility: 'private'
+        })
+
+        expect(result).toEqual({
+          success: true,
+          message: 'Strava settings saved successfully',
+          authorizeUrl: '/api/v1/fitness/strava/authorize'
+        })
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              clientId: '12345',
+              clientSecret: 'my-strava-secret',
+              defaultVisibility: 'private'
+            })
+          })
+        )
+      })
+
+      it('posts only visibility when updating an already configured integration', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            success: true,
+            message: 'Strava import visibility saved successfully'
+          }),
+          { status: 200 }
+        )
+
+        const result = await saveStravaSettings({
+          defaultVisibility: 'public'
+        })
+
+        expect(result).toEqual({
+          success: true,
+          message: 'Strava import visibility saved successfully'
+        })
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              defaultVisibility: 'public'
+            })
+          })
+        )
+      })
+
+      it('forwards optional signal to save request', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            success: true,
+            message: 'Saved'
+          }),
+          { status: 200 }
+        )
+
+        const controller = new AbortController()
+        await saveStravaSettings({
+          defaultVisibility: 'unlisted',
+          signal: controller.signal
+        })
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            signal: controller.signal
+          })
+        )
+      })
+
+      it('throws server error message on validation failure', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            error: 'Client ID and Client Secret are required'
+          }),
+          { status: 400 }
+        )
+
+        await expect(
+          saveStravaSettings({
+            clientId: '12345'
+          })
+        ).rejects.toThrow('Client ID and Client Secret are required')
+      })
+
+      it('falls back to default error on non-JSON failure', async () => {
+        fetchMock.mockResponseOnce('502 Bad Gateway', { status: 502 })
+
+        await expect(
+          saveStravaSettings({
+            defaultVisibility: 'private'
+          })
+        ).rejects.toThrow('Failed to save settings')
+      })
+
+      it('propagates network failure', async () => {
+        fetchMock.mockRejectOnce(new Error('Network disconnected'))
+
+        await expect(
+          saveStravaSettings({
+            defaultVisibility: 'private'
+          })
+        ).rejects.toThrow('Network disconnected')
+      })
+    })
+
+    describe('deleteStravaSettings', () => {
+      it('sends DELETE request and returns confirmation message', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            success: true,
+            message: 'Strava settings removed successfully'
+          }),
+          { status: 200 }
+        )
+
+        const result = await deleteStravaSettings()
+
+        expect(result).toEqual({
+          success: true,
+          message: 'Strava settings removed successfully'
+        })
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            method: 'DELETE'
+          })
+        )
+      })
+
+      it('forwards optional signal to delete request', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({
+            success: true,
+            message: 'Strava settings removed successfully'
+          }),
+          { status: 200 }
+        )
+
+        const controller = new AbortController()
+        await deleteStravaSettings({ signal: controller.signal })
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/v1/fitness/strava',
+          expect.objectContaining({
+            signal: controller.signal
+          })
+        )
+      })
+
+      it('throws server error message on 404 or other failure', async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({ error: 'No Strava settings to remove' }),
+          { status: 404 }
+        )
+
+        await expect(deleteStravaSettings()).rejects.toThrow(
+          'No Strava settings to remove'
+        )
+      })
+
+      it('falls back to default error on non-JSON failure', async () => {
+        fetchMock.mockResponseOnce('500 Internal Error', { status: 500 })
+
+        await expect(deleteStravaSettings()).rejects.toThrow(
+          'Failed to remove settings'
+        )
+      })
+
+      it('propagates network failure', async () => {
+        fetchMock.mockRejectOnce(new Error('Network timeout'))
+
+        await expect(deleteStravaSettings()).rejects.toThrow('Network timeout')
+      })
     })
   })
 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -5267,3 +5267,108 @@ export const submitOAuthConsent = async ({
   }
   return response.json()
 }
+
+export interface StravaSettingsResponse {
+  configured: boolean
+  actorId?: string
+  actorHandle?: string
+  clientId?: string
+  connected?: boolean
+  webhookUrl?: string
+  defaultVisibility: MastodonVisibility
+}
+
+export type StravaSettings = StravaSettingsResponse
+
+export interface GetStravaSettingsParams {
+  signal?: AbortSignal
+}
+
+export const getStravaSettings = async (
+  params?: GetStravaSettingsParams | AbortSignal
+): Promise<StravaSettingsResponse> => {
+  const signal = params instanceof AbortSignal ? params : params?.signal
+  const response = await fetch('/api/v1/fitness/strava', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    },
+    signal
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to load settings')
+  }
+
+  return response.json()
+}
+
+export interface SaveStravaSettingsParams {
+  clientId?: string
+  clientSecret?: string
+  defaultVisibility?: MastodonVisibility
+  signal?: AbortSignal
+}
+
+export interface SaveStravaSettingsResponse {
+  success: boolean
+  message: string
+  authorizeUrl?: string
+}
+
+export const saveStravaSettings = async ({
+  clientId,
+  clientSecret,
+  defaultVisibility,
+  signal
+}: SaveStravaSettingsParams): Promise<SaveStravaSettingsResponse> => {
+  const body: {
+    clientId?: string
+    clientSecret?: string
+    defaultVisibility?: MastodonVisibility
+  } = {}
+  if (clientId !== undefined) body.clientId = clientId
+  if (clientSecret !== undefined) body.clientSecret = clientSecret
+  if (defaultVisibility !== undefined)
+    body.defaultVisibility = defaultVisibility
+
+  const response = await fetch('/api/v1/fitness/strava', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body),
+    signal
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to save settings')
+  }
+
+  return response.json()
+}
+
+export interface DeleteStravaSettingsParams {
+  signal?: AbortSignal
+}
+
+export interface DeleteStravaSettingsResponse {
+  success: boolean
+  message: string
+}
+
+export const deleteStravaSettings = async (
+  params?: DeleteStravaSettingsParams | AbortSignal
+): Promise<DeleteStravaSettingsResponse> => {
+  const signal = params instanceof AbortSignal ? params : params?.signal
+  const response = await fetch('/api/v1/fitness/strava', {
+    method: 'DELETE',
+    signal
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to remove settings')
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## Summary
- Add typed `getStravaSettings`, `saveStravaSettings`, and `deleteStravaSettings` helpers and associated types (`StravaSettingsResponse`, `StravaSettings`, `GetStravaSettingsParams`, `SaveStravaSettingsParams`, `SaveStravaSettingsResponse`, `DeleteStravaSettingsParams`, `DeleteStravaSettingsResponse`) in `lib/client.ts` for GET/POST/DELETE `/api/v1/fitness/strava`
- Support optional `AbortSignal` for loading settings and handle aborts as cancellation rather than visible failures
- Migrate `StravaSettingsForm.tsx` from direct `fetch` to `lib/client.ts` facade methods, preserving client ID/secret submission, visibility settings, connected/configured distinctions, masked-secret behavior, unlink feedback, and authorization redirect navigation
- Remove `StravaSettingsForm.tsx` from `allowFiles` in `.oxlintrc.json`, leaving the component-fetch allowlist completely empty (`allowFiles: []`)
- Add unit tests for `getStravaSettings`, `saveStravaSettings`, and `deleteStravaSettings` in `lib/client.test.ts`
- Update `StravaSettingsForm.test.tsx` to mock `@/lib/client` and cover loading, cancellation, saving, redirect responses, unlinking, and failures while preserving import visibility alerts and disclosures
- Verified the settings UI in a real browser via Chrome DevTools (unconfigured state, credentials entry, authorization navigation, configured state with masked secret, and unlinking feedback)