### PR TITLE
refactor: extract mutes, connected apps, actor media, bookmarks, and favourites into client domain modules

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -34,10 +34,12 @@ import {
   deleteStravaSettings,
   follow,
   getActorDomains,
+  getActorMedia,
   getActorStatuses,
   getBookmarks,
   getCollectionFeed,
   getCollectionTimeline,
+  getFavourites,
   getFitnessGearActivities,
   getFitnessGearComponents,
   getFitnessGearList,
@@ -46,6 +48,7 @@ import {
   getFitnessRouteHeatmapTiles,
   getFitnessRouteHeatmaps,
   getFollowStatus,
+  getMutes,
   getPublicHeatmapTiles,
   getStravaSettings,
   getTrendingLinks,
@@ -59,6 +62,7 @@ import {
   resetPassword,
   retireFitnessGearComponent,
   revokeCollectionMembership,
+  revokeConnectedApp,
   saveStravaSettings,
   search,
   setDefaultActor,
@@ -83,6 +87,7 @@ import {
   uploadFileToPresignedUrl,
   uploadMedia
 } from './client'
+import * as accountsModule from './client/accounts'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as httpModule from './client/http'
@@ -98,6 +103,8 @@ describe('client facade statuses re-exports', () => {
     expect(updateStatusVisibility).toBe(statusesModule.updateStatusVisibility)
     expect(createPoll).toBe(statusesModule.createPoll)
     expect(deleteStatus).toBe(statusesModule.deleteStatus)
+    expect(getBookmarks).toBe(statusesModule.getBookmarks)
+    expect(getFavourites).toBe(statusesModule.getFavourites)
   })
 })
 
@@ -110,6 +117,14 @@ describe('client facade media re-exports', () => {
       mediaModule.completeUploadPresignedUrl
     )
     expect(uploadAttachment).toBe(mediaModule.uploadAttachment)
+    expect(getActorMedia).toBe(mediaModule.getActorMedia)
+  })
+})
+
+describe('client facade accounts re-exports', () => {
+  it('re-exports extracted accounts functions', () => {
+    expect(getMutes).toBe(accountsModule.getMutes)
+    expect(revokeConnectedApp).toBe(accountsModule.revokeConnectedApp)
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -4,7 +4,6 @@ import type { AdminRule } from '@/lib/services/rules/adminRule'
 import { TimelineFormat } from '@/lib/services/timelines/const'
 import { Timeline } from '@/lib/services/timelines/types'
 import type { DirectConversation } from '@/lib/types/database/operations'
-import { Attachment } from '@/lib/types/domain/attachment'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
@@ -46,8 +45,11 @@ import {
   type GetActorStatusesResult,
   type GetBlocksParams,
   type GetBlocksResult,
+  type GetMutesParams,
+  type GetMutesResult,
   type MuteParams,
   type ReportCategory,
+  type RevokeConnectedAppParams,
   type SetDefaultActorParams,
   type SetDefaultActorResult,
   type SwitchActorParams,
@@ -63,12 +65,13 @@ import {
   getActorDomains,
   getActorStatuses,
   getBlocks,
-  getCursorFromLinkHeader,
   getFollowStatus,
+  getMutes,
   getRelationship,
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeConnectedApp,
   revokeOtherSessions,
   setDefaultActor,
   switchActor,
@@ -80,10 +83,12 @@ import { ApiRequestError, parseApiError, throwApiError } from './client/http'
 import {
   type CompleteUploadPresignedUrlParams,
   type CreateUploadPresignedUrlParams,
+  type GetActorMediaParams,
   type UploadFileToPresignedUrlParams,
   type UploadMediaParams,
   completeUploadPresignedUrl,
   createUploadPresignedUrl,
+  getActorMedia,
   uploadAttachment,
   uploadFileToPresignedUrl,
   uploadMedia
@@ -92,6 +97,10 @@ import {
   type CreateNoteParams,
   type CreatePollParams,
   type DefaultStatusParams,
+  type GetBookmarksParams,
+  type GetBookmarksResult,
+  type GetFavouritesParams,
+  type GetFavouritesResult,
   type GetStatusFavouritedByParams,
   type GetStatusQuotesParams,
   type GetStatusQuotesResult,
@@ -110,7 +119,9 @@ import {
   createNote,
   createPoll,
   deleteStatus,
+  getBookmarks,
   getDefaultQuotePolicy,
+  getFavourites,
   getStatusById,
   getStatusFavouritedBy,
   getStatusQuotes,
@@ -176,6 +187,12 @@ export {
   type GetStatusFavouritedByParams,
   type StatusFavouritedByResult,
   getStatusFavouritedBy,
+  type GetBookmarksParams,
+  type GetBookmarksResult,
+  getBookmarks,
+  type GetFavouritesParams,
+  type GetFavouritesResult,
+  getFavourites,
   type VotePollParams,
   votePoll,
   type GetStatusQuotesParams,
@@ -209,8 +226,11 @@ export {
   type GetActorStatusesResult,
   type GetBlocksParams,
   type GetBlocksResult,
+  type GetMutesParams,
+  type GetMutesResult,
   type MuteParams,
   type ReportCategory,
+  type RevokeConnectedAppParams,
   type SetDefaultActorParams,
   type SetDefaultActorResult,
   type SwitchActorParams,
@@ -227,10 +247,12 @@ export {
   getActorStatuses,
   getBlocks,
   getFollowStatus,
+  getMutes,
   getRelationship,
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeConnectedApp,
   revokeOtherSessions,
   setDefaultActor,
   switchActor,
@@ -252,10 +274,12 @@ export { getTrendingLinks, getTrendingStatuses, getTrendingTags }
 export {
   type CompleteUploadPresignedUrlParams,
   type CreateUploadPresignedUrlParams,
+  type GetActorMediaParams,
   type UploadFileToPresignedUrlParams,
   type UploadMediaParams,
   completeUploadPresignedUrl,
   createUploadPresignedUrl,
+  getActorMedia,
   uploadAttachment,
   uploadFileToPresignedUrl,
   uploadMedia
@@ -281,136 +305,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-interface GetMutesParams {
-  limit?: number
-  maxId?: string
-  minId?: string
-}
-
-interface GetMutesResult {
-  accounts: MastodonAccount[]
-  nextMaxId: string | null
-  prevMinId: string | null
-}
-
-export const getMutes = async ({
-  limit,
-  maxId,
-  minId
-}: GetMutesParams = {}): Promise<GetMutesResult> => {
-  const url = new URL(`${window.origin}/api/v1/mutes`)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-  if (maxId) url.searchParams.set('max_id', maxId)
-  if (minId) url.searchParams.set('min_id', minId)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return { accounts: [], nextMaxId: null, prevMinId: null }
-  }
-
-  const linkHeader = response.headers.get('Link')
-  return {
-    accounts: (await response.json()) as MastodonAccount[],
-    nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
-    prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
-  }
-}
-
-export interface GetBookmarksParams {
-  limit?: number
-  maxBookmarkId?: string
-  minBookmarkId?: string
-}
-
-export interface GetBookmarksResult {
-  statuses: Status[]
-  nextMaxBookmarkId: string | null
-  prevMinBookmarkId: string | null
-}
-
-export const getBookmarks = async ({
-  limit,
-  maxBookmarkId,
-  minBookmarkId
-}: GetBookmarksParams = {}): Promise<GetBookmarksResult> => {
-  const url = new URL(`${window.origin}/api/v1/bookmarks`)
-  url.searchParams.set('format', TimelineFormat.enum.activities_next)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-  if (maxBookmarkId) url.searchParams.set('max_id', maxBookmarkId)
-  if (minBookmarkId) url.searchParams.set('min_id', minBookmarkId)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return {
-      statuses: [],
-      nextMaxBookmarkId: null,
-      prevMinBookmarkId: null
-    }
-  }
-
-  const data = (await response.json()) as Partial<GetBookmarksResult>
-  return {
-    statuses: data.statuses ?? [],
-    nextMaxBookmarkId: data.nextMaxBookmarkId ?? null,
-    prevMinBookmarkId: data.prevMinBookmarkId ?? null
-  }
-}
-
-export interface GetFavouritesParams {
-  limit?: number
-  maxFavouriteId?: string
-  minFavouriteId?: string
-}
-
-export interface GetFavouritesResult {
-  statuses: Status[]
-  nextMaxFavouriteId: string | null
-  prevMinFavouriteId: string | null
-}
-
-export const getFavourites = async ({
-  limit,
-  maxFavouriteId,
-  minFavouriteId
-}: GetFavouritesParams = {}): Promise<GetFavouritesResult> => {
-  const url = new URL(`${window.origin}/api/v1/favourites`)
-  url.searchParams.set('format', TimelineFormat.enum.activities_next)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-  if (maxFavouriteId) url.searchParams.set('max_id', maxFavouriteId)
-  if (minFavouriteId) url.searchParams.set('min_id', minFavouriteId)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return {
-      statuses: [],
-      nextMaxFavouriteId: null,
-      prevMinFavouriteId: null
-    }
-  }
-
-  const data = (await response.json()) as Partial<GetFavouritesResult>
-  return {
-    statuses: data.statuses ?? [],
-    nextMaxFavouriteId: data.nextMaxFavouriteId ?? null,
-    prevMinFavouriteId: data.prevMinFavouriteId ?? null
-  }
 }
 
 interface GetTimelineParams {
@@ -552,56 +446,6 @@ export const getHashtagTimeline = async ({
   }
 
   return result
-}
-
-interface RevokeConnectedAppParams {
-  clientId: string
-  actorId: string | null
-}
-// Revoke a connected app / SSO sign-in grant for the given actor.
-export const revokeConnectedApp = async ({
-  clientId,
-  actorId
-}: RevokeConnectedAppParams): Promise<boolean> => {
-  const query = actorId ? `?actorId=${encodeURIComponent(actorId)}` : ''
-  const response = await fetch(
-    `/api/v1/accounts/connected-apps/${encodeURIComponent(clientId)}${query}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.ok
-}
-
-interface GetActorMediaParams {
-  actorId: string
-  maxCreatedAt?: number
-  limit?: number
-}
-export const getActorMedia = async ({
-  actorId,
-  maxCreatedAt,
-  limit = 25
-}: GetActorMediaParams): Promise<Attachment[]> => {
-  const encodedId = toIdPathSegment(actorId)
-  const url = new URL(`${window.origin}/api/v1/accounts/${encodedId}/media`)
-  if (maxCreatedAt) {
-    url.searchParams.append('max_created_at', `${maxCreatedAt}`)
-  }
-  if (limit) {
-    url.searchParams.append('limit', `${limit}`)
-  }
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) return []
-  return response.json()
 }
 
 export interface UploadFitnessFileResult {

--- a/lib/client/accounts.test.ts
+++ b/lib/client/accounts.test.ts
@@ -14,10 +14,12 @@ import {
   getActorStatuses,
   getBlocks,
   getFollowStatus,
+  getMutes,
   getRelationship,
   isFollowing,
   mute,
   rejectFollowRequest,
+  revokeConnectedApp,
   revokeOtherSessions,
   setDefaultActor,
   switchActor,
@@ -789,6 +791,96 @@ describe('client accounts module', () => {
       fetchMock.mockResponse('', { status: 500 })
 
       const res = await revokeOtherSessions()
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('getMutes', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://llun.test' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches mutes and parses link headers', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify([{ id: 'actor-1', username: 'muted_user' }]),
+        {
+          status: 200,
+          headers: {
+            Link: '<https://llun.test/api/v1/mutes?max_id=next-cursor>; rel="next", <https://llun.test/api/v1/mutes?min_id=prev-cursor>; rel="prev"'
+          }
+        }
+      )
+
+      const res = await getMutes({ limit: 20, maxId: 'm1', minId: 'm2' })
+      expect(res.accounts).toEqual([{ id: 'actor-1', username: 'muted_user' }])
+      expect(res.nextMaxId).toBe('next-cursor')
+      expect(res.prevMinId).toBe('prev-cursor')
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/mutes?limit=20&max_id=m1&min_id=m2'),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('returns empty accounts array when status is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await getMutes()
+      expect(res).toEqual({
+        accounts: [],
+        nextMaxId: null,
+        prevMinId: null
+      })
+    })
+  })
+
+  describe('revokeConnectedApp', () => {
+    it('revokes a connected app with actorId query', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await revokeConnectedApp({
+        clientId: 'app-client-123',
+        actorId: 'https://llun.test/users/actor-1'
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/api/v1/accounts/connected-apps/app-client-123?actorId=https%3A%2F%2Fllun.test%2Fusers%2Factor-1'
+        ),
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('revokes a connected app without actorId query', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await revokeConnectedApp({
+        clientId: 'app-client-123',
+        actorId: null
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/connected-apps/app-client-123',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('returns false when status is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await revokeConnectedApp({
+        clientId: 'app-client-123',
+        actorId: null
+      })
+
       expect(res).toBe(false)
     })
   })

--- a/lib/client/accounts.ts
+++ b/lib/client/accounts.ts
@@ -502,6 +502,69 @@ export const unmute = async ({
   return (await response.json()) as MastodonRelationship
 }
 
+export interface GetMutesParams {
+  limit?: number
+  maxId?: string
+  minId?: string
+}
+
+export interface GetMutesResult {
+  accounts: MastodonAccount[]
+  nextMaxId: string | null
+  prevMinId: string | null
+}
+
+export const getMutes = async ({
+  limit,
+  maxId,
+  minId
+}: GetMutesParams = {}): Promise<GetMutesResult> => {
+  const url = new URL(`${window.origin}/api/v1/mutes`)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxId) url.searchParams.set('max_id', maxId)
+  if (minId) url.searchParams.set('min_id', minId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return { accounts: [], nextMaxId: null, prevMinId: null }
+  }
+
+  const linkHeader = response.headers.get('Link')
+  return {
+    accounts: (await response.json()) as MastodonAccount[],
+    nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
+    prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
+  }
+}
+
+export interface RevokeConnectedAppParams {
+  clientId: string
+  actorId: string | null
+}
+
+// Revoke a connected app / SSO sign-in grant for the given actor.
+export const revokeConnectedApp = async ({
+  clientId,
+  actorId
+}: RevokeConnectedAppParams): Promise<boolean> => {
+  const query = actorId ? `?actorId=${encodeURIComponent(actorId)}` : ''
+  const response = await fetch(
+    `/api/v1/accounts/connected-apps/${encodeURIComponent(clientId)}${query}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}
+
 export interface GetActorStatusesParams {
   actorId: string
   pageUrl?: string | null

--- a/lib/client/media.test.ts
+++ b/lib/client/media.test.ts
@@ -3,6 +3,7 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import {
   completeUploadPresignedUrl,
   createUploadPresignedUrl,
+  getActorMedia,
   uploadAttachment,
   uploadFileToPresignedUrl,
   uploadMedia
@@ -329,6 +330,53 @@ describe('client media module', () => {
         id: 'media-123',
         name: 'AI alt description'
       })
+    })
+  })
+
+  describe('getActorMedia', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://llun.test' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches actor media with query parameters', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify([{ id: 'media-1', type: 'image' }]),
+        { status: 200 }
+      )
+
+      const result = await getActorMedia({
+        actorId: 'https://llun.test/users/test',
+        maxCreatedAt: 12345678,
+        limit: 10
+      })
+
+      expect(result).toEqual([{ id: 'media-1', type: 'image' }])
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/api/v1/accounts/llun.test:users:test/media?max_created_at=12345678&limit=10'
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty array when status is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      const result = await getActorMedia({
+        actorId: 'actor-1'
+      })
+
+      expect(result).toEqual([])
     })
   })
 })

--- a/lib/client/media.ts
+++ b/lib/client/media.ts
@@ -1,6 +1,10 @@
 import type { PresignedUrlOutput } from '@/lib/services/medias/types'
-import type { UploadedAttachment } from '@/lib/types/domain/attachment'
+import type {
+  Attachment,
+  UploadedAttachment
+} from '@/lib/types/domain/attachment'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
+import { toIdPathSegment } from '@/lib/utils/urlToId'
 import { waitFor } from '@/lib/utils/waitFor'
 
 export interface UploadMediaParams {
@@ -229,4 +233,33 @@ export const uploadAttachment = async (
   }
 
   return completion.completed
+}
+
+export interface GetActorMediaParams {
+  actorId: string
+  maxCreatedAt?: number
+  limit?: number
+}
+
+export const getActorMedia = async ({
+  actorId,
+  maxCreatedAt,
+  limit = 25
+}: GetActorMediaParams): Promise<Attachment[]> => {
+  const encodedId = toIdPathSegment(actorId)
+  const url = new URL(`${window.origin}/api/v1/accounts/${encodedId}/media`)
+  if (maxCreatedAt) {
+    url.searchParams.append('max_created_at', `${maxCreatedAt}`)
+  }
+  if (limit) {
+    url.searchParams.append('limit', `${limit}`)
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) return []
+  return response.json()
 }

--- a/lib/client/statuses.test.ts
+++ b/lib/client/statuses.test.ts
@@ -5,7 +5,9 @@ import {
   createNote,
   createPoll,
   deleteStatus,
+  getBookmarks,
   getDefaultQuotePolicy,
+  getFavourites,
   getStatusById,
   getStatusFavouritedBy,
   getStatusQuotes,
@@ -826,6 +828,118 @@ describe('client statuses module', () => {
       await expect(retryFitnessProcessing('status-123')).rejects.toThrow(
         'Processing retry failed'
       )
+    })
+  })
+
+  describe('getBookmarks', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://llun.test' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches bookmarks with format activities_next and pagination', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-1' }],
+          nextMaxBookmarkId: 'next-1',
+          prevMinBookmarkId: 'prev-1'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getBookmarks({
+        limit: 10,
+        maxBookmarkId: 'max-1',
+        minBookmarkId: 'min-1'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-1' }],
+        nextMaxBookmarkId: 'next-1',
+        prevMinBookmarkId: 'prev-1'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/api/v1/bookmarks?format=activities_next&limit=10&max_id=max-1&min_id=min-1'
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result when status is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await getBookmarks()
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxBookmarkId: null,
+        prevMinBookmarkId: null
+      })
+    })
+  })
+
+  describe('getFavourites', () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { origin: 'https://llun.test' }
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('fetches favourites with format activities_next and pagination', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-fav' }],
+          nextMaxFavouriteId: 'next-f',
+          prevMinFavouriteId: 'prev-f'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getFavourites({
+        limit: 15,
+        maxFavouriteId: 'max-f',
+        minFavouriteId: 'min-f'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-fav' }],
+        nextMaxFavouriteId: 'next-f',
+        prevMinFavouriteId: 'prev-f'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/api/v1/favourites?format=activities_next&limit=15&max_id=max-f&min_id=min-f'
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result when status is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await getFavourites()
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxFavouriteId: null,
+        prevMinFavouriteId: null
+      })
     })
   })
 })

