### PR TITLE
test: resolve types for password reset request, reset, and password route tests

### DIFF
--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -2,7 +2,10 @@ import { NextRequest } from 'next/server'
 
 import { Database } from '@/lib/database/types'
 
-import { POST } from './route'
+import { POST as routePost } from './route'
+
+const POST = (req: NextRequest, _context?: unknown) =>
+  routePost(req, { params: Promise.resolve({}) })
 
 const mockSendMail = vi.fn()
 vi.mock('@/lib/services/email', () => ({
@@ -82,6 +85,8 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
       email: 'test@llun.test',
       passwordResetCode: 'existing-reset-code',
       passwordResetCodeExpiresAt: Date.now() + 60_000,
+      twoFactorEnabled: false,
+      emailVerified: true,
       createdAt: Date.now(),
       updatedAt: Date.now()
     })
@@ -114,6 +119,8 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
       email: 'test@llun.test',
       passwordResetCode: 'existing-reset-code',
       passwordResetCodeExpiresAt: previousExpiresAt,
+      twoFactorEnabled: false,
+      emailVerified: true,
       createdAt: Date.now(),
       updatedAt: Date.now()
     })

--- a/app/api/v1/accounts/password/reset/route.test.ts
+++ b/app/api/v1/accounts/password/reset/route.test.ts
@@ -37,7 +37,12 @@ describe('POST /api/v1/accounts/password/reset', () => {
     mockBcryptHash.mockResolvedValue('new-password-hash')
     mockDb.validatePasswordResetCode.mockResolvedValue('account-1')
     mockDb.resetPasswordWithCode.mockResolvedValue({
-      id: 'account-1'
+      id: 'account-1',
+      email: 'test@llun.test',
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
     })
   })
 

--- a/app/api/v1/accounts/password/route.test.ts
+++ b/app/api/v1/accounts/password/route.test.ts
@@ -50,6 +50,8 @@ const account = {
   email: seedActor1.email,
   defaultActorId: ACTOR1_ID,
   passwordHash: 'password-hash',
+  twoFactorEnabled: false,
+  emailVerified: true,
   createdAt: Date.now(),
   updatedAt: Date.now()
 }
@@ -222,6 +224,7 @@ describe('POST /api/v1/accounts/password', () => {
         account: {
           ...account,
           verificationCode: 'pending-code',
+          twoFactorEnabled: false,
           emailVerified: false
         }
       }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/accounts/password/reset/request/route.test.ts",
-    "app/api/v1/accounts/password/reset/route.test.ts",
-    "app/api/v1/accounts/password/route.test.ts",
     "app/api/v1/accounts/push-notifications/route.test.ts",
     "app/api/v1/accounts/reading-preferences/route.test.ts",
     "app/api/v1/accounts/sessions/route.test.ts",


### PR DESCRIPTION
Resolves Task H2 Batch 13: fixes typing for 3 route test files and removes them from tsconfig.typecheck.json:
- `app/api/v1/accounts/password/reset/request/route.test.ts`
- `app/api/v1/accounts/password/reset/route.test.ts`
- `app/api/v1/accounts/password/route.test.ts`

All DoD checks passed.