### PR TITLE
refactor: extract follow request, switch actor, actor domains, and create actor operations into lib/client/accounts.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -34,14 +34,25 @@ import { idToUrl, toIdPathSegment } from '@/lib/utils/urlToId'
 import { waitFor } from '@/lib/utils/waitFor'
 
 import {
+  type ActorDomainsResult,
+  type CreateActorParams,
+  type CreateActorResult,
   type CreateReportParams,
   type FollowParams,
+  type FollowRequestParams,
   type FollowStatusType,
+  type GetActorDomainsParams,
   type ReportCategory,
+  type SwitchActorParams,
+  acceptFollowRequest,
+  createActor,
   createReport,
   follow,
+  getActorDomains,
   getFollowStatus,
   isFollowing,
+  rejectFollowRequest,
+  switchActor,
   unfollow
 } from './client/accounts'
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
@@ -136,132 +147,26 @@ export {
 }
 
 export {
+  type ActorDomainsResult,
+  type CreateActorParams,
+  type CreateActorResult,
   type CreateReportParams,
   type FollowParams,
+  type FollowRequestParams,
   type FollowStatusType,
+  type GetActorDomainsParams,
   type ReportCategory,
+  type SwitchActorParams,
+  acceptFollowRequest,
+  createActor,
   createReport,
   follow,
+  getActorDomains,
   getFollowStatus,
   isFollowing,
+  rejectFollowRequest,
+  switchActor,
   unfollow
-}
-
-interface FollowRequestParams {
-  id: string
-}
-
-const respondToFollowRequest = async (
-  id: string,
-  action: 'authorize' | 'reject'
-) => {
-  const response = await fetch(
-    `/api/v1/follow_requests/${encodeURIComponent(id)}/${action}`,
-    {
-      method: 'POST'
-    }
-  )
-  return response.ok
-}
-
-/**
- * Accepts a pending follow request using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/follow_requests/#accept
- */
-export const acceptFollowRequest = ({ id }: FollowRequestParams) =>
-  respondToFollowRequest(id, 'authorize')
-
-/**
- * Rejects a pending follow request using Mastodon-compatible API
- * @see https://docs.joinmastodon.org/methods/follow_requests/#reject
- */
-export const rejectFollowRequest = ({ id }: FollowRequestParams) =>
-  respondToFollowRequest(id, 'reject')
-
-export interface SwitchActorParams {
-  actorId: string
-}
-
-/**
- * Switches the current session to another actor owned by the account
- */
-export const switchActor = async ({ actorId }: SwitchActorParams) => {
-  const response = await fetch('/api/v1/actors/switch', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ actorId })
-  })
-  return response.ok
-}
-
-export interface ActorDomainsResult {
-  domains: string[]
-  host: string
-}
-
-export interface GetActorDomainsParams {
-  signal?: AbortSignal
-}
-
-/**
- * Fetches the allowed domains for actor creation
- */
-export const getActorDomains = async ({
-  signal
-}: GetActorDomainsParams = {}): Promise<ActorDomainsResult> => {
-  const response = await fetch('/api/v1/actors/domains', {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    },
-    signal
-  })
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to fetch actor domains')
-  }
-
-  const data = await response.json()
-  return {
-    domains: Array.isArray(data?.domains) ? data.domains : [],
-    host: typeof data?.host === 'string' ? data.host : ''
-  }
-}
-
-export interface CreateActorParams {
-  username: string
-  domain?: string
-}
-
-export interface CreateActorResult {
-  id: string
-  username: string
-  domain: string
-}
-
-/**
- * Creates a new actor for the current account
- */
-export const createActor = async ({
-  username,
-  domain
-}: CreateActorParams): Promise<CreateActorResult> => {
-  const response = await fetch('/api/v1/actors', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      username,
-      domain
-    })
-  })
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to create actor')
-  }
-
-  return (await response.json()) as CreateActorResult
 }
 
 export interface CancelActorDeletionParams {

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -1,10 +1,15 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import {
+  acceptFollowRequest,
+  createActor,
   createReport,
   follow,
+  getActorDomains,
   getFollowStatus,
   isFollowing,
+  rejectFollowRequest,
+  switchActor,
   unfollow
 } from './accounts'
 
@@ -166,6 +171,168 @@ describe('client accounts module', () => {
 
       const res = await unfollow({ targetActorId: 'actor-123' })
       expect(res).toBe(false)
+    })
+  })
+
+  describe('acceptFollowRequest', () => {
+    it('calls authorize endpoint and returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await acceptFollowRequest({ id: 'req-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/follow_requests/req-123/authorize',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await acceptFollowRequest({ id: 'req-123' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('rejectFollowRequest', () => {
+    it('calls reject endpoint and returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await rejectFollowRequest({ id: 'req-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/follow_requests/req-123/reject',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await rejectFollowRequest({ id: 'req-123' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('switchActor', () => {
+    it('calls switch endpoint with actorId and returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await switchActor({ actorId: 'actor-456' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/switch',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-456' })
+        })
+      )
+    })
+
+    it('returns false when switch fails', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+
+      const res = await switchActor({ actorId: 'actor-456' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('getActorDomains', () => {
+    it('fetches actor domains successfully', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          domains: ['example.com', 'test.org'],
+          host: 'example.com'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getActorDomains()
+      expect(res).toEqual({
+        domains: ['example.com', 'test.org'],
+        host: 'example.com'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/domains',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('handles missing domains or host gracefully in response', async () => {
+      fetchMock.mockResponse(JSON.stringify({}), { status: 200 })
+
+      const res = await getActorDomains()
+      expect(res).toEqual({
+        domains: [],
+        host: ''
+      })
+    })
+
+    it('throws error when fetch fails', async () => {
+      fetchMock.mockResponse(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401
+      })
+
+      await expect(getActorDomains()).rejects.toThrow('Unauthorized')
+
+      fetchMock.mockResponse(JSON.stringify({}), {
+        status: 500
+      })
+
+      await expect(getActorDomains()).rejects.toThrow(
+        'Failed to fetch actor domains'
+      )
+    })
+  })
+
+  describe('createActor', () => {
+    it('creates actor and returns result on success', async () => {
+      const mockResult = {
+        id: 'actor-new',
+        username: 'alice',
+        domain: 'example.com'
+      }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await createActor({
+        username: 'alice',
+        domain: 'example.com'
+      })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            username: 'alice',
+            domain: 'example.com'
+          })
+        })
+      )
+    })
+
+    it('throws error when actor creation fails', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ error: 'Username already exists' }),
+        { status: 422 }
+      )
+
+      await expect(
+        createActor({ username: 'alice', domain: 'example.com' })
+      ).rejects.toThrow('Username already exists')
+
+      fetchMock.mockResponse(JSON.stringify({}), {
+        status: 500
+      })
+
+      await expect(
+        createActor({ username: 'alice', domain: 'example.com' })
+      ).rejects.toThrow('Failed to create actor')
     })
   })
 })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -1,5 +1,7 @@
 import { toIdPathSegment } from '@/lib/utils/urlToId'
 
