### PR TITLE
Bump version to v1.161.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.26",
+  "version": "1.161.27",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.27.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.26`
- Base main SHA: `c477ea1954711daf73f106fc37d60e9215be68d4`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
