### PR TITLE
refactor: extract media upload operations into lib/client/media.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -14,6 +14,7 @@ import {
   cancelFitnessRouteHeatmap,
   changeAccountPassword,
   clearFitnessRouteHeatmaps,
+  completeUploadPresignedUrl,
   createActor,
   createCollection,
   createDirectMessage,
@@ -22,6 +23,7 @@ import {
   createNote,
   createPoll,
   createReport,
+  createUploadPresignedUrl,
   deleteAccountMedia,
   deleteActor,
   deleteCollection,
@@ -77,11 +79,14 @@ import {
   updateFitnessGearComponent,
   updateNote,
   updateStatusVisibility,
-  uploadAttachment
+  uploadAttachment,
+  uploadFileToPresignedUrl,
+  uploadMedia
 } from './client'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as httpModule from './client/http'
+import * as mediaModule from './client/media'
 import * as statusesModule from './client/statuses'
 
 enableFetchMocks()
@@ -96,9 +101,17 @@ describe('client facade statuses re-exports', () => {
   })
 })
 
-vi.mock('@/lib/utils/getMediaWidthAndHeight', () => ({
-  getMediaWidthAndHeight: vi.fn().mockResolvedValue({ width: 10, height: 20 })
-}))
+describe('client facade media re-exports', () => {
+  it('re-exports extracted media functions', () => {
+    expect(uploadMedia).toBe(mediaModule.uploadMedia)
+    expect(createUploadPresignedUrl).toBe(mediaModule.createUploadPresignedUrl)
+    expect(uploadFileToPresignedUrl).toBe(mediaModule.uploadFileToPresignedUrl)
+    expect(completeUploadPresignedUrl).toBe(
+      mediaModule.completeUploadPresignedUrl
+    )
+    expect(uploadAttachment).toBe(mediaModule.uploadAttachment)
+  })
+})
 
 describe('client updateNote', () => {
   beforeEach(() => {
@@ -748,182 +761,6 @@ describe('client search', () => {
     await expect(search({ q: 'trail' })).rejects.toThrow(
       `Search request failed (502): ${'x'.repeat(200)}...`
     )
-  })
-})
-
-describe('client uploadAttachment presigned completion', () => {
-  let setTimeoutSpy: jest.SpyInstance
-
-  const presignedResponse = {
-    presigned: {
-      url: 'https://storage.example/upload',
-      saveFileOutput: {
-        id: 'media-1',
-        type: 'image',
-        mime_type: 'image/png',
-        url: 'https://llun.test/api/v1/files/media-1.png',
-        preview_url: null,
-        text_url: null,
-        remote_url: null,
-        meta: {
-          original: {
-            width: 10,
-            height: 20,
-            size: '10x20',
-            aspect: 0.5
-          }
-        },
-        description: ''
-      },
-      headers: {
-        'x-amz-meta-checksumsha1': 'checksum'
-      }
-    }
-  }
-
-  beforeEach(() => {
-    fetchMock.resetMocks()
-    setTimeoutSpy = vi
-      .spyOn(globalThis, 'setTimeout')
-      .mockImplementation((handler: Parameters<typeof setTimeout>[0]) => {
-        if (typeof handler === 'function') {
-          handler()
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>
-      })
-  })
-
-  afterEach(() => {
-    setTimeoutSpy.mockRestore()
-  })
-
-  it('retries presigned upload completion after the file PUT succeeds', async () => {
-    fetchMock
-      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
-      .mockResponseOnce('', { status: 200 })
-      .mockResponseOnce('', { status: 503 })
-      .mockResponseOnce('', { status: 503 })
-      .mockResponseOnce(
-        JSON.stringify({
-          media: presignedResponse.presigned.saveFileOutput
-        }),
-        { status: 200 }
-      )
-
-    await expect(
-      uploadAttachment(
-        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
-      )
-    ).resolves.toMatchObject({
-      id: 'media-1',
-      name: ''
-    })
-
-    expect(fetchMock).toHaveBeenCalledTimes(5)
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
-      '/api/v1/medias/presigned',
-      expect.objectContaining({ method: 'PATCH' })
-    )
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      5,
-      '/api/v1/medias/presigned',
-      expect.objectContaining({ method: 'PATCH' })
-    )
-    expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 250)
-    expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 500)
-  })
-
-  it('cleans up pending media when presigned upload completion is exhausted', async () => {
-    fetchMock
-      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
-      .mockResponseOnce('', { status: 200 })
-      .mockResponseOnce('', { status: 503 })
-      .mockResponseOnce('', { status: 503 })
-      .mockResponseOnce('', { status: 503 })
-      .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
-
-    await expect(
-      uploadAttachment(
-        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
-      )
-    ).resolves.toBeNull()
-
-    expect(fetchMock).toHaveBeenLastCalledWith(
-      '/api/v1/accounts/media/media-1',
-      expect.objectContaining({ method: 'DELETE' })
-    )
-  })
-
-  it('does not retry or clean up permanent presigned upload completion failures', async () => {
-    fetchMock
-      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
-      .mockResponseOnce('', { status: 200 })
-      .mockResponseOnce('', { status: 422 })
-
-    await expect(
-      uploadAttachment(
-        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
-      )
-    ).resolves.toBeNull()
-
-    expect(fetchMock).toHaveBeenCalledTimes(3)
-    expect(setTimeoutSpy).not.toHaveBeenCalled()
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
-      '/api/v1/medias/presigned',
-      expect.objectContaining({ method: 'PATCH' })
-    )
-    expect(fetchMock).not.toHaveBeenCalledWith(
-      '/api/v1/accounts/media/media-1',
-      expect.anything()
-    )
-  })
-
-  it('cleans up pending media when presigned upload completion is unauthorized', async () => {
-    fetchMock
-      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
-      .mockResponseOnce('', { status: 200 })
-      .mockResponseOnce('', { status: 401 })
-      .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
-
-    await expect(
-      uploadAttachment(
-        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
-      )
-    ).resolves.toBeNull()
-
-    expect(fetchMock).toHaveBeenCalledTimes(4)
-    expect(setTimeoutSpy).not.toHaveBeenCalled()
-    expect(fetchMock).toHaveBeenLastCalledWith(
-      '/api/v1/accounts/media/media-1',
-      expect.objectContaining({ method: 'DELETE' })
-    )
-  })
-
-  it('returns media description from upload response instead of file name on direct upload', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify(null), { status: 404 })
-    fetchMock.mockResponseOnce(
-      JSON.stringify({
-        id: 'media-123',
-        type: 'image',
-        mime_type: 'image/png',
-        url: 'https://llun.test/files/123.png',
-        preview_url: null,
-        meta: { original: { width: 100, height: 100 } },
-        description: 'AI alt description'
-      }),
-      { status: 200 }
-    )
-
-    const result = await uploadAttachment(
-      new File(['test'], 'photo.png', { type: 'image/png' })
-    )
-
-    expect(result).toMatchObject({
-      id: 'media-123',
-      name: 'AI alt description'
-    })
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,11 +1,10 @@
 import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
