### PR TITLE
test: resolve types for fitness route-data, by-status, and gear activities route tests

### DIFF
--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -164,8 +164,6 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     await database.createFitnessSettings({
       actorId: ACTOR1_ID,
       serviceType: 'general',
-      privacyHomeLatitude: null,
-      privacyHomeLongitude: null,
       privacyHideRadiusMeters: 0
     })
   }

--- a/app/api/v1/fitness-files/by-status/route.test.ts
+++ b/app/api/v1/fitness-files/by-status/route.test.ts
@@ -47,6 +47,8 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     await database.destroy()
   })
 
+  const routeContext = { params: Promise.resolve({}) }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -58,16 +60,16 @@ describe('GET /api/v1/fitness-files/by-status', () => {
       id: `${ACTOR1_ID}/statuses/public-status-files`,
       url: `${ACTOR1_ID}/statuses/public-status-files`,
       actorId: ACTOR1_ID,
-      text: 'Public import',
+      text: 'public status with files',
       to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [ACTOR1_FOLLOWER_URL]
+      cc: []
     })
 
     const first = await database.createFitnessFile({
       actorId: ACTOR1_ID,
       statusId: status.id,
-      path: 'fitness/status-file-a.fit',
-      fileName: 'status-file-a.fit',
+      path: 'fitness/first.fit',
+      fileName: 'first.fit',
       fileType: 'fit',
       mimeType: 'application/vnd.ant.fit',
       bytes: 1_024
@@ -75,8 +77,8 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const second = await database.createFitnessFile({
       actorId: ACTOR1_ID,
       statusId: status.id,
-      path: 'fitness/status-file-b.fit',
-      fileName: 'status-file-b.fit',
+      path: 'fitness/second.fit',
+      fileName: 'second.fit',
       fileType: 'fit',
       mimeType: 'application/vnd.ant.fit',
       bytes: 1_024
@@ -87,7 +89,7 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const request = new NextRequest(
       `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
     )
-    const response = await GET(request)
+    const response = await GET(request, routeContext)
     const json = (await response.json()) as { files: Array<{ id: string }> }
 
     expect(response.status).toBe(200)
@@ -145,7 +147,7 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const request = new NextRequest(
       `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
     )
-    const response = await GET(request)
+    const response = await GET(request, routeContext)
     const json = (await response.json()) as {
       files: Array<{
         id: string
@@ -222,7 +224,8 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const response = await GET(
       new NextRequest(
         `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
-      )
+      ),
+      routeContext
     )
     const json = (await response.json()) as {
       files: Array<{
@@ -271,7 +274,7 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const request = new NextRequest(
       `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
     )
-    const response = await GET(request)
+    const response = await GET(request, routeContext)
     const json = (await response.json()) as {
       files: Array<{ processingStatus: string; processingStuck: boolean }>
     }
@@ -306,7 +309,7 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const request = new NextRequest(
       `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
     )
-    const response = await GET(request)
+    const response = await GET(request, routeContext)
 
     expect(response.status).toBe(404)
   })
@@ -338,7 +341,7 @@ describe('GET /api/v1/fitness-files/by-status', () => {
     const request = new NextRequest(
       `https://llun.test/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(status.id)}`
     )
-    const response = await GET(request)
+    const response = await GET(request, routeContext)
 
     expect(response.status).toBe(200)
   })

--- a/app/api/v1/fitness/gear/[id]/activities/route.test.ts
+++ b/app/api/v1/fitness/gear/[id]/activities/route.test.ts
@@ -84,20 +84,37 @@ describe('Fitness gear activities API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGear.mockResolvedValue(gear())
     mockDb.getFitnessGearActivities.mockResolvedValue([])
     mockDb.getStatusesByIds.mockResolvedValue([])

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/fitness-files/[id]/route-data/route.test.ts",
-    "app/api/v1/fitness-files/by-status/route.test.ts",
-    "app/api/v1/fitness/gear/[id]/activities/route.test.ts",
     "app/api/v1/fitness/gear/[id]/components/[componentId]/route.test.ts",
     "app/api/v1/fitness/gear/[id]/components/route.test.ts",
     "app/api/v1/fitness/gear/[id]/retire/route.test.ts",


### PR DESCRIPTION
Resolves types and removes 3 test files from tsconfig.typecheck.json ratchet:
- app/api/v1/fitness-files/[id]/route-data/route.test.ts
- app/api/v1/fitness-files/by-status/route.test.ts
- app/api/v1/fitness/gear/[id]/activities/route.test.ts