### PR TITLE
test: resolve types for StatusBox and status page layout tests

### DIFF
--- a/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
@@ -59,6 +59,7 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
+        mapProvider={{ type: 'osm' }}
         currentActor={pollStatusFixture.actor}
         currentTime={pollStatusCurrentTime}
         status={pollStatusFixture}
@@ -89,6 +90,7 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
+        mapProvider={{ type: 'osm' }}
         currentActor={pollStatusFixture.actor}
         currentTime={pollStatusCurrentTime}
         status={pollStatusFixture}
@@ -103,6 +105,7 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
+        mapProvider={{ type: 'osm' }}
         currentActor={null}
         currentTime={pollStatusCurrentTime}
         status={pollStatusFixture}
@@ -117,6 +120,7 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
+        mapProvider={{ type: 'osm' }}
         currentActor={pollStatusFixture.actor}
         currentTime={pollStatusCurrentTime}
         status={pollStatusFixture}
@@ -138,6 +142,7 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
+        mapProvider={{ type: 'osm' }}
         currentActor={pollStatusFixture.actor}
         currentTime={pollStatusCurrentTime}
         status={pollStatusFixture}

--- a/app/(timeline)/[actor]/[status]/page.layout.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.layout.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react'
 
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { Actor } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { StatusNote } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
@@ -82,64 +82,66 @@ const mockGetActorFromSession = vi.mocked(getActorFromSession)
 const AUTHOR_ID = 'https://activities.local/users/anna'
 const VIEWER_ID = 'https://activities.local/users/viewer'
 
-const buildNote = (overrides: Partial<Status> = {}): Status =>
-  ({
-    id: 'note-id',
-    type: 'Note',
-    actorId: AUTHOR_ID,
-    actor: null,
-    url: `${AUTHOR_ID}/statuses/note-id`,
-    text: 'body',
-    reply: '',
-    replies: [],
-    to: [ACTIVITY_STREAM_PUBLIC],
-    cc: [],
-    edits: [],
-    isLocalActor: true,
-    isActorLiked: false,
-    isActorBookmarked: false,
-    actorAnnounceStatusId: null,
-    totalLikes: 0,
-    totalShares: 0,
-    attachments: [],
-    tags: [],
-    createdAt: 1,
-    updatedAt: 1,
-    ...overrides
-  }) as unknown as Status
+const buildNote = (overrides: Partial<StatusNote> = {}): StatusNote => ({
+  id: 'note-id',
+  type: 'Note',
+  actorId: AUTHOR_ID,
+  actor: null,
+  url: `${AUTHOR_ID}/statuses/note-id`,
+  text: 'body',
+  reply: '',
+  replies: [],
+  to: [ACTIVITY_STREAM_PUBLIC],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  isActorLiked: false,
+  isActorBookmarked: false,
+  actorAnnounceStatusId: null,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [],
+  tags: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
 
 // `isFitnessDashboard` keys off a completed fitness file, and that branch is a
 // separate card from the conversation one below — same defect, its own chrome.
-const buildFitnessNote = (): Status =>
+const buildFitnessNote = (): StatusNote =>
   buildNote({
     id: 'ride-1',
+    url: `${AUTHOR_ID}/statuses/ride-1`,
     fitness: {
       id: 'fit-1',
       fileName: 'ride.fit',
       fileType: 'fit',
+      mimeType: 'application/octet-stream',
+      bytes: 1000,
+      url: 'https://activities.local/files/fit-1',
       processingStatus: 'completed',
       activityType: 'ride',
       hasMapData: false
     }
-  } as Partial<Status>)
+  })
 
-const buildViewer = (): Actor =>
-  ({
-    id: VIEWER_ID,
-    type: 'Person',
-    username: 'viewer',
-    domain: 'activities.local',
-    followersUrl: `${VIEWER_ID}/followers`,
-    inboxUrl: `${VIEWER_ID}/inbox`,
-    sharedInboxUrl: 'https://activities.local/inbox',
-    publicKey: 'public-key',
-    followingCount: 0,
-    followersCount: 0,
-    statusCount: 0,
-    lastStatusAt: null,
-    createdAt: 1,
-    updatedAt: 1
-  }) as unknown as Actor
+const buildViewer = (): Actor => ({
+  id: VIEWER_ID,
+  type: 'Person',
+  username: 'viewer',
+  domain: 'activities.local',
+  followersUrl: `${VIEWER_ID}/followers`,
+  inboxUrl: `${VIEWER_ID}/inbox`,
+  sharedInboxUrl: 'https://activities.local/inbox',
+  publicKey: 'public-key',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1
+})
 
 const renderPage = async () => {
   const element = await Page({

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,8 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
     "app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx",
-    "app/(timeline)/[actor]/[status]/StatusBox.test.tsx",
-    "app/(timeline)/[actor]/[status]/page.layout.test.tsx",
     "app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx",
     "app/(timeline)/[actor]/[status]/page.visibility.test.tsx",
     "app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts",


### PR DESCRIPTION
Resolves typing issues in `app/(timeline)/[actor]/[status]/StatusBox.test.tsx` and `app/(timeline)/[actor]/[status]/page.layout.test.tsx`:

- Added required `mapProvider` prop to `StatusBox` invocations in `StatusBox.test.tsx`.
- Refactored `buildNote` and `buildFitnessNote` fixtures in `page.layout.test.tsx` to properly type `StatusNote` without `as unknown as Status` or `as Partial<Status>`, and cleaned up `buildViewer` typing.
- Removed both test files from `tsconfig.typecheck.json` exclusions.
- Passed full DoD validation (`prettier`, `lint`, `typecheck`, `build`, and `test`).