-import { PresignedUrlOutput } from '@/lib/services/medias/types'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
 import { TimelineFormat } from '@/lib/services/timelines/const'
 import { Timeline } from '@/lib/services/timelines/types'
 import type { DirectConversation } from '@/lib/types/database/operations'
-import { Attachment, UploadedAttachment } from '@/lib/types/domain/attachment'
+import { Attachment } from '@/lib/types/domain/attachment'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
@@ -19,7 +18,6 @@ import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
-import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 // `toIdPathSegment` is the ONLY id transformation this module performs, and it
 // only ever fires for a raw AP URI headed into a URL path segment. Every
@@ -28,7 +26,6 @@ import { MastodonVisibility } from '@/lib/utils/getVisibility'
 // UUIDv7 publicId as a bare host and hands back `<uuid>:`, which nothing can
 // resolve. Ids in query params and JSON bodies go out verbatim.
 import { idToUrl, toIdPathSegment } from '@/lib/utils/urlToId'
-import { waitFor } from '@/lib/utils/waitFor'
 
 import {
   type ActorDomainsResult,
@@ -80,6 +77,17 @@ import {
   unmute
 } from './client/accounts'
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
+import {
+  type CompleteUploadPresignedUrlParams,
+  type CreateUploadPresignedUrlParams,
+  type UploadFileToPresignedUrlParams,
+  type UploadMediaParams,
+  completeUploadPresignedUrl,
+  createUploadPresignedUrl,
+  uploadAttachment,
+  uploadFileToPresignedUrl,
+  uploadMedia
+} from './client/media'
 import {
   type CreateNoteParams,
   type CreatePollParams,
@@ -240,6 +248,18 @@ export {
 }
 
 export { getTrendingLinks, getTrendingStatuses, getTrendingTags }
+
+export {
+  type CompleteUploadPresignedUrlParams,
+  type CreateUploadPresignedUrlParams,
+  type UploadFileToPresignedUrlParams,
+  type UploadMediaParams,
+  completeUploadPresignedUrl,
+  createUploadPresignedUrl,
+  uploadAttachment,
+  uploadFileToPresignedUrl,
+  uploadMedia
+}
 
 interface MarkNotificationsReadParams {
   notificationIds: string[]
@@ -554,230 +574,6 @@ export const revokeConnectedApp = async ({
     }
   )
   return response.ok
-}
-
-interface UploadMediaParams {
-  media: File
-  thumbnail?: File
-  description?: string
-}
-export const uploadMedia = async ({
-  media,
-  thumbnail,
-  description
-}: UploadMediaParams) => {
-  const path = '/api/v2/media'
-  const form = new FormData()
-  form.append('file', media)
-  if (thumbnail) form.append('thumbnail', thumbnail)
-  if (description) form.append('description', description)
-  const response = await fetch(path, {
-    method: 'POST',
-    body: form
-  })
-  if (response.status !== 200) return null
-  return response.json()
-}
-
-interface CreateUploadPresignedUrlParams {
-  media: File
-}
-export const createUploadPresignedUrl = async ({
-  media
-}: CreateUploadPresignedUrlParams): Promise<{
-  presigned: PresignedUrlOutput
-} | null> => {
-  const path = '/api/v1/medias/presigned'
-  const checksum = await crypto.subtle.digest(
-    'SHA-1',
-    await media.arrayBuffer()
-  )
-  const hashArray = Array.from(new Uint8Array(checksum))
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-
-  const widthAndHeight = await getMediaWidthAndHeight(media)
-  const body = {
-    fileName: media.name,
-    checksum: hashHex,
-    contentType: media.type,
-    size: media.size,
-    ...widthAndHeight
-  }
-  const response = await fetch(path, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(body)
-  })
-  if (response.status === 404) return null
-  if (response.status !== 200) throw new Error('Failed to get presigned URL')
-  return response.json()
-}
-
-interface UploadFileToPresignedUrlParams {
-  presignedUrl: string
-  media: File
-  headers?: Record<string, string>
-}
-
-export const uploadFileToPresignedUrl = async ({
-  presignedUrl,
-  media,
-  headers = {}
-}: UploadFileToPresignedUrlParams) => {
-  const response = await fetch(presignedUrl, {
-    method: 'PUT',
-    body: media,
-    headers: { 'Content-Type': media.type, ...headers }
-  })
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => '')
-    throw new Error(
-      `Failed to upload to storage: ${response.status} ${response.statusText}${errorText ? `. ${errorText}` : ''}`
-    )
-  }
-  return response
-}
-
-export const completeUploadPresignedUrl = async ({
-  mediaId
-}: {
-  mediaId: string
-}): Promise<UploadedAttachment | null> => {
-  const result = await completeUploadPresignedUrlRequest({ mediaId })
-  return result.ok ? result.attachment : null
-}
-
-type CompleteUploadPresignedUrlResult =
-  { ok: true; attachment: UploadedAttachment } | { ok: false; status: number }
-
-const completeUploadPresignedUrlRequest = async ({
-  mediaId
-}: {
-  mediaId: string
-}): Promise<CompleteUploadPresignedUrlResult> => {
-  const response = await fetch('/api/v1/medias/presigned', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ mediaId }),
-    signal: AbortSignal.timeout(30_000)
-  })
-  if (response.status !== 200) {
-    return { ok: false, status: response.status }
-  }
-
-  const result = (await response.json()) as {
-    media: PresignedUrlOutput['saveFileOutput']
-  }
-
-  return {
-    ok: true,
-    attachment: {
-      type: 'upload',
-      id: result.media.id,
-      mediaType: result.media.mime_type,
-      url: result.media.url,
-      posterUrl: result.media.preview_url ?? undefined,
-      width: result.media.meta.original.width,
-      height: result.media.meta.original.height,
-      name: result.media.description ?? undefined
-    }
-  }
-}
-
-const isPermanentCompletionFailure = (status: number) =>
-  status >= 400 && status < 500
-
-const shouldCleanupAfterPermanentCompletionFailure = (status: number) =>
-  status === 401 || status === 403
-
-type CompleteUploadPresignedUrlWithRetryResult =
-  | { completed: UploadedAttachment; shouldCleanup: false }
-  | { completed: null; shouldCleanup: boolean }
-
-const MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS = 3
-const PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS = 250
-
-const completeUploadPresignedUrlWithRetry = async ({
-  mediaId
-}: {
-  mediaId: string
-}): Promise<CompleteUploadPresignedUrlWithRetryResult> => {
-  for (
-    let attempt = 1;
-    attempt <= MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS;
-    attempt += 1
-  ) {
-    try {
-      const completed = await completeUploadPresignedUrlRequest({ mediaId })
-      if (completed.ok) {
-        return { completed: completed.attachment, shouldCleanup: false }
-      }
-      if (isPermanentCompletionFailure(completed.status)) {
-        return {
-          completed: null,
-          shouldCleanup: shouldCleanupAfterPermanentCompletionFailure(
-            completed.status
-          )
-        }
-      }
-    } catch {
-      if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
-        return { completed: null, shouldCleanup: true }
-      }
-    }
-
-    if (attempt < MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
-      await waitFor(
-        PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS * 2 ** (attempt - 1)
-      )
-    }
-  }
-
-  return { completed: null, shouldCleanup: true }
-}
-
-const cleanupPendingUploadMedia = async (mediaId: string) => {
-  await fetch(`/api/v1/accounts/media/${mediaId}`, {
-    method: 'DELETE'
-  }).catch(() => undefined)
-}
-
-export const uploadAttachment = async (
-  file: File
-): Promise<UploadedAttachment | null> => {
-  const result = await createUploadPresignedUrl({ media: file })
-  if (!result) {
-    const media = await uploadMedia({ media: file })
-    if (!media) return null
-    return {
-      type: 'upload',
-      id: media.id,
-      mediaType: media.mime_type,
-      url: media.url,
-      posterUrl: media.preview_url,
-      width: media.meta.original.width,
-      height: media.meta.original.height,
-      name: media.description ?? undefined
-    }
-  }
-
-  const { url: presignedUrl, saveFileOutput, headers } = result.presigned
-  await uploadFileToPresignedUrl({ media: file, presignedUrl, headers })
-  const completion = await completeUploadPresignedUrlWithRetry({
-    mediaId: saveFileOutput.id
-  })
-  if (!completion.completed) {
-    if (completion.shouldCleanup) {
-      await cleanupPendingUploadMedia(saveFileOutput.id)
-    }
-    return null
-  }
-
-  return completion.completed
 }
 
 interface GetActorMediaParams {

--- a/lib/client/media.test.ts
+++ b/lib/client/media.test.ts
@@ -1,0 +1,334 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  completeUploadPresignedUrl,
+  createUploadPresignedUrl,
+  uploadAttachment,
+  uploadFileToPresignedUrl,
+  uploadMedia
+} from './media'
+
+enableFetchMocks()
+
+vi.mock('@/lib/utils/getMediaWidthAndHeight', () => ({
+  getMediaWidthAndHeight: vi.fn().mockResolvedValue({ width: 10, height: 20 })
+}))
+
+describe('client media module', () => {
+  let setTimeoutSpy: jest.SpyInstance
+
+  const presignedResponse = {
+    presigned: {
+      url: 'https://storage.example/upload',
+      saveFileOutput: {
+        id: 'media-1',
+        type: 'image',
+        mime_type: 'image/png',
+        url: 'https://llun.test/api/v1/files/media-1.png',
+        preview_url: null,
+        text_url: null,
+        remote_url: null,
+        meta: {
+          original: {
+            width: 10,
+            height: 20,
+            size: '10x20',
+            aspect: 0.5
+          }
+        },
+        description: ''
+      },
+      headers: {
+        'x-amz-meta-checksumsha1': 'checksum'
+      }
+    }
+  }
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((handler: Parameters<typeof setTimeout>[0]) => {
+        if (typeof handler === 'function') {
+          handler()
+        }
+        return 0 as unknown as ReturnType<typeof setTimeout>
+      })
+  })
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore()
+  })
+
+  describe('uploadMedia', () => {
+    it('uploads file via multipart form and returns payload on 200', async () => {
+      const mockResult = { id: 'm-1', url: 'https://llun.test/media/m-1.png' }
+      fetchMock.mockResponseOnce(JSON.stringify(mockResult), { status: 200 })
+
+      const file = new File(['data'], 'pic.png', { type: 'image/png' })
+      const res = await uploadMedia({
+        media: file,
+        description: 'a photo'
+      })
+
+      expect(res).toEqual(mockResult)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/media',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns null on non-200 response', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const file = new File(['data'], 'pic.png', { type: 'image/png' })
+      const res = await uploadMedia({ media: file })
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('createUploadPresignedUrl', () => {
+    it('creates presigned URL on 200', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(presignedResponse), {
+        status: 200
+      })
+
+      const file = new File(['data'], 'pic.png', { type: 'image/png' })
+      const res = await createUploadPresignedUrl({ media: file })
+
+      expect(res).toEqual(presignedResponse)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/medias/presigned',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns null when endpoint returns 404', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      const file = new File(['data'], 'pic.png', { type: 'image/png' })
+      const res = await createUploadPresignedUrl({ media: file })
+
+      expect(res).toBeNull()
+    })
+
+    it('throws error when endpoint returns other non-200 status', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const file = new File(['data'], 'pic.png', { type: 'image/png' })
+      await expect(createUploadPresignedUrl({ media: file })).rejects.toThrow(
+        'Failed to get presigned URL'
+      )
+    })
+  })
+
+  describe('uploadFileToPresignedUrl', () => {
+    it('PUTs media to presigned url on success', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const file = new File(['bytes'], 'pic.png', { type: 'image/png' })
+      const res = await uploadFileToPresignedUrl({
+        presignedUrl: 'https://s3.example/upload',
+        media: file,
+        headers: { 'x-custom': '1' }
+      })
+
+      expect(res.ok).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://s3.example/upload',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            'Content-Type': 'image/png',
+            'x-custom': '1'
+          })
+        })
+      )
+    })
+
+    it('throws error when upload fails', async () => {
+      fetchMock.mockResponseOnce('Access denied', {
+        status: 403,
+        statusText: 'Forbidden'
+      })
+
+      const file = new File(['bytes'], 'pic.png', { type: 'image/png' })
+      await expect(
+        uploadFileToPresignedUrl({
+          presignedUrl: 'https://s3.example/upload',
+          media: file
+        })
+      ).rejects.toThrow(
+        'Failed to upload to storage: 403 Forbidden. Access denied'
+      )
+    })
+  })
+
+  describe('completeUploadPresignedUrl', () => {
+    it('returns attachment on 200', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ media: presignedResponse.presigned.saveFileOutput }),
+        { status: 200 }
+      )
+
+      const res = await completeUploadPresignedUrl({ mediaId: 'media-1' })
+      expect(res).toEqual({
+        type: 'upload',
+        id: 'media-1',
+        mediaType: 'image/png',
+        url: 'https://llun.test/api/v1/files/media-1.png',
+        posterUrl: undefined,
+        width: 10,
+        height: 20,
+        name: ''
+      })
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await completeUploadPresignedUrl({ mediaId: 'media-1' })
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('uploadAttachment', () => {
+    it('retries presigned upload completion after the file PUT succeeds', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+        .mockResponseOnce('', { status: 200 })
+        .mockResponseOnce('', { status: 503 })
+        .mockResponseOnce('', { status: 503 })
+        .mockResponseOnce(
+          JSON.stringify({
+            media: presignedResponse.presigned.saveFileOutput
+          }),
+          { status: 200 }
+        )
+
+      await expect(
+        uploadAttachment(
+          new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+        )
+      ).resolves.toMatchObject({
+        id: 'media-1',
+        name: ''
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(5)
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        '/api/v1/medias/presigned',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        5,
+        '/api/v1/medias/presigned',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+      expect(setTimeoutSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Function),
+        250
+      )
+      expect(setTimeoutSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Function),
+        500
+      )
+    })
+
+    it('cleans up pending media when presigned upload completion is exhausted', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+        .mockResponseOnce('', { status: 200 })
+        .mockResponseOnce('', { status: 503 })
+        .mockResponseOnce('', { status: 503 })
+        .mockResponseOnce('', { status: 503 })
+        .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+
+      await expect(
+        uploadAttachment(
+          new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+        )
+      ).resolves.toBeNull()
+
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/accounts/media/media-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('does not retry or clean up permanent presigned upload completion failures', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+        .mockResponseOnce('', { status: 200 })
+        .mockResponseOnce('', { status: 422 })
+
+      await expect(
+        uploadAttachment(
+          new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+        )
+      ).resolves.toBeNull()
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(setTimeoutSpy).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        '/api/v1/medias/presigned',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        '/api/v1/accounts/media/media-1',
+        expect.anything()
+      )
+    })
+
+    it('cleans up pending media when presigned upload completion is unauthorized', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+        .mockResponseOnce('', { status: 200 })
+        .mockResponseOnce('', { status: 401 })
+        .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+
+      await expect(
+        uploadAttachment(
+          new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+        )
+      ).resolves.toBeNull()
+
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+      expect(setTimeoutSpy).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/accounts/media/media-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('returns media description from upload response instead of file name on direct upload', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(null), { status: 404 })
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'media-123',
+          type: 'image',
+          mime_type: 'image/png',
+          url: 'https://llun.test/files/123.png',
+          preview_url: null,
+          meta: { original: { width: 100, height: 100 } },
+          description: 'AI alt description'
+        }),
+        { status: 200 }
+      )
+
+      const result = await uploadAttachment(
+        new File(['test'], 'photo.png', { type: 'image/png' })
+      )
+
+      expect(result).toMatchObject({
+        id: 'media-123',
+        name: 'AI alt description'
+      })
+    })
+  })
+})

