### PR TITLE
refactor: extract conversations operations into lib/client/conversations.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,8 +1,6 @@
 import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
-import { TimelineFormat } from '@/lib/services/timelines/const'
-import type { DirectConversation } from '@/lib/types/database/operations'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { Status } from '@/lib/types/domain/status'
@@ -438,101 +436,9 @@ export * from './client/accountPreferences'
 export * from './client/fitnessHeatmaps'
 export * from './client/fitnessCalendar'
 
-export type DirectConversationView = DirectConversation & {
-  accounts: MastodonAccount[]
-}
+// --- Conversations ---
 
-export interface GetConversationsResult {
-  conversations: DirectConversationView[]
-}
-
-export const getConversations = async ({
-  limit,
-  maxId,
-  minId
-}: {
-  limit?: number
-  maxId?: string
-  minId?: string
-} = {}): Promise<GetConversationsResult> => {
-  const url = new URL(`${window.origin}/api/v1/conversations`)
-  url.searchParams.set('format', TimelineFormat.enum.activities_next)
-  if (limit !== undefined) url.searchParams.set('limit', `${limit}`)
-  if (maxId) url.searchParams.set('max_id', maxId)
-  if (minId) url.searchParams.set('min_id', minId)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (!response.ok) return { conversations: [] }
-
-  const data = (await response.json()) as Partial<GetConversationsResult>
-  return { conversations: data.conversations ?? [] }
-}
-
-export interface GetConversationStatusesResult {
-  statuses: Status[]
-  nextMaxStatusId: string | null
-}
-
-export const getConversationStatuses = async ({
-  conversationId,
-  maxStatusId,
-  minStatusId,
-  limit
-}: {
-  conversationId: string
-  maxStatusId?: string
-  minStatusId?: string
-  limit?: number
-}): Promise<GetConversationStatusesResult> => {
-  const url = new URL(
-    `${window.origin}/api/v1/conversations/${conversationId}/statuses`
-  )
-  url.searchParams.set('format', TimelineFormat.enum.activities_next)
-  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
-  if (minStatusId) url.searchParams.set('min_id', minStatusId)
-  if (limit) url.searchParams.set('limit', `${limit}`)
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  if (!response.ok) {
-    return { statuses: [], nextMaxStatusId: null }
-  }
-
-  const data = (await response.json()) as Partial<GetConversationStatusesResult>
-  return {
-    statuses: data.statuses ?? [],
-    nextMaxStatusId: data.nextMaxStatusId ?? null
-  }
-}
-
-export const markConversationRead = async ({
-  conversationId
-}: {
-  conversationId: string
-}) => {
-  const response = await fetch(`/api/v1/conversations/${conversationId}/read`, {
-    method: 'POST',
-    headers: { Accept: 'application/json' }
-  })
-  return response.ok
-}
-
-export const hideConversation = async ({
-  conversationId
-}: {
-  conversationId: string
-}) => {
-  const response = await fetch(`/api/v1/conversations/${conversationId}`, {
-    method: 'DELETE',
-    headers: { Accept: 'application/json' }
-  })
-  return response.ok
-}
+export * from './client/conversations'
 
 export type SearchType = 'accounts' | 'statuses' | 'hashtags'
 

--- a/lib/client/conversations.test.ts
+++ b/lib/client/conversations.test.ts
@@ -1,0 +1,229 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  getConversationStatuses,
+  getConversations,
+  hideConversation,
+  markConversationRead
+} from './conversations'
+
+enableFetchMocks()
+
+describe('client conversations module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { origin: 'https://llun.test' }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  describe('getConversations', () => {
+    it('fetches conversations with format activities_next and default params', async () => {
+      const mockConversations = [
+        {
+          id: 'conv-1',
+          unread: false,
+          accounts: [{ id: 'acc-1', username: 'alice' }]
+        }
+      ]
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ conversations: mockConversations }),
+        { status: 200 }
+      )
+
+      const result = await getConversations()
+
+      expect(result).toEqual({ conversations: mockConversations })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/conversations?format=activities_next',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('passes limit, maxId, and minId query params', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ conversations: [] }), {
+        status: 200
+      })
+
+      const result = await getConversations({
+        limit: 25,
+        maxId: 'max-123',
+        minId: 'min-456'
+      })
+
+      expect(result).toEqual({ conversations: [] })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/conversations?format=activities_next&limit=25&max_id=max-123&min_id=min-456',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty conversations when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      const result = await getConversations()
+
+      expect(result).toEqual({ conversations: [] })
+    })
+
+    it('returns empty array when response json does not contain conversations property', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 })
+
+      const result = await getConversations()
+
+      expect(result).toEqual({ conversations: [] })
+    })
+  })
+
+  describe('getConversationStatuses', () => {
+    it('fetches conversation statuses with format activities_next', async () => {
+      const mockStatuses = [
+        { id: 'status-1', content: 'hello' },
+        { id: 'status-2', content: 'world' }
+      ]
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: mockStatuses,
+          nextMaxStatusId: 'status-2'
+        }),
+        { status: 200 }
+      )
+
+      const result = await getConversationStatuses({
+        conversationId: 'conv-123'
+      })
+
+      expect(result).toEqual({
+        statuses: mockStatuses,
+        nextMaxStatusId: 'status-2'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/conversations/conv-123/statuses?format=activities_next',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('passes pagination and limit query params', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          statuses: [],
+          nextMaxStatusId: null
+        }),
+        { status: 200 }
+      )
+
+      const result = await getConversationStatuses({
+        conversationId: 'conv-123',
+        maxStatusId: 'max-1',
+        minStatusId: 'min-1',
+        limit: 10
+      })
+
+      expect(result).toEqual({
+        statuses: [],
+        nextMaxStatusId: null
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://llun.test/api/v1/conversations/conv-123/statuses?format=activities_next&max_id=max-1&min_id=min-1&limit=10',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns empty statuses and null nextMaxStatusId on error response', async () => {
+      fetchMock.mockResponseOnce('Not found', { status: 404 })
+
+      const result = await getConversationStatuses({
+        conversationId: 'conv-404'
+      })
+
+      expect(result).toEqual({
+        statuses: [],
+        nextMaxStatusId: null
+      })
+    })
+
+    it('handles missing fields in response payload gracefully', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 })
+
+      const result = await getConversationStatuses({
+        conversationId: 'conv-123'
+      })
+
+      expect(result).toEqual({
+        statuses: [],
+        nextMaxStatusId: null
+      })
+    })
+  })
+
+  describe('markConversationRead', () => {
+    it('sends POST request and returns true on success', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      const ok = await markConversationRead({ conversationId: 'conv-1' })
+
+      expect(ok).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/conversations/conv-1/read',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Internal server error', { status: 500 })
+
+      const ok = await markConversationRead({ conversationId: 'conv-1' })
+
+      expect(ok).toBe(false)
+    })
+  })
+
+  describe('hideConversation', () => {
+    it('sends DELETE request and returns true on success', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ success: true }), {
+        status: 200
+      })
+
+      const ok = await hideConversation({ conversationId: 'conv-2' })
+
+      expect(ok).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/conversations/conv-2',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Forbidden', { status: 403 })
+
+      const ok = await hideConversation({ conversationId: 'conv-2' })
+
+      expect(ok).toBe(false)
+    })
+  })
+})

