### PR TITLE
refactor: extract search and direct message operations into lib/client/

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3,8 +3,6 @@ import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnoun
 import type { AdminRule } from '@/lib/services/rules/adminRule'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
-import { Status } from '@/lib/types/domain/status'
-import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
@@ -12,10 +10,7 @@ import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
-import type { Tag } from '@/lib/types/mastodon/tag'
-import { normalizeActorId } from '@/lib/utils/activitypub'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
-import { idToUrl } from '@/lib/utils/urlToId'
 
 import {
   type ActorDomainsResult,
@@ -440,193 +435,13 @@ export * from './client/fitnessCalendar'
 
 export * from './client/conversations'
 
-export type SearchType = 'accounts' | 'statuses' | 'hashtags'
+// --- Search ---
 
-export interface SearchResult<TStatus = Status> {
-  accounts: MastodonAccount[]
-  statuses: TStatus[]
-  hashtags: Tag[]
-}
+export * from './client/search'
 
-export interface SearchParams {
-  q: string
-  type?: SearchType
-  limit?: number
-  offset?: number
-  resolve?: boolean
-  signal?: AbortSignal
-}
+// --- Direct messages ---
 
-const emptySearchResult = (): SearchResult => ({
-  accounts: [],
-  statuses: [],
-  hashtags: []
-})
-
-const MAX_SEARCH_ERROR_DETAIL_LENGTH = 200
-
-const truncateSearchErrorDetail = (detail: string) =>
-  detail.length > MAX_SEARCH_ERROR_DETAIL_LENGTH
-    ? `${detail.slice(0, MAX_SEARCH_ERROR_DETAIL_LENGTH)}...`
-    : detail
-
-const getSearchResponseErrorMessage = (response: Response, text: string) => {
-  let detail = text || response.statusText
-
-  try {
-    const data = JSON.parse(text) as Record<string, unknown>
-    detail =
-      typeof data.message === 'string'
-        ? data.message
-        : typeof data.error === 'string'
-          ? data.error
-          : typeof data.status === 'string'
-            ? data.status
-            : detail
-  } catch {
-    // Keep the raw response text for non-JSON failures.
-  }
-
-  detail = truncateSearchErrorDetail(detail)
-  return `Search request failed (${response.status})${detail ? `: ${detail}` : ''}`
-}
-
-export const search = async ({
-  q,
-  type,
-  limit,
-  offset,
-  resolve = true,
-  signal
-}: SearchParams): Promise<SearchResult> => {
-  const params = new URLSearchParams({
-    q,
-    resolve: resolve ? 'true' : 'false',
-    format: 'activities_next'
-  })
-  if (type) params.set('type', type)
-  if (limit !== undefined) params.set('limit', `${limit}`)
-  if (offset !== undefined) params.set('offset', `${offset}`)
-
-  const response = await fetch(`/api/v2/search?${params.toString()}`, {
-    method: 'GET',
-    headers: { Accept: 'application/json' },
-    signal
-  })
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(getSearchResponseErrorMessage(response, text))
-  }
-  try {
-    return JSON.parse(text) as SearchResult
-  } catch {
-    return emptySearchResult()
-  }
-}
-
-export const searchAccounts = async ({
-  q,
-  limit = 5,
-  resolve = true,
-  signal
-}: {
-  q: string
-  limit?: number
-  resolve?: boolean
-  signal?: AbortSignal
-}): Promise<MastodonAccount[]> => {
-  const url = new URL(`${window.origin}/api/v1/accounts/search`)
-  url.searchParams.set('q', q)
-  url.searchParams.set('limit', `${limit}`)
-  url.searchParams.set('resolve', resolve ? 'true' : 'false')
-
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers: { Accept: 'application/json' },
-    signal
-  })
-  if (!response.ok) return []
-  return (await response.json()) as MastodonAccount[]
-}
-
-const accountMention = (account: MastodonAccount) =>
-  `@${account.acct || account.username}`
-
-const getReplyParticipantIds = (replyStatus: Status) =>
-  new Set(
-    [replyStatus.actorId, ...replyStatus.to, ...replyStatus.cc]
-      .map((id) => normalizeActorId(id))
-      .filter((id): id is string => Boolean(id))
-  )
-
-const isReplyParticipant = (
-  account: MastodonAccount,
-  replyParticipantIds: Set<string>
-) => {
-  // The participant set holds ActivityPub actor URIs, so `uri` is the only
-  // encoding-independent key. `url` is a profile URL (`/@name`) on some
-  // accounts, and `id` is a publicId that cannot be decoded back to a URI at
-  // all, so both stay as fallbacks for entities built before the id flip.
-  for (const candidate of [account.uri, account.url, idToUrl(account.id)]) {
-    if (!candidate) continue
-    const accountActorId = normalizeActorId(candidate)
-    if (accountActorId && replyParticipantIds.has(accountActorId)) return true
-  }
-  return false
-}
-
-export interface CreateDirectMessageResult {
-  uri: string
-  [key: string]: unknown
-}
-
-export const createDirectMessage = async ({
-  message,
-  recipients,
-  replyStatus
-}: {
-  message: string
-  recipients: MastodonAccount[]
-  replyStatus?: Status
-}): Promise<CreateDirectMessageResult> => {
-  const normalizedMessage = message.trim()
-  if (!normalizedMessage) {
-    throw new Error('Message must not be empty')
-  }
-  if (recipients.length === 0 && !replyStatus) {
-    throw new Error('At least one recipient is required')
-  }
-
-  const replyParticipantIds = replyStatus
-    ? getReplyParticipantIds(replyStatus)
-    : null
-  const recipientsToMention = replyParticipantIds
-    ? recipients.filter(
-        (recipient) => !isReplyParticipant(recipient, replyParticipantIds)
-      )
-    : recipients
-  const mentionPrefix = recipientsToMention.map(accountMention).join(' ')
-  const status = [mentionPrefix, normalizedMessage].filter(Boolean).join(' ')
-  const response = await fetch('/api/v1/statuses', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
-    // `replyStatus.id` is the raw AP URI of the status being replied to; POST
-    // /api/v1/statuses resolves `in_reply_to_id` through resolveStatusIdParam,
-    // which passes a raw URI straight through, so send it unencoded.
-    body: JSON.stringify({
-      status,
-      visibility: 'direct',
-      ...(replyStatus ? { in_reply_to_id: replyStatus.id } : {})
-    })
-  })
-  if (!response.ok) {
-    throw new Error('Failed to send message')
-  }
-  return (await response.json()) as CreateDirectMessageResult
-}
+export * from './client/directMessages'
 
 // ============================================================================
 // Custom emoji

