### PR TITLE
refactor: extract fitness general settings into lib/client/fitnessGeneralSettings.ts

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -48,6 +48,7 @@ import {
   getFitnessGearActivities,
   getFitnessGearComponents,
   getFitnessGearList,
+  getFitnessGeneralSettings,
   getFitnessImportBatch,
   getFitnessProcessingState,
   getFitnessRouteHeatmap,
@@ -66,6 +67,7 @@ import {
   getTrendingTags,
   likeStatus,
   refitFitnessGearComponent,
+  regenerateFitnessMaps,
   removeCollectionAccounts,
   requestEmailChange,
   requestPasswordReset,
@@ -94,6 +96,7 @@ import {
   updateFitnessFileGear,
   updateFitnessGear,
   updateFitnessGearComponent,
+  updateFitnessGeneralSettings,
   updateNote,
   updateStatusVisibility,
   uploadAttachment,
@@ -104,6 +107,7 @@ import {
 import * as accountsModule from './client/accounts'
 import * as fitnessFilesModule from './client/fitnessFiles'
 import * as fitnessGearModule from './client/fitnessGear'
+import * as fitnessGeneralSettingsModule from './client/fitnessGeneralSettings'
 import * as fitnessHeatmapsModule from './client/fitnessHeatmaps'
 import * as fitnessImportsModule from './client/fitnessImports'
 import * as httpModule from './client/http'
@@ -190,6 +194,20 @@ describe('client facade fitness files re-exports', () => {
       fitnessFilesModule.getFitnessFilesByStatus
     )
     expect(getAppleMapsToken).toBe(fitnessFilesModule.getAppleMapsToken)
+  })
+})
+
+describe('client facade fitness general settings re-exports', () => {
+  it('re-exports extracted fitness general settings functions', () => {
+    expect(getFitnessGeneralSettings).toBe(
+      fitnessGeneralSettingsModule.getFitnessGeneralSettings
+    )
+    expect(updateFitnessGeneralSettings).toBe(
+      fitnessGeneralSettingsModule.updateFitnessGeneralSettings
+    )
+    expect(regenerateFitnessMaps).toBe(
+      fitnessGeneralSettingsModule.regenerateFitnessMaps
+    )
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -88,6 +88,14 @@ import {
   retryFitnessImportBatch
 } from './client/fitnessFiles'
 import {
+  type FitnessGeneralSettingsResponse,
+  type FitnessPrivacyLocationInput,
+  type RegenerateFitnessMapsResponse,
+  getFitnessGeneralSettings,
+  regenerateFitnessMaps,
+  updateFitnessGeneralSettings
+} from './client/fitnessGeneralSettings'
+import {
   type ActiveStravaArchiveImport,
   type ActiveStravaArchiveImportResponse,
   type FitnessImportBatchFile,
@@ -530,106 +538,13 @@ export const deleteFitnessFile = async (id: string): Promise<void> => {
 
 export * from './client/fitnessGear'
 
-// --- Fitness general (privacy location) settings ---
-
-export interface FitnessGeneralSettingsResponse {
-  success?: boolean
-  error?: string
-  privacyLocations?: Array<{
-    latitude: number
-    longitude: number
-    hideRadiusMeters: number
-  }>
-  privacyHomeLatitude?: number | null
-  privacyHomeLongitude?: number | null
-  privacyHideRadiusMeters?: number
-}
-
-export interface FitnessPrivacyLocationInput {
-  latitude: number
-  longitude: number
-  hideRadiusMeters: number
-}
-
-export interface RegenerateFitnessMapsResponse {
-  success?: boolean
-  error?: string
-  queuedCount?: number
-}
-
-// A bare cast would let any 200 with any body count as a loaded settings
-// object. `privacyLocations` would then read as an empty list, and because a
-// save REPLACES the whole stored list, the next save would wipe every zone the
-// actor configured. Reject the body instead so the caller's load-failure path
-// handles it.
-const assertFitnessGeneralSettings = (
-  value: unknown
-): FitnessGeneralSettingsResponse => {
-  if (
-    !value ||
-    typeof value !== 'object' ||
-    !Array.isArray((value as FitnessGeneralSettingsResponse).privacyLocations)
-  ) {
-    throw new Error('Unexpected fitness privacy settings response')
-  }
-
-  return value as FitnessGeneralSettingsResponse
-}
-
-export const getFitnessGeneralSettings =
-  async (): Promise<FitnessGeneralSettingsResponse> => {
-    const response = await fetch('/api/v1/fitness/general', {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error('Failed to load fitness privacy settings')
-    }
-
-    return assertFitnessGeneralSettings(await response.json())
-  }
-
-export const updateFitnessGeneralSettings = async (
-  privacyLocations: FitnessPrivacyLocationInput[]
-): Promise<{ ok: boolean; data: FitnessGeneralSettingsResponse }> => {
-  const response = await fetch('/api/v1/fitness/general', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      privacyLocations
-    })
-  })
-
-  const data = (await response.json()) as FitnessGeneralSettingsResponse
-
-  // On success the caller rebuilds its list from this body, so an unrecognised
-  // 200 must not be reported as a save — it would blank the list under a
-  // "saved" message and invite the user to save the emptiness for real.
-  if (response.ok) {
-    return { ok: true, data: assertFitnessGeneralSettings(data) }
-  }
-
-  return { ok: false, data }
-}
-
-export const regenerateFitnessMaps = async (): Promise<{
-  ok: boolean
-  data: RegenerateFitnessMapsResponse
-}> => {
-  const response = await fetch('/api/v1/fitness/general/regenerate-maps', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-
-  const data = (await response.json()) as RegenerateFitnessMapsResponse
-  return { ok: response.ok, data }
+export {
+  type FitnessGeneralSettingsResponse,
+  type FitnessPrivacyLocationInput,
+  type RegenerateFitnessMapsResponse,
+  getFitnessGeneralSettings,
+  regenerateFitnessMaps,
+  updateFitnessGeneralSettings
 }
 
 // --- Notification settings ---

--- a/lib/client/fitnessGeneralSettings.test.ts
+++ b/lib/client/fitnessGeneralSettings.test.ts
@@ -1,0 +1,109 @@
+import fetchMock from 'jest-fetch-mock'
+
+import {
+  getFitnessGeneralSettings,
+  regenerateFitnessMaps,
+  updateFitnessGeneralSettings
+} from '@/lib/client/fitnessGeneralSettings'
+
+describe('fitnessGeneralSettings client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getFitnessGeneralSettings', () => {
+    it('returns privacy locations and home settings on success', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          privacyLocations: [
+            { latitude: 10, longitude: 20, hideRadiusMeters: 500 }
+          ],
+          privacyHomeLatitude: 10,
+          privacyHomeLongitude: 20,
+          privacyHideRadiusMeters: 500
+        }),
+        { status: 200 }
+      )
+
+      const result = await getFitnessGeneralSettings()
+      expect(result.privacyLocations).toHaveLength(1)
+      expect(result.privacyHomeLatitude).toBe(10)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/general',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Server error' }), {
+        status: 500
+      })
+
+      await expect(getFitnessGeneralSettings()).rejects.toThrow(
+        'Failed to load fitness privacy settings'
+      )
+    })
+
+    it('throws error when response body is invalid', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      await expect(getFitnessGeneralSettings()).rejects.toThrow(
+        'Unexpected fitness privacy settings response'
+      )
+    })
+  })
+
+  describe('updateFitnessGeneralSettings', () => {
+    it('posts updated privacy locations and returns ok true with data', async () => {
+      const locations = [
+        { latitude: 12.34, longitude: 56.78, hideRadiusMeters: 200 }
+      ]
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          privacyLocations: locations
+        }),
+        { status: 200 }
+      )
+
+      const result = await updateFitnessGeneralSettings(locations)
+      expect(result.ok).toBe(true)
+      expect(result.data.privacyLocations).toEqual(locations)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/general',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ privacyLocations: locations })
+        })
+      )
+    })
+
+    it('returns ok false when server responds with error status', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Invalid data' }), {
+        status: 400
+      })
+
+      const result = await updateFitnessGeneralSettings([])
+      expect(result.ok).toBe(false)
+      expect(result.data.error).toBe('Invalid data')
+    })
+  })
+
+  describe('regenerateFitnessMaps', () => {
+    it('calls regenerate-maps endpoint and returns result', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ success: true, queuedCount: 3 }),
+        { status: 200 }
+      )
+
+      const result = await regenerateFitnessMaps()
+      expect(result.ok).toBe(true)
+      expect(result.data.queuedCount).toBe(3)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/fitness/general/regenerate-maps',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+})

