### PR TITLE
test: resolve types for resolveStatusFromPath and GearActivitiesFeed tests

### DIFF
--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
@@ -1,4 +1,9 @@
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import {
+  StatusAnnounce,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { generatePublicId } from '@/lib/utils/publicId'
 
@@ -11,14 +16,25 @@ describe('resolveStatusFromPath', () => {
   const originalUrl = 'https://remote.example/@original/123'
   const statusHash = getHashFromString(originalUrl)
 
-  const originalStatus = {
+  const buildActor = (actorId: string, username: string): ActorProfile => ({
+    id: actorId,
+    username,
+    domain: new URL(actorId).host,
+    followersUrl: `${actorId}/followers`,
+    inboxUrl: `${actorId}/inbox`,
+    sharedInboxUrl: `${actorId}/sharedInbox`,
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 0
+  })
+
+  const originalStatus: StatusNote = {
     id: 'https://remote.example/users/original/statuses/123',
     url: originalUrl,
     actorId: originalActorId,
-    actor: {
-      username: 'original',
-      domain: 'remote.example'
-    },
+    actor: buildActor(originalActorId, 'original'),
     type: StatusType.enum.Note,
     to: [],
     cc: [],
@@ -31,28 +47,26 @@ describe('resolveStatusFromPath', () => {
     replies: [],
     actorAnnounceStatusId: null,
     isActorLiked: false,
+    isActorBookmarked: false,
     totalLikes: 0,
+    totalShares: 0,
     attachments: [],
     tags: []
-  } as Status
+  }
 
-  const createAnnounce = (actorId = boosterActorId) =>
-    ({
-      id: `${actorId}/statuses/456/activity`,
-      actorId,
-      actor: {
-        username: 'booster',
-        domain: new URL(actorId).host
-      },
-      type: StatusType.enum.Announce,
-      to: [],
-      cc: [],
-      edits: [],
-      originalStatus,
-      isLocalActor: false,
-      createdAt: Date.now(),
-      updatedAt: Date.now()
-    }) as Status
+  const createAnnounce = (actorId = boosterActorId): StatusAnnounce => ({
+    id: `${actorId}/statuses/456/activity`,
+    actorId,
+    actor: buildActor(actorId, 'booster'),
+    type: StatusType.enum.Announce,
+    to: [],
+    cc: [],
+    edits: [],
+    originalStatus,
+    isLocalActor: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  })
 
   const createDatabase = () => ({
     getActorFromUsername: vi.fn().mockResolvedValue({ id: originalActorId }),

--- a/app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx
+++ b/app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/lib/client'
 import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 
 import { GearActivitiesFeed } from './GearActivitiesFeed'
 
@@ -43,17 +43,21 @@ vi.mock('@/lib/components/posts/posts', () => ({
     >
       {props.statuses.map((status) => (
         <div key={status.id}>
-          {status.text}
+          {status.type === StatusType.enum.Note ? status.text : null}
           <button type="button" onClick={() => props.onPostDeleted?.(status)}>
             {`delete ${status.id}`}
           </button>
           <button
             type="button"
             onClick={() =>
-              props.onPostUpdated?.({
-                ...status,
-                text: `${status.text} (edited)`
-              })
+              props.onPostUpdated?.(
+                status.type === StatusType.enum.Note
+                  ? {
+                      ...status,
+                      text: `${status.text} (edited)`
+                    }
+                  : status
+              )
             }
           >
             {`edit ${status.id}`}
@@ -86,7 +90,7 @@ const profile: ActorProfile = {
   createdAt: FIXED_CURRENT_TIME
 }
 
-const createStatus = (id: string, text = id): Status => ({
+const createStatus = (id: string, text = id): StatusNote => ({
   id,
   actorId: profile.id,
   actor: profile,
@@ -104,7 +108,9 @@ const createStatus = (id: string, text = id): Status => ({
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
+  totalShares: 0,
   attachments: [],
   tags: []
 })

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,8 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
     "app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx",
-    "app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts",
-    "app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx",
     "app/(timeline)/lists/[id]/ListTimeline.test.tsx",
     "app/(timeline)/messages/MessagesPage.test.tsx",
     "app/(timeline)/notifications/NotificationItem.test.tsx",


### PR DESCRIPTION
Resolves typing issues in `app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts` and `app/(timeline)/fitness/gear/[id]/GearActivitiesFeed.test.tsx`:

- Conformed mock statuses in `resolveStatusFromPath.test.ts` to `StatusNote` and `StatusAnnounce` with complete actor profiles and required fields, eliminating TS2352 conversion errors.
- Narrowed `status.type === StatusType.enum.Note` in the `Posts` stub within `GearActivitiesFeed.test.tsx` before accessing `.text`, and added missing `isActorBookmarked` and `totalShares` fields to `createStatus`.
- Removed both test files from `tsconfig.typecheck.json` exclusion list.
- Passed full DoD sequence (`prettier`, `lint`, `typecheck`, `build`, and `test`).