### PR TITLE
Bump version to v1.161.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.25",
+  "version": "1.161.26",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.26.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.25`
- Base main SHA: `a974f17c152a82e9ff231216e1018e26d9a04c3b`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