--- a/lib/client/statuses.ts
+++ b/lib/client/statuses.ts
@@ -1,4 +1,5 @@
 import { Duration } from '@/lib/services/statuses/pollDurations'
+import { TimelineFormat } from '@/lib/services/timelines/const'
 import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
@@ -774,4 +775,94 @@ export const retryFitnessProcessing = async (
   }
 
   return response.json()
+}
+
+export interface GetBookmarksParams {
+  limit?: number
+  maxBookmarkId?: string
+  minBookmarkId?: string
+}
+
+export interface GetBookmarksResult {
+  statuses: Status[]
+  nextMaxBookmarkId: string | null
+  prevMinBookmarkId: string | null
+}
+
+export const getBookmarks = async ({
+  limit,
+  maxBookmarkId,
+  minBookmarkId
+}: GetBookmarksParams = {}): Promise<GetBookmarksResult> => {
+  const url = new URL(`${window.origin}/api/v1/bookmarks`)
+  url.searchParams.set('format', TimelineFormat.enum.activities_next)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxBookmarkId) url.searchParams.set('max_id', maxBookmarkId)
+  if (minBookmarkId) url.searchParams.set('min_id', minBookmarkId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return {
+      statuses: [],
+      nextMaxBookmarkId: null,
+      prevMinBookmarkId: null
+    }
+  }
+
+  const data = (await response.json()) as Partial<GetBookmarksResult>
+  return {
+    statuses: data.statuses ?? [],
+    nextMaxBookmarkId: data.nextMaxBookmarkId ?? null,
+    prevMinBookmarkId: data.prevMinBookmarkId ?? null
+  }
+}
+
+export interface GetFavouritesParams {
+  limit?: number
+  maxFavouriteId?: string
+  minFavouriteId?: string
+}
+
+export interface GetFavouritesResult {
+  statuses: Status[]
+  nextMaxFavouriteId: string | null
+  prevMinFavouriteId: string | null
+}
+
+export const getFavourites = async ({
+  limit,
+  maxFavouriteId,
+  minFavouriteId
+}: GetFavouritesParams = {}): Promise<GetFavouritesResult> => {
+  const url = new URL(`${window.origin}/api/v1/favourites`)
+  url.searchParams.set('format', TimelineFormat.enum.activities_next)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxFavouriteId) url.searchParams.set('max_id', maxFavouriteId)
+  if (minFavouriteId) url.searchParams.set('min_id', minFavouriteId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return {
+      statuses: [],
+      nextMaxFavouriteId: null,
+      prevMinFavouriteId: null
+    }
+  }
+
+  const data = (await response.json()) as Partial<GetFavouritesResult>
+  return {
+    statuses: data.statuses ?? [],
+    nextMaxFavouriteId: data.nextMaxFavouriteId ?? null,
+    prevMinFavouriteId: data.prevMinFavouriteId ?? null
+  }
 }


### PR DESCRIPTION
Extracts 5 operations from lib/client.ts facade into client domain modules:
- getMutes (lib/client/accounts.ts)
- revokeConnectedApp (lib/client/accounts.ts)
- getActorMedia (lib/client/media.ts)
- getBookmarks (lib/client/statuses.ts)
- getFavourites (lib/client/statuses.ts)

Preserves facade exports and adds unit tests.