### PR TITLE
refactor: extract status reactions, bookmark, and unlike operations into lib/client/statuses.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -21,7 +21,6 @@ import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
 import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
-import type { StatusReaction as MastodonStatusReaction } from '@/lib/types/mastodon/statusReaction'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
@@ -40,19 +39,25 @@ import {
   type CreateNoteParams,
   type CreatePollParams,
   type DefaultStatusParams,
+  type ReactionUpdateResult,
   type TranslateStatusParams,
   type TranslationCapability,
   type UpdateNoteParams,
   type UpdateNoteResult,
   type UpdateStatusVisibilityParams,
+  bookmarkStatus,
   createNote,
   createPoll,
   deleteStatus,
   getTranslationCapability,
   likeStatus,
+  reactToStatus,
   repostStatus,
   translateStatus,
+  undoBookmarkStatus,
+  undoLikeStatus,
   undoRepostStatus,
+  unreactFromStatus,
   updateNote,
   updateStatusVisibility
 } from './client/statuses'
@@ -77,7 +82,13 @@ export {
   translateStatus,
   type TranslationCapability,
   getTranslationCapability,
-  likeStatus
+  likeStatus,
+  type ReactionUpdateResult,
+  reactToStatus,
+  unreactFromStatus,
+  bookmarkStatus,
+  undoBookmarkStatus,
+  undoLikeStatus
 }
 
 export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
@@ -157,105 +168,6 @@ export const getTranslationLanguages = (): Promise<TranslationLanguages> => {
   return translationLanguagesPromise
 }
 
