### PR TITLE
Bump version to v1.161.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.32",
+  "version": "1.161.33",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.33.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.32`
- Base main SHA: `8143a697c09c2126eec2d0e5876ea942c28a2dde`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
