### PR TITLE
test: resolve types for batchId, presigned, and archive route tests

### DIFF
--- a/app/api/v1/fitness/import/[batchId]/route.test.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.test.ts
@@ -48,10 +48,11 @@ vi.mock('@/lib/utils/getActorFromSession', () => ({
   })
 }))
 
+const mockPublish = vi.fn()
 vi.mock('@/lib/services/queue', () => ({
-  getQueue: vi.fn().mockReturnValue({
-    publish: vi.fn().mockResolvedValue(undefined)
-  })
+  getQueue: vi.fn(() => ({
+    publish: mockPublish
+  }))
 }))
 
 vi.mock('next/headers', () => ({
@@ -83,6 +84,7 @@ describe('fitness import batch route', () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: 'llun@activities.local' }
     })
+    mockPublish.mockResolvedValue(undefined)
     db.getStravaArchiveImportByBatchId.mockResolvedValue(null)
     mockDatabase = db
   })
@@ -828,7 +830,7 @@ describe('fitness import batch route', () => {
       }
     ])
 
-    getQueue().publish.mockRejectedValueOnce(new Error('queue down'))
+    mockPublish.mockRejectedValueOnce(new Error('queue down'))
 
     const request = {
       headers: new Headers(),
@@ -876,7 +878,7 @@ describe('fitness import batch route', () => {
       }
     ])
 
