### PR TITLE
Bump version to v1.161.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.27",
+  "version": "1.161.28",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.28.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.27`
- Base main SHA: `a6818780735af0497d34bb9380252d7860adbcce`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
