### PR TITLE
Bump version to v1.161.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.33",
+  "version": "1.161.34",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.34.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.33`
- Base main SHA: `93c3c3c7362702807664eea9d541e9d8a288318c`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
