### PR TITLE
Bump version to v1.161.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.30",
+  "version": "1.161.31",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.31.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.30`
- Base main SHA: `2d42fe6544a2a1eb247e8755f6b2d85c6a3f4713`
- Included commits: `8`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