-/**
- * The outcome of a reaction write. A 4xx that the user cannot retry away (the
- * per-actor cap, an emoji this instance rejects) carries the server's own
- * message so the row can say what actually went wrong instead of inviting a
- * retry that will always fail the same way.
- */
-export type ReactionUpdateResult =
-  | { ok: true; reactions: MastodonStatusReaction[] }
-  | { ok: false; error?: string }
-
-const toReactionUpdateResult = async (
-  response: Response
-): Promise<ReactionUpdateResult> => {
-  if (!response.ok) {
-    // Only a 422 the route deliberately marked with a `reason` carries copy
-    // meant for a person. Every other 4xx answers with the bare HTTP reason
-    // phrase ('Unauthorized', 'Not Found'), which must never be shown as if it
-    // explained the failure — those fall through to the caller's own wording.
-    if (response.status === 422) {
-      const body = (await response.json().catch(() => null)) as {
-        error?: unknown
-        reason?: unknown
-      } | null
-      if (
-        typeof body?.reason === 'string' &&
-        typeof body.error === 'string' &&
-        body.error.length > 0
-      ) {
-        return { ok: false, error: body.error }
-      }
-    }
-    return { ok: false }
-  }
-  const status = (await response.json()) as MastodonStatus
-  return {
-    ok: true,
-    reactions: status.pleroma?.emoji_reactions ?? status.reactions ?? []
-  }
-}
-
-/**
- * Adds the current actor's emoji reaction to a status and returns the updated
- * reaction rollups, or a failure the caller can use to revert its optimistic
- * chip. `name` is a unicode emoji or a local custom-emoji shortcode.
- *
- * Uses the Pleroma/Akkoma dialect, which is the primary reaction surface (the
- * glitch-soc `react`/`unreact` routes are aliases over the same store). This is
- * an ecosystem extension, not core Mastodon API.
- * @see https://docs.akkoma.dev/stable/development/API/pleroma_api/
- */
-export const reactToStatus = async ({
-  statusId,
-  name
-}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
-  const response = await fetch(
-    `/api/v1/pleroma/statuses/${toIdPathSegment(statusId)}/reactions/${encodeURIComponent(name)}`,
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return toReactionUpdateResult(response)
-}
-
-/**
- * Removes the current actor's emoji reaction from a status and returns the
- * updated rollups, or a failure the caller can use to revert.
- */
-export const unreactFromStatus = async ({
-  statusId,
-  name
-}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
-  const response = await fetch(
-    `/api/v1/pleroma/statuses/${toIdPathSegment(statusId)}/reactions/${encodeURIComponent(name)}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return toReactionUpdateResult(response)
-}
-
-export const bookmarkStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/bookmark`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.status === 200
-}
-
 export interface GetStatusFavouritedByParams extends DefaultStatusParams {
   limit?: number
   offset?: number
@@ -324,36 +236,6 @@ export const getStatusFavouritedBy = async ({
     limit: resolvedLimit,
     offset: resolvedOffset
   }
-}
-
-/**
- * Unfavourites/unlikes a status using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/statuses/#unfavourite
- */
-export const undoLikeStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/unfavourite`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.status === 200
-}
-
-export const undoBookmarkStatus = async ({ statusId }: DefaultStatusParams) => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/unbookmark`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.status === 200
 }
 
 interface VotePollParams {

--- a/lib/client/statuses.test.ts
+++ b/lib/client/statuses.test.ts
@@ -1,14 +1,19 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import {
+  bookmarkStatus,
   createNote,
   createPoll,
   deleteStatus,
   getTranslationCapability,
   likeStatus,
+  reactToStatus,
   repostStatus,
   translateStatus,
+  undoBookmarkStatus,
+  undoLikeStatus,
   undoRepostStatus,
+  unreactFromStatus,
   updateNote,
   updateStatusVisibility
 } from './statuses'
@@ -347,6 +352,171 @@ describe('client statuses module', () => {
 
       const res = await likeStatus({ statusId: 'status-to-like' })
       expect(res).toBe(false)
+    })
+  })
+
+  describe('undoLikeStatus', () => {
+    it('returns true on 200 OK', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await undoLikeStatus({ statusId: 'status-to-unlike' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-to-unlike/unfavourite',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await undoLikeStatus({ statusId: 'status-to-unlike' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('bookmarkStatus', () => {
+    it('returns true on 200 OK', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await bookmarkStatus({ statusId: 'status-to-bookmark' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-to-bookmark/bookmark',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await bookmarkStatus({ statusId: 'status-to-bookmark' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('undoBookmarkStatus', () => {
+    it('returns true on 200 OK', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await undoBookmarkStatus({ statusId: 'status-to-unbookmark' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-to-unbookmark/unbookmark',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await undoBookmarkStatus({ statusId: 'status-to-unbookmark' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('reactToStatus', () => {
+    it('returns pleroma emoji_reactions on success', async () => {
+      const reactions = [{ name: '🎉', count: 1, me: true }]
+      fetchMock.mockResponse(
+        JSON.stringify({
+          pleroma: { emoji_reactions: reactions }
+        }),
+        { status: 200 }
+      )
+
+      const res = await reactToStatus({
+        statusId: 'status-1',
+        name: '🎉'
+      })
+
+      expect(res).toEqual({ ok: true, reactions })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/pleroma/statuses/status-1/reactions/%F0%9F%8E%89',
+        expect.objectContaining({
+          method: 'PUT'
+        })
+      )
+    })
+
+    it('returns reactions fallback when pleroma field is missing', async () => {
+      const reactions = [{ name: '❤️', count: 2, me: false }]
+      fetchMock.mockResponse(
+        JSON.stringify({
+          reactions
+        }),
+        { status: 200 }
+      )
+
+      const res = await reactToStatus({
+        statusId: 'status-1',
+        name: '❤️'
+      })
+
+      expect(res).toEqual({ ok: true, reactions })
+    })
+
+    it('returns error from 422 with reason', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          error: 'Reaction limit reached',
+          reason: 'cap_exceeded'
+        }),
+        { status: 422 }
+      )
+
+      const res = await reactToStatus({
+        statusId: 'status-1',
+        name: '🎉'
+      })
+
+      expect(res).toEqual({ ok: false, error: 'Reaction limit reached' })
+    })
+
+    it('returns ok: false on generic failure', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await reactToStatus({
+        statusId: 'status-1',
+        name: '🎉'
+      })
+
+      expect(res).toEqual({ ok: false })
+    })
+  })
+
+  describe('unreactFromStatus', () => {
+    it('removes reaction successfully', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          pleroma: { emoji_reactions: [] }
+        }),
+        { status: 200 }
+      )
+
+      const res = await unreactFromStatus({
+        statusId: 'status-1',
+        name: '🎉'
+      })
+
+      expect(res).toEqual({ ok: true, reactions: [] })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/pleroma/statuses/status-1/reactions/%F0%9F%8E%89',
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      )
+    })
+
+    it('returns ok: false on failure', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await unreactFromStatus({
+        statusId: 'status-1',
+        name: '🎉'
+      })
+
+      expect(res).toEqual({ ok: false })
     })
   })
 })

