### PR TITLE
refactor: extract status repost, translate, capability, and like operations into lib/client/statuses.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -23,7 +23,6 @@ import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
 import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
 import type { StatusReaction as MastodonStatusReaction } from '@/lib/types/mastodon/statusReaction'
 import type { Tag } from '@/lib/types/mastodon/tag'
-import type { Translation } from '@/lib/types/mastodon/translation'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
@@ -41,12 +40,19 @@ import {
   type CreateNoteParams,
   type CreatePollParams,
   type DefaultStatusParams,
+  type TranslateStatusParams,
+  type TranslationCapability,
   type UpdateNoteParams,
   type UpdateNoteResult,
   type UpdateStatusVisibilityParams,
   createNote,
   createPoll,
   deleteStatus,
+  getTranslationCapability,
+  likeStatus,
+  repostStatus,
+  translateStatus,
+  undoRepostStatus,
   updateNote,
   updateStatusVisibility
 } from './client/statuses'
@@ -64,7 +70,14 @@ export {
   type CreatePollParams,
   createPoll,
   type DefaultStatusParams,
-  deleteStatus
+  deleteStatus,
+  repostStatus,
+  undoRepostStatus,
+  type TranslateStatusParams,
+  translateStatus,
+  type TranslationCapability,
+  getTranslationCapability,
+  likeStatus
 }
 
 export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