-    getQueue().publish.mockRejectedValueOnce(new Error('queue down'))
+    mockPublish.mockRejectedValueOnce(new Error('queue down'))
 
     const request = {
       headers: new Headers(),
@@ -930,9 +932,9 @@ describe('fitness import batch route', () => {
     await POST(request1, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const firstJobId = getQueue().publish.mock.calls[0][0].id
+    const firstJobId = mockPublish.mock.calls[0][0].id
 
-    getQueue().publish.mockClear()
+    mockPublish.mockClear()
     const request2 = {
       headers: new Headers(),
       json: async () => ({ visibility: 'private', generationId: 'test-gen-1' })
@@ -941,7 +943,7 @@ describe('fitness import batch route', () => {
     await POST(request2, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const secondJobId = getQueue().publish.mock.calls[0][0].id
+    const secondJobId = mockPublish.mock.calls[0][0].id
 
     expect(secondJobId).toBe(firstJobId)
   })
@@ -974,9 +976,9 @@ describe('fitness import batch route', () => {
     await POST(request1, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const firstJobId = getQueue().publish.mock.calls[0][0].id
+    const firstJobId = mockPublish.mock.calls[0][0].id
 
-    getQueue().publish.mockClear()
+    mockPublish.mockClear()
     const request2 = {
       headers: new Headers(),
       json: async () => ({
@@ -988,7 +990,7 @@ describe('fitness import batch route', () => {
     await POST(request2, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const secondJobId = getQueue().publish.mock.calls[0][0].id
+    const secondJobId = mockPublish.mock.calls[0][0].id
 
     expect(secondJobId).toBe(firstJobId)
   })
@@ -1018,9 +1020,9 @@ describe('fitness import batch route', () => {
     await POST(request1, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const firstJobId = getQueue().publish.mock.calls[0][0].id
+    const firstJobId = mockPublish.mock.calls[0][0].id
 
-    getQueue().publish.mockClear()
+    mockPublish.mockClear()
     const request2 = {
       headers: new Headers(),
       json: async () => ({ visibility: 'private' })
@@ -1029,7 +1031,7 @@ describe('fitness import batch route', () => {
     await POST(request2, {
       params: Promise.resolve({ batchId: 'batch-1' })
     })
-    const secondJobId = getQueue().publish.mock.calls[0][0].id
+    const secondJobId = mockPublish.mock.calls[0][0].id
 
     expect(secondJobId).not.toBe(firstJobId)
   })

--- a/app/api/v1/fitness/strava/archive/presigned/route.test.ts
+++ b/app/api/v1/fitness/strava/archive/presigned/route.test.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+
 import { getPresignedFitnessFileUrl } from '@/lib/services/fitness-files'
 
 import { POST } from './route'
@@ -52,7 +54,7 @@ describe('Strava archive presigned URL endpoint', () => {
   it('returns 404 when ObjectStorage is not available (LocalFile)', async () => {
     mockGetPresignedFitnessFileUrl.mockResolvedValue(null)
 
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',
@@ -78,7 +80,7 @@ describe('Strava archive presigned URL endpoint', () => {
       fitnessFileId: 'fitness-file-id-1'
     })
 
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',
@@ -105,7 +107,7 @@ describe('Strava archive presigned URL endpoint', () => {
   })
 
   it('returns 422 on invalid input (non-zip file)', async () => {
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',
@@ -130,7 +132,7 @@ describe('Strava archive presigned URL endpoint', () => {
       new QuotaExceededError('Quota exceeded', 1000, 500)
     )
 
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',
@@ -158,7 +160,7 @@ describe('Strava archive presigned URL endpoint', () => {
       status: 'importing'
     })
 
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',
@@ -182,7 +184,7 @@ describe('Strava archive presigned URL endpoint', () => {
   it('returns 401 when not authenticated', async () => {
     mockGetServerSession.mockResolvedValue(null)
 
-    const req = new Request(
+    const req = new NextRequest(
       'http://localhost/api/v1/fitness/strava/archive/presigned',
       {
         method: 'POST',

--- a/app/api/v1/fitness/strava/archive/route.test.ts
+++ b/app/api/v1/fitness/strava/archive/route.test.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+
 import { IMPORT_STRAVA_ARCHIVE_JOB_NAME } from '@/lib/jobs/names'
 import {
   deleteFitnessFile,
@@ -56,10 +58,11 @@ vi.mock('@/lib/services/fitness-files', () => ({
   verifyPresignedFitnessFileUpload: vi.fn()
 }))
 
+const mockPublish = vi.fn()
 vi.mock('@/lib/services/queue', () => ({
-  getQueue: vi.fn().mockReturnValue({
-    publish: vi.fn().mockResolvedValue(undefined)
-  })
+  getQueue: vi.fn(() => ({
+    publish: mockPublish
+  }))
 }))
 
 vi.mock('next/headers', () => ({
@@ -95,6 +98,7 @@ describe('Strava archive import route', () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: 'llun@activities.local' }
     })
+    mockPublish.mockResolvedValue(undefined)
     mockDatabase = db
 
     db.getActiveStravaArchiveImportByActor.mockResolvedValue(null)
@@ -405,18 +409,21 @@ describe('Strava archive import route', () => {
         'strava-archive-source:550e8400-e29b-41d4-a716-446655440001'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'pre-created-fitness-file-id',
-        archiveId: '550e8400-e29b-41d4-a716-446655440001',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440001',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
     expect(response.status).toBe(200)
@@ -439,7 +446,7 @@ describe('Strava archive import route', () => {
   })
 
   it('POST with presigned fitnessFileId rolls back verified upload when queueing fails', async () => {
-    getQueue().publish.mockRejectedValueOnce(new Error('queue unavailable'))
+    mockPublish.mockRejectedValueOnce(new Error('queue unavailable'))
     db.getFitnessFile.mockResolvedValueOnce({
       id: 'pre-created-fitness-file-id',
       actorId: 'https://llun.test/users/llun',
@@ -452,18 +459,21 @@ describe('Strava archive import route', () => {
         'strava-archive-source:550e8400-e29b-41d4-a716-446655440006'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'pre-created-fitness-file-id',
-        archiveId: '550e8400-e29b-41d4-a716-446655440006',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440006',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
 
@@ -491,18 +501,21 @@ describe('Strava archive import route', () => {
         'strava-archive-source:550e8400-e29b-41d4-a716-446655440005'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'pre-created-fitness-file-id',
-        archiveId: '550e8400-e29b-41d4-a716-446655440005',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440005',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
 
@@ -518,18 +531,21 @@ describe('Strava archive import route', () => {
       path: 'fitness/2024-01-01/xyz.zip'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'someone-elses-file',
-        archiveId: '550e8400-e29b-41d4-a716-446655440002',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'someone-elses-file',
+          archiveId: '550e8400-e29b-41d4-a716-446655440002',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
     expect(response.status).toBe(403)
@@ -548,18 +564,21 @@ describe('Strava archive import route', () => {
         'strava-archive-source:550e8400-e29b-41d4-a716-446655440003'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'pre-created-fitness-file-id',
-        archiveId: '550e8400-e29b-41d4-a716-446655440003',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440003',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
     expect(response.status).toBe(422)
@@ -578,18 +597,21 @@ describe('Strava archive import route', () => {
       importBatchId: 'strava-archive-source:different-archive-id'
     })
 
-    const req = new Request('http://localhost/api/v1/fitness/strava/archive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Origin: 'https://test.llun.dev'
-      },
-      body: JSON.stringify({
-        fitnessFileId: 'pre-created-fitness-file-id',
-        archiveId: '550e8400-e29b-41d4-a716-446655440004',
-        visibility: 'private'
-      })
-    })
+    const req = new NextRequest(
+      'http://localhost/api/v1/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://test.llun.dev'
+        },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440004',
+          visibility: 'private'
+        })
+      }
+    )
 
     const response = await POST(req, { params: Promise.resolve({}) })
     expect(response.status).toBe(422)
@@ -597,7 +619,7 @@ describe('Strava archive import route', () => {
   })
 
   it('POST attempts archive rollback even when delete returns false', async () => {
-    getQueue().publish.mockRejectedValueOnce(new Error('queue unavailable'))
+    mockPublish.mockRejectedValueOnce(new Error('queue unavailable'))
     mockDeleteFitnessFile.mockResolvedValueOnce(false)
 
     const formData = new FormData()

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/fitness/import/[batchId]/route.test.ts",
-    "app/api/v1/fitness/strava/archive/presigned/route.test.ts",
-    "app/api/v1/fitness/strava/archive/route.test.ts",
     "app/api/v1/follow_requests/route.test.ts",
     "app/api/v1/notifications/clear/route.test.ts",
     "app/api/v1/push/subscription/route.test.ts",


### PR DESCRIPTION
Resolves types and removes 3 test files from `tsconfig.typecheck.json` ratchet (Batch 21 of Task H2):
- `app/api/v1/fitness/import/[batchId]/route.test.ts`
- `app/api/v1/fitness/strava/archive/presigned/route.test.ts`
- `app/api/v1/fitness/strava/archive/route.test.ts`

Ratchet exclusion count reduced from 102 to 99 (down into double digits!).
All DoD checks pass in order: Prettier -> Oxlint -> Typecheck -> Build -> Full Vitest suite.