--- a/lib/client/statuses.ts
+++ b/lib/client/statuses.ts
@@ -2,6 +2,8 @@ import { Duration } from '@/lib/services/statuses/pollDurations'
 import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
+import type { StatusReaction as MastodonStatusReaction } from '@/lib/types/mastodon/statusReaction'
 import type { Translation } from '@/lib/types/mastodon/translation'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
@@ -355,6 +357,135 @@ export const getTranslationCapability = (): Promise<TranslationCapability> => {
 export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
   const response = await fetch(
     `/api/v1/statuses/${toIdPathSegment(statusId)}/favourite`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.status === 200
+}
+
+/**
+ * The outcome of a reaction write. A 4xx that the user cannot retry away (the
+ * per-actor cap, an emoji this instance rejects) carries the server's own
+ * message so the row can say what actually went wrong instead of inviting a
+ * retry that will always fail the same way.
+ */
+export type ReactionUpdateResult =
+  | { ok: true; reactions: MastodonStatusReaction[] }
+  | { ok: false; error?: string }
+
+const toReactionUpdateResult = async (
+  response: Response
+): Promise<ReactionUpdateResult> => {
+  if (!response.ok) {
+    // Only a 422 the route deliberately marked with a `reason` carries copy
+    // meant for a person. Every other 4xx answers with the bare HTTP reason
+    // phrase ('Unauthorized', 'Not Found'), which must never be shown as if it
+    // explained the failure — those fall through to the caller's own wording.
+    if (response.status === 422) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: unknown
+        reason?: unknown
+      } | null
+      if (
+        typeof body?.reason === 'string' &&
+        typeof body.error === 'string' &&
+        body.error.length > 0
+      ) {
+        return { ok: false, error: body.error }
+      }
+    }
+    return { ok: false }
+  }
+  const status = (await response.json()) as MastodonStatus
+  return {
+    ok: true,
+    reactions: status.pleroma?.emoji_reactions ?? status.reactions ?? []
+  }
+}
+
+/**
+ * Adds the current actor's emoji reaction to a status and returns the updated
+ * reaction rollups, or a failure the caller can use to revert its optimistic
+ * chip. `name` is a unicode emoji or a local custom-emoji shortcode.
+ *
+ * Uses the Pleroma/Akkoma dialect, which is the primary reaction surface (the
+ * glitch-soc `react`/`unreact` routes are aliases over the same store). This is
+ * an ecosystem extension, not core Mastodon API.
+ * @see https://docs.akkoma.dev/stable/development/API/pleroma_api/
+ */
+export const reactToStatus = async ({
+  statusId,
+  name
+}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
+  const response = await fetch(
+    `/api/v1/pleroma/statuses/${toIdPathSegment(statusId)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return toReactionUpdateResult(response)
+}
+
+/**
+ * Removes the current actor's emoji reaction from a status and returns the
+ * updated rollups, or a failure the caller can use to revert.
+ */
+export const unreactFromStatus = async ({
+  statusId,
+  name
+}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
+  const response = await fetch(
+    `/api/v1/pleroma/statuses/${toIdPathSegment(statusId)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return toReactionUpdateResult(response)
+}
+
+export const bookmarkStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/bookmark`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.status === 200
+}
+
+export const undoBookmarkStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/unbookmark`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.status === 200
+}
+
+/**
+ * Unfavourites/unlikes a status using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/statuses/#unfavourite
+ */
+export const undoLikeStatus = async ({ statusId }: DefaultStatusParams) => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/unfavourite`,
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Extracts `reactToStatus`, `unreactFromStatus`, `bookmarkStatus`, `undoBookmarkStatus`, and `undoLikeStatus` along with `ReactionUpdateResult` into `lib/client/statuses.ts`. Re-exports them from `lib/client.ts` to preserve backward compatibility.