--- a/lib/client/media.ts
+++ b/lib/client/media.ts
@@ -1,0 +1,232 @@
+import type { PresignedUrlOutput } from '@/lib/services/medias/types'
+import type { UploadedAttachment } from '@/lib/types/domain/attachment'
+import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
+import { waitFor } from '@/lib/utils/waitFor'
+
+export interface UploadMediaParams {
+  media: File
+  thumbnail?: File
+  description?: string
+}
+
+export const uploadMedia = async ({
+  media,
+  thumbnail,
+  description
+}: UploadMediaParams) => {
+  const path = '/api/v2/media'
+  const form = new FormData()
+  form.append('file', media)
+  if (thumbnail) form.append('thumbnail', thumbnail)
+  if (description) form.append('description', description)
+  const response = await fetch(path, {
+    method: 'POST',
+    body: form
+  })
+  if (response.status !== 200) return null
+  return response.json()
+}
+
+export interface CreateUploadPresignedUrlParams {
+  media: File
+}
+
+export const createUploadPresignedUrl = async ({
+  media
+}: CreateUploadPresignedUrlParams): Promise<{
+  presigned: PresignedUrlOutput
+} | null> => {
+  const path = '/api/v1/medias/presigned'
+  const checksum = await crypto.subtle.digest(
+    'SHA-1',
+    await media.arrayBuffer()
+  )
+  const hashArray = Array.from(new Uint8Array(checksum))
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+
+  const widthAndHeight = await getMediaWidthAndHeight(media)
+  const body = {
+    fileName: media.name,
+    checksum: hashHex,
+    contentType: media.type,
+    size: media.size,
+    ...widthAndHeight
+  }
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+  if (response.status === 404) return null
+  if (response.status !== 200) throw new Error('Failed to get presigned URL')
+  return response.json()
+}
+
+export interface UploadFileToPresignedUrlParams {
+  presignedUrl: string
+  media: File
+  headers?: Record<string, string>
+}
+
+export const uploadFileToPresignedUrl = async ({
+  presignedUrl,
+  media,
+  headers = {}
+}: UploadFileToPresignedUrlParams) => {
+  const response = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: media,
+    headers: { 'Content-Type': media.type, ...headers }
+  })
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    throw new Error(
+      `Failed to upload to storage: ${response.status} ${response.statusText}${errorText ? `. ${errorText}` : ''}`
+    )
+  }
+  return response
+}
+
+export interface CompleteUploadPresignedUrlParams {
+  mediaId: string
+}
+
+export const completeUploadPresignedUrl = async ({
+  mediaId
+}: CompleteUploadPresignedUrlParams): Promise<UploadedAttachment | null> => {
+  const result = await completeUploadPresignedUrlRequest({ mediaId })
+  return result.ok ? result.attachment : null
+}
+
+type CompleteUploadPresignedUrlResult =
+  { ok: true; attachment: UploadedAttachment } | { ok: false; status: number }
+
+const completeUploadPresignedUrlRequest = async ({
+  mediaId
+}: {
+  mediaId: string
+}): Promise<CompleteUploadPresignedUrlResult> => {
+  const response = await fetch('/api/v1/medias/presigned', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ mediaId }),
+    signal: AbortSignal.timeout(30_000)
+  })
+  if (response.status !== 200) {
+    return { ok: false, status: response.status }
+  }
+
+  const result = (await response.json()) as {
+    media: PresignedUrlOutput['saveFileOutput']
+  }
+
+  return {
+    ok: true,
+    attachment: {
+      type: 'upload',
+      id: result.media.id,
+      mediaType: result.media.mime_type,
+      url: result.media.url,
+      posterUrl: result.media.preview_url ?? undefined,
+      width: result.media.meta.original.width,
+      height: result.media.meta.original.height,
+      name: result.media.description ?? undefined
+    }
+  }
+}
+
+const isPermanentCompletionFailure = (status: number) =>
+  status >= 400 && status < 500
+
+const shouldCleanupAfterPermanentCompletionFailure = (status: number) =>
+  status === 401 || status === 403
+
+type CompleteUploadPresignedUrlWithRetryResult =
+  | { completed: UploadedAttachment; shouldCleanup: false }
+  | { completed: null; shouldCleanup: boolean }
+
+const MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS = 3
+const PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS = 250
+
+const completeUploadPresignedUrlWithRetry = async ({
+  mediaId
+}: {
+  mediaId: string
+}): Promise<CompleteUploadPresignedUrlWithRetryResult> => {
+  for (
+    let attempt = 1;
+    attempt <= MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      const completed = await completeUploadPresignedUrlRequest({ mediaId })
+      if (completed.ok) {
+        return { completed: completed.attachment, shouldCleanup: false }
+      }
+      if (isPermanentCompletionFailure(completed.status)) {
+        return {
+          completed: null,
+          shouldCleanup: shouldCleanupAfterPermanentCompletionFailure(
+            completed.status
+          )
+        }
+      }
+    } catch {
+      if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
+        return { completed: null, shouldCleanup: true }
+      }
+    }
+
+    if (attempt < MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
+      await waitFor(
+        PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS * 2 ** (attempt - 1)
+      )
+    }
+  }
+
+  return { completed: null, shouldCleanup: true }
+}
+
+const cleanupPendingUploadMedia = async (mediaId: string) => {
+  await fetch(`/api/v1/accounts/media/${mediaId}`, {
+    method: 'DELETE'
+  }).catch(() => undefined)
+}
+
+export const uploadAttachment = async (
+  file: File
+): Promise<UploadedAttachment | null> => {
+  const result = await createUploadPresignedUrl({ media: file })
+  if (!result) {
+    const media = await uploadMedia({ media: file })
+    if (!media) return null
+    return {
+      type: 'upload',
+      id: media.id,
+      mediaType: media.mime_type,
+      url: media.url,
+      posterUrl: media.preview_url,
+      width: media.meta.original.width,
+      height: media.meta.original.height,
+      name: media.description ?? undefined
+    }
+  }
+
+  const { url: presignedUrl, saveFileOutput, headers } = result.presigned
+  await uploadFileToPresignedUrl({ media: file, presignedUrl, headers })
+  const completion = await completeUploadPresignedUrlWithRetry({
+    mediaId: saveFileOutput.id
+  })
+  if (!completion.completed) {
+    if (completion.shouldCleanup) {
+      await cleanupPendingUploadMedia(saveFileOutput.id)
+    }
+    return null
+  }
+
+  return completion.completed
+}


### PR DESCRIPTION
## Summary
Extracts 5 media upload operations and their retry/completion helpers from `lib/client.ts` to a dedicated `lib/client/media.ts` module:
- `uploadMedia`
- `createUploadPresignedUrl`
- `uploadFileToPresignedUrl`
- `completeUploadPresignedUrl`
- `uploadAttachment`
- Re-exports operations from `lib/client.ts` facade for backward compatibility
- Co-locates comprehensive unit tests and completion retry/cleanup suites in `lib/client/media.test.ts`

## DoD Verification
- `yarn run prettier --write .` passed
- `yarn lint` passed (0 errors)
- `yarn typecheck` passed (0 errors)
- `yarn build` passed
- `yarn test` passed (1007 test files, 14029 tests)