### PR TITLE
test: resolve types for connected-apps, email-notifications, and email route tests

### DIFF
--- a/app/api/v1/accounts/connected-apps/[clientId]/route.test.ts
+++ b/app/api/v1/accounts/connected-apps/[clientId]/route.test.ts
@@ -38,10 +38,25 @@ vi.mock('next/headers', () => ({
 const account = {
   id: 'account-1',
   email: seedActor1.email,
-  defaultActorId: ACTOR1_ID
+  defaultActorId: ACTOR1_ID,
+  twoFactorEnabled: false,
+  emailVerified: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
 }
 
-const actor = { ...seedActor1, id: ACTOR1_ID, account }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  account,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 const buildRequest = (url: string) =>
   new NextRequest(url, {

--- a/app/api/v1/accounts/email-notifications/route.test.ts
+++ b/app/api/v1/accounts/email-notifications/route.test.ts
@@ -39,7 +39,17 @@ vi.mock('next/headers', () => ({
   })
 }))
 
-const actor = { ...seedActor1, id: ACTOR1_ID }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 describe('POST /api/v1/accounts/email-notifications', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
@@ -62,11 +72,15 @@ describe('POST /api/v1/accounts/email-notifications', () => {
     mockDb.getAccountFromEmail.mockResolvedValue({
       id: 'account1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
     })
     mockDb.getActorsForAccount.mockResolvedValue([actor])
     mockDb.getActorFromId.mockResolvedValue(actor)
-    mockDb.getActorSettings.mockResolvedValue(null)
+    mockDb.getActorSettings.mockResolvedValue(undefined)
     mockDb.updateActor.mockResolvedValue(undefined as never)
   })
 

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -50,6 +50,8 @@ const account = {
   id: 'account-1',
   email: seedActor1.email,
   defaultActorId: ACTOR1_ID,
+  twoFactorEnabled: false,
+  emailVerified: true,
   createdAt: Date.now(),
   updatedAt: Date.now()
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/accounts/connected-apps/[clientId]/route.test.ts",
-    "app/api/v1/accounts/email-notifications/route.test.ts",
-    "app/api/v1/accounts/email/route.test.ts",
     "app/api/v1/accounts/email/verify/route.test.ts",
     "app/api/v1/accounts/lookup/route.test.ts",
     "app/api/v1/accounts/navigation-preferences/route.test.ts",


### PR DESCRIPTION
Part of Task H2 (Batch 11): resolve types for excluded test files and shrink ratchet in tsconfig.typecheck.json.

- Resolve types in `app/api/v1/accounts/connected-apps/[clientId]/route.test.ts`
- Resolve types in `app/api/v1/accounts/email-notifications/route.test.ts`
- Resolve types in `app/api/v1/accounts/email/route.test.ts`
- Remove all 3 files from `tsconfig.typecheck.json` exclusion list.