### PR TITLE
test: resolve types for MessagesPage and NotificationItem tests

### DIFF
--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -22,7 +22,7 @@ import {
 import type { DirectConversationView } from '@/lib/client'
 import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 
 import { MessagesPage } from './MessagesPage'
@@ -77,7 +77,7 @@ const account = (id: string, name: string): MastodonAccount =>
     header_static: ''
   }) as MastodonAccount
 
-const status = (id: string, text: string): Status => ({
+const status = (id: string, text: string): StatusNote => ({
   id,
   actorId: currentActor.id,
   actor: currentActor,
@@ -167,7 +167,7 @@ describe('MessagesPage', () => {
       participantName: 'Ada'
     })
     htmlConversation.lastStatus = {
-      ...htmlConversation.lastStatus,
+      ...(htmlConversation.lastStatus as StatusNote),
       text: '<p>Hello <strong>Ada</strong> &amp; Bea</p><p>See &lt;you&gt;</p>'
     }
 
@@ -1060,7 +1060,7 @@ describe('MessagesPage', () => {
   })
 
   it('surfaces non-visual attachments as a download link instead of an empty bubble', async () => {
-    const fileStatus: Status = {
+    const fileStatus: StatusNote = {
       ...status('file-1', ''),
       attachments: [
         {
@@ -1088,7 +1088,7 @@ describe('MessagesPage', () => {
   })
 
   it('renders a fitness file as a card with its filename and metrics', async () => {
-    const fitnessStatus: Status = {
+    const fitnessStatus: StatusNote = {
       ...status('fit-1', ''),
       fitness: {
         id: 'fitness-1',
@@ -1123,7 +1123,7 @@ describe('MessagesPage', () => {
     // `GET /api/v1/fitness-files/:id` is owner-only — so a recipient's copy of
     // the card must not be an anchor. The card itself stays: name, type and
     // metrics are the message's content.
-    const receivedFitnessStatus: Status = {
+    const receivedFitnessStatus: StatusNote = {
       ...status('fit-2', ''),
       actorId: 'https://example.com/users/ada',
       fitness: {

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -24,12 +24,19 @@ const account: Mastodon.Account = {
   username: 'ride',
   acct: 'ride@llun.social',
   url: 'https://llun.social/@ride',
+  uri: 'https://llun.social/users/ride',
   display_name: 'Ride',
   note: '',
   avatar: '',
   avatar_static: '',
+  avatar_description: '',
   header: '',
   header_static: '',
+  header_description: '',
+  roles: [],
+  indexable: false,
+  hide_collections: false,
+  noindex: false,
   locked: false,
   source: {
     note: '',
@@ -37,6 +44,7 @@ const account: Mastodon.Account = {
     privacy: 'public',
     sensitive: false,
     language: 'en',
+    attribution_domains: [],
     follow_requests_count: 0
   },
   fields: [],
@@ -88,26 +96,41 @@ const status: StatusNote = {
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   totalShares: 0,
   attachments: [],
   tags: []
 }
 
-const renderNotificationItem = (notification: NotificationItemNotification) => {
+const renderNotificationItem = (
+  notification: Partial<NotificationItemNotification> &
+    Pick<NotificationItemNotification, 'id' | 'type'>
+) => {
   return renderNotificationItemWithOptions(notification)
 }
 
 const renderNotificationItemWithOptions = (
-  notification: NotificationItemNotification,
+  notification: Partial<NotificationItemNotification> &
+    Pick<NotificationItemNotification, 'id' | 'type'>,
   options: {
     isRead?: boolean
     observeElement?: (element: HTMLElement | null) => void
   } = {}
 ) => {
+  const fullNotification: NotificationItemNotification = {
+    actorId: 'https://llun.social/users/llun',
+    sourceActorId: account.id,
+    isRead: true,
+    filtered: false,
+    createdAt: currentTime,
+    updatedAt: currentTime,
+    account,
+    ...notification
+  }
   return render(
     <NotificationItem
-      notification={notification}
+      notification={fullNotification}
       host="llun.social"
       isRead={options.isRead ?? true}
       currentTime={currentTime}
@@ -327,6 +350,7 @@ describe('NotificationItem', () => {
       type: 'follow_request' as const,
       sourceActorId: account.id,
       isRead: true,
+      filtered: false,
       createdAt: currentTime,
       updatedAt: currentTime,
       account
@@ -634,6 +658,7 @@ describe('NotificationItem', () => {
     type: 'added_to_collection',
     sourceActorId: account.id,
     isRead: true,
+    filtered: false,
     createdAt: currentTime,
     updatedAt: currentTime,
     account,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -16,8 +16,6 @@
     // *.test.ts(x) may appear here. Remove a file in the PR that makes it
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
-    "app/(timeline)/messages/MessagesPage.test.tsx",
-    "app/(timeline)/notifications/NotificationItem.test.tsx",
     "app/(timeline)/notifications/components/FollowNotification.test.tsx",
     "app/(timeline)/notifications/components/FollowRequestNotification.test.tsx",
     "app/(timeline)/search/SearchPageClient.test.tsx",


### PR DESCRIPTION
Resolves typing issues in `app/(timeline)/messages/MessagesPage.test.tsx` and `app/(timeline)/notifications/NotificationItem.test.tsx` and removes them from `tsconfig.typecheck.json` ratchet.