--- a/lib/client/directMessages.test.ts
+++ b/lib/client/directMessages.test.ts
@@ -1,0 +1,187 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import type { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import { generatePublicId } from '@/lib/utils/publicId'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { createDirectMessage } from './directMessages'
+
+enableFetchMocks()
+
+describe('client directMessages module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('createDirectMessage', () => {
+    it('throws when message is empty or whitespace only', async () => {
+      await expect(
+        createDirectMessage({
+          message: '   ',
+          recipients: [
+            {
+              id: 'acc-1',
+              username: 'ada',
+              acct: 'ada'
+            } as MastodonAccount
+          ]
+        })
+      ).rejects.toThrow('Message must not be empty')
+    })
+
+    it('throws when recipients list is empty and no replyStatus is provided', async () => {
+      await expect(
+        createDirectMessage({
+          message: 'hello',
+          recipients: []
+        })
+      ).rejects.toThrow('At least one recipient is required')
+    })
+
+    it('sends direct message without replyStatus', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'status-1',
+          uri: 'https://local.example/statuses/1'
+        }),
+        {
+          status: 200
+        }
+      )
+
+      const recipient = {
+        id: 'acc-1',
+        username: 'ada',
+        acct: 'ada@example.com'
+      } as MastodonAccount
+
+      const result = await createDirectMessage({
+        message: 'Hello Ada',
+        recipients: [recipient]
+      })
+
+      expect(result).toEqual({
+        id: 'status-1',
+        uri: 'https://local.example/statuses/1'
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json'
+          },
+          body: JSON.stringify({
+            status: '@ada@example.com Hello Ada',
+            visibility: 'direct'
+          })
+        })
+      )
+    })
+
+    it('mentions extra reply recipients without duplicating existing participants', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'status-1',
+          uri: 'https://local.example/statuses/1'
+        }),
+        {
+          status: 200
+        }
+      )
+
+      const replyStatus = {
+        id: 'https://local.example/users/me/statuses/root',
+        actorId: 'https://local.example/users/me',
+        to: ['https://local.example/users/ada'],
+        cc: ['https://local.example/users/me']
+      } as Status
+      const existingRecipientActorId = 'https://local.example/users/ada'
+      const existingRecipient = {
+        id: urlToId(existingRecipientActorId),
+        url: 'https://local.example/@ada',
+        username: 'ada',
+        acct: 'ada@local.example'
+      } as MastodonAccount
+      const extraRecipient = {
+        id: 'https://remote.example/users/bea',
+        url: 'https://remote.example/users/bea',
+        username: 'bea',
+        acct: 'bea@remote.example'
+      } as MastodonAccount
+
+      await createDirectMessage({
+        message: 'hello',
+        recipients: [existingRecipient, extraRecipient],
+        replyStatus
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses',
+        expect.objectContaining({
+          body: JSON.stringify({
+            status: '@bea@remote.example hello',
+            visibility: 'direct',
+            in_reply_to_id: replyStatus.id
+          })
+        })
+      )
+    })
+
+    it('recognizes an existing participant whose account id is a public id', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: 'status-1',
+          uri: 'https://local.example/statuses/1'
+        }),
+        {
+          status: 200
+        }
+      )
+
+      const replyStatus = {
+        id: 'https://local.example/users/me/statuses/root',
+        actorId: 'https://local.example/users/me',
+        to: ['https://local.example/users/ada'],
+        cc: ['https://local.example/users/me']
+      } as Status
+      const existingRecipient = {
+        id: generatePublicId(),
+        uri: 'https://local.example/users/ada',
+        url: 'https://local.example/@ada',
+        username: 'ada',
+        acct: 'ada@local.example'
+      } as MastodonAccount
+
+      await createDirectMessage({
+        message: 'hello',
+        recipients: [existingRecipient],
+        replyStatus
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/statuses',
+        expect.objectContaining({
+          body: JSON.stringify({
+            status: 'hello',
+            visibility: 'direct',
+            in_reply_to_id: replyStatus.id
+          })
+        })
+      )
+    })
+
+    it('throws when the status creation fails', async () => {
+      fetchMock.mockResponseOnce('Forbidden', { status: 403 })
+
+      await expect(
+        createDirectMessage({
+          message: 'hello',
+          recipients: [{ id: 'acc-1', username: 'ada' } as MastodonAccount]
+        })
+      ).rejects.toThrow('Failed to send message')
+    })
+  })
+})