+import { throwApiError } from './http'
+
 export type ReportCategory = 'spam' | 'legal' | 'violation' | 'other'
 
 export interface CreateReportParams {
@@ -119,4 +121,121 @@ export const unfollow = async ({ targetActorId }: FollowParams) => {
   })
   if (response.status !== 200) return false
   return true
+}
+
+export interface FollowRequestParams {
+  id: string
+}
+
+const respondToFollowRequest = async (
+  id: string,
+  action: 'authorize' | 'reject'
+) => {
+  const response = await fetch(
+    `/api/v1/follow_requests/${encodeURIComponent(id)}/${action}`,
+    {
+      method: 'POST'
+    }
+  )
+  return response.ok
+}
+
+/**
+ * Accepts a pending follow request using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/follow_requests/#accept
+ */
+export const acceptFollowRequest = ({ id }: FollowRequestParams) =>
+  respondToFollowRequest(id, 'authorize')
+
+/**
+ * Rejects a pending follow request using Mastodon-compatible API
+ * @see https://docs.joinmastodon.org/methods/follow_requests/#reject
+ */
+export const rejectFollowRequest = ({ id }: FollowRequestParams) =>
+  respondToFollowRequest(id, 'reject')
+
+export interface SwitchActorParams {
+  actorId: string
+}
+
+/**
+ * Switches the current session to another actor owned by the account
+ */
+export const switchActor = async ({ actorId }: SwitchActorParams) => {
+  const response = await fetch('/api/v1/actors/switch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ actorId })
+  })
+  return response.ok
+}
+
+export interface ActorDomainsResult {
+  domains: string[]
+  host: string
+}
+
+export interface GetActorDomainsParams {
+  signal?: AbortSignal
+}
+
+/**
+ * Fetches the allowed domains for actor creation
+ */
+export const getActorDomains = async ({
+  signal
+}: GetActorDomainsParams = {}): Promise<ActorDomainsResult> => {
+  const response = await fetch('/api/v1/actors/domains', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    },
+    signal
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to fetch actor domains')
+  }
+
+  const data = await response.json()
+  return {
+    domains: Array.isArray(data?.domains) ? data.domains : [],
+    host: typeof data?.host === 'string' ? data.host : ''
+  }
+}
+
+export interface CreateActorParams {
+  username: string
+  domain?: string
+}
+
+export interface CreateActorResult {
+  id: string
+  username: string
+  domain: string
+}
+
+/**
+ * Creates a new actor for the current account
+ */
+export const createActor = async ({
+  username,
+  domain
+}: CreateActorParams): Promise<CreateActorResult> => {
+  const response = await fetch('/api/v1/actors', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      username,
+      domain
+    })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to create actor')
+  }
+
+  return (await response.json()) as CreateActorResult
 }


### PR DESCRIPTION
Part of Task J1 (Batch 7): extract next 5 operations into `lib/client/accounts.ts` and re-export from facade.

- Extract `acceptFollowRequest`
- Extract `rejectFollowRequest`
- Extract `switchActor`
- Extract `getActorDomains`
- Extract `createActor`
- Add unit tests for all 5 operations in `lib/client/accounts.test.ts`
- Re-export all operations and their types from `lib/client.ts`.