### PR TITLE
test: resolve types for statuses route tests

### DIFF
--- a/app/api/v1/statuses/[id]/favourite/route.test.ts
+++ b/app/api/v1/statuses/[id]/favourite/route.test.ts
@@ -3,7 +3,7 @@ import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -99,6 +99,10 @@ describe('Status Action Endpoints', () => {
       })
 
       expect(announce).not.toBeNull()
+      expect(announce?.type).toBe(StatusType.enum.Announce)
+      if (!announce || announce.type !== StatusType.enum.Announce) {
+        throw new Error('Expected announce status')
+      }
       expect(announce.originalStatus.id).toBe(originalStatusId)
     })
 
@@ -114,10 +118,15 @@ describe('Status Action Endpoints', () => {
   describe('status source', () => {
     it('returns source text for status', async () => {
       const statusId = `${ACTOR1_ID}/statuses/post-1`
-      const status = (await database.getStatus({
+      const status = await database.getStatus({
         statusId,
         withReplies: false
-      })) as Status
+      })
+
+      expect(status?.type).toBe(StatusType.enum.Note)
+      if (!status || status.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
 
       expect(status.text).toBeTruthy()
 
@@ -139,10 +148,15 @@ describe('Status Action Endpoints', () => {
   describe('status history', () => {
     it('returns history array with at least current version', async () => {
       const statusId = `${ACTOR1_ID}/statuses/post-1`
-      const status = (await database.getStatus({
+      const status = await database.getStatus({
         statusId,
         withReplies: false
-      })) as Status
+      })
+
+      expect(status?.type).toBe(StatusType.enum.Note)
+      if (!status || status.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
 
       // Build history (current implementation returns single entry)
       const history = [
@@ -169,7 +183,7 @@ describe('Status Action Endpoints', () => {
         statusId
       })
 
-      const actors = await database.getFavouritedBy({ statusId })
+      const actors = await database.getFavouritedBy({ statusId, limit: 40 })
 
       expect(actors).toBeArray()
       expect(actors.length).toBeGreaterThanOrEqual(1)

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1835,10 +1835,14 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(response.status).toBe(200)
 
       // Every photo plus the route map remain on the status.
-      const updatedStatus = (await database.getStatus({
+      const updatedStatus = await database.getStatus({
         statusId,
         withReplies: false
-      })) as Status
+      })
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
       expect(updatedStatus.attachments).toHaveLength(mediaIds.length)
       expect(
         updatedStatus.attachments.some(
@@ -2143,7 +2147,11 @@ describe('GET /api/v1/statuses/[id]', () => {
       const attachments = await database.getAttachments({ statusId })
 
       expect(response.status).toBe(422)
-      expect(updatedStatus?.text).toBe('')
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.text).toBe('')
       expect(attachments).toHaveLength(1)
       expect(attachments[0]).toMatchObject({
         url: 'https://llun.test/api/v1/files/medias/api-edit-reject-clear-media-only.webp',
@@ -2210,7 +2218,11 @@ describe('GET /api/v1/statuses/[id]', () => {
       const attachments = await database.getAttachments({ statusId })
 
       expect(response.status).toBe(422)
-      expect(updatedStatus?.text).toBe('Original text before rejected edit')
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.text).toBe('Original text before rejected edit')
       expect(attachments).toHaveLength(1)
       expect(attachments[0]).toMatchObject({
         url: 'https://llun.test/api/v1/files/medias/api-edit-reject-blank-clear-media.webp',
@@ -2265,7 +2277,11 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       const updatedStatus = await database.getStatus({ statusId })
       expect(response.status).toBe(422)
-      expect(updatedStatus?.text).toBe('Original media ownership text')
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.text).toBe('Original media ownership text')
       expect(getQueue().publish).not.toHaveBeenCalled()
     })
 
@@ -2307,7 +2323,11 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       expect(data.visibility).toBe('private')
       expect(data.spoiler_text).toBe('')
-      expect(updatedStatus?.summary).toBeNull()
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.summary).toBeNull()
       expect(updatedStatus?.to).toEqual([`${ACTOR1_ID}/followers`])
       expect(updatedStatus?.cc).toEqual([])
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
@@ -2474,7 +2494,11 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       expect(response.status).toBe(400)
       const updatedStatus = await database.getStatus({ statusId })
-      expect(updatedStatus?.text).toBe('Malformed edit target')
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.text).toBe('Malformed edit target')
     })
 
     it('applies a visibility-only edit from a urlencoded body', async () => {
@@ -2549,7 +2573,11 @@ describe('GET /api/v1/statuses/[id]', () => {
       const updatedStatus = await database.getStatus({ statusId })
 
       expect(data.spoiler_text).toBe('')
-      expect(updatedStatus?.summary).toBeNull()
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.summary).toBeNull()
     })
 
     it('does not partially apply visibility when content update is forbidden', async () => {
@@ -2590,7 +2618,11 @@ describe('GET /api/v1/statuses/[id]', () => {
       const updatedStatus = await database.getStatus({ statusId })
 
       expect(response.status).toBe(403)
-      expect(updatedStatus?.summary).toBe('Existing warning')
+      expect(updatedStatus?.type).toBe(StatusType.enum.Note)
+      if (!updatedStatus || updatedStatus.type !== StatusType.enum.Note) {
+        throw new Error('Expected note status')
+      }
+      expect(updatedStatus.summary).toBe('Existing warning')
       expect(updatedStatus?.to).toEqual([ACTIVITY_STREAM_PUBLIC])
       expect(updatedStatus?.cc).toEqual([`${ACTOR1_ID}/followers`])
       expect(getQueue().publish).not.toHaveBeenCalled()

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -18,7 +18,7 @@ import { statusPublicId } from '@/lib/stub/publicIds'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
-import { Status, StatusPoll } from '@/lib/types/domain/status'
+import { Status, StatusPoll, StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { generatePublicId } from '@/lib/utils/publicId'
@@ -220,10 +220,14 @@ describe('POST /api/v1/statuses', () => {
 
         expect(response.status).toBe(200)
         const mastodonStatus = await response.json()
-        const created = (await database.getStatus({
+        const created = await database.getStatus({
           statusId: mastodonStatus.uri,
           withReplies: false
-        })) as Status
+        })
+        expect(created?.type).toBe(StatusType.enum.Note)
+        if (!created || created.type !== StatusType.enum.Note) {
+          throw new Error('Expected note status')
+        }
         expect(created.reply).toBe(parent.id)
       }
     )

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/statuses/[id]/favourite/route.test.ts",
-    "app/api/v1/statuses/[id]/route.test.ts",
-    "app/api/v1/statuses/route.test.ts",
     "app/api/v1/timelines/tag/[hashtag]/route.test.ts",
     "app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx",
     "lib/actions/createNote.test.ts",


### PR DESCRIPTION
Resolves types for H2 Batch 23 and removes from tsconfig.typecheck.json ratchet.