### PR TITLE
Bump version to v1.161.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.31",
+  "version": "1.161.32",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.32.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.31`
- Base main SHA: `df6524ac784ea6944e150e980ff923075917052c`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