@@ -106,103 +119,6 @@ export const createReport = async ({
   return response.status === 200
 }
 
-/**
- * Reblogs/reposts a status using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/statuses/#boost
- */
-export const repostStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/reblog`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  if (response.status !== 200) return null
-  const mastodonStatus = await response.json()
-  return { statusId: mastodonStatus.id }
-}
-
-/**
- * Undoes a reblog/repost using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/statuses/#unreblog
- */
-export const undoRepostStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/unreblog`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  if (response.status !== 200) return null
-  const mastodonStatus = await response.json()
-  return { statusId: mastodonStatus.id }
-}
-
-export interface TranslateStatusParams extends DefaultStatusParams {
-  // Target language as an ISO 639-1 code. Omitted lets the server default to
-  // its primary language.
-  language?: string
-}
-
-/**
- * Translates a status using the Mastodon-compatible translate API. Returns the
- * Translation entity, or null when the server cannot translate it (no backend,
- * unsupported language, non-public status, or a backend failure).
- * @see https://docs.joinmastodon.org/methods/statuses/#translate
- */
-export const translateStatus = async ({
-  statusId,
-  language
-}: TranslateStatusParams): Promise<Translation | null> => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/translate`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(language ? { lang: language } : {})
-    }
-  )
-  if (response.status !== 200) return null
-  return (await response.json()) as Translation
-}
-
-export interface TranslationCapability {
-  // Whether a translation backend is configured on this server.
-  enabled: boolean
-  // The server's primary language (ISO 639-1); the default translation target.
-  defaultLanguage: string | null
-}
-
-let translationCapabilityPromise: Promise<TranslationCapability> | null = null
-
-/**
- * Reads the server's translation capability from `/api/v2/instance`, memoized
- * for the session so every post does not refetch it. Used by the Translate
- * control to avoid showing a dead button when no backend is configured.
- */
-export const getTranslationCapability = (): Promise<TranslationCapability> => {
-  if (!translationCapabilityPromise) {
-    translationCapabilityPromise = fetch('/api/v2/instance')
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data) => ({
-        enabled: Boolean(data?.configuration?.translation?.enabled),
-        defaultLanguage: Array.isArray(data?.languages)
-          ? (data.languages[0] ?? null)
-          : null
-      }))
-      .catch(() => ({ enabled: false, defaultLanguage: null }))
-  }
-  return translationCapabilityPromise
-}
-
 // A map of source language (ISO 639-1) → the target languages the configured
 // backend can translate it into.
 export type TranslationLanguages = Record<string, string[]>
@@ -239,23 +155,6 @@ export const getTranslationLanguages = (): Promise<TranslationLanguages> => {
       })
   }
   return translationLanguagesPromise
-}
-
-/**
- * Favourites/likes a status using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/statuses/#favourite
- */
-export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/favourite`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.status === 200
 }
 
 /**

--- a/lib/client/statuses.test.ts
+++ b/lib/client/statuses.test.ts
@@ -4,6 +4,11 @@ import {
   createNote,
   createPoll,
   deleteStatus,
+  getTranslationCapability,
+  likeStatus,
+  repostStatus,
+  translateStatus,
+  undoRepostStatus,
   updateNote,
   updateStatusVisibility
 } from './statuses'
@@ -221,6 +226,126 @@ describe('client statuses module', () => {
       fetchMock.mockResponse('', { status: 404 })
 
       const res = await deleteStatus({ statusId: 'missing-status' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('repostStatus', () => {
+    it('returns new statusId on success', async () => {
+      fetchMock.mockResponse(JSON.stringify({ id: 'boost-123' }), {
+        status: 200
+      })
+
+      const res = await repostStatus({ statusId: 'target-status' })
+      expect(res).toEqual({ statusId: 'boost-123' })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/target-status/reblog',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await repostStatus({ statusId: 'target-status' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('undoRepostStatus', () => {
+    it('returns statusId on success', async () => {
+      fetchMock.mockResponse(JSON.stringify({ id: 'original-123' }), {
+        status: 200
+      })
+
+      const res = await undoRepostStatus({ statusId: 'target-status' })
+      expect(res).toEqual({ statusId: 'original-123' })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/target-status/unreblog',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await undoRepostStatus({ statusId: 'target-status' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('translateStatus', () => {
+    it('returns translation entity when successful', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          content: 'Hello world',
+          detected_source_language: 'es',
+          provider: 'LibreTranslate'
+        }),
+        { status: 200 }
+      )
+
+      const res = await translateStatus({
+        statusId: 'status-1',
+        language: 'en'
+      })
+      expect(res).toEqual({
+        content: 'Hello world',
+        detected_source_language: 'es',
+        provider: 'LibreTranslate'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-1/translate',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ lang: 'en' })
+        })
+      )
+    })
+
+    it('returns null on error', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await translateStatus({ statusId: 'status-1' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('getTranslationCapability', () => {
+    it('returns capability from /api/v2/instance', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          configuration: { translation: { enabled: true } },
+          languages: ['en', 'th']
+        }),
+        { status: 200 }
+      )
+
+      const res = await getTranslationCapability()
+      expect(res).toEqual({
+        enabled: true,
+        defaultLanguage: 'en'
+      })
+      expect(fetchMock).toHaveBeenCalledWith('/api/v2/instance')
+    })
+  })
+
+  describe('likeStatus', () => {
+    it('returns true on 200 OK', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await likeStatus({ statusId: 'status-to-like' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-to-like/favourite',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await likeStatus({ statusId: 'status-to-like' })
       expect(res).toBe(false)
     })
   })

--- a/lib/client/statuses.ts
+++ b/lib/client/statuses.ts
@@ -2,6 +2,7 @@ import { Duration } from '@/lib/services/statuses/pollDurations'
 import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+import type { Translation } from '@/lib/types/mastodon/translation'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
 
@@ -248,4 +249,118 @@ export const deleteStatus = async ({ statusId }: DefaultStatusParams) => {
   }
 
   return true
+}
+
+/**
+ * Reblogs/reposts a status using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/statuses/#boost
+ */
+export const repostStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/reblog`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  if (response.status !== 200) return null
+  const mastodonStatus = await response.json()
+  return { statusId: mastodonStatus.id }
+}
+
+/**
+ * Undoes a reblog/repost using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/statuses/#unreblog
+ */
+export const undoRepostStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/unreblog`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  if (response.status !== 200) return null
+  const mastodonStatus = await response.json()
+  return { statusId: mastodonStatus.id }
+}
+
+export interface TranslateStatusParams extends DefaultStatusParams {
+  // Target language as an ISO 639-1 code. Omitted lets the server default to
+  // its primary language.
+  language?: string
+}
+
+/**
+ * Translates a status using the Mastodon-compatible translate API. Returns the
+ * Translation entity, or null when the server cannot translate it (no backend,
+ * unsupported language, non-public status, or a backend failure).
+ * @see https://docs.joinmastodon.org/methods/statuses/#translate
+ */
+export const translateStatus = async ({
+  statusId,
+  language
+}: TranslateStatusParams): Promise<Translation | null> => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/translate`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(language ? { lang: language } : {})
+    }
+  )
+  if (response.status !== 200) return null
+  return (await response.json()) as Translation
+}
+
+export interface TranslationCapability {
+  // Whether a translation backend is configured on this server.
+  enabled: boolean
+  // The server's primary language (ISO 639-1); the default translation target.
+  defaultLanguage: string | null
+}
+
+let translationCapabilityPromise: Promise<TranslationCapability> | null = null
+
+/**
+ * Reads the server's translation capability from `/api/v2/instance`, memoized
+ * for the session so every post does not refetch it. Used by the Translate
+ * control to avoid showing a dead button when no backend is configured.
+ */
+export const getTranslationCapability = (): Promise<TranslationCapability> => {
+  if (!translationCapabilityPromise) {
+    translationCapabilityPromise = fetch('/api/v2/instance')
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => ({
+        enabled: Boolean(data?.configuration?.translation?.enabled),
+        defaultLanguage: Array.isArray(data?.languages)
+          ? (data.languages[0] ?? null)
+          : null
+      }))
+      .catch(() => ({ enabled: false, defaultLanguage: null }))
+  }
+  return translationCapabilityPromise
+}
+
+/**
+ * Favourites/likes a status using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/statuses/#favourite
+ */
+export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/favourite`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.status === 200
 }


### PR DESCRIPTION
Extracts `repostStatus`, `undoRepostStatus`, `translateStatus`, `getTranslationCapability`, and `likeStatus` plus associated types into `lib/client/statuses.ts` while preserving re-exports from `lib/client.ts`.