### PR TITLE
test: resolve types for conversations, custom emojis, and email confirmation route tests

### DIFF
--- a/app/api/v1/conversations/route.test.ts
+++ b/app/api/v1/conversations/route.test.ts
@@ -52,6 +52,8 @@ const conversation = (id: string) => ({
 })
 
 describe('GET /api/v1/conversations', () => {
+  const routeContext = { params: Promise.resolve({}) }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -63,7 +65,8 @@ describe('GET /api/v1/conversations', () => {
     ])
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/conversations?limit=2')
+      new NextRequest('https://llun.test/api/v1/conversations?limit=2'),
+      routeContext
     )
 
     expect(response.status).toBe(200)
@@ -85,7 +88,8 @@ describe('GET /api/v1/conversations', () => {
     ])
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/conversations?limit=2')
+      new NextRequest('https://llun.test/api/v1/conversations?limit=2'),
+      routeContext
     )
 
     expect(response.status).toBe(200)
@@ -103,7 +107,8 @@ describe('GET /api/v1/conversations', () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v1/conversations?limit=2&since_id=1'
-      )
+      ),
+      routeContext
     )
 
     expect(response.status).toBe(200)
@@ -124,7 +129,8 @@ describe('GET /api/v1/conversations', () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v1/conversations?min_id=2&since_id=1'
-      )
+      ),
+      routeContext
     )
 
     expect(response.status).toBe(200)
@@ -141,7 +147,8 @@ describe('GET /api/v1/conversations', () => {
     mockDatabase.getDirectConversations.mockResolvedValueOnce([])
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/conversations?limit=80')
+      new NextRequest('https://llun.test/api/v1/conversations?limit=80'),
+      routeContext
     )
 
     expect(response.status).toBe(200)

--- a/app/api/v1/custom_emojis/route.test.ts
+++ b/app/api/v1/custom_emojis/route.test.ts
@@ -41,8 +41,10 @@ describe('/api/v1/custom_emojis', () => {
       }
     ])
 
+    const routeContext = { params: Promise.resolve({}) }
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/custom_emojis')
+      new NextRequest('https://llun.test/api/v1/custom_emojis'),
+      routeContext
     )
     const data = await response.json()
 
@@ -62,8 +64,10 @@ describe('/api/v1/custom_emojis', () => {
 
   it('returns an empty array when there are no emoji', async () => {
     mockDatabase.getCustomEmojis.mockResolvedValue([])
+    const routeContext = { params: Promise.resolve({}) }
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/custom_emojis')
+      new NextRequest('https://llun.test/api/v1/custom_emojis'),
+      routeContext
     )
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual([])

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -71,6 +71,7 @@ const buildAccount = (
   email: seedActor1.email,
   verificationCode,
   emailVerified,
+  twoFactorEnabled: false,
   defaultActorId: ACTOR1_ID,
   createdAt: Date.now(),
   updatedAt: Date.now()

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/conversations/route.test.ts",
-    "app/api/v1/custom_emojis/route.test.ts",
-    "app/api/v1/emails/confirmations/route.test.ts",
     "app/api/v1/fitness-files/[id]/route-data/route.test.ts",
     "app/api/v1/fitness-files/by-status/route.test.ts",
     "app/api/v1/fitness/gear/[id]/activities/route.test.ts",


### PR DESCRIPTION
Resolves types and removes 3 test files from tsconfig.typecheck.json ratchet:
- app/api/v1/conversations/route.test.ts
- app/api/v1/custom_emojis/route.test.ts
- app/api/v1/emails/confirmations/route.test.ts