### PR TITLE
refactor: extract remaining status and quote operations into lib/client/statuses.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -20,7 +20,6 @@ import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
-import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
@@ -43,18 +42,21 @@ import {
   type GetStatusQuotesParams,
   type GetStatusQuotesResult,
   type ReactionUpdateResult,
+  type RevokeStatusQuoteParams,
   type StatusFavouritedByResult,
   type TranslateStatusParams,
   type TranslationCapability,
   type TranslationLanguages,
   type UpdateNoteParams,
   type UpdateNoteResult,
+  type UpdateStatusInteractionPolicyParams,
   type UpdateStatusVisibilityParams,
   type VotePollParams,
   bookmarkStatus,
   createNote,
   createPoll,
   deleteStatus,
+  getDefaultQuotePolicy,
   getStatusById,
   getStatusFavouritedBy,
   getStatusQuotes,
@@ -63,12 +65,15 @@ import {
   likeStatus,
   reactToStatus,
   repostStatus,
+  retryFitnessProcessing,
+  revokeStatusQuote,
   translateStatus,
   undoBookmarkStatus,
   undoLikeStatus,
   undoRepostStatus,
   unreactFromStatus,
   updateNote,
+  updateStatusInteractionPolicy,
   updateStatusVisibility,
   votePoll
 } from './client/statuses'
@@ -110,7 +115,13 @@ export {
   type GetStatusQuotesParams,
   type GetStatusQuotesResult,
   getStatusQuotes,
-  getStatusById
+  getStatusById,
+  type RevokeStatusQuoteParams,
+  revokeStatusQuote,
+  type UpdateStatusInteractionPolicyParams,
+  updateStatusInteractionPolicy,
+  getDefaultQuotePolicy,
+  retryFitnessProcessing
 }
 
 export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
@@ -587,59 +598,6 @@ export const getBlocks = async ({
     accounts: (await response.json()) as MastodonAccount[],
     nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
     prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
-  }
-}
-
-export const revokeStatusQuote = async ({
-  quotedStatusId,
-  quotingStatusId
-}: {
-  quotedStatusId: string
-  quotingStatusId: string
-}): Promise<MastodonStatus | null> => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(quotedStatusId)}/quotes/${toIdPathSegment(quotingStatusId)}/revoke`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json' } }
-  )
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonStatus
-}
-
-export const updateStatusInteractionPolicy = async ({
-  statusId,
-  quoteApprovalPolicy
-}: {
-  statusId: string
-  quoteApprovalPolicy: QuoteApprovalPolicy
-}): Promise<MastodonStatus | null> => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/interaction_policy`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ quote_approval_policy: quoteApprovalPolicy })
-    }
-  )
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonStatus
-}
-
-// The default quote-approval policy for new statuses (Mastodon 4.5
-// posting:default:quote_policy). Falls back to 'public' on any failure.
-export const getDefaultQuotePolicy = async (): Promise<QuoteApprovalPolicy> => {
-  try {
-    const response = await fetch('/api/v1/preferences', {
-      method: 'GET',
-      headers: { Accept: 'application/json' }
-    })
-    if (response.status !== 200) return 'public'
-    const preferences = (await response.json()) as Record<string, unknown>
-    const policy = preferences['posting:default:quote_policy']
-    return QuoteApprovalPolicy.safeParse(policy).success
-      ? (policy as QuoteApprovalPolicy)
-      : 'public'
-  } catch {
-    return 'public'
   }
 }
 
@@ -1976,25 +1934,6 @@ export const retryAllFitnessImports = async (): Promise<{
     const errorDetails = await parseApiError(
       response,
       'Failed to retry fitness imports.'
-    )
-    throw new Error(errorDetails)
-  }
-
-  return response.json()
-}
-
-export const retryFitnessProcessing = async (
-  statusId: string
-): Promise<{ statusId: string; retried: number }> => {
-  const response = await fetch(
-    `/api/v1/statuses/${toIdPathSegment(statusId)}/retry-fitness`,
-    { method: 'POST' }
-  )
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to retry fitness processing.'
     )
     throw new Error(errorDetails)
   }

