### PR TITLE
Bump version to v1.161.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.29",
+  "version": "1.161.30",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.30.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.29`
- Base main SHA: `a0ae59bc582a06de3d844e98ef8b40fadff45992`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
