### PR TITLE
Bump version to v1.161.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.28",
+  "version": "1.161.29",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.29.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.28`
- Base main SHA: `19de51016f296ad990ad92632b634749a2c02800`
- Included commits: `14`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
