### PR TITLE
refactor: extract account preferences and fitness calendar operations into lib/client/

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -5,7 +5,7 @@ import { TimelineFormat } from '@/lib/services/timelines/const'
 import type { DirectConversation } from '@/lib/types/database/operations'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
-import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
+import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
@@ -17,13 +17,7 @@ import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
-// `toIdPathSegment` is the ONLY id transformation this module performs, and it
-// only ever fires for a raw AP URI headed into a URL path segment. Every
-// id-accepting route resolves a publicId, a legacy colon/`apurl_` id, or a raw
-// URI, so re-encoding a client id here can only corrupt it — `urlToId` reads a
-// UUIDv7 publicId as a bare host and hands back `<uuid>:`, which nothing can
-// resolve. Ids in query params and JSON bodies go out verbatim.
-import { idToUrl, toIdPathSegment } from '@/lib/utils/urlToId'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 import {
   type ActorDomainsResult,
@@ -437,117 +431,12 @@ export * from './client/notificationSettings'
 
 // --- Preferences ---
 
-export interface PreferencesInput {
-  // Posting defaults — saved through the standard Mastodon credential endpoint.
-  visibility: 'public' | 'unlisted' | 'private' | 'direct'
-  // Default quote-approval policy for new public/unlisted posts (Mastodon 4.5).
-  quotePolicy: QuoteApprovalPolicy
-  sensitive: boolean
-  language: string
-  // Reading preferences — saved through the web-internal endpoint.
-  expandMedia: 'default' | 'show_all' | 'hide_all'
-  expandSpoilers: boolean
-  autoplayGifs: boolean
-}
+export * from './client/accountPreferences'
 
-// Persists posting defaults and reading preferences. Posting defaults go to
-// PATCH /api/v1/accounts/update_credentials (the documented Mastodon write path
-// third-party clients also use); reading preferences go to the web-internal
-// endpoint since GET /api/v1/preferences is read-only by design.
-//
-// The two writes run sequentially and the reading POST is skipped if the
-// posting PATCH fails. This narrows — but does not eliminate — the partial-
-// update window: if the PATCH succeeds and the POST then fails, the posting
-// defaults are already persisted while the reading prefs are not. Both writes
-// are idempotent, so retrying after any failure re-applies the identical
-// payloads and converges to a consistent state.
-export const updatePreferences = async (
-  preferences: PreferencesInput
-): Promise<boolean> => {
-  const postingResponse = await fetch('/api/v1/accounts/update_credentials', {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      source: {
-        privacy: preferences.visibility,
-        quote_policy: preferences.quotePolicy,
-        sensitive: preferences.sensitive,
-        language: preferences.language
-      }
-    })
-  })
-  if (!postingResponse.ok) return false
-
-  const readingResponse = await fetch('/api/v1/accounts/reading-preferences', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      readingExpandMedia: preferences.expandMedia,
-      readingExpandSpoilers: preferences.expandSpoilers,
-      readingAutoplayGifs: preferences.autoplayGifs
-    })
-  })
-  return readingResponse.ok
-}
-
-// --- Navigation customization ---
-
-export interface NavigationPreferencesInput {
-  // The user's sidebar order and the items tucked under "More". Both are full
-  // snapshots: the caller sends the entire list on every save so concurrent
-  // edits resolve to last-write-wins rather than interleaving deltas. Empty
-  // arrays reset to the shipped defaults.
-  navOrder: string[]
-  navHidden: string[]
-}
-
-export const updateNavigationPreferences = async (
-  preferences: NavigationPreferencesInput
-): Promise<boolean> => {
-  const response = await fetch('/api/v1/accounts/navigation-preferences', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(preferences)
-  })
-  return response.ok
-}
+// --- Fitness calendar and heatmaps ---
 
 export * from './client/fitnessHeatmaps'
