### PR TITLE
refactor: extract block, unblock, getBlocks, mute, and unmute operations into lib/client/accounts.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -10,7 +10,6 @@ import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
-import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
@@ -47,11 +46,15 @@ import {
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
+  type GetBlocksParams,
+  type GetBlocksResult,
+  type MuteParams,
   type ReportCategory,
   type SetDefaultActorParams,
   type SetDefaultActorResult,
   type SwitchActorParams,
   acceptFollowRequest,
+  block,
   cancelActorDeletion,
   createActor,
   createReport,
@@ -59,13 +62,18 @@ import {
   deleteActor,
   follow,
   getActorDomains,
+  getBlocks,
+  getCursorFromLinkHeader,
   getFollowStatus,
   getRelationship,
   isFollowing,
+  mute,
   rejectFollowRequest,
   setDefaultActor,
   switchActor,
-  unfollow
+  unblock,
+  unfollow,
+  unmute
 } from './client/accounts'
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
 import {
@@ -172,11 +180,15 @@ export {
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
+  type GetBlocksParams,
+  type GetBlocksResult,
+  type MuteParams,
   type ReportCategory,
   type SetDefaultActorParams,
   type SetDefaultActorResult,
   type SwitchActorParams,
   acceptFollowRequest,
+  block,
   cancelActorDeletion,
   createActor,
   createReport,
@@ -184,13 +196,17 @@ export {
   deleteActor,
   follow,
   getActorDomains,
+  getBlocks,
   getFollowStatus,
   getRelationship,
   isFollowing,
+  mute,
   rejectFollowRequest,
   setDefaultActor,
   switchActor,
-  unfollow
+  unblock,
+  unfollow,
+  unmute
 }
 
 interface MarkNotificationsReadParams {
@@ -213,120 +229,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-export const block = async ({
-  targetActorId
-}: FollowParams): Promise<MastodonRelationship | null> => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/block`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonRelationship
-}
-
-export const unblock = async ({
-  targetActorId
-}: FollowParams): Promise<MastodonRelationship | null> => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/unblock`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonRelationship
-}
-
-interface GetBlocksParams {
-  limit?: number
-  maxId?: string
-  minId?: string
-}
-
-interface GetBlocksResult {
-  accounts: MastodonAccount[]
-  nextMaxId: string | null
-  prevMinId: string | null
-}
-
-const getCursorFromLinkHeader = (linkHeader: string | null, rel: string) => {
-  if (!linkHeader) return null
-
-  const links = linkHeader.split(',').map((item) => item.trim())
-  const matchingLink = links.find((link) => link.endsWith(`rel="${rel}"`))
-  const url = matchingLink?.match(/<([^>]+)>/)?.[1]
-  if (!url) return null
-
-  return new URL(url).searchParams.get(rel === 'next' ? 'max_id' : 'min_id')
-}
-
-export const getBlocks = async ({
-  limit,
-  maxId,
-  minId
-}: GetBlocksParams = {}): Promise<GetBlocksResult> => {
-  const url = new URL(`${window.origin}/api/v1/blocks`)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-  if (maxId) url.searchParams.set('max_id', maxId)
-  if (minId) url.searchParams.set('min_id', minId)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return { accounts: [], nextMaxId: null, prevMinId: null }
-  }
-
-  const linkHeader = response.headers.get('Link')
-  return {
-    accounts: (await response.json()) as MastodonAccount[],
-    nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
-    prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
-  }
-}
-
-interface MuteParams {
-  targetActorId: string
-  notifications?: boolean
-}
-
-export const mute = async ({
-  targetActorId,
-  notifications
-}: MuteParams): Promise<MastodonRelationship | null> => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/mute`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(notifications === undefined ? {} : { notifications })
-  })
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonRelationship
-}
-
-export const unmute = async ({
-  targetActorId
-}: FollowParams): Promise<MastodonRelationship | null> => {
-  const encodedId = toIdPathSegment(targetActorId)
-  const response = await fetch(`/api/v1/accounts/${encodedId}/unmute`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return null
-  return (await response.json()) as MastodonRelationship
 }
 
 interface GetMutesParams {

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -2,6 +2,7 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import {
   acceptFollowRequest,
+  block,
   cancelActorDeletion,
   createActor,
   createReport,
@@ -9,13 +10,17 @@ import {
   deleteActor,
   follow,
   getActorDomains,
+  getBlocks,
   getFollowStatus,
   getRelationship,
   isFollowing,
+  mute,
   rejectFollowRequest,
   setDefaultActor,
   switchActor,
-  unfollow
+  unblock,
+  unfollow,
+  unmute
 } from './accounts'
 
 enableFetchMocks()
@@ -535,6 +540,162 @@ describe('client accounts module', () => {
       fetchMock.mockResponse(JSON.stringify([]), { status: 200 })
 
       const res = await getRelationship({ targetActorId: 'actor-target' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('block', () => {
+    it('blocks an account and returns the relationship on 200', async () => {
+      const mockRel = { id: 'actor-1', blocking: true }
+      fetchMock.mockResponse(JSON.stringify(mockRel), { status: 200 })
+
+      const res = await block({ targetActorId: 'actor-1' })
+      expect(res).toEqual(mockRel)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-1/block',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns null on non-200', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+      const res = await block({ targetActorId: 'actor-1' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('unblock', () => {
+    it('unblocks an account and returns the relationship on 200', async () => {
+      const mockRel = { id: 'actor-1', blocking: false }
+      fetchMock.mockResponse(JSON.stringify(mockRel), { status: 200 })
+
+      const res = await unblock({ targetActorId: 'actor-1' })
+      expect(res).toEqual(mockRel)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-1/unblock',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns null on non-200', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+      const res = await unblock({ targetActorId: 'actor-1' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('getBlocks', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://local.example' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches blocks with pagination query params and parses Link header', async () => {
+      const mockAccounts = [{ id: 'acc-1' }]
+      fetchMock.mockResponse(JSON.stringify(mockAccounts), {
+        status: 200,
+        headers: {
+          Link: '<https://local.example/api/v1/blocks?max_id=next-max>; rel="next", <https://local.example/api/v1/blocks?min_id=prev-min>; rel="prev"'
+        }
+      })
+
+      const res = await getBlocks({ limit: 10, maxId: 'm1', minId: 'm2' })
+      expect(res).toEqual({
+        accounts: mockAccounts,
+        nextMaxId: 'next-max',
+        prevMinId: 'prev-min'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://local.example/api/v1/blocks?limit=10&max_id=m1&min_id=m2',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result on non-200', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+      const res = await getBlocks()
+      expect(res).toEqual({
+        accounts: [],
+        nextMaxId: null,
+        prevMinId: null
+      })
+    })
+  })
+
+  describe('mute', () => {
+    it('mutes account with notifications flag and returns relationship', async () => {
+      const mockRel = { id: 'actor-1', muting: true }
+      fetchMock.mockResponse(JSON.stringify(mockRel), { status: 200 })
+
+      const res = await mute({ targetActorId: 'actor-1', notifications: true })
+      expect(res).toEqual(mockRel)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-1/mute',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ notifications: true })
+        })
+      )
+    })
+
+    it('mutes account without notifications flag when omitted', async () => {
+      const mockRel = { id: 'actor-1', muting: true }
+      fetchMock.mockResponse(JSON.stringify(mockRel), { status: 200 })
+
+      const res = await mute({ targetActorId: 'actor-1' })
+      expect(res).toEqual(mockRel)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-1/mute',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        })
+      )
+    })
+
+    it('returns null on non-200', async () => {
+      fetchMock.mockResponse('', { status: 400 })
+      const res = await mute({ targetActorId: 'actor-1' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('unmute', () => {
+    it('unmutes account and returns relationship on 200', async () => {
+      const mockRel = { id: 'actor-1', muting: false }
+      fetchMock.mockResponse(JSON.stringify(mockRel), { status: 200 })
+
+      const res = await unmute({ targetActorId: 'actor-1' })
+      expect(res).toEqual(mockRel)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/actor-1/unmute',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns null on non-200', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+      const res = await unmute({ targetActorId: 'actor-1' })
       expect(res).toBeNull()
     })
   })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -1,3 +1,4 @@
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
 
@@ -381,4 +382,121 @@ export const getRelationship = async ({
 
   const relationships = (await response.json()) as MastodonRelationship[]
   return relationships[0] ?? null
+}
+
+export const block = async ({
+  targetActorId
+}: FollowParams): Promise<MastodonRelationship | null> => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/block`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
+}
+
+export const unblock = async ({
+  targetActorId
+}: FollowParams): Promise<MastodonRelationship | null> => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/unblock`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
+}
+
+export interface GetBlocksParams {
+  limit?: number
+  maxId?: string
+  minId?: string
+}
+
+export interface GetBlocksResult {
+  accounts: MastodonAccount[]
+  nextMaxId: string | null
+  prevMinId: string | null
+}
+
+export const getCursorFromLinkHeader = (
+  linkHeader: string | null,
+  rel: string
+) => {
+  if (!linkHeader) return null
+
+  const links = linkHeader.split(',').map((item) => item.trim())
+  const matchingLink = links.find((link) => link.endsWith(`rel="${rel}"`))
+  const url = matchingLink?.match(/<([^>]+)>/)?.[1]
+  if (!url) return null
+
+  return new URL(url).searchParams.get(rel === 'next' ? 'max_id' : 'min_id')
+}
+
+export const getBlocks = async ({
+  limit,
+  maxId,
+  minId
+}: GetBlocksParams = {}): Promise<GetBlocksResult> => {
+  const url = new URL(`${window.origin}/api/v1/blocks`)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxId) url.searchParams.set('max_id', maxId)
+  if (minId) url.searchParams.set('min_id', minId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return { accounts: [], nextMaxId: null, prevMinId: null }
+  }
+
+  const linkHeader = response.headers.get('Link')
+  return {
+    accounts: (await response.json()) as MastodonAccount[],
+    nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
+    prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
+  }
+}
+
+export interface MuteParams {
+  targetActorId: string
+  notifications?: boolean
+}
+
+export const mute = async ({
+  targetActorId,
+  notifications
+}: MuteParams): Promise<MastodonRelationship | null> => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/mute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(notifications === undefined ? {} : { notifications })
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
+}
+
+export const unmute = async ({
+  targetActorId
+}: FollowParams): Promise<MastodonRelationship | null> => {
+  const encodedId = toIdPathSegment(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/unmute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
 }


### PR DESCRIPTION
Resolves Task J1 Batch 9: extracts 5 account relationships/moderation operations into `lib/client/accounts.ts` and re-exports them from `lib/client.ts`:
- `block`
- `unblock`
- `getBlocks`
- `mute`
- `unmute`

Full DoD sequence passed cleanly.