### PR TITLE
test: resolve types for createNoteEmoji, createPoll, and deleteStatus tests

### DIFF
--- a/lib/actions/createNoteEmoji.test.ts
+++ b/lib/actions/createNoteEmoji.test.ts
@@ -91,7 +91,9 @@ describe('Custom emoji status federation', () => {
       text: 'party :blobcat:',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const note = getNoteFromStatus(status)
     const tags = Array.isArray(note?.tag) ? note?.tag : [note?.tag]
@@ -113,7 +115,9 @@ describe('Custom emoji status federation', () => {
       text: 'mix :hidden: :gone:',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const emojiNames = status.tags
       .filter((tag) => tag.type === 'emoji')
@@ -130,7 +134,9 @@ describe('Custom emoji status federation', () => {
       endAt: 4102444800000,
       database
     })
-    if (!status) throw new Error('Expected a poll status')
+    if (!status || status.type !== StatusType.enum.Poll) {
+      throw new Error('Expected a poll status')
+    }
 
     const question = toActivityPubObject(status)
     const tags = Array.isArray(question.tag) ? question.tag : [question.tag]
@@ -152,7 +158,9 @@ describe('Custom emoji status federation', () => {
       text: 'first :blobcat:',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const updated = await updateNoteFromUserInput({
       statusId: status.id,
@@ -173,7 +181,9 @@ describe('Custom emoji status federation', () => {
       text: 'plain text',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
     expect(
       (await database.getTags({ statusId: status.id })).filter(
         (tag) => tag.type === 'emoji'
@@ -195,7 +205,10 @@ describe('Custom emoji status federation', () => {
 
     // The returned status (used for the optimistic client render + timeline
     // cache) must already include the re-synced emoji tag.
-    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toEqual([
+    if (!updated || updated.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
+    expect(updated.tags.filter((tag) => tag.type === 'emoji')).toEqual([
       expect.objectContaining({ name: ':blobcat:' })
     ])
   })
@@ -207,7 +220,9 @@ describe('Custom emoji status federation', () => {
       summary: 'spoiler with :blobcat:',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
@@ -231,7 +246,9 @@ describe('Custom emoji status federation', () => {
       ],
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
@@ -246,7 +263,9 @@ describe('Custom emoji status federation', () => {
       endAt: 4102444800000,
       database
     })
-    if (!status) throw new Error('Expected a poll status')
+    if (!status || status.type !== StatusType.enum.Poll) {
+      throw new Error('Expected a poll status')
+    }
 
     const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
@@ -260,7 +279,9 @@ describe('Custom emoji status federation', () => {
       summary: 'plain summary',
       database
     })
-    if (!status) throw new Error('Expected a status')
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
 
     const updated = await updateNoteFromUserInput({
       statusId: status.id,
@@ -274,7 +295,10 @@ describe('Custom emoji status federation', () => {
     const emojiTags = tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
     expect(emojiTags[0].name).toBe(':blobcat:')
-    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
+    if (!updated || updated.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
+    expect(updated.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
   })
 
   it('re-syncs emoji tags when poll choices are updated', async () => {
@@ -285,7 +309,9 @@ describe('Custom emoji status federation', () => {
       endAt: 4102444800000,
       database
     })
-    if (!status) throw new Error('Expected a poll status')
+    if (!status || status.type !== StatusType.enum.Poll) {
+      throw new Error('Expected a poll status')
+    }
 
     const updated = await updatePollFromUserInput({
       statusId: status.id,
@@ -301,6 +327,9 @@ describe('Custom emoji status federation', () => {
     const emojiTags = tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
     expect(emojiTags[0].name).toBe(':blobcat:')
-    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
+    if (!updated || updated.type !== StatusType.enum.Poll) {
+      throw new Error('Expected a poll status')
+    }
+    expect(updated.tags.filter((tag) => tag.type === 'emoji')).toHaveLength(1)
   })
 })

--- a/lib/actions/createPoll.test.ts
+++ b/lib/actions/createPoll.test.ts
@@ -8,6 +8,7 @@ import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
 import { Actor } from '@/lib/types/domain/actor'
+import { Status, StatusPoll, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { isPublicId } from '@/lib/utils/publicId'
 
@@ -16,6 +17,12 @@ enableFetchMocks()
 vi.mock('@/lib/services/timelines', () => ({
   addStatusToTimelines: vi.fn().mockResolvedValue(undefined)
 }))
+
+const findPoll = (statuses: Status[], text: string): StatusPoll | undefined =>
+  statuses.find(
+    (s): s is StatusPoll =>
+      s.type === StatusType.enum.Poll && s.text.includes(text)
+  )
 
 describe('Create poll action', () => {
   const database = getTestSQLDatabase()
@@ -60,9 +67,7 @@ describe('Create poll action', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) =>
-        s.text.includes('What is your favorite color?')
-      )
+      const poll = findPoll(statuses, 'What is your favorite color?')
 
       expect(poll).toBeDefined()
       expect(createdPoll?.id).toBe(poll?.id)
@@ -97,7 +102,10 @@ describe('Create poll action', () => {
         endAt: Date.now() + 24 * 60 * 60 * 1000
       })
 
-      expect(createdPoll?.sensitive).toBe(true)
+      if (!createdPoll || createdPoll.type !== StatusType.enum.Poll) {
+        throw new Error('Expected a poll status')
+      }
+      expect(createdPoll.sensitive).toBe(true)
     })
 
     it('stores a content-detected language that overrides a mislabeled declared language', async () => {
@@ -110,8 +118,11 @@ describe('Create poll action', () => {
         language: 'en'
       })
 
-      expect(createdPoll?.language).toBe('en')
-      expect(createdPoll?.detectedLanguage).toBe('th')
+      if (!createdPoll || createdPoll.type !== StatusType.enum.Poll) {
+        throw new Error('Expected a poll status')
+      }
+      expect(createdPoll.language).toBe('en')
+      expect(createdPoll.detectedLanguage).toBe('th')
     })
 
     it('returns null for direct polls without explicit recipients', async () => {
@@ -140,7 +151,7 @@ describe('Create poll action', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Choose the culprit'))
+      const poll = findPoll(statuses, 'Choose the culprit')
 
       expect(poll?.summary).toBe('Mystery spoilers')
     })
@@ -158,7 +169,7 @@ describe('Create poll action', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('What do you think?'))
+      const poll = findPoll(statuses, 'What do you think?')
 
       expect(poll).toBeDefined()
       expect(poll?.to).toContain(ACTIVITY_STREAM_PUBLIC)
@@ -182,7 +193,7 @@ describe('Create poll action', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Poll reply'))
+      const poll = findPoll(statuses, 'Poll reply')
 
       expect(poll).toBeDefined()
       expect(poll?.reply).toBe(replyStatusId)
@@ -204,7 +215,7 @@ describe('Create poll action', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Timed poll'))
+      const poll = findPoll(statuses, 'Timed poll')
 
       expect(poll).toBeDefined()
     })
@@ -223,9 +234,7 @@ describe('Create poll action', () => {
         const statuses = await database.getActorStatuses({
           actorId: actor1.id
         })
-        const poll = statuses.find((s) =>
-          s.text.includes('Private poll question')
-        )
+        const poll = findPoll(statuses, 'Private poll question')
 
         expect(poll).toBeDefined()
         expect(poll?.to).toContain(`${actor1.id}/followers`)
@@ -246,9 +255,7 @@ describe('Create poll action', () => {
         const statuses = await database.getActorStatuses({
           actorId: actor1.id
         })
-        const poll = statuses.find((s) =>
-          s.text.includes('Unlisted poll question')
-        )
+        const poll = findPoll(statuses, 'Unlisted poll question')
 
         expect(poll).toBeDefined()
         expect(poll?.to).toContain(`${actor1.id}/followers`)
@@ -278,9 +285,7 @@ describe('Create poll action', () => {
         const statuses = await database.getActorStatuses({
           actorId: actor1.id
         })
-        const poll = statuses.find((s) =>
-          s.text.includes('Poll reply to private')
-        )
+        const poll = findPoll(statuses, 'Poll reply to private')
 
         expect(poll).toBeDefined()
         // Should inherit private visibility - no Public in to or cc
@@ -310,10 +315,9 @@ describe('Create poll action', () => {
         const statuses = await database.getActorStatuses({
           actorId: actor1.id
         })
-        const poll = statuses.find((status) =>
-          status.text.includes(
-            'Poll reply without manually rementioning everyone'
-          )
+        const poll = findPoll(
+          statuses,
+          'Poll reply without manually rementioning everyone'
         )
         const mentionTags = await database.getTags({ statusId: poll?.id || '' })
 

--- a/lib/actions/deleteStatus.test.ts
+++ b/lib/actions/deleteStatus.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
+import { Config } from '@/lib/config'
+import {
+  CloudTasksConfig,
+  DatabaseQueueConfig,
+  QStashConfig,
+  QueueConfig
+} from '@/lib/config/queue'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
 import { SEND_DELETE_NOTE_JOB_NAME } from '@/lib/jobs/names'
@@ -10,15 +17,15 @@ import { DatabaseQueue } from '@/lib/services/queue/database'
 import { NoQueue } from '@/lib/services/queue/noqueue'
 import { QStashQueue } from '@/lib/services/queue/qstash'
 import { Actor } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
-let currentMockConfig: { queue?: any } = { queue: undefined }
+let currentMockConfig: { queue?: QueueConfig } = { queue: undefined }
 
 vi.mock('@/lib/config', () => ({
-  getConfig: vi.fn(() => currentMockConfig)
+  getConfig: vi.fn(() => currentMockConfig as Config)
 }))
 
 vi.mock('@/lib/services/queue', () => ({
@@ -26,6 +33,33 @@ vi.mock('@/lib/services/queue', () => ({
 }))
 
 const CURRENT_ACTOR = { id: 'https://llun.test/users/me' } as Actor
+
+const createMockStatus = (overrides: Partial<StatusNote> = {}): StatusNote => ({
+  id: 'https://llun.test/users/me/statuses/1',
+  url: 'https://llun.test/users/me/statuses/1',
+  actorId: CURRENT_ACTOR.id,
+  actor: null,
+  type: StatusType.enum.Note,
+  text: 'Hello',
+  summary: null,
+  reply: '',
+  replies: [],
+  totalReplies: 0,
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  isActorBookmarked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  to: [ACTIVITY_STREAM_PUBLIC],
+  cc: [],
+  edits: [],
+  attachments: [],
+  tags: [],
+  isLocalActor: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  ...overrides
+})
 
 const createDatabase = (status: Status | null) =>
   ({
@@ -42,21 +76,23 @@ describe('deleteStatusFromUserInput', () => {
 
   describe('Database queue backend', () => {
     beforeEach(() => {
-      currentMockConfig = {
-        queue: { type: 'database', maxRetries: 16 }
+      const queueConfig: DatabaseQueueConfig = {
+        type: 'database',
+        maxRetries: 16
       }
-      const dbQueue = new DatabaseQueue(currentMockConfig.queue)
+      currentMockConfig = { queue: queueConfig }
+      const dbQueue = new DatabaseQueue(queueConfig)
       vi.spyOn(dbQueue, 'publish')
       vi.mocked(getQueue).mockReturnValue(dbQueue)
     })
 
     it('atomically deletes status and enqueues deletion job via deleteStatusWithQueueJob', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/db-delete-1',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: ['https://llun.test/users/me/followers']
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -96,18 +132,20 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('respects custom maxRetries from DatabaseQueueConfig', async () => {
-      currentMockConfig = {
-        queue: { type: 'database', maxRetries: 5 }
+      const queueConfig: DatabaseQueueConfig = {
+        type: 'database',
+        maxRetries: 5
       }
-      const dbQueue = new DatabaseQueue(currentMockConfig.queue)
+      currentMockConfig = { queue: queueConfig }
+      const dbQueue = new DatabaseQueue(queueConfig)
       vi.mocked(getQueue).mockReturnValue(dbQueue)
 
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/db-custom-retries',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -126,12 +164,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('snapshots recipient addresses (to, cc) in the job payload', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/snapshot-test',
         actorId: CURRENT_ACTOR.id,
         to: ['https://remote.example/users/alice', ACTIVITY_STREAM_PUBLIC],
         cc: ['https://remote.example/users/bob']
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -155,12 +193,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('propagates transaction failure when deleteStatusWithQueueJob rejects', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/db-tx-fail',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       const txError = new Error('Database transaction rolled back')
       vi.mocked(database.deleteStatusWithQueueJob).mockRejectedValueOnce(
@@ -177,12 +215,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('rejects deletion when status is owned by another actor', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/other/statuses/unauthorized',
         actorId: 'https://llun.test/users/other',
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -210,12 +248,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('handles repeated deletion gracefully when deleteStatusWithQueueJob returns false', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/race-condition',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       vi.mocked(database.deleteStatusWithQueueJob).mockResolvedValueOnce(false)
 
@@ -233,27 +271,26 @@ describe('deleteStatusFromUserInput', () => {
     let qstashQueue: QStashQueue
 
     beforeEach(() => {
-      currentMockConfig = {
-        queue: {
-          type: 'qstash',
-          url: 'https://qstash.example.com',
-          token: 'token',
-          currentSigningKey: 'sig1',
-          nextSigningKey: 'sig2'
-        }
+      const queueConfig: QStashConfig = {
+        type: 'qstash',
+        url: 'https://qstash.example.com',
+        token: 'token',
+        currentSigningKey: 'sig1',
+        nextSigningKey: 'sig2'
       }
-      qstashQueue = new QStashQueue(currentMockConfig.queue)
+      currentMockConfig = { queue: queueConfig }
+      qstashQueue = new QStashQueue(queueConfig)
       vi.spyOn(qstashQueue, 'publish').mockResolvedValue(undefined)
       vi.mocked(getQueue).mockReturnValue(qstashQueue)
     })
 
     it('deletes locally before publishing to QStash', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/qstash-delete',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: ['https://remote.example/users/bob']
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -287,12 +324,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('swallows and logs QStash enqueue error without failing the deletion', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/qstash-fail',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       vi.spyOn(qstashQueue, 'publish').mockRejectedValueOnce(
         new Error('QStash network error')
@@ -321,12 +358,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('rejects deletion when status is owned by another actor', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/other/statuses/qstash-unauthorized',
         actorId: 'https://llun.test/users/other',
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -344,25 +381,24 @@ describe('deleteStatusFromUserInput', () => {
     let cloudTasksQueue: CloudTasksQueue
 
     beforeEach(() => {
-      currentMockConfig = {
-        queue: {
-          type: 'cloudtasks',
-          location: 'us-central1',
-          project: 'test-project'
-        }
+      const queueConfig: CloudTasksConfig = {
+        type: 'cloudtasks',
+        location: 'us-central1',
+        project: 'test-project'
       }
-      cloudTasksQueue = new CloudTasksQueue(currentMockConfig.queue)
+      currentMockConfig = { queue: queueConfig }
+      cloudTasksQueue = new CloudTasksQueue(queueConfig)
       vi.spyOn(cloudTasksQueue, 'publish').mockResolvedValue(undefined)
       vi.mocked(getQueue).mockReturnValue(cloudTasksQueue)
     })
 
     it('deletes locally before publishing to CloudTasks', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/cloudtasks-delete',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -384,12 +420,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('swallows and logs CloudTasks publish failure', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/cloudtasks-fail',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       vi.spyOn(cloudTasksQueue, 'publish').mockRejectedValueOnce(
         new Error('CloudTasks quota exceeded')
@@ -422,12 +458,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('deletes locally before publishing to inline queue', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/inline-delete',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
 
       await deleteStatusFromUserInput({
@@ -449,12 +485,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('swallows inline publish failure after local deletion committed', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/inline-fail',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       vi.spyOn(noQueue, 'publish').mockRejectedValueOnce(
         new Error('Inline handler failure')
@@ -472,12 +508,12 @@ describe('deleteStatusFromUserInput', () => {
     })
 
     it('propagates error when local database.deleteStatus fails', async () => {
-      const status = {
+      const status = createMockStatus({
         id: 'https://llun.test/users/me/statuses/local-db-fail',
         actorId: CURRENT_ACTOR.id,
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
-      } as Status
+      })
       const database = createDatabase(status)
       vi.mocked(database.deleteStatus).mockRejectedValueOnce(
         new Error('Disk I/O error')
@@ -502,10 +538,12 @@ describe('deleteStatusFromUserInput', () => {
     beforeEach(async () => {
       database = await getTestSQLDatabase()
       await database.migrate()
-      currentMockConfig = {
-        queue: { type: 'database', maxRetries: 16 }
+      const queueConfig: DatabaseQueueConfig = {
+        type: 'database',
+        maxRetries: 16
       }
-      const dbQueue = new DatabaseQueue(currentMockConfig.queue, database)
+      currentMockConfig = { queue: queueConfig }
+      const dbQueue = new DatabaseQueue(queueConfig, database)
       vi.mocked(getQueue).mockReturnValue(dbQueue)
 
       await database.createAccount({

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/actions/createNoteEmoji.test.ts",
-    "lib/actions/createPoll.test.ts",
-    "lib/actions/deleteStatus.test.ts",
     "lib/actions/updateNote.test.ts",
     "lib/actions/visibility.integration.test.ts",
     "lib/activities/getActorPosts.test.ts",


### PR DESCRIPTION
This PR resolves type errors in the top 3 test files in `tsconfig.typecheck.json` and removes them from the exclude ratchet list:

- `lib/actions/createNoteEmoji.test.ts`: Type narrowing on returned status and updated status (`StatusNote` and `StatusPoll`) to properly access `tags` property.
- `lib/actions/createPoll.test.ts`: Type narrowing on status array search (`findPoll` helper typed as `StatusPoll | undefined`) and assertion on created poll status type (`StatusPoll`).
- `lib/actions/deleteStatus.test.ts`: Replaced mock status type casts (`as Status`) with a properly typed `createMockStatus` helper returning a complete `StatusNote`, and strongly typed `queueConfig` across queue backend fixtures.

### Ratchet Count
- H2 tracking: down from 90 to 87
- Total `tsconfig.typecheck.json` exclusions: down from 92 to 89