### PR TITLE
Bump version to v1.161.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.24",
+  "version": "1.161.25",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.25.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.24`
- Base main SHA: `270cf11a8698d3713383f3aed5939461173de731`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
