### PR TITLE
test: resolve types for regenerate-maps, strava, and translation-languages route tests

### DIFF
--- a/app/api/v1/fitness/general/regenerate-maps/route.test.ts
+++ b/app/api/v1/fitness/general/regenerate-maps/route.test.ts
@@ -69,31 +69,32 @@ describe('POST /api/v1/fitness/general/regenerate-maps', () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
-    mockDb.getAccountFromEmail.mockResolvedValue({
+    const mockAccount = {
       id: 'account-1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      {
-        ...seedActor1,
-        id: ACTOR1_ID,
-        account: {
-          id: 'account-1',
-          email: seedActor1.email,
-          defaultActorId: ACTOR1_ID
-        }
-      }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: 1000,
+      updatedAt: 1000
+    }
+
+    const mockActor = {
       ...seedActor1,
       id: ACTOR1_ID,
-      account: {
-        id: 'account-1',
-        email: seedActor1.email,
-        defaultActorId: ACTOR1_ID
-      }
-    })
+      followersUrl: `${ACTOR1_ID}/followers`,
+      inboxUrl: `${ACTOR1_ID}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 1000,
+      updatedAt: 1000,
+      account: mockAccount
+    }
+
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
     mockDb.updateFitnessFilesProcessingStatus.mockResolvedValue(0)
     mockDb.updateFitnessFileProcessingStatus.mockResolvedValue(true)
     mockPublish.mockResolvedValue(undefined)

--- a/app/api/v1/fitness/strava/route.test.ts
+++ b/app/api/v1/fitness/strava/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { Database } from '@/lib/database/types'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import type { FitnessSettings } from '@/lib/types/database/fitnessSettings'
 
 import { DELETE, GET, POST } from './route'
 
@@ -51,6 +52,17 @@ vi.mock('@/lib/services/strava/webhookSubscription', () => ({
   ensureWebhookSubscription: vi.fn().mockResolvedValue({ success: true })
 }))
 
+const mockFitnessSettings = (
+  overrides: Partial<FitnessSettings> = {}
+): FitnessSettings => ({
+  id: 'fitness-settings-1',
+  actorId: ACTOR1_ID,
+  serviceType: 'strava',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides
+})
+
 describe('Strava Settings API', () => {
   // Mock database object
   const mockDb: jest.Mocked<MockDatabase> = {
@@ -80,23 +92,37 @@ describe('Strava Settings API', () => {
     // Reset mocks
     vi.clearAllMocks()
 
-    // Default mock implementations
-    mockDb.getFitnessSettings.mockResolvedValue(null)
-    mockDb.createFitnessSettings.mockResolvedValue({})
-    mockDb.deleteFitnessSettings.mockResolvedValue(undefined)
-    mockDb.updateFitnessSettings.mockResolvedValue({})
-    mockDb.getAccountFromEmail.mockResolvedValue({
+    const mockAccount = {
       id: 'account-1',
       email: seedActor1.email,
-      defaultActorId: ACTOR1_ID
-    })
-    mockDb.getActorsForAccount.mockResolvedValue([
-      { ...seedActor1, id: ACTOR1_ID }
-    ])
-    mockDb.getActorFromId.mockResolvedValue({
+      defaultActorId: ACTOR1_ID,
+      twoFactorEnabled: false,
+      emailVerified: true,
+      createdAt: 1000,
+      updatedAt: 1000
+    }
+
+    const mockActor = {
       ...seedActor1,
-      id: ACTOR1_ID
-    })
+      id: ACTOR1_ID,
+      followersUrl: `${ACTOR1_ID}/followers`,
+      inboxUrl: `${ACTOR1_ID}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 1000,
+      updatedAt: 1000,
+      account: mockAccount
+    }
+
+    // Default mock implementations
+    mockDb.getFitnessSettings.mockResolvedValue(null)
+    mockDb.createFitnessSettings.mockResolvedValue(mockFitnessSettings())
+    mockDb.deleteFitnessSettings.mockResolvedValue(undefined)
+    mockDb.updateFitnessSettings.mockResolvedValue(mockFitnessSettings())
+    mockDb.getAccountFromEmail.mockResolvedValue(mockAccount)
+    mockDb.getActorsForAccount.mockResolvedValue([mockActor])
+    mockDb.getActorFromId.mockResolvedValue(mockActor)
   })
 
   describe('GET /api/v1/fitness/strava', () => {
@@ -123,12 +149,12 @@ describe('Strava Settings API', () => {
     })
 
     it('returns clientId without secret when configured', async () => {
-      mockDb.getFitnessSettings.mockResolvedValue({
-        actorId: ACTOR1_ID,
-        serviceType: 'strava',
-        clientId: '12345',
-        clientSecret: 'secret123'
-      })
+      mockDb.getFitnessSettings.mockResolvedValue(
+        mockFitnessSettings({
+          clientId: '12345',
+          clientSecret: 'secret123'
+        })
+      )
 
       const request = new NextRequest(
         'http://llun.test/api/v1/fitness/strava',
@@ -152,13 +178,13 @@ describe('Strava Settings API', () => {
     })
 
     it('returns saved default visibility when configured', async () => {
-      mockDb.getFitnessSettings.mockResolvedValue({
-        actorId: ACTOR1_ID,
-        serviceType: 'strava',
-        clientId: '12345',
-        clientSecret: 'secret123',
-        defaultVisibility: 'unlisted'
-      })
+      mockDb.getFitnessSettings.mockResolvedValue(
+        mockFitnessSettings({
+          clientId: '12345',
+          clientSecret: 'secret123',
+          defaultVisibility: 'unlisted'
+        })
+      )
 
       const request = new NextRequest(
         'http://llun.test/api/v1/fitness/strava',
@@ -210,13 +236,12 @@ describe('Strava Settings API', () => {
     })
 
     it('updates visibility without requiring credentials for existing settings', async () => {
-      mockDb.getFitnessSettings.mockResolvedValue({
-        id: 'fitness-settings-1',
-        actorId: ACTOR1_ID,
-        serviceType: 'strava',
-        clientId: '12345',
-        clientSecret: 'secret123'
-      })
+      mockDb.getFitnessSettings.mockResolvedValue(
+        mockFitnessSettings({
+          clientId: '12345',
+          clientSecret: 'secret123'
+        })
+      )
 
       const request = new NextRequest(
         'http://llun.test/api/v1/fitness/strava',
@@ -329,12 +354,12 @@ describe('Strava Settings API', () => {
 
   describe('DELETE /api/v1/fitness/strava', () => {
     it('removes existing Strava settings', async () => {
-      mockDb.getFitnessSettings.mockResolvedValue({
-        actorId: ACTOR1_ID,
-        serviceType: 'strava',
-        clientId: '99999',
-        clientSecret: 'deleteme'
-      })
+      mockDb.getFitnessSettings.mockResolvedValue(
+        mockFitnessSettings({
+          clientId: '99999',
+          clientSecret: 'deleteme'
+        })
+      )
 
       mockGetSubscription.mockResolvedValueOnce({
         id: 12345

--- a/app/api/v1/instance/translation_languages/route.test.ts
+++ b/app/api/v1/instance/translation_languages/route.test.ts
@@ -11,26 +11,31 @@ vi.mock('@/lib/services/translation', () => ({
 const request = () =>
   new NextRequest('https://llun.test/api/v1/instance/translation_languages')
 
+const routeContext = { params: Promise.resolve({}) }
+
 describe('GET /api/v1/instance/translation_languages', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('returns an empty map when no backend is configured', async () => {
-    ;(getTranslationProvider as jest.Mock).mockReturnValue(null)
+    vi.mocked(getTranslationProvider).mockReturnValue(null)
 
-    const response = await GET(request())
+    const response = await GET(request(), routeContext)
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({})
   })
 
   it('maps every source language to the supported targets', async () => {
-    ;(getTranslationProvider as jest.Mock).mockReturnValue({
+    vi.mocked(getTranslationProvider).mockReturnValue({
+      providerName: 'mock',
+      cacheKey: 'mock',
+      translate: vi.fn(),
       async languages() {
         return { source: ['en', 'de'], target: ['en', 'de', 'fr'] }
       }
     })
 
-    const response = await GET(request())
+    const response = await GET(request(), routeContext)
 
     expect(await response.json()).toEqual({
       en: ['en', 'de', 'fr'],
@@ -39,13 +44,16 @@ describe('GET /api/v1/instance/translation_languages', () => {
   })
 
   it('falls back to an empty map when the backend cannot report languages', async () => {
-    ;(getTranslationProvider as jest.Mock).mockReturnValue({
+    vi.mocked(getTranslationProvider).mockReturnValue({
+      providerName: 'mock',
+      cacheKey: 'mock',
+      translate: vi.fn(),
       async languages() {
         throw new Error('backend down')
       }
     })
 
-    const response = await GET(request())
+    const response = await GET(request(), routeContext)
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({})

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,13 +17,10 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/fitness/general/regenerate-maps/route.test.ts",
     "app/api/v1/fitness/import/[batchId]/route.test.ts",
     "app/api/v1/fitness/strava/archive/presigned/route.test.ts",
     "app/api/v1/fitness/strava/archive/route.test.ts",
-    "app/api/v1/fitness/strava/route.test.ts",
     "app/api/v1/follow_requests/route.test.ts",
-    "app/api/v1/instance/translation_languages/route.test.ts",
     "app/api/v1/notifications/clear/route.test.ts",
     "app/api/v1/push/subscription/route.test.ts",
     "app/api/v1/statuses/[id]/favourite/route.test.ts",


### PR DESCRIPTION
Resolves types and removes 3 test files from `tsconfig.typecheck.json` ratchet (Batch 20 of Task H2):
- `app/api/v1/fitness/general/regenerate-maps/route.test.ts`
- `app/api/v1/fitness/strava/route.test.ts`
- `app/api/v1/instance/translation_languages/route.test.ts`

Ratchet exclusion count reduced from 105 to 102.
All DoD checks pass in order: Prettier -> Oxlint -> Typecheck -> Build -> Full Vitest suite.