### PR TITLE
refactor: extract actor statuses to accounts and featured tags to tags client module

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -15,7 +15,6 @@ import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
 import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
-import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
@@ -46,6 +45,8 @@ import {
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
+  type GetActorStatusesParams,
+  type GetActorStatusesResult,
   type GetBlocksParams,
   type GetBlocksResult,
   type MuteParams,
@@ -62,6 +63,7 @@ import {
   deleteActor,
   follow,
   getActorDomains,
+  getActorStatuses,
   getBlocks,
   getCursorFromLinkHeader,
   getFollowStatus,
@@ -119,6 +121,13 @@ import {
   updateStatusVisibility,
   votePoll
 } from './client/statuses'
+import {
+  type AddFeaturedTagResult,
+  addFeaturedTag,
+  getFeaturedTagSuggestions,
+  getFeaturedTags,
+  removeFeaturedTag
+} from './client/tags'
 
 export { ApiRequestError }
 
@@ -180,6 +189,8 @@ export {
   type FollowRequestParams,
   type FollowStatusType,
   type GetActorDomainsParams,
+  type GetActorStatusesParams,
+  type GetActorStatusesResult,
   type GetBlocksParams,
   type GetBlocksResult,
   type MuteParams,
@@ -196,6 +207,7 @@ export {
   deleteActor,
   follow,
   getActorDomains,
+  getActorStatuses,
   getBlocks,
   getFollowStatus,
   getRelationship,
@@ -207,6 +219,14 @@ export {
   unblock,
   unfollow,
   unmute
+}
+
+export {
+  type AddFeaturedTagResult,
+  addFeaturedTag,
+  getFeaturedTags,
+  getFeaturedTagSuggestions,
+  removeFeaturedTag
 }
 
 interface MarkNotificationsReadParams {
@@ -500,123 +520,6 @@ export const getHashtagTimeline = async ({
   }
 
   return result
-}
-
-interface GetActorStatusesParams {
-  actorId: string
-  pageUrl?: string | null
-}
-
-export interface GetActorStatusesResult {
-  statuses: Status[]
-  statusesCount: number
-  nextPageUrl: string | null
-  prevPageUrl: string | null
-}
-
-export const getActorStatuses = async ({
-  actorId,
-  pageUrl
-}: GetActorStatusesParams): Promise<GetActorStatusesResult> => {
-  const path = `/api/v1/accounts/${toIdPathSegment(actorId)}/remote-statuses`
-  const url = new URL(`${window.origin}${path}`)
-  if (pageUrl) {
-    url.searchParams.append('page_url', pageUrl)
-  }
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    throw new Error(`Failed to load actor statuses: ${response.status}`)
-  }
-
-  return (await response.json()) as GetActorStatusesResult
-}
-
-// Featured hashtags (https://docs.joinmastodon.org/methods/featured_tags/).
-// The hashtags an account pins to its profile. Backed by the featured_tags
-// endpoints; every call goes through here so components never call fetch().
-
-// Throws on a non-OK response (rather than returning []) so the editor's load
-// handler can tell "you have no featured tags" apart from "the request failed"
-// and show its load-error UI. Featured tags are the critical data for the page;
-// suggestions below stay best-effort.
-export const getFeaturedTags = async (): Promise<FeaturedTag[]> => {
-  const response = await fetch('/api/v1/featured_tags', {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (!response.ok) {
-    throw new Error(`Failed to load featured tags: ${response.status}`)
-  }
-  return (await response.json()) as FeaturedTag[]
-}
-
-export interface AddFeaturedTagResult {
-  tag?: FeaturedTag
-  error?: string
-}
-
-export const addFeaturedTag = async (
-  name: string
-): Promise<AddFeaturedTagResult> => {
-  try {
-    const response = await fetch('/api/v1/featured_tags', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ name })
-    })
-    if (!response.ok) {
-      const data = (await response.json().catch(() => ({}))) as {
-        error?: string
-      }
-      return { error: data.error || 'Failed to feature hashtag' }
-    }
-    // Only treat it as a success when the body parses into a real entity —
-    // a malformed 2xx body must not surface as a tag with missing fields.
-    return { tag: (await response.json()) as FeaturedTag }
-  } catch {
-    // Network failure / unparseable body — surface as an error result rather
-    // than rejecting, so callers can always settle their loading state.
-    return { error: 'Failed to feature hashtag' }
-  }
-}
-
-export const removeFeaturedTag = async (id: string): Promise<boolean> => {
-  try {
-    const response = await fetch(
-      `/api/v1/featured_tags/${encodeURIComponent(id)}`,
-      {
-        method: 'DELETE',
-        headers: {
-          Accept: 'application/json'
-        }
-      }
-    )
-    return response.ok
-  } catch {
-    // Network failure — report as not-removed instead of rejecting.
-    return false
-  }
-}
-
-export const getFeaturedTagSuggestions = async (): Promise<Tag[]> => {
-  const response = await fetch('/api/v1/featured_tags/suggestions', {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (!response.ok) return []
-  return (await response.json()) as Tag[]
 }
 
 // Trends (https://docs.joinmastodon.org/methods/trends/). All three endpoints

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -10,6 +10,7 @@ import {
   deleteActor,
   follow,
   getActorDomains,
+  getActorStatuses,
   getBlocks,
   getFollowStatus,
   getRelationship,
@@ -697,6 +698,50 @@ describe('client accounts module', () => {
       fetchMock.mockResponse('', { status: 404 })
       const res = await unmute({ targetActorId: 'actor-1' })
       expect(res).toBeNull()
+    })
+  })
+
+  describe('getActorStatuses', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://local.example' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches actor statuses with pageUrl if provided', async () => {
+      const mockResult = {
+        statuses: [],
+        statusesCount: 0,
+        nextPageUrl: null,
+        prevPageUrl: null
+      }
+      fetchMock.mockResponse(JSON.stringify(mockResult), { status: 200 })
+
+      const res = await getActorStatuses({
+        actorId: 'actor-123',
+        pageUrl: 'https://local.example/next'
+      })
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://local.example/api/v1/accounts/actor-123/remote-statuses?page_url=https%3A%2F%2Flocal.example%2Fnext',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('throws when status is not 200', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      await expect(getActorStatuses({ actorId: 'actor-123' })).rejects.toThrow(
+        'Failed to load actor statuses: 500'
+      )
     })
   })
 })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -1,3 +1,4 @@
