### PR TITLE
test: resolve types for email verify, lookup, and navigation preferences route tests

### DIFF
--- a/app/api/v1/accounts/email/verify/route.test.ts
+++ b/app/api/v1/accounts/email/verify/route.test.ts
@@ -39,6 +39,8 @@ const account = {
   id: 'account-1',
   email: seedActor1.email,
   defaultActorId: ACTOR1_ID,
+  twoFactorEnabled: false,
+  emailVerified: true,
   createdAt: Date.now(),
   updatedAt: Date.now()
 }

--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -1,8 +1,12 @@
 import { NextRequest } from 'next/server'
 
 import { resetRefreshRemoteActorStateForTesting } from '@/lib/services/actors/refreshRemoteActor'
+import type { Actor } from '@/lib/types/domain/actor'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 
-import { GET } from './route'
+import { GET as routeGet } from './route'
+
+const GET = (req: NextRequest) => routeGet(req, { params: Promise.resolve({}) })
 
 const mockGetActorFromUsername = vi.fn()
 const mockGetActorFromId = vi.fn()
@@ -544,7 +548,7 @@ describe('GET /api/v1/accounts/lookup', () => {
       username: 'person',
       acct: 'person@remote.test',
       url: 'https://remote.test/users/person'
-    } as MastodonActor)
+    } as MastodonAccount)
     // Default mockStoredToken (null) makes any presented bearer invalid.
 
     const response = await GET(

--- a/app/api/v1/accounts/navigation-preferences/route.test.ts
+++ b/app/api/v1/accounts/navigation-preferences/route.test.ts
@@ -39,7 +39,17 @@ vi.mock('next/headers', () => ({
   })
 }))
 
-const actor = { ...seedActor1, id: ACTOR1_ID }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 const buildRequest = (body: string) =>
   new NextRequest('http://localhost/api/v1/accounts/navigation-preferences', {
@@ -72,11 +82,15 @@ describe('POST /api/v1/accounts/navigation-preferences', () => {
     mockDb.getAccountFromEmail.mockResolvedValue({
       id: 'account1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
     })
     mockDb.getActorsForAccount.mockResolvedValue([actor])
     mockDb.getActorFromId.mockResolvedValue(actor)
-    mockDb.getActorSettings.mockResolvedValue(null)
+    mockDb.getActorSettings.mockResolvedValue(undefined)
     mockDb.updateActor.mockResolvedValue(undefined as never)
   })
 

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/accounts/email/verify/route.test.ts",
-    "app/api/v1/accounts/lookup/route.test.ts",
-    "app/api/v1/accounts/navigation-preferences/route.test.ts",
     "app/api/v1/accounts/password/reset/request/route.test.ts",
     "app/api/v1/accounts/password/reset/route.test.ts",
     "app/api/v1/accounts/password/route.test.ts",


### PR DESCRIPTION
Resolves Task H2 Batch 12: fixes typing for 3 route test files and removes them from tsconfig.typecheck.json:
- `app/api/v1/accounts/email/verify/route.test.ts`
- `app/api/v1/accounts/lookup/route.test.ts`
- `app/api/v1/accounts/navigation-preferences/route.test.ts`

All DoD checks passed.