### PR TITLE
refactor: extract trends and session operations from client facade

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -17,7 +17,6 @@ import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
-import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
@@ -41,6 +40,7 @@ import {
   type DeleteAccountMediaParams,
   type DeleteActorParams,
   type DeleteActorResult,
+  type DeleteSessionParams,
   type FollowParams,
   type FollowRequestParams,
   type FollowStatusType,
@@ -61,6 +61,7 @@ import {
   createReport,
   deleteAccountMedia,
   deleteActor,
+  deleteSession,
   follow,
   getActorDomains,
   getActorStatuses,
@@ -71,6 +72,7 @@ import {
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeOtherSessions,
   setDefaultActor,
   switchActor,
   unblock,
@@ -128,6 +130,11 @@ import {
   getFeaturedTags,
   removeFeaturedTag
 } from './client/tags'
+import {
+  getTrendingLinks,
+  getTrendingStatuses,
+  getTrendingTags
+} from './client/trends'
 
 export { ApiRequestError }
 
@@ -185,6 +192,7 @@ export {
   type DeleteAccountMediaParams,
   type DeleteActorParams,
   type DeleteActorResult,
+  type DeleteSessionParams,
   type FollowParams,
   type FollowRequestParams,
   type FollowStatusType,
@@ -205,6 +213,7 @@ export {
   createReport,
   deleteAccountMedia,
   deleteActor,
+  deleteSession,
   follow,
   getActorDomains,
   getActorStatuses,
@@ -214,6 +223,7 @@ export {
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeOtherSessions,
   setDefaultActor,
   switchActor,
   unblock,
@@ -228,6 +238,8 @@ export {
   getFeaturedTagSuggestions,
   removeFeaturedTag
 }
+
+export { getTrendingLinks, getTrendingStatuses, getTrendingTags }
 
 interface MarkNotificationsReadParams {
   notificationIds: string[]
@@ -520,91 +532,6 @@ export const getHashtagTimeline = async ({
   }
 
   return result
-}
-
-// Trends (https://docs.joinmastodon.org/methods/trends/). All three endpoints
-// are read-scope and tolerate logged-out callers. Each helper throws on a
-// non-OK response (mirroring getActorStatuses) so the Explore page can tell a
-// real failure apart from "nothing is trending" and render its error state; the
-// callers that prefer to stay quiet (the Search "Trending now" block) catch and
-// hide instead.
-const buildTrendsQuery = (limit?: number) =>
-  typeof limit === 'number' ? `?limit=${limit}` : ''
-
-const getTrends = async <T>(
-  resource: 'tags' | 'statuses' | 'links',
-  limit?: number
-): Promise<T> => {
-  const response = await fetch(
-    `/api/v1/trends/${resource}${buildTrendsQuery(limit)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-  if (!response.ok) {
-    throw new Error(`Failed to load trending ${resource}: ${response.status}`)
-  }
-  // Every trends endpoint returns a JSON array; coerce anything else to an empty
-  // list so callers can safely `.map`/`.length` over the result.
-  const data = await response.json()
-  return (Array.isArray(data) ? data : []) as T
-}
-
-export const getTrendingTags = (limit?: number): Promise<Tag[]> =>
-  getTrends<Tag[]>('tags', limit)
-
-// The /explore Posts tab renders trending statuses with the interactive timeline
-// post component, which consumes the app's domain Status shape — so this asks the
-// endpoint for `format=activities_next` (like the search client) rather than the
-// default Mastodon serialization.
-export const getTrendingStatuses = async (
-  limit?: number
-): Promise<Status[]> => {
-  const params = new URLSearchParams({ format: 'activities_next' })
-  if (typeof limit === 'number') params.set('limit', `${limit}`)
-  const response = await fetch(`/api/v1/trends/statuses?${params.toString()}`, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (!response.ok) {
-    throw new Error(`Failed to load trending statuses: ${response.status}`)
-  }
-  const data = await response.json()
-  return Array.isArray(data) ? (data as Status[]) : []
-}
-
-export const getTrendingLinks = (limit?: number): Promise<PreviewCard[]> =>
-  getTrends<PreviewCard[]>('links', limit)
-
-interface DeleteSessionParams {
-  token: string
-}
-export const deleteSession = async ({ token }: DeleteSessionParams) => {
-  const path = `/api/v1/accounts/sessions/${token}`
-  const response = await fetch(path, {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (response.status !== 200) return false
-  return true
-}
-
-// Revoke every session for the account except the current device.
-export const revokeOtherSessions = async (): Promise<boolean> => {
-  const response = await fetch('/api/v1/accounts/sessions', {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  return response.ok
 }
 
 interface RevokeConnectedAppParams {

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -8,6 +8,7 @@ import {
   createReport,
   deleteAccountMedia,
   deleteActor,
+  deleteSession,
   follow,
   getActorDomains,
   getActorStatuses,
@@ -17,6 +18,7 @@ import {
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeOtherSessions,
   setDefaultActor,
   switchActor,
   unblock,
@@ -742,6 +744,52 @@ describe('client accounts module', () => {
       await expect(getActorStatuses({ actorId: 'actor-123' })).rejects.toThrow(
         'Failed to load actor statuses: 500'
       )
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('deletes session and returns true on 200', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await deleteSession({ token: 'sess-token-123' })
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/sessions/sess-token-123',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns false when status is not 200', async () => {
+      fetchMock.mockResponse('', { status: 404 })
+
+      const res = await deleteSession({ token: 'invalid' })
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('revokeOtherSessions', () => {
+    it('revokes other sessions and returns true on ok response', async () => {
+      fetchMock.mockResponse('', { status: 200 })
+
+      const res = await revokeOtherSessions()
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/sessions',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('returns false on non-ok response', async () => {
+      fetchMock.mockResponse('', { status: 500 })
+
+      const res = await revokeOtherSessions()
+      expect(res).toBe(false)
     })
   })
 })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -536,3 +536,32 @@ export const getActorStatuses = async ({
 
   return (await response.json()) as GetActorStatusesResult
 }
+
+export interface DeleteSessionParams {
+  token: string
+}
+
+export const deleteSession = async ({
+  token
+}: DeleteSessionParams): Promise<boolean> => {
+  const path = `/api/v1/accounts/sessions/${token}`
+  const response = await fetch(path, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return false
+  return true
+}
+
+// Revoke every session for the account except the current device.
+export const revokeOtherSessions = async (): Promise<boolean> => {
+  const response = await fetch('/api/v1/accounts/sessions', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  return response.ok
+}

--- a/lib/client/trends.test.ts
+++ b/lib/client/trends.test.ts
@@ -1,0 +1,118 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  getTrendingLinks,
+  getTrendingStatuses,
+  getTrendingTags
+} from './trends'
+
+enableFetchMocks()
+
+describe('client trends module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getTrendingTags', () => {
+    it('requests trending tags with a limit and returns the payload', async () => {
+      const tags = [
+        { name: 'gravel', url: 'https://llun.test/tags/gravel', history: [] }
+      ]
+      fetchMock.mockResponseOnce(JSON.stringify(tags), { status: 200 })
+
+      await expect(getTrendingTags(10)).resolves.toEqual(tags)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/tags?limit=10',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('omits the limit query when none is provided', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([]), { status: 200 })
+
+      await getTrendingTags()
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/tags',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('throws when trending tags respond non-OK', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(getTrendingTags()).rejects.toThrow(
+        'Failed to load trending tags: 500'
+      )
+    })
+
+    it('coerces non-array responses to empty list', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'none' }), {
+        status: 200
+      })
+
+      await expect(getTrendingTags()).resolves.toEqual([])
+    })
+  })
+
+  describe('getTrendingStatuses', () => {
+    it('throws when trending statuses respond non-OK', async () => {
+      fetchMock.mockResponseOnce('', { status: 503 })
+
+      await expect(getTrendingStatuses(20)).rejects.toThrow(
+        'Failed to load trending statuses: 503'
+      )
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/statuses?format=activities_next&limit=20',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('returns the domain trending statuses payload', async () => {
+      const statuses = [{ id: 'https://llun.test/users/a/statuses/1' }]
+      fetchMock.mockResponseOnce(JSON.stringify(statuses), { status: 200 })
+
+      await expect(getTrendingStatuses()).resolves.toEqual(statuses)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/statuses?format=activities_next',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('coerces a non-array trending statuses response to an empty list', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 })
+
+      await expect(getTrendingStatuses()).resolves.toEqual([])
+    })
+  })
+
+  describe('getTrendingLinks', () => {
+    it('returns trending links from the payload with limit', async () => {
+      const links = [{ url: 'https://example.com/news', title: 'News' }]
+      fetchMock.mockResponseOnce(JSON.stringify(links), { status: 200 })
+
+      await expect(getTrendingLinks(5)).resolves.toEqual(links)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/links?limit=5',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('returns trending links without limit', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([]), { status: 200 })
+
+      await expect(getTrendingLinks()).resolves.toEqual([])
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/trends/links',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('throws when trending links respond non-OK', async () => {
+      fetchMock.mockResponseOnce('', { status: 502 })
+
+      await expect(getTrendingLinks()).rejects.toThrow(
+        'Failed to load trending links: 502'
+      )
+    })
+  })
+})

--- a/lib/client/trends.ts
+++ b/lib/client/trends.ts
@@ -1,0 +1,62 @@
+import { Status } from '@/lib/types/domain/status'
+import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
+import type { Tag } from '@/lib/types/mastodon/tag'
+
+// Trends (https://docs.joinmastodon.org/methods/trends/). All three endpoints
+// are read-scope and tolerate logged-out callers. Each helper throws on a
+// non-OK response (mirroring getActorStatuses) so the Explore page can tell a
+// real failure apart from "nothing is trending" and render its error state; the
+// callers that prefer to stay quiet (the Search "Trending now" block) catch and
+// hide instead.
+const buildTrendsQuery = (limit?: number) =>
+  typeof limit === 'number' ? `?limit=${limit}` : ''
+
+const getTrends = async <T>(
+  resource: 'tags' | 'statuses' | 'links',
+  limit?: number
+): Promise<T> => {
+  const response = await fetch(
+    `/api/v1/trends/${resource}${buildTrendsQuery(limit)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`Failed to load trending ${resource}: ${response.status}`)
+  }
+  // Every trends endpoint returns a JSON array; coerce anything else to an empty
+  // list so callers can safely `.map`/`.length` over the result.
+  const data = await response.json()
+  return (Array.isArray(data) ? data : []) as T
+}
+
+export const getTrendingTags = (limit?: number): Promise<Tag[]> =>
+  getTrends<Tag[]>('tags', limit)
+
+// The /explore Posts tab renders trending statuses with the interactive timeline
+// post component, which consumes the app's domain Status shape — so this asks the
+// endpoint for `format=activities_next` (like the search client) rather than the
+// default Mastodon serialization.
+export const getTrendingStatuses = async (
+  limit?: number
+): Promise<Status[]> => {
+  const params = new URLSearchParams({ format: 'activities_next' })
+  if (typeof limit === 'number') params.set('limit', `${limit}`)
+  const response = await fetch(`/api/v1/trends/statuses?${params.toString()}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to load trending statuses: ${response.status}`)
+  }
+  const data = await response.json()
+  return Array.isArray(data) ? (data as Status[]) : []
+}
+
+export const getTrendingLinks = (limit?: number): Promise<PreviewCard[]> =>
+  getTrends<PreviewCard[]>('links', limit)


### PR DESCRIPTION
## Summary
Extracts 5 client operations from `lib/client.ts` to maintain modular client domain structure:
- `getTrendingTags`, `getTrendingStatuses`, and `getTrendingLinks` into `lib/client/trends.ts`
- `deleteSession` and `revokeOtherSessions` into `lib/client/accounts.ts`
- Re-exports operations from `lib/client.ts` facade for backward compatibility
- Co-locates comprehensive unit tests in `lib/client/trends.test.ts` and `lib/client/accounts.test.ts`

## DoD Verification
- `yarn run prettier --write .` passed
- `yarn lint` passed (0 errors)
- `yarn typecheck` passed (0 errors)
- `yarn build` passed
- `yarn test` passed (1006 test files, 14019 tests)