### PR TITLE
test: resolve types for fitness gear component and retire route tests

### DIFF
--- a/app/api/v1/fitness/gear/[id]/components/[componentId]/route.test.ts
+++ b/app/api/v1/fitness/gear/[id]/components/[componentId]/route.test.ts
@@ -102,20 +102,37 @@ describe('Fitness gear component item API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGearComponentDistanceRollups.mockResolvedValue({})
     mockDb.getFitnessGearComponents.mockResolvedValue([component()])
     mockDb.getFitnessGear.mockResolvedValue(bikeGear)

--- a/app/api/v1/fitness/gear/[id]/components/route.test.ts
+++ b/app/api/v1/fitness/gear/[id]/components/route.test.ts
@@ -98,20 +98,37 @@ describe('Fitness gear components API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGear.mockResolvedValue(gear)
     mockDb.getFitnessGearComponents.mockResolvedValue([])
     mockDb.getFitnessGearComponentDistanceRollups.mockResolvedValue({})

--- a/app/api/v1/fitness/gear/[id]/retire/route.test.ts
+++ b/app/api/v1/fitness/gear/[id]/retire/route.test.ts
@@ -65,20 +65,37 @@ describe('Fitness gear retire API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGearDistanceRollups.mockResolvedValue({})
     // The route loads the gear before writing, so "not yours" stays a 404 and a
     // recording device is rejected without a state change.

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/fitness/gear/[id]/components/[componentId]/route.test.ts",
-    "app/api/v1/fitness/gear/[id]/components/route.test.ts",
-    "app/api/v1/fitness/gear/[id]/retire/route.test.ts",
     "app/api/v1/fitness/gear/[id]/route.test.ts",
     "app/api/v1/fitness/gear/route.test.ts",
     "app/api/v1/fitness/general/regenerate-maps/route.test.ts",


### PR DESCRIPTION
Resolves mock account and actor types in gear component and retire route tests, and removes all 3 from the tsconfig.typecheck.json ratchet.