### PR TITLE
test: resolve types for hashtag timeline, shared heatmap page, and createNote tests

### DIFF
--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/lib/services/guards/OAuthGuard', () => ({
         req: NextRequest,
         context: {
           database: typeof mockDatabase
-          currentActor: typeof mockCurrentActor
+          currentActor: typeof mockCurrentActor | undefined
           params: Promise<{ hashtag: string }>
         }
       ) => Promise<Response> | Response

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 
-import { SharedHeatmapPage } from './SharedHeatmapPage'
+import { SharedHeatmapPage, SharedHeatmapPageProps } from './SharedHeatmapPage'
 import { SharedHeatmapView } from './sharedHeatmapView'
 
 // The route map mounts a GL map; stub it so the test stays focused on chrome.
@@ -37,11 +37,13 @@ const baseView: SharedHeatmapView = {
   }
 }
 
-const defaultProps = {
+const defaultProps: SharedHeatmapPageProps = {
   view: baseView,
+  mapProvider: { type: 'osm' },
   signupOpen: true,
   signinUrl: '/auth/signin',
-  signupUrl: '/auth/signup'
+  signupUrl: '/auth/signup',
+  token: 'tok123'
 }
 
 describe('SharedHeatmapPage', () => {

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -16,7 +16,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
-import { Note } from '@/lib/types/activitypub'
+import { Document, Note } from '@/lib/types/activitypub'
 import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { StatusNote } from '@/lib/types/domain/status'
@@ -746,9 +746,9 @@ How are you?
       const expectedUrls = status.attachments
         .slice(0, MAX_FEDERATION_MEDIA_ATTACHMENTS)
         .map((attachment) => attachment.url)
-      expect(attachments.map((attachment) => attachment.url)).toEqual(
-        expectedUrls
-      )
+      expect(
+        attachments.map((attachment) => (attachment as Document).url)
+      ).toEqual(expectedUrls)
     })
 
     describe('visibility support', () => {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "app/api/v1/timelines/tag/[hashtag]/route.test.ts",
-    "app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx",
-    "lib/actions/createNote.test.ts",
     "lib/actions/createNoteEmoji.test.ts",
     "lib/actions/createPoll.test.ts",
     "lib/actions/deleteStatus.test.ts",


### PR DESCRIPTION
Resolves typecheck errors in the top 3 test files and removes them from the `tsconfig.typecheck.json` ratchet list:
- `app/api/v1/timelines/tag/[hashtag]/route.test.ts`
- `app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx`
- `lib/actions/createNote.test.ts`

Ratchet count reduced down from 93 to 90 (95 to 92 total test exclusions remaining).