### PR TITLE
refactor: extract fitness import operations into lib/client/fitnessImports.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -12,6 +12,7 @@ import {
   bookmarkStatus,
   cancelActorDeletion,
   cancelFitnessRouteHeatmap,
+  cancelStravaArchiveImport,
   changeAccountPassword,
   clearFitnessRouteHeatmaps,
   completeUploadPresignedUrl,
@@ -23,6 +24,7 @@ import {
   createNote,
   createPoll,
   createReport,
+  createStravaArchivePresignedUrl,
   createUploadPresignedUrl,
   deleteAccountMedia,
   deleteActor,
@@ -33,6 +35,7 @@ import {
   deleteStatus,
   deleteStravaSettings,
   follow,
+  getActiveStravaArchiveImport,
   getActorDomains,
   getActorMedia,
   getActorStatuses,
@@ -64,6 +67,7 @@ import {
   requestPasswordReset,
   resetPassword,
   retireFitnessGearComponent,
+  retryStravaArchiveImport,
   revokeCollectionMembership,
   revokeConnectedApp,
   saveStravaSettings,
@@ -72,6 +76,7 @@ import {
   setFitnessGearRetired,
   setFitnessRouteHeatmapRegionName,
   shareFitnessRouteHeatmap,
+  startFitnessImport,
   startStravaArchiveImport,
   submitOAuthConsent,
   switchActor,
@@ -88,11 +93,13 @@ import {
   updateStatusVisibility,
   uploadAttachment,
   uploadFileToPresignedUrl,
+  uploadFitnessFile,
   uploadMedia
 } from './client'
 import * as accountsModule from './client/accounts'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
+import * as fitnessImportsModule from './client/fitnessImports'
 import * as httpModule from './client/http'
 import * as mediaModule from './client/media'
 import * as statusesModule from './client/statuses'
@@ -139,6 +146,28 @@ describe('client facade accounts re-exports', () => {
   it('re-exports extracted accounts functions', () => {
     expect(getMutes).toBe(accountsModule.getMutes)
     expect(revokeConnectedApp).toBe(accountsModule.revokeConnectedApp)
+  })
+})
+
+describe('client facade fitness imports re-exports', () => {
+  it('re-exports extracted fitness import functions', () => {
+    expect(uploadFitnessFile).toBe(fitnessImportsModule.uploadFitnessFile)
+    expect(startFitnessImport).toBe(fitnessImportsModule.startFitnessImport)
+    expect(createStravaArchivePresignedUrl).toBe(
+      fitnessImportsModule.createStravaArchivePresignedUrl
+    )
+    expect(startStravaArchiveImport).toBe(
+      fitnessImportsModule.startStravaArchiveImport
+    )
+    expect(getActiveStravaArchiveImport).toBe(
+      fitnessImportsModule.getActiveStravaArchiveImport
+    )
+    expect(retryStravaArchiveImport).toBe(
+      fitnessImportsModule.retryStravaArchiveImport
+    )
+    expect(cancelStravaArchiveImport).toBe(
+      fitnessImportsModule.cancelStravaArchiveImport
+    )
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -78,6 +78,23 @@ import {
   unfollow,
   unmute
 } from './client/accounts'
+import {
+  type ActiveStravaArchiveImport,
+  type ActiveStravaArchiveImportResponse,
+  type FitnessImportBatchFile,
+  type FitnessImportBatchResult,
+  type StartFitnessImportResult,
+  type StartStravaArchiveImportResult,
+  type StravaArchivePresignedResult,
+  type UploadFitnessFileResult,
+  cancelStravaArchiveImport,
+  createStravaArchivePresignedUrl,
+  getActiveStravaArchiveImport,
+  retryStravaArchiveImport,
+  startFitnessImport,
+  startStravaArchiveImport,
+  uploadFitnessFile
+} from './client/fitnessImports'
 import { ApiRequestError, parseApiError, throwApiError } from './client/http'
 import {
   type CompleteUploadPresignedUrlParams,
@@ -311,6 +328,24 @@ export {
   uploadMedia
 }
 
+export {
+  type ActiveStravaArchiveImport,
+  type ActiveStravaArchiveImportResponse,
+  type FitnessImportBatchFile,
+  type FitnessImportBatchResult,
+  type StartFitnessImportResult,
+  type StartStravaArchiveImportResult,
+  type StravaArchivePresignedResult,
+  type UploadFitnessFileResult,
+  cancelStravaArchiveImport,
+  createStravaArchivePresignedUrl,
+  getActiveStravaArchiveImport,
+  retryStravaArchiveImport,
+  startFitnessImport,
+  startStravaArchiveImport,
+  uploadFitnessFile
+}
+
 interface MarkNotificationsReadParams {
   notificationIds: string[]
 }
@@ -331,294 +366,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-export interface UploadFitnessFileResult {
-  id: string
-  type: 'fitness'
-  file_type: 'fit' | 'gpx' | 'tcx' | 'zip'
-  mime_type: string
-  url: string
-  fileName: string
-  size: number
-  description?: string
-  hasMapData?: boolean
-  mapImageUrl?: string
-}
-
-export interface FitnessImportBatchFile {
-  id: string
-  actorId: string
-  fileName: string
-  fileType: 'fit' | 'gpx' | 'tcx' | 'zip'
-  statusId: string | null
-  isPrimary: boolean
-  importStatus: 'pending' | 'completed' | 'failed'
-  importError: string | null
-  activityStartTime: number | null
-  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
-}
-
-export interface FitnessImportBatchResult {
-  batchId: string
-  status: 'pending' | 'completed' | 'failed' | 'partially_failed'
-  summary: {
-    total: number
-    pending: number
-    completed: number
-    failed: number
-  }
-  files: FitnessImportBatchFile[]
-}
-
-export interface StartFitnessImportResult {
-  batchId: string
-  fileCount: number
-}
-
-export interface StartStravaArchiveImportResult {
-  archiveId: string
-  batchId: string
-  importId: string
-}
-
-export interface ActiveStravaArchiveImport {
-  id: string
-  archiveId: string
-  archiveFitnessFileId: string
-  batchId: string
-  visibility: MastodonVisibility
-  status: 'importing' | 'failed'
-  nextActivityIndex: number
-  mediaAttachmentRetry: number
-  totalActivitiesCount: number | null
-  completedActivitiesCount: number
-  failedActivitiesCount: number
-  firstFailureMessage: string | null
-  lastError: string | null
-  pendingMediaActivitiesCount: number
-  createdAt: number
-  updatedAt: number
-}
-
-export interface ActiveStravaArchiveImportResponse {
-  activeImport: ActiveStravaArchiveImport | null
-}
-
-export const uploadFitnessFile = async (
-  file: File,
-  description?: string
-): Promise<UploadFitnessFileResult> => {
-  const formData = new FormData()
-  formData.append('file', file)
-  if (description) {
-    formData.append('description', description)
-  }
-
-  const response = await fetch('/api/v1/fitness-files', {
-    method: 'POST',
-    body: formData
-  })
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to upload fitness file.'
-    )
-
-    throw new Error(
-      `Failed to upload fitness file: ${response.status} ${errorDetails}`
-    )
-  }
-
-  return response.json()
-}
-
-export const startFitnessImport = async (
-  files: File[],
-  visibility: MastodonVisibility
-): Promise<StartFitnessImportResult> => {
-  const formData = new FormData()
-  files.forEach((file) => {
-    formData.append('files', file)
-  })
-  formData.append('visibility', visibility)
-
-  const response = await fetch('/api/v1/fitness/import', {
-    method: 'POST',
-    body: formData
-  })
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to import fitness files.'
-    )
-    throw new Error(
-      `Failed to import fitness files: ${response.status} ${errorDetails}`
-    )
-  }
-
-  return response.json()
-}
-
-interface StravaArchivePresignedResult {
-  presigned: {
-    url: string
-    fitnessFileId: string
-    archiveId: string
-  }
-}
-
-export const createStravaArchivePresignedUrl = async (
-  archive: File
-): Promise<StravaArchivePresignedResult | null> => {
-  const response = await fetch('/api/v1/fitness/strava/archive/presigned', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      fileName: archive.name,
-      contentType: archive.type || 'application/zip',
-      size: archive.size
-    })
-  })
-  if (response.status === 404) return null
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to get presigned URL for archive'
-    )
-    throw new ApiRequestError(
-      `Failed to get presigned URL for archive: ${response.status} ${errorDetails}`,
-      response.status
-    )
-  }
-  return response.json()
-}
-
-export const startStravaArchiveImport = async (
-  archive: File,
-  visibility: MastodonVisibility
-): Promise<StartStravaArchiveImportResult> => {
-  // Try presigned upload first (ObjectStorage/S3 backends)
-  let presignedResult: StravaArchivePresignedResult | null = null
-  try {
-    presignedResult = await createStravaArchivePresignedUrl(archive)
-  } catch (error) {
-    if (
-      error instanceof ApiRequestError &&
-      error.status >= 400 &&
-      error.status < 500
-    ) {
-      throw error
-    }
-  }
-
-  if (presignedResult) {
-    const { url, fitnessFileId, archiveId } = presignedResult.presigned
-
-    try {
-      // Upload archive directly to ObjectStorage via presigned PUT.
-      await uploadFileToPresignedUrl({ presignedUrl: url, media: archive })
-    } catch {
-      // Presigned PUT failed (e.g. CORS not configured on the bucket).
-      // Fall through to the server-side upload path below.
-      presignedResult = null
-    }
-
-    if (presignedResult) {
-      // Notify server to create import record and queue the job
-      const response = await fetch('/api/v1/fitness/strava/archive', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fitnessFileId, archiveId, visibility })
-      })
-      if (!response.ok) {
-        throw new Error('Failed to start Strava archive import')
-      }
-      return response.json()
-    }
-  }
-
-  // Fallback: upload archive through the Next.js server (LocalFile storage)
-  const formData = new FormData()
-  formData.append('archive', archive)
-  formData.append('visibility', visibility)
-
-  const response = await fetch('/api/v1/fitness/strava/archive', {
-    method: 'POST',
-    body: formData
-  })
-  if (!response.ok) {
-    throw new Error('Failed to start Strava archive import')
-  }
-  return response.json()
-}
-
-export const getActiveStravaArchiveImport =
-  async (): Promise<ActiveStravaArchiveImportResponse> => {
-    const response = await fetch('/api/v1/fitness/strava/archive', {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      const errorDetails = await parseApiError(
-        response,
-        'Failed to load Strava archive import state.'
-      )
-      throw new Error(errorDetails)
-    }
-
-    return response.json()
-  }
-
-export const retryStravaArchiveImport = async (): Promise<{
-  success: boolean
-  activeImport: ActiveStravaArchiveImport | null
-}> => {
-  const response = await fetch('/api/v1/fitness/strava/archive', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ action: 'retry' })
-  })
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to retry Strava archive import.'
-    )
-    throw new Error(errorDetails)
-  }
-
-  return response.json()
-}
-
-export const cancelStravaArchiveImport = async (): Promise<{
-  success: boolean
-  cancelled: boolean
-}> => {
-  const response = await fetch('/api/v1/fitness/strava/archive', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ action: 'cancel' })
-  })
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to cancel Strava archive import.'
-    )
-    throw new Error(errorDetails)
-  }
-
-  return response.json()
 }
 
 export const getFitnessImportBatch = async (

--- a/lib/client/fitnessImports.test.ts
+++ b/lib/client/fitnessImports.test.ts
@@ -1,0 +1,260 @@
+import fetchMock from 'jest-fetch-mock'
+
+import {
+  cancelStravaArchiveImport,
+  createStravaArchivePresignedUrl,
+  getActiveStravaArchiveImport,
+  retryStravaArchiveImport,
+  startFitnessImport,
+  startStravaArchiveImport,
+  uploadFitnessFile
+} from '@/lib/client/fitnessImports'
+
+describe('fitnessImports client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('uploadFitnessFile', () => {
+    it('uploads fitness file via FormData and returns result', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'fitness-file-1',
+          type: 'fitness',
+          file_type: 'fit',
+          mime_type: 'application/vnd.ant.fit',
+          url: 'https://llun.test/files/1.fit',
+          fileName: 'run.fit',
+          size: 1234
+        }),
+        { status: 200 }
+      )
+
+      const file = new File(['mock content'], 'run.fit', {
+        type: 'application/vnd.ant.fit'
+      })
+      const result = await uploadFitnessFile(file, 'Morning run')
+
+      expect(result.id).toBe('fitness-file-1')
+      expect(result.fileName).toBe('run.fit')
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness-files',
+        expect.objectContaining({
+          method: 'POST'
+        })
+      )
+    })
+
+    it('throws error when upload fails', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Invalid fit file' }),
+        {
+          status: 400
+        }
+      )
+
+      const file = new File(['invalid'], 'bad.fit')
+      await expect(uploadFitnessFile(file)).rejects.toThrow(
+        'Failed to upload fitness file: 400 Invalid fit file'
+      )
+    })
+  })
+
+  describe('startFitnessImport', () => {
+    it('sends files and visibility via FormData', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          batchId: 'batch-1',
+          fileCount: 2
+        }),
+        { status: 200 }
+      )
+
+      const file1 = new File(['content1'], '1.fit')
+      const file2 = new File(['content2'], '2.fit')
+      const result = await startFitnessImport([file1, file2], 'public')
+
+      expect(result.batchId).toBe('batch-1')
+      expect(result.fileCount).toBe(2)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/import',
+        expect.objectContaining({
+          method: 'POST'
+        })
+      )
+    })
+
+    it('throws error when start import fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Too many files' }), {
+        status: 422
+      })
+
+      const file = new File(['content'], '1.fit')
+      await expect(startFitnessImport([file], 'public')).rejects.toThrow(
+        'Failed to import fitness files: 422 Too many files'
+      )
+    })
+  })
+
+  describe('createStravaArchivePresignedUrl', () => {
+    it('returns null on 404', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+      const file = new File(['zip'], 'export.zip', { type: 'application/zip' })
+      const result = await createStravaArchivePresignedUrl(file)
+      expect(result).toBeNull()
+    })
+
+    it('returns presigned output on success', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          presigned: {
+            url: 'https://storage/upload',
+            fitnessFileId: 'fit-1',
+            archiveId: 'arch-1'
+          }
+        }),
+        { status: 200 }
+      )
+      const file = new File(['zip'], 'export.zip', { type: 'application/zip' })
+      const result = await createStravaArchivePresignedUrl(file)
+      expect(result?.presigned.url).toBe('https://storage/upload')
+    })
+  })
+
+  describe('startStravaArchiveImport', () => {
+    it('does not fall back to multipart upload when presigned setup is rejected', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'active import' }), {
+        status: 409
+      })
+
+      await expect(
+        startStravaArchiveImport(
+          new File([Buffer.from('zip-data')], 'export.zip', {
+            type: 'application/zip'
+          }),
+          'private'
+        )
+      ).rejects.toThrow('Failed to get presigned URL for archive')
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/strava/archive/presigned',
+        expect.objectContaining({
+          method: 'POST'
+        })
+      )
+    })
+
+    it('does not fall back to multipart upload when presigned import commit is rejected', async () => {
+      fetchMock
+        .mockResponseOnce(
+          JSON.stringify({
+            presigned: {
+              url: 'https://storage.example/archive.zip',
+              fitnessFileId: 'fitness-file-1',
+              archiveId: 'archive-1'
+            }
+          }),
+          { status: 200 }
+        )
+        .mockResponseOnce('', { status: 200 })
+        .mockResponseOnce(JSON.stringify({ error: 'active import' }), {
+          status: 409
+        })
+
+      await expect(
+        startStravaArchiveImport(
+          new File([Buffer.from('zip-data')], 'export.zip', {
+            type: 'application/zip'
+          }),
+          'private'
+        )
+      ).rejects.toThrow('Failed to start Strava archive import')
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        '/api/v1/fitness/strava/archive',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+  })
+
+  describe('getActiveStravaArchiveImport', () => {
+    it('fetches active strava archive import', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          activeImport: {
+            id: 'import-1',
+            status: 'importing'
+          }
+        }),
+        { status: 200 }
+      )
+
+      const result = await getActiveStravaArchiveImport()
+      expect(result.activeImport?.id).toBe('import-1')
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/strava/archive',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('throws on failure', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not authorized' }), {
+        status: 401
+      })
+
+      await expect(getActiveStravaArchiveImport()).rejects.toThrow(
+        'Not authorized'
+      )
+    })
+  })
+
+  describe('retryStravaArchiveImport', () => {
+    it('sends PATCH with action retry', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          success: true,
+          activeImport: { id: 'import-1', status: 'importing' }
+        }),
+        { status: 200 }
+      )
+
+      const result = await retryStravaArchiveImport()
+      expect(result.success).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/strava/archive',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ action: 'retry' })
+        })
+      )
+    })
+  })
+
+  describe('cancelStravaArchiveImport', () => {
+    it('sends PATCH with action cancel', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          success: true,
+          cancelled: true
+        }),
+        { status: 200 }
+      )
+
+      const result = await cancelStravaArchiveImport()
+      expect(result.cancelled).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/strava/archive',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ action: 'cancel' })
+        })
+      )
+    })
+  })
+})

