### PR TITLE
test: resolve types for push-notifications, reading-preferences, and sessions route tests

### DIFF
--- a/app/api/v1/accounts/push-notifications/route.test.ts
+++ b/app/api/v1/accounts/push-notifications/route.test.ts
@@ -39,7 +39,17 @@ vi.mock('next/headers', () => ({
   })
 }))
 
-const actor = { ...seedActor1, id: ACTOR1_ID }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 describe('POST /api/v1/accounts/push-notifications', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
@@ -62,11 +72,15 @@ describe('POST /api/v1/accounts/push-notifications', () => {
     mockDb.getAccountFromEmail.mockResolvedValue({
       id: 'account1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
     })
     mockDb.getActorsForAccount.mockResolvedValue([actor])
     mockDb.getActorFromId.mockResolvedValue(actor)
-    mockDb.getActorSettings.mockResolvedValue(null)
+    mockDb.getActorSettings.mockResolvedValue(undefined)
     mockDb.updateActor.mockResolvedValue(undefined as never)
   })
 

--- a/app/api/v1/accounts/reading-preferences/route.test.ts
+++ b/app/api/v1/accounts/reading-preferences/route.test.ts
@@ -39,7 +39,17 @@ vi.mock('next/headers', () => ({
   })
 }))
 
-const actor = { ...seedActor1, id: ACTOR1_ID }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 const buildRequest = (body: string) =>
   new NextRequest('http://localhost/api/v1/accounts/reading-preferences', {
@@ -72,11 +82,15 @@ describe('POST /api/v1/accounts/reading-preferences', () => {
     mockDb.getAccountFromEmail.mockResolvedValue({
       id: 'account1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
     })
     mockDb.getActorsForAccount.mockResolvedValue([actor])
     mockDb.getActorFromId.mockResolvedValue(actor)
-    mockDb.getActorSettings.mockResolvedValue(null)
+    mockDb.getActorSettings.mockResolvedValue(undefined)
     mockDb.updateActor.mockResolvedValue(undefined as never)
   })
 

--- a/app/api/v1/accounts/sessions/route.test.ts
+++ b/app/api/v1/accounts/sessions/route.test.ts
@@ -38,10 +38,25 @@ vi.mock('next/headers', () => ({
 const account = {
   id: 'account-1',
   email: seedActor1.email,
-  defaultActorId: ACTOR1_ID
+  defaultActorId: ACTOR1_ID,
+  twoFactorEnabled: false,
+  emailVerified: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
 }
 
-const actor = { ...seedActor1, id: ACTOR1_ID, account }
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  account,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
 
 const buildRequest = () =>
   new NextRequest('http://llun.test/api/v1/accounts/sessions', {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/accounts/push-notifications/route.test.ts",
-    "app/api/v1/accounts/reading-preferences/route.test.ts",
-    "app/api/v1/accounts/sessions/route.test.ts",
     "app/api/v1/actors/route.test.ts",
     "app/api/v1/apps/createApplication.test.ts",
     "app/api/v1/apps/route.test.ts",


### PR DESCRIPTION
Resolves Task H2 Batch 14: fixes typing for 3 route test files and removes them from tsconfig.typecheck.json:
- `app/api/v1/accounts/push-notifications/route.test.ts`
- `app/api/v1/accounts/reading-preferences/route.test.ts`
- `app/api/v1/accounts/sessions/route.test.ts`

All DoD checks passed.