### PR TITLE
test: resolve types for status page remote signing and visibility tests

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx
@@ -9,7 +9,7 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { getQueue } from '@/lib/services/queue'
 import { Actor } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { StatusNote } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { logger } from '@/lib/utils/logger'
@@ -128,7 +128,7 @@ const buildViewer = (): Actor =>
     updatedAt: 1
   }) as unknown as Actor
 
-const buildRemoteNote = (): Status =>
+const buildRemoteNote = (): StatusNote =>
   ({
     id: REMOTE_STATUS_URL,
     type: 'Note',
@@ -151,7 +151,7 @@ const buildRemoteNote = (): Status =>
     tags: [],
     createdAt: 1,
     updatedAt: 1
-  }) as unknown as Status
+  }) as unknown as StatusNote
 
 const renderRemoteStatusPage = async () => {
   const element = await Page({

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { Actor } from '@/lib/types/domain/actor'
 import { FollowStatus } from '@/lib/types/domain/follow'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusNote } from '@/lib/types/domain/status'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
@@ -87,7 +87,7 @@ const AUTHOR_ID = 'https://activities.local/users/anna'
 // `/followers` — used to exercise the exact-match followers audience check.
 const REMOTE_AUTHOR_ID = 'https://remote.example/users/anna'
 
-const buildNote = (overrides: Partial<Status> = {}): Status =>
+const buildNote = (overrides: Partial<StatusNote> = {}): StatusNote =>
   ({
     id: 'note-id',
     type: 'Note',
@@ -111,7 +111,7 @@ const buildNote = (overrides: Partial<Status> = {}): Status =>
     createdAt: 1,
     updatedAt: 1,
     ...overrides
-  }) as unknown as Status
+  }) as unknown as StatusNote
 
 const buildAnnounce = (
   originalStatus: Status,
@@ -336,7 +336,7 @@ describe('Page visibility for logged-out visitors', () => {
         url: 'https://activities.local/fit/run.fit',
         processingStatus: 'completed'
       }
-    } as unknown as Partial<Status>)
+    } as unknown as Partial<StatusNote>)
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: focused,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,8 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
     "app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx",
-    "app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx",
-    "app/(timeline)/[actor]/[status]/page.visibility.test.tsx",
     "app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts",
     "app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx",
     "app/(timeline)/lists/[id]/ListTimeline.test.tsx",


### PR DESCRIPTION
Resolves typing issues in `app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx` and `app/(timeline)/[actor]/[status]/page.visibility.test.tsx`:

- Typed `buildRemoteNote` to return `StatusNote` in `page.remote-signing.test.tsx` so mock resolution matches `getRemoteStatus` signature.
- Typed `buildNote` to return `StatusNote` and updated partial fixture cast in `page.visibility.test.tsx` to safely provide access to `.url` without errors on `StatusAnnounce`.
- Removed both test files from `tsconfig.typecheck.json` ratchet.
- Passed full DoD validation (`prettier`, `lint`, `typecheck`, `build`, and `test`).