### PR TITLE
Bump version to v1.161.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.34",
+  "version": "1.161.35",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.35.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.34`
- Base main SHA: `31f5b44ff00a4db17301a5c2721960dcbcea30cf`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
