### PR TITLE
refactor: extract cancel actor deletion, set default actor, delete actor, delete account media, and get relationship operations into lib/client/accounts.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -35,23 +35,35 @@ import { waitFor } from '@/lib/utils/waitFor'
 
 import {
   type ActorDomainsResult,
+  type CancelActorDeletionParams,
+  type CancelActorDeletionResult,
   type CreateActorParams,
   type CreateActorResult,
   type CreateReportParams,
+  type DeleteAccountMediaParams,
+  type DeleteActorParams,
+  type DeleteActorResult,
   type FollowParams,
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
   type ReportCategory,
+  type SetDefaultActorParams,
+  type SetDefaultActorResult,
   type SwitchActorParams,
   acceptFollowRequest,
+  cancelActorDeletion,
   createActor,
   createReport,
+  deleteAccountMedia,
+  deleteActor,
   follow,
   getActorDomains,
   getFollowStatus,
+  getRelationship,
   isFollowing,
   rejectFollowRequest,
+  setDefaultActor,
   switchActor,
   unfollow
 } from './client/accounts'
@@ -148,145 +160,37 @@ export {
 
 export {
   type ActorDomainsResult,
+  type CancelActorDeletionParams,
+  type CancelActorDeletionResult,
   type CreateActorParams,
   type CreateActorResult,
   type CreateReportParams,
+  type DeleteAccountMediaParams,
+  type DeleteActorParams,
+  type DeleteActorResult,
   type FollowParams,
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
   type ReportCategory,
+  type SetDefaultActorParams,
+  type SetDefaultActorResult,
   type SwitchActorParams,
   acceptFollowRequest,
+  cancelActorDeletion,
   createActor,
   createReport,
+  deleteAccountMedia,
+  deleteActor,
   follow,
   getActorDomains,
   getFollowStatus,
+  getRelationship,
   isFollowing,
   rejectFollowRequest,
+  setDefaultActor,
   switchActor,
   unfollow
-}
-
-export interface CancelActorDeletionParams {
-  actorId: string
-}
-
-export interface CancelActorDeletionResult {
-  actorId: string
-  status: string
-}
-
-/**
- * Cancels a scheduled actor deletion
- */
-export const cancelActorDeletion = async ({
-  actorId
-}: CancelActorDeletionParams): Promise<CancelActorDeletionResult> => {
-  const response = await fetch('/api/v1/actors/cancel-deletion', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ actorId })
-  })
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to cancel actor deletion')
-  }
-
-  return (await response.json()) as CancelActorDeletionResult
-}
-
-export interface SetDefaultActorParams {
-  actorId: string
-}
-
-export interface SetDefaultActorResult {
-  defaultActorId: string
-  id: string
-  username: string
-  domain: string
-}
-
-/**
- * Sets the default actor for the current account
- */
-export const setDefaultActor = async ({
-  actorId
-}: SetDefaultActorParams): Promise<SetDefaultActorResult> => {
-  const response = await fetch('/api/v1/actors/default', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ actorId })
-  })
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to update default actor')
-  }
-
-  return (await response.json()) as SetDefaultActorResult
-}
-
-export interface DeleteActorParams {
-  actorId: string
-  delayDays?: number
-}
-
-export interface DeleteActorResult {
-  actorId: string
-  status: string
-  scheduledAt: string | null
-  immediate: boolean
-}
-
-/**
- * Schedules or immediately executes deletion of an actor
- */
-export const deleteActor = async ({
-  actorId,
-  delayDays = 0
-}: DeleteActorParams): Promise<DeleteActorResult> => {
-  const response = await fetch('/api/v1/actors/delete', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ actorId, delayDays })
-  })
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to delete actor')
-  }
-
-  return (await response.json()) as DeleteActorResult
-}
-
-export interface DeleteAccountMediaParams {
-  mediaId: string
-}
-
-/**
- * Deletes a media item owned by the current account
- */
-export const deleteAccountMedia = async ({
-  mediaId
-}: DeleteAccountMediaParams): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/accounts/media/${encodeURIComponent(mediaId)}`,
-    {
-      method: 'DELETE'
-    }
-  )
-
-  if (!response.ok) {
-    await throwApiError(response, 'Failed to delete media')
-  }
-
-  return true
 }
 
 interface MarkNotificationsReadParams {
@@ -309,24 +213,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-export const getRelationship = async ({
-  targetActorId
-}: FollowParams): Promise<MastodonRelationship | null> => {
-  const response = await fetch(
-    `/api/v1/accounts/relationships?id[]=${encodeURIComponent(targetActorId)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-  if (response.status !== 200) return null
-
-  const relationships = (await response.json()) as MastodonRelationship[]
-  return relationships[0] ?? null
 }
 
 export const block = async ({

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -2,13 +2,18 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import {
   acceptFollowRequest,
+  cancelActorDeletion,
   createActor,
   createReport,
+  deleteAccountMedia,
+  deleteActor,
   follow,
   getActorDomains,
   getFollowStatus,
+  getRelationship,
   isFollowing,
   rejectFollowRequest,
+  setDefaultActor,
   switchActor,
   unfollow
 } from './accounts'
@@ -333,6 +338,204 @@ describe('client accounts module', () => {
       await expect(
         createActor({ username: 'alice', domain: 'example.com' })
       ).rejects.toThrow('Failed to create actor')
+    })
+  })
+
+  describe('cancelActorDeletion', () => {
+    it('cancels deletion and returns result on success', async () => {
+      const mockResult = { actorId: 'actor-1', status: 'cancelled' }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await cancelActorDeletion({ actorId: 'actor-1' })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/cancel-deletion',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1' })
+        })
+      )
+    })
+
+    it('throws error when cancel deletion fails', async () => {
+      fetchMock.mockResponse(JSON.stringify({ error: 'Not scheduled' }), {
+        status: 400
+      })
+
+      await expect(cancelActorDeletion({ actorId: 'actor-1' })).rejects.toThrow(
+        'Not scheduled'
+      )
+
+      fetchMock.mockResponse(JSON.stringify({}), { status: 500 })
+      await expect(cancelActorDeletion({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to cancel actor deletion'
+      )
+    })
+  })
+
+  describe('setDefaultActor', () => {
+    it('sets default actor and returns result on success', async () => {
+      const mockResult = {
+        defaultActorId: 'actor-1',
+        id: 'actor-1',
+        username: 'alice',
+        domain: 'example.com'
+      }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await setDefaultActor({ actorId: 'actor-1' })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/default',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1' })
+        })
+      )
+    })
+
+    it('throws error when updating default actor fails', async () => {
+      fetchMock.mockResponse(JSON.stringify({ error: 'Actor not found' }), {
+        status: 404
+      })
+
+      await expect(setDefaultActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Actor not found'
+      )
+
+      fetchMock.mockResponse(JSON.stringify({}), { status: 500 })
+      await expect(setDefaultActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to update default actor'
+      )
+    })
+  })
+
+  describe('deleteActor', () => {
+    it('schedules deletion and returns result on success', async () => {
+      const mockResult = {
+        actorId: 'actor-1',
+        status: 'scheduled',
+        scheduledAt: '2026-09-14T00:00:00Z',
+        immediate: false
+      }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await deleteActor({ actorId: 'actor-1', delayDays: 7 })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/delete',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ actorId: 'actor-1', delayDays: 7 })
+        })
+      )
+    })
+
+    it('defaults delayDays to 0 when omitted', async () => {
+      const mockResult = {
+        actorId: 'actor-1',
+        status: 'deleted',
+        scheduledAt: null,
+        immediate: true
+      }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await deleteActor({ actorId: 'actor-1' })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/actors/delete',
+        expect.objectContaining({
+          body: JSON.stringify({ actorId: 'actor-1', delayDays: 0 })
+        })
+      )
+    })
+
+    it('throws error when deletion fails', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ error: 'Cannot delete default actor' }),
+        {
+          status: 422
+        }
+      )
+
+      await expect(deleteActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Cannot delete default actor'
+      )
+
+      fetchMock.mockResponse(JSON.stringify({}), { status: 500 })
+      await expect(deleteActor({ actorId: 'actor-1' })).rejects.toThrow(
+        'Failed to delete actor'
+      )
+    })
+  })
+
+  describe('deleteAccountMedia', () => {
+    it('deletes media and returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await deleteAccountMedia({ mediaId: 'media-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/media/media-123',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('throws error when delete media fails', async () => {
+      fetchMock.mockResponse(JSON.stringify({ error: 'Media not found' }), {
+        status: 404
+      })
+
+      await expect(
+        deleteAccountMedia({ mediaId: 'media-123' })
+      ).rejects.toThrow('Media not found')
+
+      fetchMock.mockResponse(JSON.stringify({}), { status: 500 })
+      await expect(
+        deleteAccountMedia({ mediaId: 'media-123' })
+      ).rejects.toThrow('Failed to delete media')
+    })
+  })
+
+  describe('getRelationship', () => {
+    it('fetches and returns relationship object on 200', async () => {
+      const mockRelationship = {
+        id: 'actor-target',
+        following: true,
+        followedBy: false,
+        blocking: false,
+        muting: false
+      }
+      fetchMock.mockResponse(JSON.stringify([mockRelationship]), {
+        status: 200
+      })
+
+      const res = await getRelationship({ targetActorId: 'actor-target' })
+      expect(res).toEqual(mockRelationship)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/relationships?id[]=actor-target',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns null when response is not 200', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await getRelationship({ targetActorId: 'actor-target' })
+      expect(res).toBeNull()
+    })
+
+    it('returns null when relationships array is empty', async () => {
+      fetchMock.mockResponse(JSON.stringify([]), { status: 200 })
+
+      const res = await getRelationship({ targetActorId: 'actor-target' })
+      expect(res).toBeNull()
     })
   })
 })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -1,3 +1,4 @@