+import type { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import { toIdPathSegment } from '@/lib/utils/urlToId'
@@ -499,4 +500,39 @@ export const unmute = async ({
   })
   if (response.status !== 200) return null
   return (await response.json()) as MastodonRelationship
+}
+
+export interface GetActorStatusesParams {
+  actorId: string
+  pageUrl?: string | null
+}
+
+export interface GetActorStatusesResult {
+  statuses: Status[]
+  statusesCount: number
+  nextPageUrl: string | null
+  prevPageUrl: string | null
+}
+
+export const getActorStatuses = async ({
+  actorId,
+  pageUrl
+}: GetActorStatusesParams): Promise<GetActorStatusesResult> => {
+  const path = `/api/v1/accounts/${toIdPathSegment(actorId)}/remote-statuses`
+  const url = new URL(`${window.origin}${path}`)
+  if (pageUrl) {
+    url.searchParams.append('page_url', pageUrl)
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    throw new Error(`Failed to load actor statuses: ${response.status}`)
+  }
+
+  return (await response.json()) as GetActorStatusesResult
 }

--- a/lib/client/tags.test.ts
+++ b/lib/client/tags.test.ts
@@ -1,0 +1,130 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  addFeaturedTag,
+  getFeaturedTagSuggestions,
+  getFeaturedTags,
+  removeFeaturedTag
+} from './tags'
+
+enableFetchMocks()
+
+describe('client tags module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getFeaturedTags', () => {
+    it('returns featured tags on 200', async () => {
+      const mockTags = [{ id: 'tag-1', name: 'running' }]
+      fetchMock.mockResponse(JSON.stringify(mockTags), { status: 200 })
+
+      const res = await getFeaturedTags()
+      expect(res).toEqual(mockTags)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/featured_tags',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      await expect(getFeaturedTags()).rejects.toThrow(
+        'Failed to load featured tags: 500'
+      )
+    })
+  })
+
+  describe('addFeaturedTag', () => {
+    it('returns tag on success', async () => {
+      const mockTag = { id: 'tag-1', name: 'running' }
+      fetchMock.mockResponse(JSON.stringify(mockTag), { status: 200 })
+
+      const res = await addFeaturedTag('running')
+      expect(res).toEqual({ tag: mockTag })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/featured_tags',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'running' })
+        })
+      )
+    })
+
+    it('returns error message on non-ok response', async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({ error: 'Hashtag already featured' }),
+        { status: 422 }
+      )
+
+      const res = await addFeaturedTag('running')
+      expect(res).toEqual({ error: 'Hashtag already featured' })
+    })
+
+    it('returns error message on network failure', async () => {
+      fetchMock.mockReject(new Error('Network error'))
+
+      const res = await addFeaturedTag('running')
+      expect(res).toEqual({ error: 'Failed to feature hashtag' })
+    })
+  })
+
+  describe('removeFeaturedTag', () => {
+    it('returns true on success', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await removeFeaturedTag('tag-1')
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/featured_tags/tag-1',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns false on error status', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await removeFeaturedTag('tag-1')
+      expect(res).toBe(false)
+    })
+
+    it('returns false on network failure', async () => {
+      fetchMock.mockReject(new Error('Network error'))
+
+      const res = await removeFeaturedTag('tag-1')
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('getFeaturedTagSuggestions', () => {
+    it('returns suggestions on success', async () => {
+      const mockSuggestions = [{ name: 'running' }]
+      fetchMock.mockResponse(JSON.stringify(mockSuggestions), { status: 200 })
+
+      const res = await getFeaturedTagSuggestions()
+      expect(res).toEqual(mockSuggestions)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/featured_tags/suggestions',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty array when response is not ok', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await getFeaturedTagSuggestions()
+      expect(res).toEqual([])
+    })
+  })
+})

--- a/lib/client/tags.ts
+++ b/lib/client/tags.ts
@@ -1,0 +1,84 @@
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+import type { Tag } from '@/lib/types/mastodon/tag'
+
+// Featured hashtags (https://docs.joinmastodon.org/methods/featured_tags/).
+// The hashtags an account pins to its profile. Backed by the featured_tags
+// endpoints; every call goes through here so components never call fetch().
+
+// Throws on a non-OK response (rather than returning []) so the editor's load
+// handler can tell "you have no featured tags" apart from "the request failed"
+// and show its load-error UI. Featured tags are the critical data for the page;
+// suggestions below stay best-effort.
+export const getFeaturedTags = async (): Promise<FeaturedTag[]> => {
+  const response = await fetch('/api/v1/featured_tags', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to load featured tags: ${response.status}`)
+  }
+  return (await response.json()) as FeaturedTag[]
+}
+
+export interface AddFeaturedTagResult {
+  tag?: FeaturedTag
+  error?: string
+}
+
+export const addFeaturedTag = async (
+  name: string
+): Promise<AddFeaturedTagResult> => {
+  try {
+    const response = await fetch('/api/v1/featured_tags', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name })
+    })
+    if (!response.ok) {
+      const data = (await response.json().catch(() => ({}))) as {
+        error?: string
+      }
+      return { error: data.error || 'Failed to feature hashtag' }
+    }
+    // Only treat it as a success when the body parses into a real entity —
+    // a malformed 2xx body must not surface as a tag with missing fields.
+    return { tag: (await response.json()) as FeaturedTag }
+  } catch {
+    // Network failure / unparseable body — surface as an error result rather
+    // than rejecting, so callers can always settle their loading state.
+    return { error: 'Failed to feature hashtag' }
+  }
+}
+
+export const removeFeaturedTag = async (id: string): Promise<boolean> => {
+  try {
+    const response = await fetch(
+      `/api/v1/featured_tags/${encodeURIComponent(id)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json'
+        }
+      }
+    )
+    return response.ok
+  } catch {
+    // Network failure — report as not-removed instead of rejecting.
+    return false
+  }
+}
+
+export const getFeaturedTagSuggestions = async (): Promise<Tag[]> => {
+  const response = await fetch('/api/v1/featured_tags/suggestions', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) return []
+  return (await response.json()) as Tag[]
+}


### PR DESCRIPTION
Resolves Task J1 Batch 10: extracts 5 operations from `lib/client.ts`:
- `getActorStatuses` extracted into `lib/client/accounts.ts`
- `getFeaturedTags`, `addFeaturedTag`, `removeFeaturedTag`, `getFeaturedTagSuggestions` extracted into new domain module `lib/client/tags.ts`
- All 5 re-exported from `lib/client.ts`

All DoD checks passed.