### PR TITLE
test: resolve types for follow_requests, notifications clear, and push subscription route tests

### DIFF
--- a/app/api/v1/follow_requests/route.test.ts
+++ b/app/api/v1/follow_requests/route.test.ts
@@ -172,7 +172,7 @@ describe('GET /api/v1/follow_requests', () => {
 
   it('returns pending follow requests as accounts newest first', async () => {
     vi.useFakeTimers({
-      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+      toNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
     })
     try {
       await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
@@ -195,7 +195,7 @@ describe('GET /api/v1/follow_requests', () => {
 
   it('paginates with Mastodon Link headers using follow ids', async () => {
     vi.useFakeTimers({
-      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+      toNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
     })
     try {
       await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
@@ -238,7 +238,7 @@ describe('GET /api/v1/follow_requests', () => {
   it('returns newer requests after a since_id cursor', async () => {
     const created: { id: string }[] = []
     vi.useFakeTimers({
-      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+      toNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
     })
     try {
       created.push(
@@ -269,7 +269,7 @@ describe('GET /api/v1/follow_requests', () => {
   it('returns newer requests after a min_id cursor', async () => {
     const created: { id: string }[] = []
     vi.useFakeTimers({
-      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+      toNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
     })
     try {
       created.push(
@@ -304,7 +304,7 @@ describe('GET /api/v1/follow_requests', () => {
     // follow rows so a full page still advertises rel="next".
     const ghostRequester = 'https://remote.test/users/ghost-follow-request'
     vi.useFakeTimers({
-      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+      toNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
     })
     try {
       await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))

--- a/app/api/v1/notifications/clear/route.test.ts
+++ b/app/api/v1/notifications/clear/route.test.ts
@@ -39,9 +39,7 @@ describe('Notification Endpoints', () => {
       await database.createNotification({
         actorId: ACTOR1_ID,
         type: 'follow',
-        sourceActorId: ACTOR2_ID,
-        statusId: null,
-        createdAt: Date.now()
+        sourceActorId: ACTOR2_ID
       })
 
       const notifications = await database.getNotifications({
@@ -64,8 +62,7 @@ describe('Notification Endpoints', () => {
         actorId: ACTOR1_ID,
         type: 'mention',
         sourceActorId: ACTOR2_ID,
-        statusId,
-        createdAt: Date.now()
+        statusId
       })
 
       const mastodonNotification = await getMastodonNotification(
@@ -97,10 +94,9 @@ describe('Notification Endpoints', () => {
       // Create a notification
       const notification = await database.createNotification({
         actorId: ACTOR1_ID,
-        type: 'favourite',
+        type: 'like',
         sourceActorId: ACTOR2_ID,
-        statusId: `${ACTOR1_ID}/statuses/post-1`,
-        createdAt: Date.now()
+        statusId: `${ACTOR1_ID}/statuses/post-1`
       })
 
       // Verify it exists
@@ -131,9 +127,7 @@ describe('Notification Endpoints', () => {
         await database.createNotification({
           actorId: ACTOR1_ID,
           type: 'follow',
-          sourceActorId: ACTOR2_ID,
-          statusId: null,
-          createdAt: Date.now() + i
+          sourceActorId: ACTOR2_ID
         })
       }
 
@@ -162,9 +156,7 @@ describe('Notification Endpoints', () => {
         actorId: ACTOR1_ID,
         type: 'follow',
         sourceActorId: ACTOR2_ID,
-        statusId: null,
-        filtered: true,
-        createdAt: Date.now()
+        filtered: true
       })
 
       const before = await database.getNotifications({
@@ -198,9 +190,7 @@ describe('Notification Endpoints', () => {
       const notification = await database.createNotification({
         actorId: ACTOR1_ID,
         type: 'follow',
-        sourceActorId: ACTOR2_ID,
-        statusId: null,
-        createdAt: Date.now()
+        sourceActorId: ACTOR2_ID
       })
 
       const mastodonNotification = await getMastodonNotification(
@@ -218,8 +208,7 @@ describe('Notification Endpoints', () => {
         actorId: ACTOR1_ID,
         type: 'reblog',
         sourceActorId: ACTOR2_ID,
-        statusId: `${ACTOR1_ID}/statuses/post-1`,
-        createdAt: Date.now()
+        statusId: `${ACTOR1_ID}/statuses/post-1`
       })
 
       const mastodonNotification = await getMastodonNotification(
@@ -236,8 +225,7 @@ describe('Notification Endpoints', () => {
         actorId: ACTOR1_ID,
         type: 'like',
         sourceActorId: ACTOR2_ID,
-        statusId: `${ACTOR1_ID}/statuses/post-1`,
-        createdAt: Date.now()
+        statusId: `${ACTOR1_ID}/statuses/post-1`
       })
 
       const mastodonNotification = await getMastodonNotification(

--- a/app/api/v1/push/subscription/route.test.ts
+++ b/app/api/v1/push/subscription/route.test.ts
@@ -1,13 +1,13 @@
 import { NextRequest } from 'next/server'
 
-import { getConfig } from '@/lib/config'
+import { type Config, getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { Scope } from '@/lib/types/database/operations'
 
 import { DELETE, GET, POST, PUT } from './route'
 
-const mockGetConfig = getConfig as jest.Mock
+const mockGetConfig = vi.mocked(getConfig)
 
 const mockOAuthGuard = vi.fn()
 const mockCurrentActor = { ...seedActor1, id: ACTOR1_ID }
@@ -390,7 +390,7 @@ describe('push subscription when push is not configured', () => {
       host: 'llun.test',
       allowEmails: [],
       allowActorDomains: []
-    }
+    } as unknown as Config
     mockGetConfig.mockReturnValue(noPushConfig)
 
     const post = new NextRequest('http://localhost/api/v1/push/subscription', {
@@ -427,8 +427,12 @@ describe('push subscription when push is not configured', () => {
 
     mockGetConfig.mockReturnValue({
       ...noPushConfig,
-      push: { vapidPublicKey: 'test-vapid-public-key' }
-    })
+      push: {
+        vapidPublicKey: 'test-vapid-public-key',
+        vapidPrivateKey: 'test-vapid-private-key',
+        vapidEmail: 'test@llun.test'
+      }
+    } as unknown as Config)
   })
 
   it('DELETE still succeeds when push is not configured (cleanup is always allowed)', async () => {
@@ -436,7 +440,7 @@ describe('push subscription when push is not configured', () => {
       host: 'llun.test',
       allowEmails: [],
       allowActorDomains: []
-    }
+    } as unknown as Config
     mockGetConfig.mockReturnValue(noPushConfig)
 
     const del = new NextRequest('http://localhost/api/v1/push/subscription', {
@@ -449,7 +453,11 @@ describe('push subscription when push is not configured', () => {
 
     mockGetConfig.mockReturnValue({
       ...noPushConfig,
-      push: { vapidPublicKey: 'test-vapid-public-key' }
-    })
+      push: {
+        vapidPublicKey: 'test-vapid-public-key',
+        vapidPrivateKey: 'test-vapid-private-key',
+        vapidEmail: 'test@llun.test'
+      }
+    } as unknown as Config)
   })
 })

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/follow_requests/route.test.ts",
-    "app/api/v1/notifications/clear/route.test.ts",
-    "app/api/v1/push/subscription/route.test.ts",
     "app/api/v1/statuses/[id]/favourite/route.test.ts",
     "app/api/v1/statuses/[id]/route.test.ts",
     "app/api/v1/statuses/route.test.ts",


### PR DESCRIPTION
Resolves types for H2 Batch 22 and removes from tsconfig.typecheck.json ratchet.