### PR TITLE
refactor: extract timeline operations into lib/client/timelines.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -48,9 +48,12 @@ import {
   getFitnessRouteHeatmapTiles,
   getFitnessRouteHeatmaps,
   getFollowStatus,
+  getHashtagTimeline,
+  getListTimeline,
   getMutes,
   getPublicHeatmapTiles,
   getStravaSettings,
+  getTimeline,
   getTrendingLinks,
   getTrendingStatuses,
   getTrendingTags,
@@ -93,6 +96,7 @@ import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as httpModule from './client/http'
 import * as mediaModule from './client/media'
 import * as statusesModule from './client/statuses'
+import * as timelinesModule from './client/timelines'
 
 enableFetchMocks()
 
@@ -105,6 +109,16 @@ describe('client facade statuses re-exports', () => {
     expect(deleteStatus).toBe(statusesModule.deleteStatus)
     expect(getBookmarks).toBe(statusesModule.getBookmarks)
     expect(getFavourites).toBe(statusesModule.getFavourites)
+  })
+})
+
+describe('client facade timelines re-exports', () => {
+  it('re-exports extracted timeline functions', () => {
+    expect(getTimeline).toBe(timelinesModule.getTimeline)
+    expect(getHashtagTimeline).toBe(timelinesModule.getHashtagTimeline)
+    expect(getListTimeline).toBe(timelinesModule.getListTimeline)
+    expect(getCollectionTimeline).toBe(timelinesModule.getCollectionTimeline)
+    expect(getCollectionFeed).toBe(timelinesModule.getCollectionFeed)
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2,7 +2,6 @@ import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
 import { TimelineFormat } from '@/lib/services/timelines/const'
-import { Timeline } from '@/lib/services/timelines/types'
 import type { DirectConversation } from '@/lib/types/database/operations'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
@@ -150,6 +149,19 @@ import {
   removeFeaturedTag
 } from './client/tags'
 import {
+  type GetCollectionTimelineParams,
+  type GetHashtagTimelineParams,
+  type GetHashtagTimelineResult,
+  type GetListTimelineParams,
+  type GetTimelineParams,
+  type GetTimelineResult,
+  getCollectionFeed,
+  getCollectionTimeline,
+  getHashtagTimeline,
+  getListTimeline,
+  getTimeline
+} from './client/timelines'
+import {
   getTrendingLinks,
   getTrendingStatuses,
   getTrendingTags
@@ -269,6 +281,20 @@ export {
   removeFeaturedTag
 }
 
+export {
+  type GetCollectionTimelineParams,
+  type GetHashtagTimelineParams,
+  type GetHashtagTimelineResult,
+  type GetListTimelineParams,
+  type GetTimelineParams,
+  type GetTimelineResult,
+  getCollectionFeed,
+  getCollectionTimeline,
+  getHashtagTimeline,
+  getListTimeline,
+  getTimeline
+}
+
 export { getTrendingLinks, getTrendingStatuses, getTrendingTags }
 
 export {
@@ -305,147 +331,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-interface GetTimelineParams {
-  timeline: Timeline
-  minStatusId?: string
-  maxStatusId?: string
-  limit?: number
-}
-
-interface GetTimelineResult {
-  statuses: Status[]
-  nextMaxStatusId: string | null
-  prevMinStatusId: string | null
-}
-
-const MAX_EMPTY_TIMELINE_CONTINUATIONS = 2
-
-const getTimelinePage = async ({
-  timeline,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetTimelineParams): Promise<GetTimelineResult> => {
-  const path = `/api/v1/timelines/${timeline}?format=${TimelineFormat.enum.activities_next}`
-  const url = new URL(`${window.origin}${path}`)
-  if (minStatusId) {
-    url.searchParams.append('min_id', minStatusId)
-  }
-  if (maxStatusId) {
-    url.searchParams.append('max_id', maxStatusId)
-  }
-  if (limit) {
-    url.searchParams.append('limit', `${limit}`)
-  }
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
-  }
-  const data = await response.json()
-  return {
-    statuses: data.statuses as Status[],
-    nextMaxStatusId: data.nextMaxStatusId ?? null,
-    prevMinStatusId: data.prevMinStatusId ?? null
-  }
-}
-
-export const getTimeline = async ({
-  timeline,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetTimelineParams): Promise<GetTimelineResult> => {
-  let result = await getTimelinePage({
-    timeline,
-    minStatusId,
-    maxStatusId,
-    limit
-  })
-  let currentMaxStatusId = result.nextMaxStatusId
-  let continuations = 0
-
-  while (
-    result.statuses.length === 0 &&
-    currentMaxStatusId &&
-    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
-  ) {
-    continuations++
-    result = await getTimelinePage({
-      timeline,
-      minStatusId,
-      maxStatusId: currentMaxStatusId,
-      limit
-    })
-    currentMaxStatusId = result.nextMaxStatusId
-  }
-
-  return result
-}
-
-interface GetHashtagTimelineParams {
-  tag: string
-  maxStatusId?: string
-}
-
-interface GetHashtagTimelineResult {
-  statuses: Status[]
-  nextMaxStatusId: string | null
-}
-
-const getHashtagTimelinePage = async ({
-  tag,
-  maxStatusId
-}: GetHashtagTimelineParams): Promise<GetHashtagTimelineResult> => {
-  const path = `/api/v1/tags/${encodeURIComponent(tag)}?format=${TimelineFormat.enum.activities_next}`
-  const url = new URL(`${window.origin}${path}`)
-  if (maxStatusId) {
-    url.searchParams.append('max_id', maxStatusId)
-  }
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (response.status !== 200) {
-    return { statuses: [], nextMaxStatusId: null }
-  }
-  const data = await response.json()
-  return {
-    statuses: data.statuses as Status[],
-    nextMaxStatusId: data.nextMaxStatusId ?? null
-  }
-}
-
-export const getHashtagTimeline = async ({
-  tag,
-  maxStatusId
-}: GetHashtagTimelineParams): Promise<GetHashtagTimelineResult> => {
-  let result = await getHashtagTimelinePage({ tag, maxStatusId })
-  let currentMaxStatusId = result.nextMaxStatusId
-  let continuations = 0
-
-  while (
-    result.statuses.length === 0 &&
-    currentMaxStatusId &&
-    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
-  ) {
-    continuations++
-    result = await getHashtagTimelinePage({
-      tag,
-      maxStatusId: currentMaxStatusId
-    })
-    currentMaxStatusId = result.nextMaxStatusId
-  }
-
-  return result
 }
 
 export interface UploadFitnessFileResult {
@@ -1827,47 +1712,6 @@ export const removeListAccounts = (
   params: ListAccountsMutationParams
 ): Promise<boolean> => mutateListAccounts('DELETE', params)
 
-export interface GetListTimelineParams {
-  listId: string
-  minStatusId?: string
-  maxStatusId?: string
-  limit?: number
-}
-
-// The list timeline does no server-side content filtering, so an empty page
-// always carries a null cursor (end of list). That's unlike the home timeline,
-// where filtered-out pages can still report a next cursor and need the
-// empty-continuation loop in getTimeline — here a single page fetch suffices.
-export const getListTimeline = async ({
-  listId,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetListTimelineParams): Promise<GetTimelineResult> => {
-  const url = new URL(
-    `${window.origin}/api/v1/timelines/list/${encodeURIComponent(
-      listId
-    )}?format=${TimelineFormat.enum.activities_next}`
-  )
-  if (minStatusId) url.searchParams.set('min_id', minStatusId)
-  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (response.status !== 200) {
-    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
-  }
-  const data = await response.json()
-  return {
-    statuses: data.statuses as Status[],
-    nextMaxStatusId: data.nextMaxStatusId ?? null,
-    prevMinStatusId: data.prevMinStatusId ?? null
-  }
-}
-
 // Collections (Mastodon 4.6 Collections API + activities.next feed extension).
 // A collection is a shareable, consent-gated feed of accounts the owner
 // highlights. Like list ids, collection ids are opaque UUIDs (not url/id
@@ -2013,79 +1857,6 @@ export const approveCollectionMembership = (
 export const revokeCollectionMembership = (
   params: CollectionMembershipParams
 ): Promise<boolean> => setCollectionMembership('revoke', params)
-
-export interface GetCollectionTimelineParams {
-  collectionId: string
-  minStatusId?: string
-  maxStatusId?: string
-  limit?: number
-}
-
-// The owner's private collection feed (every member, owner visibility). Mirrors
-// getListTimeline: a single page fetch, null cursor at the end.
-export const getCollectionTimeline = async ({
-  collectionId,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetCollectionTimelineParams): Promise<GetTimelineResult> => {
-  const url = new URL(
-    `${window.origin}/api/v1/timelines/collection/${encodeURIComponent(
-      collectionId
-    )}?format=${TimelineFormat.enum.activities_next}`
-  )
-  if (minStatusId) url.searchParams.set('min_id', minStatusId)
-  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (response.status !== 200) {
-    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
-  }
-  const data = await response.json()
-  return {
-    statuses: data.statuses as Status[],
-    nextMaxStatusId: data.nextMaxStatusId ?? null,
-    prevMinStatusId: data.prevMinStatusId ?? null
-  }
-}
-
-// The public, consent-gated projection of a collection's feed (approved members
-// ∩ public posts). Unauthenticated-readable; used for the owner's "Public
-// preview" toggle and the public collection page. Requests the internal format
-// so the same <Posts> path renders it.
-export const getCollectionFeed = async ({
-  collectionId,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetCollectionTimelineParams): Promise<GetTimelineResult> => {
-  const url = new URL(
-    `${window.origin}/api/v1/collections/${encodeURIComponent(
-      collectionId
-    )}/feed?format=${TimelineFormat.enum.activities_next}`
-  )
-  if (minStatusId) url.searchParams.set('min_id', minStatusId)
-  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (response.status !== 200) {
-    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
-  }
-  const data = await response.json()
-  return {
-    statuses: data.statuses as Status[],
-    nextMaxStatusId: data.nextMaxStatusId ?? null,
-    prevMinStatusId: data.prevMinStatusId ?? null
-  }
-}
 
 // Filters (https://docs.joinmastodon.org/methods/filters/).
 // Keyword filters for the account scope (/api/v2/filters) and the instance

--- a/lib/client/timelines.test.ts
+++ b/lib/client/timelines.test.ts
@@ -1,0 +1,262 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { Timeline } from '@/lib/services/timelines/types'
+
+import {
+  getCollectionFeed,
+  getCollectionTimeline,
+  getHashtagTimeline,
+  getListTimeline,
+  getTimeline
+} from './timelines'
+
+enableFetchMocks()
+
+describe('client timelines module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { origin: 'https://llun.test' }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  describe('getTimeline', () => {
+    it('fetches timeline with format activities_next and pagination', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-1' }],
+          nextMaxStatusId: 'next-1',
+          prevMinStatusId: 'prev-1'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getTimeline({
+        timeline: Timeline.HOME,
+        limit: 20,
+        maxStatusId: 'max-1',
+        minStatusId: 'min-1'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-1' }],
+        nextMaxStatusId: 'next-1',
+        prevMinStatusId: 'prev-1'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/timelines/home?format=activities_next&min_id=min-1&max_id=max-1&limit=20',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('continues fetching when statuses array is empty and nextMaxStatusId exists', async () => {
+      fetchMock
+        .mockResponseOnce(
+          JSON.stringify({
+            statuses: [],
+            nextMaxStatusId: 'cont-1',
+            prevMinStatusId: null
+          }),
+          { status: 200 }
+        )
+        .mockResponseOnce(
+          JSON.stringify({
+            statuses: [{ id: 'status-cont' }],
+            nextMaxStatusId: 'cont-2',
+            prevMinStatusId: null
+          }),
+          { status: 200 }
+        )
+
+      const res = await getTimeline({ timeline: Timeline.HOME })
+      expect(res.statuses).toHaveLength(1)
+      expect(res.statuses[0].id).toBe('status-cont')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns empty result when status is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await getTimeline({ timeline: Timeline.HOME })
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+    })
+  })
+
+  describe('getHashtagTimeline', () => {
+    it('fetches hashtag timeline with format activities_next', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-tag' }],
+          nextMaxStatusId: 'next-tag'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getHashtagTimeline({
+        tag: 'running',
+        maxStatusId: 'max-tag'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-tag' }],
+        nextMaxStatusId: 'next-tag'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/tags/running?format=activities_next&max_id=max-tag',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result when response is not 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      const res = await getHashtagTimeline({ tag: 'missing' })
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxStatusId: null
+      })
+    })
+  })
+
+  describe('getListTimeline', () => {
+    it('fetches list timeline with encoded id', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-list' }],
+          nextMaxStatusId: 'next-list',
+          prevMinStatusId: 'prev-list'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getListTimeline({
+        listId: 'list-123',
+        limit: 10,
+        maxStatusId: 'max-l',
+        minStatusId: 'min-l'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-list' }],
+        nextMaxStatusId: 'next-list',
+        prevMinStatusId: 'prev-list'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/timelines/list/list-123?format=activities_next&min_id=min-l&max_id=max-l&limit=10',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result on non-200 response', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      const res = await getListTimeline({ listId: 'bad-list' })
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+    })
+  })
+
+  describe('getCollectionTimeline', () => {
+    it('fetches collection timeline with encoded id', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-col' }],
+          nextMaxStatusId: 'next-c',
+          prevMinStatusId: 'prev-c'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getCollectionTimeline({
+        collectionId: 'col-123',
+        limit: 5
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-col' }],
+        nextMaxStatusId: 'next-c',
+        prevMinStatusId: 'prev-c'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/timelines/collection/col-123?format=activities_next&limit=5',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result on non-200 response', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      const res = await getCollectionTimeline({ collectionId: 'err-col' })
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+    })
+  })
+
+  describe('getCollectionFeed', () => {
+    it('fetches public collection feed with encoded id', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [{ id: 'status-feed' }],
+          nextMaxStatusId: 'next-f',
+          prevMinStatusId: 'prev-f'
+        }),
+        { status: 200 }
+      )
+
+      const res = await getCollectionFeed({
+        collectionId: 'col-456'
+      })
+
+      expect(res).toEqual({
+        statuses: [{ id: 'status-feed' }],
+        nextMaxStatusId: 'next-f',
+        prevMinStatusId: 'prev-f'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/collections/col-456/feed?format=activities_next',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty result on non-200 response', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      const res = await getCollectionFeed({ collectionId: 'err-feed' })
+      expect(res).toEqual({
+        statuses: [],
+        nextMaxStatusId: null,
+        prevMinStatusId: null
+      })
+    })
+  })
+})

--- a/lib/client/timelines.ts
+++ b/lib/client/timelines.ts
@@ -1,0 +1,258 @@
+import { TimelineFormat } from '@/lib/services/timelines/const'
+import { Timeline } from '@/lib/services/timelines/types'
+import type { Status } from '@/lib/types/domain/status'
+
+export interface GetTimelineParams {
+  timeline: Timeline
+  minStatusId?: string
+  maxStatusId?: string
+  limit?: number
+}
+
+export interface GetTimelineResult {
+  statuses: Status[]
+  nextMaxStatusId: string | null
+  prevMinStatusId: string | null
+}
+
+const MAX_EMPTY_TIMELINE_CONTINUATIONS = 2
+
+const getTimelinePage = async ({
+  timeline,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetTimelineParams): Promise<GetTimelineResult> => {
+  const path = `/api/v1/timelines/${timeline}?format=${TimelineFormat.enum.activities_next}`
+  const url = new URL(`${window.origin}${path}`)
+  if (minStatusId) {
+    url.searchParams.append('min_id', minStatusId)
+  }
+  if (maxStatusId) {
+    url.searchParams.append('max_id', maxStatusId)
+  }
+  if (limit) {
+    url.searchParams.append('limit', `${limit}`)
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null,
+    prevMinStatusId: data.prevMinStatusId ?? null
+  }
+}
+
+export const getTimeline = async ({
+  timeline,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetTimelineParams): Promise<GetTimelineResult> => {
+  let result = await getTimelinePage({
+    timeline,
+    minStatusId,
+    maxStatusId,
+    limit
+  })
+  let currentMaxStatusId = result.nextMaxStatusId
+  let continuations = 0
+
+  while (
+    result.statuses.length === 0 &&
+    currentMaxStatusId &&
+    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
+  ) {
+    continuations++
+    result = await getTimelinePage({
+      timeline,
+      minStatusId,
+      maxStatusId: currentMaxStatusId,
+      limit
+    })
+    currentMaxStatusId = result.nextMaxStatusId
+  }
+
+  return result
+}
+
+export interface GetHashtagTimelineParams {
+  tag: string
+  maxStatusId?: string
+}
+
+export interface GetHashtagTimelineResult {
+  statuses: Status[]
+  nextMaxStatusId: string | null
+}
+
+const getHashtagTimelinePage = async ({
+  tag,
+  maxStatusId
+}: GetHashtagTimelineParams): Promise<GetHashtagTimelineResult> => {
+  const path = `/api/v1/tags/${encodeURIComponent(tag)}?format=${TimelineFormat.enum.activities_next}`
+  const url = new URL(`${window.origin}${path}`)
+  if (maxStatusId) {
+    url.searchParams.append('max_id', maxStatusId)
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null
+  }
+}
+
+export const getHashtagTimeline = async ({
+  tag,
+  maxStatusId
+}: GetHashtagTimelineParams): Promise<GetHashtagTimelineResult> => {
+  let result = await getHashtagTimelinePage({ tag, maxStatusId })
+  let currentMaxStatusId = result.nextMaxStatusId
+  let continuations = 0
+
+  while (
+    result.statuses.length === 0 &&
+    currentMaxStatusId &&
+    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
+  ) {
+    continuations++
+    result = await getHashtagTimelinePage({
+      tag,
+      maxStatusId: currentMaxStatusId
+    })
+    currentMaxStatusId = result.nextMaxStatusId
+  }
+
+  return result
+}
+
+export interface GetListTimelineParams {
+  listId: string
+  minStatusId?: string
+  maxStatusId?: string
+  limit?: number
+}
+
+// The list timeline does no server-side content filtering, so an empty page
+// always carries a null cursor (end of list). That's unlike the home timeline,
+// where filtered-out pages can still report a next cursor and need the
+// empty-continuation loop in getTimeline — here a single page fetch suffices.
+export const getListTimeline = async ({
+  listId,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetListTimelineParams): Promise<GetTimelineResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/timelines/list/${encodeURIComponent(
+      listId
+    )}?format=${TimelineFormat.enum.activities_next}`
+  )
+  if (minStatusId) url.searchParams.set('min_id', minStatusId)
+  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null,
+    prevMinStatusId: data.prevMinStatusId ?? null
+  }
+}
+
+export interface GetCollectionTimelineParams {
+  collectionId: string
+  minStatusId?: string
+  maxStatusId?: string
+  limit?: number
+}
+
+// The owner's private collection feed (every member, owner visibility). Mirrors
+// getListTimeline: a single page fetch, null cursor at the end.
+export const getCollectionTimeline = async ({
+  collectionId,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetCollectionTimelineParams): Promise<GetTimelineResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/timelines/collection/${encodeURIComponent(
+      collectionId
+    )}?format=${TimelineFormat.enum.activities_next}`
+  )
+  if (minStatusId) url.searchParams.set('min_id', minStatusId)
+  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null,
+    prevMinStatusId: data.prevMinStatusId ?? null
+  }
+}
+
+// The public, consent-gated projection of a collection's feed (approved members
+// ∩ public posts). Unauthenticated-readable; used for the owner's "Public
+// preview" toggle and the public collection page. Requests the internal format
+// so the same <Posts> path renders it.
+export const getCollectionFeed = async ({
+  collectionId,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetCollectionTimelineParams): Promise<GetTimelineResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/collections/${encodeURIComponent(
+      collectionId
+    )}/feed?format=${TimelineFormat.enum.activities_next}`
+  )
+  if (minStatusId) url.searchParams.set('min_id', minStatusId)
+  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null,
+    prevMinStatusId: data.prevMinStatusId ?? null
+  }
+}


### PR DESCRIPTION
Extracts 5 timeline operations (getTimeline, getHashtagTimeline, getListTimeline, getCollectionTimeline, getCollectionFeed) from lib/client.ts into lib/client/timelines.ts with comprehensive unit tests and facade re-exports.