### PR TITLE
refactor: extract initial status operations into lib/client/statuses.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -19,6 +19,7 @@ import {
   createDirectMessage,
   createFitnessGear,
   createFitnessGearComponent,
+  createNote,
   createPoll,
   createReport,
   deleteAccountMedia,
@@ -75,13 +76,25 @@ import {
   updateFitnessGear,
   updateFitnessGearComponent,
   updateNote,
+  updateStatusVisibility,
   uploadAttachment
 } from './client'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as httpModule from './client/http'
+import * as statusesModule from './client/statuses'
 
 enableFetchMocks()
+
+describe('client facade statuses re-exports', () => {
+  it('re-exports extracted status functions', () => {
+    expect(createNote).toBe(statusesModule.createNote)
+    expect(updateNote).toBe(statusesModule.updateNote)
+    expect(updateStatusVisibility).toBe(statusesModule.updateStatusVisibility)
+    expect(createPoll).toBe(statusesModule.createPoll)
+    expect(deleteStatus).toBe(statusesModule.deleteStatus)
+  })
+})
 
 vi.mock('@/lib/utils/getMediaWidthAndHeight', () => ({
   getMediaWidthAndHeight: vi.fn().mockResolvedValue({ width: 10, height: 20 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2,15 +2,10 @@ import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
 import { PresignedUrlOutput } from '@/lib/services/medias/types'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
-import { Duration } from '@/lib/services/statuses/pollDurations'
 import { TimelineFormat } from '@/lib/services/timelines/const'
 import { Timeline } from '@/lib/services/timelines/types'
 import type { DirectConversation } from '@/lib/types/database/operations'
-import {
-  Attachment,
-  PostBoxAttachment,
-  UploadedAttachment
-} from '@/lib/types/domain/attachment'
+import { Attachment, UploadedAttachment } from '@/lib/types/domain/attachment'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
@@ -24,7 +19,6 @@ import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
-import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
 import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
 import type { StatusReaction as MastodonStatusReaction } from '@/lib/types/mastodon/statusReaction'
@@ -43,248 +37,34 @@ import { idToUrl, toIdPathSegment } from '@/lib/utils/urlToId'
 import { waitFor } from '@/lib/utils/waitFor'
 
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
+import {
+  type CreateNoteParams,
+  type CreatePollParams,
+  type DefaultStatusParams,
+  type UpdateNoteParams,
+  type UpdateNoteResult,
+  type UpdateStatusVisibilityParams,
+  createNote,
+  createPoll,
+  deleteStatus,
+  updateNote,
+  updateStatusVisibility
+} from './client/statuses'
 
 export { ApiRequestError }
 
-export interface CreateNoteParams {
-  message: string
-  contentWarning?: string
-  replyStatus?: Status
-  quotedStatus?: Status
-  quoteApprovalPolicy?: QuoteApprovalPolicy
-  attachments?: PostBoxAttachment[]
-  fitnessFileId?: string
-  visibility?: MastodonVisibility
-}
-export const createNote = async ({
-  message,
-  contentWarning,
-  replyStatus,
-  quotedStatus,
-  quoteApprovalPolicy,
-  attachments = [],
-  fitnessFileId,
-  visibility
-}: CreateNoteParams) => {
-  if (
-    message.trim().length === 0 &&
-    attachments.length === 0 &&
-    !fitnessFileId
-  ) {
-    throw new Error('Message or attachments must not be empty')
-  }
-
-  const response = await fetch('/api/v1/accounts/outbox', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      type: 'note',
-      replyStatus,
-      message,
-      contentWarning,
-      attachments,
-      fitnessFileId,
-      quotedStatusId: quotedStatus?.id,
-      quoteApprovalPolicy,
-      visibility
-    })
-  })
-  if (response.status !== 200) {
-    await throwApiError(response, 'Fail to create a new note')
-  }
-
-  const json = await response.json()
-  return {
-    status: json.status as Status,
-    attachments: json.attachments as Attachment[]
-  }
-}
-
-export interface UpdateNoteParams {
-  statusId: string
-  message?: string
-  contentWarning?: string
-  attachments?: PostBoxAttachment[]
-}
-export interface UpdateNoteResult {
-  content: string
-  spoilerText: string
-  mediaAttachments: MediaAttachment[]
-  status: {
-    id: string
-    text: string | null
-    createdAt: number
-    updatedAt?: number
-    reply: string
-  }
-}
-
-const parseTimestamp = (value: unknown, fallback: number) => {
-  if (typeof value !== 'string') return fallback
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? fallback : timestamp
-}
-
-export const updateNote = async ({
-  statusId,
-  message,
-  contentWarning,
-  attachments
-}: UpdateNoteParams): Promise<UpdateNoteResult> => {
-  const hasMessageChange = message !== undefined
-  const hasAttachmentChanges = attachments !== undefined
-
-  if (
-    !hasMessageChange &&
-    contentWarning === undefined &&
-    !hasAttachmentChanges
-  ) {
-    throw new Error('Message, content warning, or attachments must be provided')
-  }
-
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}`,
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        ...(hasMessageChange ? { status: message } : {}),
-        ...(contentWarning !== undefined
-          ? { spoiler_text: contentWarning }
-          : {}),
-        ...(attachments !== undefined
-          ? { media_ids: attachments.map((attachment) => attachment.id) }
-          : {})
-      })
-    }
-  )
-  if (response.status !== 200) {
-    await throwApiError(response, 'Fail to update the note')
-  }
-
-  const mastodonStatus = await response.json()
-  const createdAt = parseTimestamp(mastodonStatus.created_at, Date.now())
-  return {
-    content: mastodonStatus.content,
-    spoilerText: mastodonStatus.spoiler_text ?? '',
-    mediaAttachments: Array.isArray(mastodonStatus.media_attachments)
-      ? mastodonStatus.media_attachments
-      : [],
-    status: {
-      id: mastodonStatus.uri ?? mastodonStatus.id,
-      text: mastodonStatus.text ?? null,
-      createdAt,
-      updatedAt: mastodonStatus.edited_at
-        ? parseTimestamp(mastodonStatus.edited_at, createdAt)
-        : undefined,
-      reply: mastodonStatus.in_reply_to_id || ''
-    }
-  }
-}
-
-export interface UpdateStatusVisibilityParams {
-  statusId: string
-  visibility: MastodonVisibility
-}
-
-export const updateStatusVisibility = async ({
-  statusId,
-  visibility
-}: UpdateStatusVisibilityParams): Promise<boolean> => {
-  try {
-    const response = await fetch(
-      `/api/v1/statuses/${toIdPathSegment(statusId)}`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ visibility })
-      }
-    )
-    return response.status === 200
-  } catch {
-    return false
-  }
-}
-
-export interface CreatePollParams {
-  message: string
-  contentWarning?: string
-  choices: string[]
-  durationInSeconds: Duration
-  pollType?: 'oneOf' | 'anyOf'
-  replyStatus?: Status
-  visibility?: MastodonVisibility
-}
-
-export const createPoll = async ({
-  message,
-  contentWarning,
-  choices,
-  durationInSeconds,
-  pollType,
-  replyStatus,
-  visibility
-}: CreatePollParams) => {
-  if (message.trim().length === 0 && choices.length === 0) {
-    throw new Error('Message or choices must not be empty')
-  }
-
-  for (const choice of choices) {
-    if (choice.trim().length === 0) {
-      throw new Error('Choice text must not be empty')
-    }
-  }
-
-  const response = await fetch('/api/v1/accounts/outbox', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      type: 'poll',
-      replyStatus,
-      message,
-      contentWarning,
-      durationInSeconds,
-      pollType,
-      choices,
-      visibility
-    })
-  })
-  if (response.status !== 200) {
-    await throwApiError(response, 'Fail to create a new poll')
-  }
-}
-
-export interface DefaultStatusParams {
-  statusId: string
-}
-
-/**
- * Deletes a status using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/statuses/#delete
- */
-export const deleteStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  if (response.status !== 200) {
-    return false
-  }
-
-  return true
+export {
+  type CreateNoteParams,
+  createNote,
+  type UpdateNoteParams,
+  type UpdateNoteResult,
+  updateNote,
+  type UpdateStatusVisibilityParams,
+  updateStatusVisibility,
+  type CreatePollParams,
+  createPoll,
+  type DefaultStatusParams,
+  deleteStatus
 }
 
 export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'

--- a/lib/client/statuses.test.ts
+++ b/lib/client/statuses.test.ts
@@ -1,0 +1,227 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  createNote,
+  createPoll,
+  deleteStatus,
+  updateNote,
+  updateStatusVisibility
+} from './statuses'
+
+enableFetchMocks()
+
+describe('client statuses module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('updateNote', () => {
+    beforeEach(() => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          id: '123',
+          content: '',
+          created_at: '2026-04-26T10:00:00.000Z',
+          edited_at: null,
+          in_reply_to_id: null
+        })
+      )
+    })
+
+    it('omits empty status text for content-warning-only edits', async () => {
+      await updateNote({
+        statusId: '123',
+        contentWarning: 'Updated warning'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/123',
+        expect.objectContaining({
+          body: JSON.stringify({
+            spoiler_text: 'Updated warning'
+          })
+        })
+      )
+    })
+
+    it('sends empty status text when clearing an edit message', async () => {
+      await updateNote({
+        statusId: '123',
+        message: ''
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/123',
+        expect.objectContaining({
+          body: JSON.stringify({
+            status: ''
+          })
+        })
+      )
+    })
+
+    it('sends empty status text with media ids when clearing text during media edits', async () => {
+      await updateNote({
+        statusId: '123',
+        message: '',
+        attachments: [
+          {
+            type: 'upload',
+            id: 'media-1',
+            mediaType: 'image/jpeg',
+            url: 'https://llun.test/api/v1/files/media-1.jpg',
+            width: 640,
+            height: 480,
+            name: 'media-1.jpg'
+          }
+        ]
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/123',
+        expect.objectContaining({
+          body: JSON.stringify({
+            status: '',
+            media_ids: ['media-1']
+          })
+        })
+      )
+    })
+
+    it('throws when no changes are provided', async () => {
+      await expect(
+        updateNote({
+          statusId: '123'
+        })
+      ).rejects.toThrow(
+        'Message, content warning, or attachments must be provided'
+      )
+    })
+  })
+
+  describe('createNote', () => {
+    it('throws when message, attachments, and fitnessFileId are all empty', async () => {
+      await expect(
+        createNote({
+          message: '   ',
+          attachments: []
+        })
+      ).rejects.toThrow('Message or attachments must not be empty')
+    })
+
+    it('creates note successfully', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          status: { id: 'status-1', text: 'Hello world' },
+          attachments: []
+        })
+      )
+
+      const result = await createNote({
+        message: 'Hello world'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/outbox',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"message":"Hello world"')
+        })
+      )
+      expect(result.status.id).toBe('status-1')
+    })
+  })
+
+  describe('updateStatusVisibility', () => {
+    it('returns true on 200 response', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const success = await updateStatusVisibility({
+        statusId: 'status-1',
+        visibility: 'public'
+      })
+
+      expect(success).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ visibility: 'public' })
+        })
+      )
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const success = await updateStatusVisibility({
+        statusId: 'status-1',
+        visibility: 'public'
+      })
+
+      expect(success).toBe(false)
+    })
+  })
+
+  describe('createPoll', () => {
+    it('throws when message and choices are empty', async () => {
+      await expect(
+        createPoll({
+          message: '',
+          choices: [],
+          durationInSeconds: 300
+        })
+      ).rejects.toThrow('Message or choices must not be empty')
+    })
+
+    it('throws when any choice is blank', async () => {
+      await expect(
+        createPoll({
+          message: 'Pick one',
+          choices: ['Option 1', '  '],
+          durationInSeconds: 300
+        })
+      ).rejects.toThrow('Choice text must not be empty')
+    })
+
+    it('creates poll successfully', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      await createPoll({
+        message: 'Favorite color?',
+        choices: ['Red', 'Blue'],
+        durationInSeconds: 1800
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/outbox',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"type":"poll"')
+        })
+      )
+    })
+  })
+
+  describe('deleteStatus', () => {
+    it('returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await deleteStatus({ statusId: 'status-to-delete' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-to-delete',
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      )
+    })
+
+    it('returns false on failure', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await deleteStatus({ statusId: 'missing-status' })
+      expect(res).toBe(false)
+    })
+  })
+})

--- a/lib/client/statuses.ts
+++ b/lib/client/statuses.ts
@@ -1,0 +1,251 @@
+import { Duration } from '@/lib/services/statuses/pollDurations'
+import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
+import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
+import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+import { MastodonVisibility } from '@/lib/utils/getVisibility'
+import { toIdPathSegment } from '@/lib/utils/urlToId'
+
+import { throwApiError } from './http'
+
+export interface CreateNoteParams {
+  message: string
+  contentWarning?: string
+  replyStatus?: Status
+  quotedStatus?: Status
+  quoteApprovalPolicy?: QuoteApprovalPolicy
+  attachments?: PostBoxAttachment[]
+  fitnessFileId?: string
+  visibility?: MastodonVisibility
+}
+
+export const createNote = async ({
+  message,
+  contentWarning,
+  replyStatus,
+  quotedStatus,
+  quoteApprovalPolicy,
+  attachments = [],
+  fitnessFileId,
+  visibility
+}: CreateNoteParams) => {
+  if (
+    message.trim().length === 0 &&
+    attachments.length === 0 &&
+    !fitnessFileId
+  ) {
+    throw new Error('Message or attachments must not be empty')
+  }
+
+  const response = await fetch('/api/v1/accounts/outbox', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      type: 'note',
+      replyStatus,
+      message,
+      contentWarning,
+      attachments,
+      fitnessFileId,
+      quotedStatusId: quotedStatus?.id,
+      quoteApprovalPolicy,
+      visibility
+    })
+  })
+  if (response.status !== 200) {
+    await throwApiError(response, 'Fail to create a new note')
+  }
+
+  const json = await response.json()
+  return {
+    status: json.status as Status,
+    attachments: json.attachments as Attachment[]
+  }
+}
+
+export interface UpdateNoteParams {
+  statusId: string
+  message?: string
+  contentWarning?: string
+  attachments?: PostBoxAttachment[]
+}
+
+export interface UpdateNoteResult {
+  content: string
+  spoilerText: string
+  mediaAttachments: MediaAttachment[]
+  status: {
+    id: string
+    text: string | null
+    createdAt: number
+    updatedAt?: number
+    reply: string
+  }
+}
+
+const parseTimestamp = (value: unknown, fallback: number) => {
+  if (typeof value !== 'string') return fallback
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? fallback : timestamp
+}
+
+export const updateNote = async ({
+  statusId,
+  message,
+  contentWarning,
+  attachments
+}: UpdateNoteParams): Promise<UpdateNoteResult> => {
+  const hasMessageChange = message !== undefined
+  const hasAttachmentChanges = attachments !== undefined
+
+  if (
+    !hasMessageChange &&
+    contentWarning === undefined &&
+    !hasAttachmentChanges
+  ) {
+    throw new Error('Message, content warning, or attachments must be provided')
+  }
+
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        ...(hasMessageChange ? { status: message } : {}),
+        ...(contentWarning !== undefined
+          ? { spoiler_text: contentWarning }
+          : {}),
+        ...(attachments !== undefined
+          ? { media_ids: attachments.map((attachment) => attachment.id) }
+          : {})
+      })
+    }
+  )
+  if (response.status !== 200) {
+    await throwApiError(response, 'Fail to update the note')
+  }
+
+  const mastodonStatus = await response.json()
+  const createdAt = parseTimestamp(mastodonStatus.created_at, Date.now())
+  return {
+    content: mastodonStatus.content,
+    spoilerText: mastodonStatus.spoiler_text ?? '',
+    mediaAttachments: Array.isArray(mastodonStatus.media_attachments)
+      ? mastodonStatus.media_attachments
+      : [],
+    status: {
+      id: mastodonStatus.uri ?? mastodonStatus.id,
+      text: mastodonStatus.text ?? null,
+      createdAt,
+      updatedAt: mastodonStatus.edited_at
+        ? parseTimestamp(mastodonStatus.edited_at, createdAt)
+        : undefined,
+      reply: mastodonStatus.in_reply_to_id || ''
+    }
+  }
+}
+
+export interface UpdateStatusVisibilityParams {
+  statusId: string
+  visibility: MastodonVisibility
+}
+
+export const updateStatusVisibility = async ({
+  statusId,
+  visibility
+}: UpdateStatusVisibilityParams): Promise<boolean> => {
+  try {
+    const response = await fetch(
+      `/api/v1/statuses/${toIdPathSegment(statusId)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ visibility })
+      }
+    )
+    return response.status === 200
+  } catch {
+    return false
+  }
+}
+
+export interface CreatePollParams {
+  message: string
+  contentWarning?: string
+  choices: string[]
+  durationInSeconds: Duration
+  pollType?: 'oneOf' | 'anyOf'
+  replyStatus?: Status
+  visibility?: MastodonVisibility
+}
+
+export const createPoll = async ({
+  message,
+  contentWarning,
+  choices,
+  durationInSeconds,
+  pollType,
+  replyStatus,
+  visibility
+}: CreatePollParams) => {
+  if (message.trim().length === 0 && choices.length === 0) {
+    throw new Error('Message or choices must not be empty')
+  }
+
+  for (const choice of choices) {
+    if (choice.trim().length === 0) {
+      throw new Error('Choice text must not be empty')
+    }
+  }
+
+  const response = await fetch('/api/v1/accounts/outbox', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      type: 'poll',
+      replyStatus,
+      message,
+      contentWarning,
+      durationInSeconds,
+      pollType,
+      choices,
+      visibility
+    })
+  })
+  if (response.status !== 200) {
+    await throwApiError(response, 'Fail to create a new poll')
+  }
+}
+
+export interface DefaultStatusParams {
+  statusId: string
+}
+
+/**
+ * Deletes a status using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/statuses/#delete
+ */
+export const deleteStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  if (response.status !== 200) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
### Task J1 (Batch 1): Extract status operations into lib/client/statuses.ts

- Extracts the first 5 status request operations and their types from `lib/client.ts` into modular `lib/client/statuses.ts`:
  - `createNote`
  - `updateNote`
  - `updateStatusVisibility`
  - `createPoll`
  - `deleteStatus`
- Uses the neutral `lib/client/http.ts` error helper and avoids imports back through the facade.
- Preserves 100% backwards-compatible public re-exports from `lib/client.ts`.
- Adds focused unit tests in `lib/client/statuses.test.ts` and re-export verification in `lib/client.test.ts`.
- Follows full Definition of Done: prettier, lint, typecheck, build, test (1,003 test files, 13,909 tests passed).