-
-export interface FitnessCalendarDay {
-  date: string
-  count: number
-  totalDistanceMeters: number
-  totalDurationSeconds: number
-}
-
-export const getFitnessCalendarData = async ({
-  actorId,
-  startDate,
-  endDate,
-  activityType
-}: {
-  actorId: string
-  startDate: number
-  endDate: number
-  activityType?: string
-}): Promise<FitnessCalendarDay[]> => {
-  const encodedId = toIdPathSegment(actorId)
-  const url = new URL(
-    `${window.origin}/api/v1/accounts/${encodedId}/fitness-calendar`
-  )
-  url.searchParams.append('start_date', `${startDate}`)
-  url.searchParams.append('end_date', `${endDate}`)
-  if (activityType) {
-    url.searchParams.append('activity_type', activityType)
-  }
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (!response.ok) return []
-  return response.json()
-}
+export * from './client/fitnessCalendar'
 
 export type DirectConversationView = DirectConversation & {
   accounts: MastodonAccount[]

--- a/lib/client/accountPreferences.test.ts
+++ b/lib/client/accountPreferences.test.ts
@@ -1,0 +1,131 @@
+import fetchMock from 'jest-fetch-mock'
+
+import {
+  PreferencesInput,
+  updateNavigationPreferences,
+  updatePreferences
+} from './accountPreferences'
+
+describe('accountPreferences client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('updatePreferences', () => {
+    const preferences: PreferencesInput = {
+      visibility: 'public',
+      quotePolicy: 'public',
+      sensitive: false,
+      language: 'en',
+      expandMedia: 'default',
+      expandSpoilers: false,
+      autoplayGifs: true
+    }
+
+    it('returns true when both posting and reading preferences are saved successfully', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+        .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+
+      const result = await updatePreferences(preferences)
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        '/api/v1/accounts/update_credentials',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            source: {
+              privacy: 'public',
+              quote_policy: 'public',
+              sensitive: false,
+              language: 'en'
+            }
+          })
+        }
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/accounts/reading-preferences',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            readingExpandMedia: 'default',
+            readingExpandSpoilers: false,
+            readingAutoplayGifs: true
+          })
+        }
+      )
+    })
+
+    it('returns false and skips reading preferences when posting preferences update fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Failed' }), {
+        status: 500
+      })
+
+      const result = await updatePreferences(preferences)
+
+      expect(result).toBe(false)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/update_credentials',
+        expect.anything()
+      )
+    })
+
+    it('returns false when reading preferences update fails', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+        .mockResponseOnce(JSON.stringify({ error: 'Failed' }), { status: 500 })
+
+      const result = await updatePreferences(preferences)
+
+      expect(result).toBe(false)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('updateNavigationPreferences', () => {
+    it('sends navigation preferences and returns true on success', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      const input = {
+        navOrder: ['timeline', 'notifications', 'messages'],
+        navHidden: ['bookmarks']
+      }
+
+      const result = await updateNavigationPreferences(input)
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/accounts/navigation-preferences',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input)
+        }
+      )
+    })
+
+    it('returns false when request fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Failed' }), {
+        status: 400
+      })
+
+      const input = {
+        navOrder: [],
+        navHidden: []
+      }
+
+      const result = await updateNavigationPreferences(input)
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/lib/client/accountPreferences.ts
+++ b/lib/client/accountPreferences.ts
@@ -1,0 +1,76 @@
+import type { QuoteApprovalPolicy } from '@/lib/types/domain/status'
+
+export interface PreferencesInput {
+  // Posting defaults — saved through the standard Mastodon credential endpoint.
+  visibility: 'public' | 'unlisted' | 'private' | 'direct'
+  // Default quote-approval policy for new public/unlisted posts (Mastodon 4.5).
+  quotePolicy: QuoteApprovalPolicy
+  sensitive: boolean
+  language: string
+  // Reading preferences — saved through the web-internal endpoint.
+  expandMedia: 'default' | 'show_all' | 'hide_all'
+  expandSpoilers: boolean
+  autoplayGifs: boolean
+}
+
+// Persists posting defaults and reading preferences. Posting defaults go to
+// PATCH /api/v1/accounts/update_credentials (the documented Mastodon write path
+// third-party clients also use); reading preferences go to the web-internal
+// endpoint since GET /api/v1/preferences is read-only by design.
+//
+// The two writes run sequentially and the reading POST is skipped if the
+// posting PATCH fails. This narrows — but does not eliminate — the partial-
+// update window: if the PATCH succeeds and the POST then fails, the posting
+// defaults are already persisted while the reading prefs are not. Both writes
+// are idempotent, so retrying after any failure re-applies the identical
+// payloads and converges to a consistent state.
+export const updatePreferences = async (
+  preferences: PreferencesInput
+): Promise<boolean> => {
+  const postingResponse = await fetch('/api/v1/accounts/update_credentials', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      source: {
+        privacy: preferences.visibility,
+        quote_policy: preferences.quotePolicy,
+        sensitive: preferences.sensitive,
+        language: preferences.language
+      }
+    })
+  })
+  if (!postingResponse.ok) return false
+
+  const readingResponse = await fetch('/api/v1/accounts/reading-preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      readingExpandMedia: preferences.expandMedia,
+      readingExpandSpoilers: preferences.expandSpoilers,
+      readingAutoplayGifs: preferences.autoplayGifs
+    })
+  })
+  return readingResponse.ok
+}
+
+// --- Navigation customization ---
+
+export interface NavigationPreferencesInput {
+  // The user's sidebar order and the items tucked under "More". Both are full
+  // snapshots: the caller sends the entire list on every save so concurrent
+  // edits resolve to last-write-wins rather than interleaving deltas. Empty
+  // arrays reset to the shipped defaults.
+  navOrder: string[]
+  navHidden: string[]
+}
+
+export const updateNavigationPreferences = async (
+  preferences: NavigationPreferencesInput
+): Promise<boolean> => {
+  const response = await fetch('/api/v1/accounts/navigation-preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(preferences)
+  })
+  return response.ok
+}