--- a/lib/client/fitnessGeneralSettings.ts
+++ b/lib/client/fitnessGeneralSettings.ts
@@ -1,0 +1,99 @@
+export interface FitnessGeneralSettingsResponse {
+  success?: boolean
+  error?: string
+  privacyLocations?: Array<{
+    latitude: number
+    longitude: number
+    hideRadiusMeters: number
+  }>
+  privacyHomeLatitude?: number | null
+  privacyHomeLongitude?: number | null
+  privacyHideRadiusMeters?: number
+}
+
+export interface FitnessPrivacyLocationInput {
+  latitude: number
+  longitude: number
+  hideRadiusMeters: number
+}
+
+export interface RegenerateFitnessMapsResponse {
+  success?: boolean
+  error?: string
+  queuedCount?: number
+}
+
+// A bare cast would let any 200 with any body count as a loaded settings
+// object. `privacyLocations` would then read as an empty list, and because a
+// save REPLACES the whole stored list, the next save would wipe every zone the
+// actor configured. Reject the body instead so the caller's load-failure path
+// handles it.
+const assertFitnessGeneralSettings = (
+  value: unknown
+): FitnessGeneralSettingsResponse => {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Array.isArray((value as FitnessGeneralSettingsResponse).privacyLocations)
+  ) {
+    throw new Error('Unexpected fitness privacy settings response')
+  }
+
+  return value as FitnessGeneralSettingsResponse
+}
+
+export const getFitnessGeneralSettings =
+  async (): Promise<FitnessGeneralSettingsResponse> => {
+    const response = await fetch('/api/v1/fitness/general', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to load fitness privacy settings')
+    }
+
+    return assertFitnessGeneralSettings(await response.json())
+  }
+
+export const updateFitnessGeneralSettings = async (
+  privacyLocations: FitnessPrivacyLocationInput[]
+): Promise<{ ok: boolean; data: FitnessGeneralSettingsResponse }> => {
+  const response = await fetch('/api/v1/fitness/general', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      privacyLocations
+    })
+  })
+
+  const data = (await response.json()) as FitnessGeneralSettingsResponse
+
+  // On success the caller rebuilds its list from this body, so an unrecognised
+  // 200 must not be reported as a save — it would blank the list under a
+  // "saved" message and invite the user to save the emptiness for real.
+  if (response.ok) {
+    return { ok: true, data: assertFitnessGeneralSettings(data) }
+  }
+
+  return { ok: false, data }
+}
+
+export const regenerateFitnessMaps = async (): Promise<{
+  ok: boolean
+  data: RegenerateFitnessMapsResponse
+}> => {
+  const response = await fetch('/api/v1/fitness/general/regenerate-maps', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+
+  const data = (await response.json()) as RegenerateFitnessMapsResponse
+  return { ok: response.ok, data }
+}


### PR DESCRIPTION
Extracts fitness general (privacy location) settings operations into `lib/client/fitnessGeneralSettings.ts` as part of Task J1:
- `getFitnessGeneralSettings`
- `updateFitnessGeneralSettings`
- `regenerateFitnessMaps`

Adds unit tests in `lib/client/fitnessGeneralSettings.test.ts` and re-export verification in `lib/client.test.ts`. Re-exports all functions and types from `lib/client.ts` for backward compatibility.

All DoD checks pass in order: Prettier -> Oxlint -> Typecheck -> Build -> Full Vitest suite.