--- a/lib/client/conversations.ts
+++ b/lib/client/conversations.ts
@@ -1,0 +1,108 @@
+import { TimelineFormat } from '@/lib/services/timelines/const'
+import type { DirectConversation } from '@/lib/types/database/operations'
+import type { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+
+export type DirectConversationView = DirectConversation & {
+  accounts: MastodonAccount[]
+}
+
+export interface GetConversationsParams {
+  limit?: number
+  maxId?: string
+  minId?: string
+}
+
+export interface GetConversationsResult {
+  conversations: DirectConversationView[]
+}
+
+export const getConversations = async ({
+  limit,
+  maxId,
+  minId
+}: GetConversationsParams = {}): Promise<GetConversationsResult> => {
+  const url = new URL(`${window.origin}/api/v1/conversations`)
+  url.searchParams.set('format', TimelineFormat.enum.activities_next)
+  if (limit !== undefined) url.searchParams.set('limit', `${limit}`)
+  if (maxId) url.searchParams.set('max_id', maxId)
+  if (minId) url.searchParams.set('min_id', minId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (!response.ok) return { conversations: [] }
+
+  const data = (await response.json()) as Partial<GetConversationsResult>
+  return { conversations: data.conversations ?? [] }
+}
+
+export interface GetConversationStatusesParams {
+  conversationId: string
+  maxStatusId?: string
+  minStatusId?: string
+  limit?: number
+}
+
+export interface GetConversationStatusesResult {
+  statuses: Status[]
+  nextMaxStatusId: string | null
+}
+
+export const getConversationStatuses = async ({
+  conversationId,
+  maxStatusId,
+  minStatusId,
+  limit
+}: GetConversationStatusesParams): Promise<GetConversationStatusesResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/conversations/${conversationId}/statuses`
+  )
+  url.searchParams.set('format', TimelineFormat.enum.activities_next)
+  if (maxStatusId) url.searchParams.set('max_id', maxStatusId)
+  if (minStatusId) url.searchParams.set('min_id', minStatusId)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (!response.ok) {
+    return { statuses: [], nextMaxStatusId: null }
+  }
+
+  const data = (await response.json()) as Partial<GetConversationStatusesResult>
+  return {
+    statuses: data.statuses ?? [],
+    nextMaxStatusId: data.nextMaxStatusId ?? null
+  }
+}
+
+export interface MarkConversationReadParams {
+  conversationId: string
+}
+
+export const markConversationRead = async ({
+  conversationId
+}: MarkConversationReadParams): Promise<boolean> => {
+  const response = await fetch(`/api/v1/conversations/${conversationId}/read`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' }
+  })
+  return response.ok
+}
+
+export interface HideConversationParams {
+  conversationId: string
+}
+
+export const hideConversation = async ({
+  conversationId
+}: HideConversationParams): Promise<boolean> => {
+  const response = await fetch(`/api/v1/conversations/${conversationId}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' }
+  })
+  return response.ok
+}


### PR DESCRIPTION
Extract conversation client operations out of `lib/client.ts` into `lib/client/conversations.ts`:

- Extracted types:
  - `DirectConversationView`
  - `GetConversationsResult`
  - `GetConversationStatusesResult`
  - Added typed parameter interfaces `GetConversationsParams`, `GetConversationStatusesParams`, `MarkConversationReadParams`, `HideConversationParams`
- Extracted functions:
  - `getConversations`
  - `getConversationStatuses`
  - `markConversationRead`
  - `hideConversation`
- Re-exported `* from './client/conversations'` in `lib/client.ts` to maintain seamless backward compatibility
- Added unit tests in `lib/client/conversations.test.ts`