--- a/lib/client/statuses.test.ts
+++ b/lib/client/statuses.test.ts
@@ -5,6 +5,7 @@ import {
   createNote,
   createPoll,
   deleteStatus,
+  getDefaultQuotePolicy,
   getStatusById,
   getStatusFavouritedBy,
   getStatusQuotes,
@@ -13,12 +14,15 @@ import {
   likeStatus,
   reactToStatus,
   repostStatus,
+  retryFitnessProcessing,
+  revokeStatusQuote,
   translateStatus,
   undoBookmarkStatus,
   undoLikeStatus,
   undoRepostStatus,
   unreactFromStatus,
   updateNote,
+  updateStatusInteractionPolicy,
   updateStatusVisibility,
   votePoll
 } from './statuses'
@@ -698,6 +702,130 @@ describe('client statuses module', () => {
 
       const res = await getStatusById('missing-status')
       expect(res).toBeNull()
+    })
+  })
+
+  describe('revokeStatusQuote', () => {
+    it('revokes quote successfully', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ id: 'quoted-1', text: 'Quoted' }),
+        { status: 200 }
+      )
+
+      const res = await revokeStatusQuote({
+        quotedStatusId: 'quoted-1',
+        quotingStatusId: 'quoting-2'
+      })
+      expect(res).toEqual({ id: 'quoted-1', text: 'Quoted' })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/quoted-1/quotes/quoting-2/revoke',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns null on error', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await revokeStatusQuote({
+        quotedStatusId: 'quoted-1',
+        quotingStatusId: 'quoting-2'
+      })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('updateStatusInteractionPolicy', () => {
+    it('updates policy successfully', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ id: 'status-1', text: 'Status' }),
+        { status: 200 }
+      )
+
+      const res = await updateStatusInteractionPolicy({
+        statusId: 'status-1',
+        quoteApprovalPolicy: 'nobody'
+      })
+      expect(res).toEqual({ id: 'status-1', text: 'Status' })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-1/interaction_policy',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quote_approval_policy: 'nobody' })
+        })
+      )
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+
+      const res = await updateStatusInteractionPolicy({
+        statusId: 'status-1',
+        quoteApprovalPolicy: 'nobody'
+      })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('getDefaultQuotePolicy', () => {
+    it('returns preferences policy when valid', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ 'posting:default:quote_policy': 'followers' }),
+        { status: 200 }
+      )
+
+      const policy = await getDefaultQuotePolicy()
+      expect(policy).toBe('followers')
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/preferences',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('falls back to public on failure or invalid policy', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+      const policy1 = await getDefaultQuotePolicy()
+      expect(policy1).toBe('public')
+
+      fetchMock.mockResponse(
+        JSON.stringify({ 'posting:default:quote_policy': 'invalid-choice' }),
+        { status: 200 }
+      )
+      const policy2 = await getDefaultQuotePolicy()
+      expect(policy2).toBe('public')
+    })
+  })
+
+  describe('retryFitnessProcessing', () => {
+    it('sends POST and returns payload on success', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ statusId: 'status-123', retried: 1 }),
+        { status: 200 }
+      )
+
+      const res = await retryFitnessProcessing('status-123')
+      expect(res).toEqual({ statusId: 'status-123', retried: 1 })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses/status-123/retry-fitness',
+        { method: 'POST' }
+      )
+    })
+
+    it('throws on non-ok response', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ error: 'Processing retry failed' }),
+        { status: 400 }
+      )
+
+      await expect(retryFitnessProcessing('status-123')).rejects.toThrow(
+        'Processing retry failed'
+      )
     })
   })
 })

--- a/lib/client/statuses.ts
+++ b/lib/client/statuses.ts
@@ -9,7 +9,7 @@ import type { Translation } from '@/lib/types/mastodon/translation'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
 
-import { throwApiError } from './http'
+import { parseApiError, throwApiError } from './http'
 
 export interface CreateNoteParams {
   message: string
@@ -698,4 +698,80 @@ export const getStatusById = async (
   )
   if (response.status !== 200) return null
   return (await response.json()) as MastodonStatus
+}
+
+export interface RevokeStatusQuoteParams {
+  quotedStatusId: string
+  quotingStatusId: string
+}
+
+export const revokeStatusQuote = async ({
+  quotedStatusId,
+  quotingStatusId
+}: RevokeStatusQuoteParams): Promise<MastodonStatus | null> => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(quotedStatusId)}/quotes/${toIdPathSegment(quotingStatusId)}/revoke`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+  )
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonStatus
+}
+
+export interface UpdateStatusInteractionPolicyParams {
+  statusId: string
+  quoteApprovalPolicy: QuoteApprovalPolicy
+}
+
+export const updateStatusInteractionPolicy = async ({
+  statusId,
+  quoteApprovalPolicy
+}: UpdateStatusInteractionPolicyParams): Promise<MastodonStatus | null> => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/interaction_policy`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quote_approval_policy: quoteApprovalPolicy })
+    }
+  )
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonStatus
+}
+
+// The default quote-approval policy for new statuses (Mastodon 4.5
+// posting:default:quote_policy). Falls back to 'public' on any failure.
+export const getDefaultQuotePolicy = async (): Promise<QuoteApprovalPolicy> => {
+  try {
+    const response = await fetch('/api/v1/preferences', {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    })
+    if (response.status !== 200) return 'public'
+    const preferences = (await response.json()) as Record<string, unknown>
+    const policy = preferences['posting:default:quote_policy']
+    return QuoteApprovalPolicy.safeParse(policy).success
+      ? (policy as QuoteApprovalPolicy)
+      : 'public'
+  } catch {
+    return 'public'
+  }
+}
+
+export const retryFitnessProcessing = async (
+  statusId: string
+): Promise<{ statusId: string; retried: number }> => {
+  const response = await fetch(
+    `/api/v1/statuses/${toIdPathSegment(statusId)}/retry-fitness`,
+    { method: 'POST' }
+  )
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to retry fitness processing.'
+    )
+    throw new Error(errorDetails)
+  }
+
+  return response.json()
 }


### PR DESCRIPTION
Extracts remaining status and quote operations (`revokeStatusQuote`, `updateStatusInteractionPolicy`, `getDefaultQuotePolicy`, `retryFitnessProcessing`) into `lib/client/statuses.ts` and re-exports them from `lib/client.ts` as part of Task J1.