### PR TITLE
refactor: extract initial account and follow operations into lib/client/accounts.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -33,6 +33,17 @@ import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { idToUrl, toIdPathSegment } from '@/lib/utils/urlToId'
 import { waitFor } from '@/lib/utils/waitFor'
 
+import {
+  type CreateReportParams,
+  type FollowParams,
+  type FollowStatusType,
+  type ReportCategory,
+  createReport,
+  follow,
+  getFollowStatus,
+  isFollowing,
+  unfollow
+} from './client/accounts'
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
 import {
   type CreateNoteParams,
@@ -124,125 +135,16 @@ export {
   retryFitnessProcessing
 }
 
-export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
-
-interface CreateReportParams {
-  targetActorId: string
-  statusId?: string
-  category?: ReportCategory
-  comment?: string
-}
-
-/**
- * Reports an account (optionally tied to a status) using the
- * Mastodon-compatible reports API.
- * @see https://docs.joinmastodon.org/methods/reports/#post
- */
-export const createReport = async ({
-  targetActorId,
-  statusId,
-  category,
-  comment
-}: CreateReportParams): Promise<boolean> => {
-  const response = await fetch('/api/v1/reports', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    // Ids in a JSON body are never re-encoded: /api/v1/reports resolves
-    // `account_id`/`status_ids` through resolveActorIdParam /
-    // resolveStatusIdParams, which take a publicId, a legacy colon/`apurl_`
-    // id, or a raw AP URI as-is.
-    body: JSON.stringify({
-      account_id: targetActorId,
-      ...(statusId ? { status_ids: [statusId] } : {}),
-      ...(category ? { category } : {}),
-      ...(comment ? { comment } : {})
-    })
-  })
-  return response.status === 200
-}
-
-interface FollowParams {
-  targetActorId: string
-}
-
-export type FollowStatusType = 'not_following' | 'requested' | 'following'
-
-/**
- * Gets the follow status of the current user to the target actor
- * @returns 'following' if actively following, 'requested' if follow is pending approval, 'not_following' otherwise
- * @see https://docs.joinmastodon.org/methods/accounts/#relationships
- */
-export const getFollowStatus = async ({
-  targetActorId
-}: FollowParams): Promise<FollowStatusType> => {
-  const response = await fetch(
-    `/api/v1/accounts/relationships?id[]=${encodeURIComponent(targetActorId)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-  if (response.status !== 200) {
-    return 'not_following'
-  }
-
-  const relationships = await response.json()
-  if (!relationships.length) return 'not_following'
-
-  const relationship = relationships[0]
-  if (relationship.following === true) {
-    return 'following'
-  }
-  if (relationship.requested === true) {
-    return 'requested'
-  }
-  return 'not_following'
-}
-
-/**
- * Checks if current user is following the target actor using Mastodon-compatible API
- * @deprecated Use getFollowStatus for more detailed status including pending requests
- * @see https://docs.joinmastodon.org/methods/accounts/#relationships
- */
-export const isFollowing = async ({ targetActorId }: FollowParams) => {
-  const status = await getFollowStatus({ targetActorId })
-  return status === 'following'
-}
-
-/**
- * Follows an account using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/accounts/#follow
- */
-export const follow = async ({ targetActorId }: FollowParams) => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/follow`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return false
-  return true
-}
-
-/**
- * Unfollows an account using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/accounts/#unfollow
- */
-export const unfollow = async ({ targetActorId }: FollowParams) => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/unfollow`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return false
-  return true
+export {
+  type CreateReportParams,
+  type FollowParams,
+  type FollowStatusType,
+  type ReportCategory,
+  createReport,
+  follow,
+  getFollowStatus,
+  isFollowing,
+  unfollow
 }
 
 interface FollowRequestParams {

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -1,0 +1,171 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  createReport,
+  follow,
+  getFollowStatus,
+  isFollowing,
+  unfollow
+} from './accounts'
+
+enableFetchMocks()
+
+describe('client accounts module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('createReport', () => {
+    it('creates report and returns true on 200', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await createReport({
+        targetActorId: 'actor-123',
+        statusId: 'status-456',
+        category: 'spam',
+        comment: 'Spam post'
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/reports',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            account_id: 'actor-123',
+            status_ids: ['status-456'],
+            category: 'spam',
+            comment: 'Spam post'
+          })
+        })
+      )
+    })
+
+    it('returns false on non-200 status', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+
+      const res = await createReport({ targetActorId: 'actor-123' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('getFollowStatus', () => {
+    it('returns following when following is true', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify([
+          { id: 'actor-123', following: true, requested: false }
+        ]),
+        { status: 200 }
+      )
+
+      const res = await getFollowStatus({ targetActorId: 'actor-123' })
+      expect(res).toBe('following')
+    })
+
+    it('returns requested when requested is true', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify([
+          { id: 'actor-123', following: false, requested: true }
+        ]),
+        { status: 200 }
+      )
+
+      const res = await getFollowStatus({ targetActorId: 'actor-123' })
+      expect(res).toBe('requested')
+    })
+
+    it('returns not_following when relationship not present or neither flag is set', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify([
+          { id: 'actor-123', following: false, requested: false }
+        ]),
+        { status: 200 }
+      )
+
+      const res = await getFollowStatus({ targetActorId: 'actor-123' })
+      expect(res).toBe('not_following')
+
+      fetchMock.mockResponse(JSON.stringify([]), { status: 200 })
+      const resEmpty = await getFollowStatus({ targetActorId: 'actor-123' })
+      expect(resEmpty).toBe('not_following')
+    })
+
+    it('returns not_following on non-200 status', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await getFollowStatus({ targetActorId: 'actor-123' })
+      expect(res).toBe('not_following')
+    })
+  })
+
+  describe('isFollowing', () => {
+    it('returns true when getFollowStatus is following', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify([{ id: 'actor-123', following: true }]),
+        { status: 200 }
+      )
+
+      const res = await isFollowing({ targetActorId: 'actor-123' })
+      expect(res).toBe(true)
+    })
+
+    it('returns false when getFollowStatus is not following', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify([
+          { id: 'actor-123', following: false, requested: true }
+        ]),
+        { status: 200 }
+      )
+
+      const res = await isFollowing({ targetActorId: 'actor-123' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('follow', () => {
+    it('calls follow endpoint and returns true on 200', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await follow({ targetActorId: 'actor-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-123/follow',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns false on error status', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+
+      const res = await follow({ targetActorId: 'actor-123' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('unfollow', () => {
+    it('calls unfollow endpoint and returns true on 200', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await unfollow({ targetActorId: 'actor-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-123/unfollow',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns false on error status', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+
+      const res = await unfollow({ targetActorId: 'actor-123' })
+      expect(res).toBe(false)
+    })
+  })
+})

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -1,0 +1,122 @@
+import { toIdPathSegment } from '@/lib/utils/urlToId'
+
+export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
+
+export interface CreateReportParams {
+  targetActorId: string
+  statusId?: string
+  category?: ReportCategory
+  comment?: string
+}
+
+/**
+ * Reports an account (optionally tied to a status) using the
+ * Mastodon-compatible reports API.
+ * @see https://docs.joinmastodon.org/methods/reports/#post
+ */
+export const createReport = async ({
+  targetActorId,
+  statusId,
+  category,
+  comment
+}: CreateReportParams): Promise<boolean> => {
+  const response = await fetch('/api/v1/reports', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    // Ids in a JSON body are never re-encoded: /api/v1/reports resolves
+    // `account_id`/`status_ids` through resolveActorIdParam /
+    // resolveStatusIdParams, which take a publicId, a legacy colon/`apurl_`
+    // id, or a raw AP URI as-is.
+    body: JSON.stringify({
+      account_id: targetActorId,
+      ...(statusId ? { status_ids: [statusId] } : {}),
+      ...(category ? { category } : {}),
+      ...(comment ? { comment } : {})
+    })
+  })
+  return response.status === 200
+}
+
+export interface FollowParams {
+  targetActorId: string
+}
+
+export type FollowStatusType = 'not_following' | 'requested' | 'following'
+
+/**
+ * Gets the follow status of the current user to the target actor
+ * @returns 'following' if actively following, 'requested' if follow is pending approval, 'not_following' otherwise
+ * @see https://docs.joinmastodon.org/methods/accounts/#relationships
+ */
+export const getFollowStatus = async ({
+  targetActorId
+}: FollowParams): Promise<FollowStatusType> => {
+  const response = await fetch(
+    `/api/v1/accounts/relationships?id[]=${encodeURIComponent(targetActorId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+  if (response.status !== 200) {
+    return 'not_following'
+  }
+
+  const relationships = await response.json()
+  if (!relationships.length) return 'not_following'
+
+  const relationship = relationships[0]
+  if (relationship.following === true) {
+    return 'following'
+  }
+  if (relationship.requested === true) {
+    return 'requested'
+  }
+  return 'not_following'
+}
+
+/**
+ * Checks if current user is following the target actor using Mastodon-compatible API
+ * @deprecated Use getFollowStatus for more detailed status including pending requests
+ * @see https://docs.joinmastodon.org/methods/accounts/#relationships
+ */
+export const isFollowing = async ({ targetActorId }: FollowParams) => {
+  const status = await getFollowStatus({ targetActorId })
+  return status === 'following'
+}
+
+/**
+ * Follows an account using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/accounts/#follow
+ */
+export const follow = async ({ targetActorId }: FollowParams) => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/follow`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return false
+  return true
+}
+
+/**
+ * Unfollows an account using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/accounts/#unfollow
+ */
+export const unfollow = async ({ targetActorId }: FollowParams) => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/unfollow`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return false
+  return true
+}


### PR DESCRIPTION
Extracts initial account and follow operations (`createReport`, `getFollowStatus`, `isFollowing`, `follow`, `unfollow`) into `lib/client/accounts.ts` and re-exports them from `lib/client.ts` as part of Task J1 (Batch 6).