### PR TITLE
feat: collapse alt text by default and support single image collapsing

### DIFF
--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -293,13 +293,66 @@ describe('Attachments', () => {
         />
       )
 
+      // Single image collapses alt text by default
+      const toggleButton = screen.getByRole('button', {
+        name: 'Expand alt text'
+      })
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(
+        screen.queryByText('A mountaineer hiking on a ridge')
+      ).not.toBeInTheDocument()
+
+      // Expand
+      fireEvent.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
       const alt = screen.getByText('A mountaineer hiking on a ridge')
       expect(alt).toBeInTheDocument()
       expect(alt).toHaveClass('text-muted-foreground', 'text-sm')
-      // Single image should not render an ALT badge or collapse/expand toggle button
+
+      // Single image should not render an ALT badge
       expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+    })
+
+    it('collapses alt text by default and allows expanding and re-collapsing for a single image', () => {
+      render(
+        <Attachments
+          status={buildNoteStatus([
+            buildAttachment({
+              width: 800,
+              height: 600,
+              name: 'A mountaineer hiking on a ridge'
+            })
+          ])}
+          onMediaSelected={vi.fn()}
+        />
+      )
+
+      const toggleButton = screen.getByRole('button', {
+        name: 'Expand alt text'
+      })
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(toggleButton).not.toHaveAttribute('aria-controls')
       expect(
-        screen.queryByRole('button', { name: /alt text/i })
+        screen.queryByText('A mountaineer hiking on a ridge')
+      ).not.toBeInTheDocument()
+
+      // Expand
+      fireEvent.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+      expect(toggleButton).toHaveAttribute('aria-controls')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
+      expect(
+        screen.getByText('A mountaineer hiking on a ridge')
+      ).toBeInTheDocument()
+
+      // Collapse
+      fireEvent.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Expand alt text')
+      expect(toggleButton).not.toHaveAttribute('aria-controls')
+      expect(
+        screen.queryByText('A mountaineer hiking on a ridge')
       ).not.toBeInTheDocument()
     })
 
@@ -318,6 +371,9 @@ describe('Attachments', () => {
       )
 
       expect(container.querySelector('p')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /alt text/i })
+      ).not.toBeInTheDocument()
     })
 
     it('stops click propagation when clicking on the alt text', () => {
@@ -337,7 +393,32 @@ describe('Attachments', () => {
         </div>
       )
 
+      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
       fireEvent.click(screen.getByText('Description'))
+      expect(parentOnClick).not.toHaveBeenCalled()
+    })
+
+    it('stops click propagation when clicking on the single image collapse/expand button', () => {
+      const parentOnClick = vi.fn()
+      render(
+        <div onClick={parentOnClick}>
+          <Attachments
+            status={buildNoteStatus([
+              buildAttachment({
+                width: 800,
+                height: 600,
+                name: 'Description'
+              })
+            ])}
+            onMediaSelected={vi.fn()}
+          />
+        </div>
+      )
+
+      const toggleButton = screen.getByRole('button', {
+        name: 'Expand alt text'
+      })
+      fireEvent.click(toggleButton)
       expect(parentOnClick).not.toHaveBeenCalled()
     })
   })
@@ -525,7 +606,11 @@ describe('Attachments', () => {
         )
       ).not.toBeInTheDocument()
 
-      // Numbered alt text list underneath
+      // Numbered alt text list underneath (after expanding)
+      const toggleButton = screen.getByRole('button', {
+        name: 'Expand alt text'
+      })
+      fireEvent.click(toggleButton)
       expect(screen.getByText('First cat eating')).toBeInTheDocument()
       expect(screen.getByText('Second cat resting')).toBeInTheDocument()
     })
@@ -563,6 +648,9 @@ describe('Attachments', () => {
             element.textContent === 'ALT2'
         )
       ).toBeInTheDocument()
+
+      // Expand the alt text list
+      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
 
       // The grouped item shows indices "1 2" together
       expect(screen.getByText('1 2')).toBeInTheDocument()
