### PR TITLE
test: resolve types for userinfo and fitness heatmap route tests

### DIFF
--- a/app/api/oauth/userinfo/route.test.ts
+++ b/app/api/oauth/userinfo/route.test.ts
@@ -49,6 +49,7 @@ const makeAccount = (overrides: Partial<Account> = {}): Account => {
     // default-filled `verifiedAt` this fixture used to rely on.
     emailVerified: true,
     emailVerifiedAt: now,
+    twoFactorEnabled: false,
     createdAt: now,
     updatedAt: now,
     ...overrides
@@ -61,16 +62,19 @@ const makeActor = (account: Account | null): Actor => ({
   domain: 'example.com',
   name: 'Test User',
   iconUrl: 'https://example.com/avatar.png',
-  headerImageUrl: null,
   summary: 'A test user',
   followersUrl: 'https://example.com/users/testuser/followers',
   inboxUrl: 'https://example.com/users/testuser/inbox',
   sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
   publicKey: 'public-key',
   privateKey: 'private-key',
   createdAt: Date.now(),
   updatedAt: Date.now(),
-  ...(account ? { account } : { account: null })
+  account: account ?? undefined
 })
 
 const callGet = () =>

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
@@ -78,6 +78,7 @@ describe('/api/v1/accounts/[id]/fitness-heatmap legacy adapter', () => {
       segments: [],
       activityCount: 1,
       pointCount: 2,
+      totalCount: 1,
       cursorOffset: 0,
       isPartial: false,
       createdAt: createdTime,

--- a/app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts
@@ -60,6 +60,7 @@ describe('/api/v1/accounts/[id]/fitness-heatmaps legacy adapter', () => {
         status: 'completed',
         activityCount: 1,
         pointCount: 2,
+        totalCount: 1,
         cursorOffset: 0,
         isPartial: false,
         createdAt: createdTime,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/oauth/userinfo/route.test.ts",
-    "app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts",
-    "app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts",
     "app/api/v1/accounts/[id]/fitness-route-heatmap/route.test.ts",
     "app/api/v1/accounts/[id]/follow/route.test.ts",
     "app/api/v1/accounts/[id]/statuses/route.test.ts",


### PR DESCRIPTION
Resolves types in `app/api/oauth/userinfo/route.test.ts`, `app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts`, and `app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts`, removing all three from `tsconfig.typecheck.json` as part of Task H2 (Batch 9).