### PR TITLE
test: resolve types for fitness gear and general route tests

### DIFF
--- a/app/api/v1/fitness/gear/[id]/route.test.ts
+++ b/app/api/v1/fitness/gear/[id]/route.test.ts
@@ -69,20 +69,37 @@ describe('Fitness gear item API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGearDistanceRollups.mockResolvedValue({})
     mockDb.getFitnessGearDeviceRollups.mockResolvedValue({})
   })

--- a/app/api/v1/fitness/gear/route.test.ts
+++ b/app/api/v1/fitness/gear/route.test.ts
@@ -67,20 +67,37 @@ describe('Fitness gear collection API', () => {
     mockDatabase = mockDb
   })
 
+  const mockAccount = {
+    id: 'account-1',
+    email: seedActor1.email,
+    defaultActorId: ACTOR1_ID,
+    twoFactorEnabled: false,
+    emailVerified: true,
+    createdAt: 1000,
+    updatedAt: 1000
+  }
+
+  const mockActor = {
+    ...seedActor1,
+    id: ACTOR1_ID,
+    followersUrl: `${ACTOR1_ID}/followers`,
+    inboxUrl: `${ACTOR1_ID}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    account: mockAccount
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({ ...seedActor1, id: ACTOR1_ID })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.getFitnessGearsByActor.mockResolvedValue([])
     mockDb.getFitnessGearDistanceRollups.mockResolvedValue({})
     mockDb.getFitnessGearDeviceRollups.mockResolvedValue({})

--- a/app/api/v1/fitness/general/route.test.ts
+++ b/app/api/v1/fitness/general/route.test.ts
@@ -63,6 +63,29 @@ describe('Fitness General Settings API', () => {
 
     vi.clearAllMocks()
 
+    const mockAccount = {
+      id: 'account-1',
+      email: seedActor1.email,
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: 1000,
+      updatedAt: 1000
+    }
+
+    const mockActor = {
+      ...seedActor1,
+      id: ACTOR1_ID,
+      followersUrl: `${ACTOR1_ID}/followers`,
+      inboxUrl: `${ACTOR1_ID}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 1000,
+      updatedAt: 1000,
+      account: mockAccount
+    }
+
     mockDb.getFitnessSettings.mockResolvedValue(null)
     mockDb.createFitnessSettings.mockResolvedValue({
       id: 'general-settings-id',
@@ -82,18 +105,9 @@ describe('Fitness General Settings API', () => {
       createdAt: Date.now(),
       updatedAt: Date.now()
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
-      id: 'account-1',
-      email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({
-      ...seedActor1,
-      id: ACTOR1_ID
-    })
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
   })
 
   describe('GET /api/v1/fitness/general', () => {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,10 +17,7 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/fitness/gear/[id]/route.test.ts",
-    "app/api/v1/fitness/gear/route.test.ts",
     "app/api/v1/fitness/general/regenerate-maps/route.test.ts",
-    "app/api/v1/fitness/general/route.test.ts",
     "app/api/v1/fitness/import/[batchId]/route.test.ts",
     "app/api/v1/fitness/strava/archive/presigned/route.test.ts",
     "app/api/v1/fitness/strava/archive/route.test.ts",


### PR DESCRIPTION
Resolves mock account and actor types in fitness gear route tests and general settings route tests, removing all 3 files from the tsconfig.typecheck.json ratchet.