--- a/lib/client/directMessages.ts
+++ b/lib/client/directMessages.ts
@@ -1,0 +1,85 @@
+import type { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import { normalizeActorId } from '@/lib/utils/activitypub'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const accountMention = (account: MastodonAccount) =>
+  `@${account.acct || account.username}`
+
+const getReplyParticipantIds = (replyStatus: Status) =>
+  new Set(
+    [replyStatus.actorId, ...replyStatus.to, ...replyStatus.cc]
+      .map((id) => normalizeActorId(id))
+      .filter((id): id is string => Boolean(id))
+  )
+
+const isReplyParticipant = (
+  account: MastodonAccount,
+  replyParticipantIds: Set<string>
+) => {
+  // The participant set holds ActivityPub actor URIs, so `uri` is the only
+  // encoding-independent key. `url` is a profile URL (`/@name`) on some
+  // accounts, and `id` is a publicId that cannot be decoded back to a URI at
+  // all, so both stay as fallbacks for entities built before the id flip.
+  for (const candidate of [account.uri, account.url, idToUrl(account.id)]) {
+    if (!candidate) continue
+    const accountActorId = normalizeActorId(candidate)
+    if (accountActorId && replyParticipantIds.has(accountActorId)) return true
+  }
+  return false
+}
+
+export interface CreateDirectMessageResult {
+  uri: string
+  [key: string]: unknown
+}
+
+export interface CreateDirectMessageParams {
+  message: string
+  recipients: MastodonAccount[]
+  replyStatus?: Status
+}
+
+export const createDirectMessage = async ({
+  message,
+  recipients,
+  replyStatus
+}: CreateDirectMessageParams): Promise<CreateDirectMessageResult> => {
+  const normalizedMessage = message.trim()
+  if (!normalizedMessage) {
+    throw new Error('Message must not be empty')
+  }
+  if (recipients.length === 0 && !replyStatus) {
+    throw new Error('At least one recipient is required')
+  }
+
+  const replyParticipantIds = replyStatus
+    ? getReplyParticipantIds(replyStatus)
+    : null
+  const recipientsToMention = replyParticipantIds
+    ? recipients.filter(
+        (recipient) => !isReplyParticipant(recipient, replyParticipantIds)
+      )
+    : recipients
+  const mentionPrefix = recipientsToMention.map(accountMention).join(' ')
+  const status = [mentionPrefix, normalizedMessage].filter(Boolean).join(' ')
+  const response = await fetch('/api/v1/statuses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    // `replyStatus.id` is the raw AP URI of the status being replied to; POST
+    // /api/v1/statuses resolves `in_reply_to_id` through resolveStatusIdParam,
+    // which passes a raw URI straight through, so send it unencoded.
+    body: JSON.stringify({
+      status,
+      visibility: 'direct',
+      ...(replyStatus ? { in_reply_to_id: replyStatus.id } : {})
+    })
+  })
+  if (!response.ok) {
+    throw new Error('Failed to send message')
+  }
+  return (await response.json()) as CreateDirectMessageResult
+}

