### PR TITLE
refactor: extract fitness files operations into lib/client/fitnessFiles.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -39,13 +39,17 @@ import {
   getActorDomains,
   getActorMedia,
   getActorStatuses,
+  getAppleMapsToken,
   getBookmarks,
   getCollectionFeed,
   getCollectionTimeline,
   getFavourites,
+  getFitnessFilesByStatus,
   getFitnessGearActivities,
   getFitnessGearComponents,
   getFitnessGearList,
+  getFitnessImportBatch,
+  getFitnessProcessingState,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmapRegionNames,
   getFitnessRouteHeatmapTiles,
@@ -67,6 +71,7 @@ import {
   requestPasswordReset,
   resetPassword,
   retireFitnessGearComponent,
+  retryFitnessImportBatch,
   retryStravaArchiveImport,
   revokeCollectionMembership,
   revokeConnectedApp,
@@ -97,6 +102,7 @@ import {
   uploadMedia
 } from './client'
 import * as accountsModule from './client/accounts'
+import * as fitnessFilesModule from './client/fitnessFiles'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as fitnessImportsModule from './client/fitnessImports'
@@ -168,6 +174,22 @@ describe('client facade fitness imports re-exports', () => {
     expect(cancelStravaArchiveImport).toBe(
       fitnessImportsModule.cancelStravaArchiveImport
     )
+  })
+})
+
+describe('client facade fitness files re-exports', () => {
+  it('re-exports extracted fitness file functions', () => {
+    expect(getFitnessImportBatch).toBe(fitnessFilesModule.getFitnessImportBatch)
+    expect(retryFitnessImportBatch).toBe(
+      fitnessFilesModule.retryFitnessImportBatch
+    )
+    expect(getFitnessProcessingState).toBe(
+      fitnessFilesModule.getFitnessProcessingState
+    )
+    expect(getFitnessFilesByStatus).toBe(
+      fitnessFilesModule.getFitnessFilesByStatus
+    )
+    expect(getAppleMapsToken).toBe(fitnessFilesModule.getAppleMapsToken)
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -79,6 +79,15 @@ import {
   unmute
 } from './client/accounts'
 import {
+  type FitnessProcessingState,
+  type StatusFitnessFileItem,
+  getAppleMapsToken,
+  getFitnessFilesByStatus,
+  getFitnessImportBatch,
+  getFitnessProcessingState,
+  retryFitnessImportBatch
+} from './client/fitnessFiles'
+import {
   type ActiveStravaArchiveImport,
   type ActiveStravaArchiveImportResponse,
   type FitnessImportBatchFile,
@@ -346,6 +355,16 @@ export {
   uploadFitnessFile
 }
 
+export {
+  type FitnessProcessingState,
+  type StatusFitnessFileItem,
+  getAppleMapsToken,
+  getFitnessFilesByStatus,
+  getFitnessImportBatch,
+  getFitnessProcessingState,
+  retryFitnessImportBatch
+}
+
 interface MarkNotificationsReadParams {
   notificationIds: string[]
 }
@@ -366,139 +385,6 @@ export const markNotificationsRead = async ({
     })
   })
   return response.ok
-}
-
-export const getFitnessImportBatch = async (
-  batchId: string
-): Promise<FitnessImportBatchResult> => {
-  const response = await fetch(
-    `/api/v1/fitness/import/${encodeURIComponent(batchId)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to fetch fitness import batch.'
-    )
-    throw new ApiRequestError(errorDetails, response.status)
-  }
-
-  return response.json()
-}
-
-export const retryFitnessImportBatch = async (
-  batchId: string,
-  visibility: MastodonVisibility
-): Promise<{ batchId: string; retried: number }> => {
-  const response = await fetch(
-    `/api/v1/fitness/import/${encodeURIComponent(batchId)}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ visibility })
-    }
-  )
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to retry fitness import.'
-    )
-    throw new Error(errorDetails)
-  }
-
-  return response.json()
-}
-
-export interface FitnessProcessingState {
-  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
-  processingStuck: boolean
-  hasMapData: boolean
-}
-
-/**
- * Returns the processing state of a status's primary fitness file so a
- * processing post can poll for progress and resolve to its finished state
- * without a manual reload. Returns null when the status has no fitness file
- * (e.g. it was deleted) so callers can stop polling.
- */
-export const getFitnessProcessingState = async (
-  statusId: string
-): Promise<FitnessProcessingState | null> => {
-  const response = await fetch(
-    `/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(statusId)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-
-  if (!response.ok) {
-    const errorDetails = await parseApiError(
-      response,
-      'Failed to fetch fitness processing state.'
-    )
-    throw new ApiRequestError(errorDetails, response.status)
-  }
-
-  const data = (await response.json()) as {
-    files?: Array<{
-      isPrimary?: boolean
-      processingStatus?: FitnessProcessingState['processingStatus']
-      processingStuck?: boolean
-      hasMapData?: boolean
-    }>
-  }
-
-  const files = data.files ?? []
-  if (files.length === 0) {
-    return null
-  }
-
-  // The post surfaces its primary file; fall back to the first file when no
-  // file is flagged primary (older rows default to primary anyway).
-  const primary = files.find((file) => file.isPrimary) ?? files[0]
-
-  return {
-    processingStatus: primary.processingStatus ?? 'pending',
-    processingStuck: Boolean(primary.processingStuck),
-    hasMapData: Boolean(primary.hasMapData)
-  }
-}
-
-export interface StatusFitnessFileItem {
-  id: string
-  actorId: string
-  fileName: string
-  fileType: 'fit' | 'gpx' | 'tcx'
-  statusId: string | null
-  isPrimary: boolean
-  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
-  totalDistanceMeters: number | null
-  totalDurationSeconds: number | null
-  movingTimeSeconds: number | null
-  elevationGainMeters: number | null
-  activityType: string | null
-  activityStartTime: number | null
-  hasMapData: boolean
-  description: string | null
-  deviceManufacturer: string | null
-  deviceName: string | null
-  sourceUrl: string | null
-  gearId: string | null
-  gearName: string | null
-  deviceGearId: string | null
-  deviceGearName: string | null
 }
 
 export interface FitnessRouteSample {
@@ -525,55 +411,6 @@ export interface FitnessRouteDataResponse {
   heartRateSeries?: number[]
   altitudeSeries?: number[]
   speedSeries?: number[]
-}
-
-/**
- * Lists every fitness file attached to a status (an activity can aggregate
- * several uploaded files). Returns null when the endpoint is unavailable so the
- * caller can fall back to the file metadata embedded in the status payload.
- */
-export const getFitnessFilesByStatus = async (
-  statusId: string
-): Promise<StatusFitnessFileItem[] | null> => {
-  const response = await fetch(
-    `/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(statusId)}`,
-    {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    }
-  )
-
-  if (!response.ok) return null
-
-  const data = (await response.json()) as {
-    files?: StatusFitnessFileItem[]
-  } | null
-  return data && Array.isArray(data.files) ? data.files : null
-}
-
-/**
- * Fetches a short-lived Apple MapKit JS authorization token. Returns `null` when
- * the instance is not configured for the Apple map provider, or on any failure,
- * so the caller can fall back to another provider. The token is deliberately not
- * cached: MapKit re-invokes its `authorizationCallback` when the token expires.
- */
-export const getAppleMapsToken = async (): Promise<string | null> => {
-  try {
-    const response = await fetch('/api/v1/fitness/apple-maps-token', {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    })
-    if (!response.ok) return null
-
-    const data = (await response.json()) as { token?: string } | null
-    return typeof data?.token === 'string' ? data.token : null
-  } catch {
-    return null
-  }
 }
 
 /**

--- a/lib/client/fitnessFiles.test.ts
+++ b/lib/client/fitnessFiles.test.ts
@@ -1,0 +1,179 @@
+import fetchMock from 'jest-fetch-mock'
+
+import {
+  getAppleMapsToken,
+  getFitnessFilesByStatus,
+  getFitnessImportBatch,
+  getFitnessProcessingState,
+  retryFitnessImportBatch
+} from '@/lib/client/fitnessFiles'
+
+describe('fitnessFiles client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getFitnessImportBatch', () => {
+    it('fetches fitness import batch data', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          batchId: 'batch-123',
+          status: 'completed',
+          summary: { total: 1, pending: 0, completed: 1, failed: 0 },
+          files: []
+        }),
+        { status: 200 }
+      )
+
+      const result = await getFitnessImportBatch('batch-123')
+      expect(result.batchId).toBe('batch-123')
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/import/batch-123',
+        expect.objectContaining({
+          method: 'GET'
+        })
+      )
+    })
+
+    it('throws error when request fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not found' }), {
+        status: 404
+      })
+
+      await expect(getFitnessImportBatch('batch-999')).rejects.toThrow(
+        'Not found'
+      )
+    })
+  })
+
+  describe('retryFitnessImportBatch', () => {
+    it('posts retry request with visibility', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ batchId: 'batch-123', retried: 2 }),
+        { status: 200 }
+      )
+
+      const result = await retryFitnessImportBatch('batch-123', 'public')
+      expect(result.retried).toBe(2)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/import/batch-123',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ visibility: 'public' })
+        })
+      )
+    })
+
+    it('throws error when retry fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Server error' }), {
+        status: 500
+      })
+
+      await expect(
+        retryFitnessImportBatch('batch-123', 'public')
+      ).rejects.toThrow('Server error')
+    })
+  })
+
+  describe('getFitnessProcessingState', () => {
+    it('returns processing state for primary file', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          files: [
+            {
+              isPrimary: true,
+              processingStatus: 'completed',
+              processingStuck: false,
+              hasMapData: true
+            }
+          ]
+        }),
+        { status: 200 }
+      )
+
+      const state = await getFitnessProcessingState('status-1')
+      expect(state).toEqual({
+        processingStatus: 'completed',
+        processingStuck: false,
+        hasMapData: true
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness-files/by-status?statusId=status-1',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('returns null when no files found', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ files: [] }), { status: 200 })
+
+      const state = await getFitnessProcessingState('status-empty')
+      expect(state).toBeNull()
+    })
+
+    it('throws when endpoint returns error', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Failed' }), {
+        status: 500
+      })
+
+      await expect(getFitnessProcessingState('status-err')).rejects.toThrow(
+        'Failed'
+      )
+    })
+  })
+
+  describe('getFitnessFilesByStatus', () => {
+    it('returns list of fitness files', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          files: [
+            {
+              id: 'file-1',
+              fileName: 'run.fit',
+              fileType: 'fit',
+              isPrimary: true
+            }
+          ]
+        }),
+        { status: 200 }
+      )
+
+      const files = await getFitnessFilesByStatus('status-1')
+      expect(files).toHaveLength(1)
+      expect(files?.[0].id).toBe('file-1')
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      const files = await getFitnessFilesByStatus('status-err')
+      expect(files).toBeNull()
+    })
+  })
+
+  describe('getAppleMapsToken', () => {
+    it('returns token on success', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'test-token' }), {
+        status: 200
+      })
+
+      const token = await getAppleMapsToken()
+      expect(token).toBe('test-token')
+    })
+
+    it('returns null on error status', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not configured' }), {
+        status: 404
+      })
+
+      const token = await getAppleMapsToken()
+      expect(token).toBeNull()
+    })
+
+    it('returns null on network exception', async () => {
+      fetchMock.mockRejectOnce(new Error('Network error'))
+
+      const token = await getAppleMapsToken()
+      expect(token).toBeNull()
+    })
+  })
+})

--- a/lib/client/fitnessFiles.ts
+++ b/lib/client/fitnessFiles.ts
@@ -1,0 +1,186 @@
+import { ApiRequestError, parseApiError } from '@/lib/client/http'
+import type { MastodonVisibility } from '@/lib/utils/getVisibility'
+
+import type { FitnessImportBatchResult } from './fitnessImports'
+
+export interface FitnessProcessingState {
+  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
+  processingStuck: boolean
+  hasMapData: boolean
+}
+
+export interface StatusFitnessFileItem {
+  id: string
+  actorId: string
+  fileName: string
+  fileType: 'fit' | 'gpx' | 'tcx'
+  statusId: string | null
+  isPrimary: boolean
+  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
+  totalDistanceMeters: number | null
+  totalDurationSeconds: number | null
+  movingTimeSeconds: number | null
+  elevationGainMeters: number | null
+  activityType: string | null
+  activityStartTime: number | null
+  hasMapData: boolean
+  description: string | null
+  deviceManufacturer: string | null
+  deviceName: string | null
+  sourceUrl: string | null
+  gearId: string | null
+  gearName: string | null
+  deviceGearId: string | null
+  deviceGearName: string | null
+}
+
+export const getFitnessImportBatch = async (
+  batchId: string
+): Promise<FitnessImportBatchResult> => {
+  const response = await fetch(
+    `/api/v1/fitness/import/${encodeURIComponent(batchId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to fetch fitness import batch.'
+    )
+    throw new ApiRequestError(errorDetails, response.status)
+  }
+
+  return response.json()
+}
+
+export const retryFitnessImportBatch = async (
+  batchId: string,
+  visibility: MastodonVisibility
+): Promise<{ batchId: string; retried: number }> => {
+  const response = await fetch(
+    `/api/v1/fitness/import/${encodeURIComponent(batchId)}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ visibility })
+    }
+  )
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to retry fitness import.'
+    )
+    throw new Error(errorDetails)
+  }
+
+  return response.json()
+}
+
+/**
+ * Returns the processing state of a status's primary fitness file so a
+ * processing post can poll for progress and resolve to its finished state
+ * without a manual reload. Returns null when the status has no fitness file
+ * (e.g. it was deleted) so callers can stop polling.
+ */
+export const getFitnessProcessingState = async (
+  statusId: string
+): Promise<FitnessProcessingState | null> => {
+  const response = await fetch(
+    `/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(statusId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to fetch fitness processing state.'
+    )
+    throw new ApiRequestError(errorDetails, response.status)
+  }
+
+  const data = (await response.json()) as {
+    files?: Array<{
+      isPrimary?: boolean
+      processingStatus?: FitnessProcessingState['processingStatus']
+      processingStuck?: boolean
+      hasMapData?: boolean
+    }>
+  }
+
+  const files = data.files ?? []
+  if (files.length === 0) {
+    return null
+  }
+
+  // The post surfaces its primary file; fall back to the first file when no
+  // file is flagged primary (older rows default to primary anyway).
+  const primary = files.find((file) => file.isPrimary) ?? files[0]
+
+  return {
+    processingStatus: primary.processingStatus ?? 'pending',
+    processingStuck: Boolean(primary.processingStuck),
+    hasMapData: Boolean(primary.hasMapData)
+  }
+}
+
+/**
+ * Lists every fitness file attached to a status (an activity can aggregate
+ * several uploaded files). Returns null when the endpoint is unavailable so the
+ * caller can fall back to the file metadata embedded in the status payload.
+ */
+export const getFitnessFilesByStatus = async (
+  statusId: string
+): Promise<StatusFitnessFileItem[] | null> => {
+  const response = await fetch(
+    `/api/v1/fitness-files/by-status?statusId=${encodeURIComponent(statusId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+
+  if (!response.ok) return null
+
+  const data = (await response.json()) as {
+    files?: StatusFitnessFileItem[]
+  } | null
+  return data && Array.isArray(data.files) ? data.files : null
+}
+
+/**
+ * Fetches a short-lived Apple MapKit JS authorization token. Returns `null` when
+ * the instance is not configured for the Apple map provider, or on any failure,
+ * so the caller can fall back to another provider. The token is deliberately not
+ * cached: MapKit re-invokes its `authorizationCallback` when the token expires.
+ */
+export const getAppleMapsToken = async (): Promise<string | null> => {
+  try {
+    const response = await fetch('/api/v1/fitness/apple-maps-token', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+    if (!response.ok) return null
+
+    const data = (await response.json()) as { token?: string } | null
+    return typeof data?.token === 'string' ? data.token : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Extracts 5 fitness file operations into a dedicated domain module `lib/client/fitnessFiles.ts` as part of Task J1:
- `getFitnessImportBatch`
- `retryFitnessImportBatch`
- `getFitnessProcessingState`
- `getFitnessFilesByStatus`
- `getAppleMapsToken`

Adds comprehensive unit tests in `lib/client/fitnessFiles.test.ts` and re-export verification in `lib/client.test.ts`. Re-exports all functions and types from `lib/client.ts` to maintain full backward compatibility.

All DoD checks pass: Prettier -> Oxlint -> Typecheck -> Build -> Vitest suite.