--- a/lib/client/fitnessImports.ts
+++ b/lib/client/fitnessImports.ts
@@ -1,0 +1,291 @@
+import { ApiRequestError, parseApiError } from '@/lib/client/http'
+import { uploadFileToPresignedUrl } from '@/lib/client/media'
+import type { MastodonVisibility } from '@/lib/utils/getVisibility'
+
+export interface UploadFitnessFileResult {
+  id: string
+  type: 'fitness'
+  file_type: 'fit' | 'gpx' | 'tcx' | 'zip'
+  mime_type: string
+  url: string
+  fileName: string
+  size: number
+  description?: string
+  hasMapData?: boolean
+  mapImageUrl?: string
+}
+
+export interface FitnessImportBatchFile {
+  id: string
+  actorId: string
+  fileName: string
+  fileType: 'fit' | 'gpx' | 'tcx' | 'zip'
+  statusId: string | null
+  isPrimary: boolean
+  importStatus: 'pending' | 'completed' | 'failed'
+  importError: string | null
+  activityStartTime: number | null
+  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
+}
+
+export interface FitnessImportBatchResult {
+  batchId: string
+  status: 'pending' | 'completed' | 'failed' | 'partially_failed'
+  summary: {
+    total: number
+    pending: number
+    completed: number
+    failed: number
+  }
+  files: FitnessImportBatchFile[]
+}
+
+export interface StartFitnessImportResult {
+  batchId: string
+  fileCount: number
+}
+
+export interface StartStravaArchiveImportResult {
+  archiveId: string
+  batchId: string
+  importId: string
+}
+
+export interface ActiveStravaArchiveImport {
+  id: string
+  archiveId: string
+  archiveFitnessFileId: string
+  batchId: string
+  visibility: MastodonVisibility
+  status: 'importing' | 'failed'
+  nextActivityIndex: number
+  mediaAttachmentRetry: number
+  totalActivitiesCount: number | null
+  completedActivitiesCount: number
+  failedActivitiesCount: number
+  firstFailureMessage: string | null
+  lastError: string | null
+  pendingMediaActivitiesCount: number
+  createdAt: number
+  updatedAt: number
+}
+
+export interface ActiveStravaArchiveImportResponse {
+  activeImport: ActiveStravaArchiveImport | null
+}
+
+export const uploadFitnessFile = async (
+  file: File,
+  description?: string
+): Promise<UploadFitnessFileResult> => {
+  const formData = new FormData()
+  formData.append('file', file)
+  if (description) {
+    formData.append('description', description)
+  }
+
+  const response = await fetch('/api/v1/fitness-files', {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to upload fitness file.'
+    )
+
+    throw new Error(
+      `Failed to upload fitness file: ${response.status} ${errorDetails}`
+    )
+  }
+
+  return response.json()
+}
+
+export const startFitnessImport = async (
+  files: File[],
+  visibility: MastodonVisibility
+): Promise<StartFitnessImportResult> => {
+  const formData = new FormData()
+  files.forEach((file) => {
+    formData.append('files', file)
+  })
+  formData.append('visibility', visibility)
+
+  const response = await fetch('/api/v1/fitness/import', {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to import fitness files.'
+    )
+    throw new Error(
+      `Failed to import fitness files: ${response.status} ${errorDetails}`
+    )
+  }
+
+  return response.json()
+}
+
+export interface StravaArchivePresignedResult {
+  presigned: {
+    url: string
+    fitnessFileId: string
+    archiveId: string
+  }
+}
+
+export const createStravaArchivePresignedUrl = async (
+  archive: File
+): Promise<StravaArchivePresignedResult | null> => {
+  const response = await fetch('/api/v1/fitness/strava/archive/presigned', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      fileName: archive.name,
+      contentType: archive.type || 'application/zip',
+      size: archive.size
+    })
+  })
+  if (response.status === 404) return null
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to get presigned URL for archive'
+    )
+    throw new ApiRequestError(
+      `Failed to get presigned URL for archive: ${response.status} ${errorDetails}`,
+      response.status
+    )
+  }
+  return response.json()
+}
+
+export const startStravaArchiveImport = async (
+  archive: File,
+  visibility: MastodonVisibility
+): Promise<StartStravaArchiveImportResult> => {
+  // Try presigned upload first (ObjectStorage/S3 backends)
+  let presignedResult: StravaArchivePresignedResult | null = null
+  try {
+    presignedResult = await createStravaArchivePresignedUrl(archive)
+  } catch (error) {
+    if (
+      error instanceof ApiRequestError &&
+      error.status >= 400 &&
+      error.status < 500
+    ) {
+      throw error
+    }
+  }
+
+  if (presignedResult) {
+    const { url, fitnessFileId, archiveId } = presignedResult.presigned
+
+    try {
+      // Upload archive directly to ObjectStorage via presigned PUT.
+      await uploadFileToPresignedUrl({ presignedUrl: url, media: archive })
+    } catch {
+      // Presigned PUT failed (e.g. CORS not configured on the bucket).
+      // Fall through to the server-side upload path below.
+      presignedResult = null
+    }
+
+    if (presignedResult) {
+      // Notify server to create import record and queue the job
+      const response = await fetch('/api/v1/fitness/strava/archive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fitnessFileId, archiveId, visibility })
+      })
+      if (!response.ok) {
+        throw new Error('Failed to start Strava archive import')
+      }
+      return response.json()
+    }
+  }
+
+  // Fallback: upload archive through the Next.js server (LocalFile storage)
+  const formData = new FormData()
+  formData.append('archive', archive)
+  formData.append('visibility', visibility)
+
+  const response = await fetch('/api/v1/fitness/strava/archive', {
+    method: 'POST',
+    body: formData
+  })
+  if (!response.ok) {
+    throw new Error('Failed to start Strava archive import')
+  }
+  return response.json()
+}
+
+export const getActiveStravaArchiveImport =
+  async (): Promise<ActiveStravaArchiveImportResponse> => {
+    const response = await fetch('/api/v1/fitness/strava/archive', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+
+    if (!response.ok) {
+      const errorDetails = await parseApiError(
+        response,
+        'Failed to load Strava archive import state.'
+      )
+      throw new Error(errorDetails)
+    }
+
+    return response.json()
+  }
+
+export const retryStravaArchiveImport = async (): Promise<{
+  success: boolean
+  activeImport: ActiveStravaArchiveImport | null
+}> => {
+  const response = await fetch('/api/v1/fitness/strava/archive', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ action: 'retry' })
+  })
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to retry Strava archive import.'
+    )
+    throw new Error(errorDetails)
+  }
+
+  return response.json()
+}
+
+export const cancelStravaArchiveImport = async (): Promise<{
+  success: boolean
+  cancelled: boolean
+}> => {
+  const response = await fetch('/api/v1/fitness/strava/archive', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ action: 'cancel' })
+  })
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to cancel Strava archive import.'
+    )
+    throw new Error(errorDetails)
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
Extracts fitness import operations (uploadFitnessFile, startFitnessImport, createStravaArchivePresignedUrl, startStravaArchiveImport, getActiveStravaArchiveImport, retryStravaArchiveImport, cancelStravaArchiveImport) and associated types into lib/client/fitnessImports.ts with facade re-exports and unit tests.