--- a/lib/client/search.test.ts
+++ b/lib/client/search.test.ts
@@ -1,0 +1,167 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { search, searchAccounts } from './search'
+
+enableFetchMocks()
+
+describe('client search module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { origin: 'https://llun.test' }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  describe('search', () => {
+    it('builds the v2 search URL with typed filters and forwards abort signals', async () => {
+      const abortController = new AbortController()
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          accounts: [],
+          statuses: [{ id: 'status-1' }],
+          hashtags: []
+        }),
+        { status: 200 }
+      )
+
+      await expect(
+        search({
+          q: 'trail run',
+          type: 'statuses',
+          limit: 10,
+          offset: 20,
+          resolve: true,
+          signal: abortController.signal
+        })
+      ).resolves.toEqual({
+        accounts: [],
+        statuses: [{ id: 'status-1' }],
+        hashtags: []
+      })
+
+      const [url, init] = fetchMock.mock.calls[0]
+      const parsedUrl = new URL(url as string, 'https://llun.test')
+      expect(parsedUrl.pathname).toBe('/api/v2/search')
+      expect(parsedUrl.searchParams.get('q')).toBe('trail run')
+      expect(parsedUrl.searchParams.get('type')).toBe('statuses')
+      expect(parsedUrl.searchParams.get('limit')).toBe('10')
+      expect(parsedUrl.searchParams.get('offset')).toBe('20')
+      expect(parsedUrl.searchParams.get('resolve')).toBe('true')
+      expect(parsedUrl.searchParams.get('format')).toBe('activities_next')
+      expect(init).toEqual(
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+          signal: abortController.signal
+        })
+      )
+    })
+
+    it('returns an empty result when the search response is not JSON', async () => {
+      fetchMock.mockResponseOnce('<html>bad gateway</html>', { status: 200 })
+
+      await expect(search({ q: 'trail' })).resolves.toEqual({
+        accounts: [],
+        statuses: [],
+        hashtags: []
+      })
+    })
+
+    it('throws a detailed error when the search request is rejected', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ message: 'Unauthorized' }), {
+        status: 401
+      })
+
+      await expect(search({ q: 'trail' })).rejects.toThrow(
+        'Search request failed (401): Unauthorized'
+      )
+    })
+
+    it('throws raw response text when the search error response is not JSON', async () => {
+      fetchMock.mockResponseOnce('Bad gateway', { status: 502 })
+
+      await expect(search({ q: 'trail' })).rejects.toThrow(
+        'Search request failed (502): Bad gateway'
+      )
+    })
+
+    it('truncates long raw response text from failed search requests', async () => {
+      const longResponseText = 'x'.repeat(250)
+      fetchMock.mockResponseOnce(longResponseText, { status: 502 })
+
+      await expect(search({ q: 'trail' })).rejects.toThrow(
+        `Search request failed (502): ${'x'.repeat(200)}...`
+      )
+    })
+
+    it('truncates long JSON messages from failed search requests', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ message: 'x'.repeat(250) }), {
+        status: 502
+      })
+
+      await expect(search({ q: 'trail' })).rejects.toThrow(
+        `Search request failed (502): ${'x'.repeat(200)}...`
+      )
+    })
+  })
+
+  describe('searchAccounts', () => {
+    it('fetches accounts with default limit and resolve params', async () => {
+      const mockAccounts = [{ id: 'acc-1', username: 'alice' }]
+      fetchMock.mockResponseOnce(JSON.stringify(mockAccounts), { status: 200 })
+
+      const result = await searchAccounts({ q: 'alice' })
+
+      expect(result).toEqual(mockAccounts)
+      const [url, init] = fetchMock.mock.calls[0]
+      const parsedUrl = new URL(url as string)
+      expect(parsedUrl.origin).toBe('https://llun.test')
+      expect(parsedUrl.pathname).toBe('/api/v1/accounts/search')
+      expect(parsedUrl.searchParams.get('q')).toBe('alice')
+      expect(parsedUrl.searchParams.get('limit')).toBe('5')
+      expect(parsedUrl.searchParams.get('resolve')).toBe('true')
+      expect(init).toEqual(
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Accept: 'application/json' }
+        })
+      )
+    })
+
+    it('passes custom limit and resolve params and forwards abort signal', async () => {
+      const abortController = new AbortController()
+      fetchMock.mockResponseOnce(JSON.stringify([]), { status: 200 })
+
+      const result = await searchAccounts({
+        q: 'bob',
+        limit: 10,
+        resolve: false,
+        signal: abortController.signal
+      })
+
+      expect(result).toEqual([])
+      const [url, init] = fetchMock.mock.calls[0]
+      const parsedUrl = new URL(url as string)
+      expect(parsedUrl.searchParams.get('limit')).toBe('10')
+      expect(parsedUrl.searchParams.get('resolve')).toBe('false')
+      expect(init).toEqual(
+        expect.objectContaining({
+          signal: abortController.signal
+        })
+      )
+    })
+
+    it('returns empty array when the response is not ok', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      const result = await searchAccounts({ q: 'carol' })
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/lib/client/search.ts
+++ b/lib/client/search.ts
@@ -1,0 +1,114 @@
+import type { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import type { Tag } from '@/lib/types/mastodon/tag'
+
+export type SearchType = 'accounts' | 'statuses' | 'hashtags'
+
+export interface SearchResult<TStatus = Status> {
+  accounts: MastodonAccount[]
+  statuses: TStatus[]
+  hashtags: Tag[]
+}
+
+export interface SearchParams {
+  q: string
+  type?: SearchType
+  limit?: number
+  offset?: number
+  resolve?: boolean
+  signal?: AbortSignal
+}
+
+export interface SearchAccountsParams {
+  q: string
+  limit?: number
+  resolve?: boolean
+  signal?: AbortSignal
+}
+
+const emptySearchResult = (): SearchResult => ({
+  accounts: [],
+  statuses: [],
+  hashtags: []
+})
+
+const MAX_SEARCH_ERROR_DETAIL_LENGTH = 200
+
+const truncateSearchErrorDetail = (detail: string) =>
+  detail.length > MAX_SEARCH_ERROR_DETAIL_LENGTH
+    ? `${detail.slice(0, MAX_SEARCH_ERROR_DETAIL_LENGTH)}...`
+    : detail
+
+const getSearchResponseErrorMessage = (response: Response, text: string) => {
+  let detail = text || response.statusText
+
+  try {
+    const data = JSON.parse(text) as Record<string, unknown>
+    detail =
+      typeof data.message === 'string'
+        ? data.message
+        : typeof data.error === 'string'
+          ? data.error
+          : typeof data.status === 'string'
+            ? data.status
+            : detail
+  } catch {
+    // Keep the raw response text for non-JSON failures.
+  }
+
+  detail = truncateSearchErrorDetail(detail)
+  return `Search request failed (${response.status})${detail ? `: ${detail}` : ''}`
+}
+
+export const search = async ({
+  q,
+  type,
+  limit,
+  offset,
+  resolve = true,
+  signal
+}: SearchParams): Promise<SearchResult> => {
+  const params = new URLSearchParams({
+    q,
+    resolve: resolve ? 'true' : 'false',
+    format: 'activities_next'
+  })
+  if (type) params.set('type', type)
+  if (limit !== undefined) params.set('limit', `${limit}`)
+  if (offset !== undefined) params.set('offset', `${offset}`)
+
+  const response = await fetch(`/api/v2/search?${params.toString()}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(getSearchResponseErrorMessage(response, text))
+  }
+  try {
+    return JSON.parse(text) as SearchResult
+  } catch {
+    return emptySearchResult()
+  }
+}
+
+export const searchAccounts = async ({
+  q,
+  limit = 5,
+  resolve = true,
+  signal
+}: SearchAccountsParams): Promise<MastodonAccount[]> => {
+  const url = new URL(`${window.origin}/api/v1/accounts/search`)
+  url.searchParams.set('q', q)
+  url.searchParams.set('limit', `${limit}`)
+  url.searchParams.set('resolve', resolve ? 'true' : 'false')
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal
+  })
+  if (!response.ok) return []
+  return (await response.json()) as MastodonAccount[]
+}


### PR DESCRIPTION
### Summary

This PR completes Task J1 Batch 22 by extracting search and direct message client operations from `lib/client.ts` into dedicated client domain modules:

1. **Search Domain** (`lib/client/search.ts`):
   - `SearchType`
   - `SearchResult`
   - `SearchParams`
   - `SearchAccountsParams`
   - `search`
   - `searchAccounts`
   - Unit tests in `lib/client/search.test.ts`

2. **Direct Message Domain** (`lib/client/directMessages.ts`):
   - `CreateDirectMessageResult`
   - `CreateDirectMessageParams`
   - `createDirectMessage`
   - Internal helper methods (`accountMention`, `getReplyParticipantIds`, `isReplyParticipant`)
   - Unit tests in `lib/client/directMessages.test.ts`

3. **Client Entrypoint** (`lib/client.ts`):
   - Re-export `* from './client/search'`
   - Re-export `* from './client/directMessages'`
   - Removed duplicate implementations and now-unused imports (`Status`, `MastodonAccount`, `Tag`, `normalizeActorId`, `idToUrl`)
   - Full backward compatibility preserved for existing imports from `@/lib/client`