### PR TITLE
test: resolve types for actors and apps route tests

### DIFF
--- a/app/api/v1/actors/route.test.ts
+++ b/app/api/v1/actors/route.test.ts
@@ -31,11 +31,12 @@ vi.mock('next/headers', async () => ({
 }))
 
 vi.mock('crypto', async () => {
-  const actual = await vi.importActual('crypto')
-  const { promisify } = await vi.importActual('util')
-  const mockGenerateKeyPair = vi.fn()
-  mockGenerateKeyPair[promisify.custom] = () =>
-    Promise.resolve({ publicKey: 'public-key', privateKey: 'private-key' })
+  const actual = await vi.importActual<typeof import('crypto')>('crypto')
+  const { promisify } = await vi.importActual<typeof import('util')>('util')
+  const mockGenerateKeyPair = Object.assign(vi.fn(), {
+    [promisify.custom]: () =>
+      Promise.resolve({ publicKey: 'public-key', privateKey: 'private-key' })
+  })
   return {
     ...actual,
     generateKeyPair: mockGenerateKeyPair

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -80,6 +80,8 @@ describe('apps route', () => {
     process.env = originalEnv
   })
 
+  const routeContext = { params: Promise.resolve({}) }
+
   test('does not derive registration limits from untrusted forwarded IP headers', async () => {
     const req = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
@@ -95,7 +97,7 @@ describe('apps route', () => {
       })
     })
 
-    await POST(req)
+    await POST(req, routeContext)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
       registrationKey: undefined
@@ -120,7 +122,7 @@ describe('apps route', () => {
       })
     })
 
-    await POST(forwardedReq)
+    await POST(forwardedReq, routeContext)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
       registrationKey: hashIpRegistrationKey('198.51.100.30')
@@ -146,7 +148,7 @@ describe('apps route', () => {
       })
     })
 
-    await POST(directReq)
+    await POST(directReq, routeContext)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
       registrationKey: undefined
@@ -170,8 +172,8 @@ describe('apps route', () => {
         })
       })
 
-    await POST(createRequest('first'))
-    await POST(createRequest('second'))
+    await POST(createRequest('first'), routeContext)
+    await POST(createRequest('second'), routeContext)
 
     expect(mockCreateApplication).toHaveBeenCalledTimes(2)
     expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
@@ -190,7 +192,7 @@ describe('apps route', () => {
       })
     })
 
-    const response = await POST(req)
+    const response = await POST(req, routeContext)
 
     expect(response.status).toBe(200)
     expect(mockCreateApplication).toHaveBeenCalledWith(
@@ -218,7 +220,7 @@ describe('apps route', () => {
       })
     })
 
-    const response = await POST(req)
+    const response = await POST(req, routeContext)
     const body = await response.json()
 
     expect(response.status).toBe(200)
@@ -246,7 +248,7 @@ describe('apps route', () => {
       })
     })
 
-    const response = await POST(req)
+    const response = await POST(req, routeContext)
     const body = await response.json()
 
     expect(body.vapid_key).toBeNull()
@@ -268,7 +270,7 @@ describe('apps route', () => {
       })
     })
 
-    const response = await POST(req)
+    const response = await POST(req, routeContext)
 
     await expect(response.json()).resolves.toEqual({
       error: 'Too Many Requests'
@@ -291,7 +293,7 @@ describe('apps route', () => {
       })
     })
 
-    const response = await POST(req)
+    const response = await POST(req, routeContext)
     expect(response.status).toBe(422)
 
     const rejectionLog = mockLoggerWarn.mock.calls.find(

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/actors/route.test.ts",
-    "app/api/v1/apps/createApplication.test.ts",
-    "app/api/v1/apps/route.test.ts",
     "app/api/v1/conversations/route.test.ts",
     "app/api/v1/custom_emojis/route.test.ts",
     "app/api/v1/emails/confirmations/route.test.ts",


### PR DESCRIPTION
## Summary
Resolves TypeScript errors in and removes 3 test files from the `tsconfig.typecheck.json` ratchet:
1. `app/api/v1/actors/route.test.ts` — typed mock key pair generator with `promisify.custom`
2. `app/api/v1/apps/createApplication.test.ts` — verified type-clean and removed from ratchet
3. `app/api/v1/apps/route.test.ts` — passed route context to `POST` route handler calls

## DoD Verification
- `yarn run prettier --write .` passed
- `yarn lint` passed (0 errors)
- `yarn typecheck` passed (0 errors)
- `yarn build` passed
- `yarn test` passed (1005 test files, 14005 tests)