@@ -608,11 +696,12 @@ describe('Attachments', () => {
         </div>
       )
 
+      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
       fireEvent.click(screen.getByText('Cat photo'))
       expect(parentOnClick).not.toHaveBeenCalled()
     })
 
-    it('expands alt text by default and allows collapsing and re-expanding', () => {
+    it('collapses alt text by default and allows expanding and re-collapsing', () => {
       const first = buildAttachment({
         width: 800,
         height: 600,
@@ -632,10 +721,18 @@ describe('Attachments', () => {
       )
 
       const toggleButton = screen.getByRole('button', {
-        name: 'Collapse alt text'
+        name: 'Expand alt text'
       })
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(toggleButton).not.toHaveAttribute('aria-controls')
+      expect(screen.queryByText('First description')).not.toBeInTheDocument()
+      expect(screen.queryByText('Second description')).not.toBeInTheDocument()
+
+      // Expand
+      fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
       expect(toggleButton).toHaveAttribute('aria-controls')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
       expect(screen.getByText('First description')).toBeInTheDocument()
       expect(screen.getByText('Second description')).toBeInTheDocument()
 
@@ -679,7 +776,7 @@ describe('Attachments', () => {
       )
 
       const toggleButton = screen.getByRole('button', {
-        name: 'Collapse alt text'
+        name: 'Expand alt text'
       })
       fireEvent.click(toggleButton)
       expect(parentOnClick).not.toHaveBeenCalled()
@@ -1315,6 +1412,7 @@ describe('Attachments', () => {
 
     render(<Attachments status={status} onMediaSelected={vi.fn()} />)
 
+    fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
     const img = screen.getByRole('img', { name: ':blobcat:' })
     expect(img).toBeInTheDocument()
     expect(img).toHaveAttribute('src', 'https://example.com/blobcat.png')
@@ -1352,6 +1450,7 @@ describe('Attachments', () => {
 
     render(<Attachments status={status} onMediaSelected={vi.fn()} />)
 
+    fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
     const imgs = screen.getAllByRole('img', { name: ':blobcat:' })
     expect(imgs.length).toBeGreaterThanOrEqual(1)
     expect(imgs[0]).toHaveAttribute('src', 'https://example.com/blobcat.png')

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -194,7 +194,7 @@ const AltTextToggle: FC<AltTextToggleProps> = ({
       e.stopPropagation()
       onToggle()
     }}
-    className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none"
+    className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-sm"
   >
     <span>Alt text</span>
     <ChevronDown
@@ -244,6 +244,21 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
       })),
     [pictures]
   )
+
+  const altEntries = useMemo(() => {
+    const entries: { indices: number[]; text: string }[] = []
+    pictures.forEach((pic, i) => {
+      const text = pic.name?.trim()
+      if (!text) return
+      const existing = entries.find((e) => e.text === text)
+      if (existing) {
+        existing.indices.push(i + 1)
+      } else {
+        entries.push({ indices: [i + 1], text })
+      }
+    })
+    return entries
+  }, [pictures])
 
   const strip = useMediaStripScroll(items.map((item) => item.width).join(','))
   const { canScrollLeft, canScrollRight } = strip
@@ -340,21 +355,6 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
       </>
     )
   }
-
-  const altEntries = useMemo(() => {
-    const entries: { indices: number[]; text: string }[] = []
-    pictures.forEach((pic, i) => {
-      const text = pic.name?.trim()
-      if (!text) return
-      const existing = entries.find((e) => e.text === text)
-      if (existing) {
-        existing.indices.push(i + 1)
-      } else {
-        entries.push({ indices: [i + 1], text })
-      }
-    })
-    return entries
-  }, [pictures])
 
   const stripStyle: CSSProperties = {
     height: STRIP_ROW_HEIGHT,

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -174,13 +174,46 @@ const STRIP_FOCUS_CLASS =
 const CHEVRON_CLASS =
   'absolute top-1/2 flex size-8 -translate-y-1/2 items-center justify-center rounded-full border bg-popover text-foreground shadow-sm hover:bg-muted'
 
+interface AltTextToggleProps {
+  isExpanded: boolean
+  controlsId: string
+  onToggle: () => void
+}
+
+const AltTextToggle: FC<AltTextToggleProps> = ({
+  isExpanded,
+  controlsId,
+  onToggle
+}) => (
+  <button
+    type="button"
+    aria-expanded={isExpanded}
+    aria-controls={isExpanded ? controlsId : undefined}
+    aria-label={isExpanded ? 'Collapse alt text' : 'Expand alt text'}
+    onClick={(e) => {
+      e.stopPropagation()
+      onToggle()
+    }}
+    className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none"
+  >
+    <span>Alt text</span>
+    <ChevronDown
+      className={cn(
+        'size-3.5 transition-transform duration-200',
+        isExpanded && 'rotate-180'
+      )}
+      aria-hidden="true"
+    />
+  </button>
+)
+
 interface Props {
   status: Status
   onMediaSelected: OnMediaSelectedHandle
 }
 
 export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
-  const [isAltExpanded, setIsAltExpanded] = useState(true)
+  const [isAltExpanded, setIsAltExpanded] = useState(false)
   const altListId = useId()
   const attachments = useMemo(
     () => (status.type === StatusType.enum.Note ? status.attachments : []),
@@ -283,12 +316,24 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
             />
           </button>
           {altText ? (
-            <p
+            <div
+              className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
               onClick={(e) => e.stopPropagation()}
-              className="mt-1.5 text-sm leading-relaxed text-muted-foreground break-words select-text"
             >
-              <CustomEmojiText text={altText} tags={status.tags} />
-            </p>
+              <AltTextToggle
+                isExpanded={isAltExpanded}
+                controlsId={altListId}
+                onToggle={() => setIsAltExpanded((prev) => !prev)}
+              />
+              {isAltExpanded ? (
+                <p
+                  id={altListId}
+                  className="text-sm leading-relaxed text-muted-foreground break-words"
+                >
+                  <CustomEmojiText text={altText} tags={status.tags} />
+                </p>
+              ) : null}
+            </div>
           ) : null}
         </div>
         {audioPlayers}
@@ -420,28 +465,11 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
               onClick={(e) => e.stopPropagation()}
             >
-              <button
-                type="button"
-                aria-expanded={isAltExpanded}
-                aria-controls={isAltExpanded ? altListId : undefined}
-                aria-label={
-                  isAltExpanded ? 'Collapse alt text' : 'Expand alt text'
-                }
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setIsAltExpanded((prev) => !prev)
-                }}
-                className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none"
-              >
-                <span>Alt text</span>
-                <ChevronDown
-                  className={cn(
-                    'size-3.5 transition-transform duration-200',
-                    isAltExpanded && 'rotate-180'
-                  )}
-                  aria-hidden="true"
-                />
-              </button>
+              <AltTextToggle
+                isExpanded={isAltExpanded}
+                controlsId={altListId}
+                onToggle={() => setIsAltExpanded((prev) => !prev)}
+              />
               {isAltExpanded ? (
                 <div id={altListId} className="flex flex-col gap-1">
                   {altEntries.map((entry) => (


### PR DESCRIPTION
## Summary
- Make alt text collapsible and collapsed by default across all attachment layouts.
- Add toggle button to single-image attachment alt text matching multi-image behavior.
- Extract `AltTextToggle` component for consistent accessible collapse/expand behavior.
- Update unit and interaction tests for single- and multi-image alt text.
- Verify behavior in local real browser via Playwright/DevTools.

## Testing Done
- `yarn run prettier --write .` passed
- `yarn lint` passed with 0 errors
- `yarn typecheck` passed with 0 errors
- `yarn build` passed
- `yarn test` passed (1006 test files passed, 14021 tests passed)
- Local browser test verified single image and multi-image alt text collapsed by default and toggles correctly.