--- a/lib/client/fitnessCalendar.test.ts
+++ b/lib/client/fitnessCalendar.test.ts
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import fetchMock from 'jest-fetch-mock'
+
+import { getFitnessCalendarData } from './fitnessCalendar'
+
+describe('fitnessCalendar client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('getFitnessCalendarData', () => {
+    it('fetches fitness calendar data successfully', async () => {
+      const mockData = [
+        {
+          date: '2026-09-01',
+          count: 2,
+          totalDistanceMeters: 10000,
+          totalDurationSeconds: 3600
+        }
+      ]
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockData), { status: 200 })
+
+      const result = await getFitnessCalendarData({
+        actorId: 'test-user',
+        startDate: 1725148800,
+        endDate: 1725235200
+      })
+
+      expect(result).toEqual(mockData)
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${window.origin}/api/v1/accounts/test-user/fitness-calendar?start_date=1725148800&end_date=1725235200`,
+        {
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        }
+      )
+    })
+
+    it('appends activity_type parameter when provided', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([]), { status: 200 })
+
+      await getFitnessCalendarData({
+        actorId: 'test-user',
+        startDate: 1725148800,
+        endDate: 1725235200,
+        activityType: 'running'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${window.origin}/api/v1/accounts/test-user/fitness-calendar?start_date=1725148800&end_date=1725235200&activity_type=running`,
+        expect.anything()
+      )
+    })
+
+    it('correctly encodes actorId with special characters or URLs', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([]), { status: 200 })
+
+      await getFitnessCalendarData({
+        actorId: 'https://example.com/users/alice',
+        startDate: 1725148800,
+        endDate: 1725235200
+      })
+
+      // toIdPathSegment converts https://example.com/users/alice to example.com:users:alice
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/api/v1/accounts/example.com:users:alice/fitness-calendar'
+        ),
+        expect.anything()
+      )
+    })
+
+    it('returns empty array when request fails', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Server error' }), {
+        status: 500
+      })
+
+      const result = await getFitnessCalendarData({
+        actorId: 'test-user',
+        startDate: 1725148800,
+        endDate: 1725235200
+      })
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/lib/client/fitnessCalendar.ts
+++ b/lib/client/fitnessCalendar.ts
@@ -1,0 +1,42 @@
+// `toIdPathSegment` is the ONLY id transformation this module performs, and it
+// only ever fires for a raw AP URI headed into a URL path segment. Every
+// id-accepting route resolves a publicId, a legacy colon/`apurl_` id, or a raw
+// URI, so re-encoding a client id here can only corrupt it — `urlToId` reads a
+// UUIDv7 publicId as a bare host and hands back `<uuid>:`, which nothing can
+// resolve. Ids in query params and JSON bodies go out verbatim.
+import { toIdPathSegment } from '@/lib/utils/urlToId'
+
+export interface FitnessCalendarDay {
+  date: string
+  count: number
+  totalDistanceMeters: number
+  totalDurationSeconds: number
+}
+
+export const getFitnessCalendarData = async ({
+  actorId,
+  startDate,
+  endDate,
+  activityType
+}: {
+  actorId: string
+  startDate: number
+  endDate: number
+  activityType?: string
+}): Promise<FitnessCalendarDay[]> => {
+  const encodedId = toIdPathSegment(actorId)
+  const url = new URL(
+    `${window.origin}/api/v1/accounts/${encodedId}/fitness-calendar`
+  )
+  url.searchParams.append('start_date', `${startDate}`)
+  url.searchParams.append('end_date', `${endDate}`)
+  if (activityType) {
+    url.searchParams.append('activity_type', activityType)
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (!response.ok) return []
+  return response.json()
+}


### PR DESCRIPTION
### Summary of changes

Extracts preferences and fitness calendar client operations out of `lib/client.ts` as part of Task J1 Batch 20:

1. **`lib/client/accountPreferences.ts`**:
   - Extracted `PreferencesInput` and `updatePreferences`
   - Extracted `NavigationPreferencesInput` and `updateNavigationPreferences`
   - Added unit tests in `lib/client/accountPreferences.test.ts`

2. **`lib/client/fitnessCalendar.ts`**:
   - Extracted `FitnessCalendarDay` and `getFitnessCalendarData`
   - Added unit tests in `lib/client/fitnessCalendar.test.ts`

3. **`lib/client.ts`**:
   - Re-exported all from `./client/accountPreferences` and `./client/fitnessCalendar`
   - Removed duplicated types and extracted function implementations
   - Cleaned up unused imports
   - Retained full backward compatibility for existing imports from `@/lib/client`

### Definition of Done
- [x] `yarn run prettier --write .` passed
- [x] `yarn lint` passed (0 errors)
- [x] `yarn typecheck` passed (0 errors)
- [x] `yarn build` passed
- [x] `yarn test` passed (1015 test files, 14,121 tests passed)