+import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
 
 import { throwApiError } from './http'
@@ -238,4 +239,146 @@ export const createActor = async ({
   }
 
   return (await response.json()) as CreateActorResult
+}
+
+export interface CancelActorDeletionParams {
+  actorId: string
+}
+
+export interface CancelActorDeletionResult {
+  actorId: string
+  status: string
+}
+
+/**
+ * Cancels a scheduled actor deletion
+ */
+export const cancelActorDeletion = async ({
+  actorId
+}: CancelActorDeletionParams): Promise<CancelActorDeletionResult> => {
+  const response = await fetch('/api/v1/actors/cancel-deletion', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to cancel actor deletion')
+  }
+
+  return (await response.json()) as CancelActorDeletionResult
+}
+
+export interface SetDefaultActorParams {
+  actorId: string
+}
+
+export interface SetDefaultActorResult {
+  defaultActorId: string
+  id: string
+  username: string
+  domain: string
+}
+
+/**
+ * Sets the default actor for the current account
+ */
+export const setDefaultActor = async ({
+  actorId
+}: SetDefaultActorParams): Promise<SetDefaultActorResult> => {
+  const response = await fetch('/api/v1/actors/default', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to update default actor')
+  }
+
+  return (await response.json()) as SetDefaultActorResult
+}
+
+export interface DeleteActorParams {
+  actorId: string
+  delayDays?: number
+}
+
+export interface DeleteActorResult {
+  actorId: string
+  status: string
+  scheduledAt: string | null
+  immediate: boolean
+}
+
+/**
+ * Schedules or immediately executes deletion of an actor
+ */
+export const deleteActor = async ({
+  actorId,
+  delayDays = 0
+}: DeleteActorParams): Promise<DeleteActorResult> => {
+  const response = await fetch('/api/v1/actors/delete', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ actorId, delayDays })
+  })
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to delete actor')
+  }
+
+  return (await response.json()) as DeleteActorResult
+}
+
+export interface DeleteAccountMediaParams {
+  mediaId: string
+}
+
+/**
+ * Deletes a media item owned by the current account
+ */
+export const deleteAccountMedia = async ({
+  mediaId
+}: DeleteAccountMediaParams): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/accounts/media/${encodeURIComponent(mediaId)}`,
+    {
+      method: 'DELETE'
+    }
+  )
+
+  if (!response.ok) {
+    await throwApiError(response, 'Failed to delete media')
+  }
+
+  return true
+}
+
+/**
+ * Gets relationship between current user and target actor
+ * @see https://docs.joinmastodon.org/methods/accounts/#relationships
+ */
+export const getRelationship = async ({
+  targetActorId
+}: FollowParams): Promise<MastodonRelationship | null> => {
+  const response = await fetch(
+    `/api/v1/accounts/relationships?id[]=${encodeURIComponent(targetActorId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+  if (response.status !== 200) return null
+
+  const relationships = (await response.json()) as MastodonRelationship[]
+  return relationships[0] ?? null
 }


### PR DESCRIPTION
Part of Task J1 (Batch 8): extract next 5 operations into `lib/client/accounts.ts` and re-export from facade.

- Extract `cancelActorDeletion`
- Extract `setDefaultActor`
- Extract `deleteActor`
- Extract `deleteAccountMedia`
- Extract `getRelationship`
- Add unit tests for all 5 operations in `lib/client/accounts.test.ts`
- Re-export all operations and their types from `lib/client.ts`.