### PR TITLE
test: resolve types for updateNote, visibility integration, and getActorPosts tests

### DIFF
--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
 
 describe('Update note action', () => {
   const database = getTestSQLDatabase()
-  let actor1: Actor | undefined
+  let actor1: Actor | null | undefined
 
   beforeAll(async () => {
     await database.migrate()

--- a/lib/actions/visibility.integration.test.ts
+++ b/lib/actions/visibility.integration.test.ts
@@ -208,7 +208,9 @@ describe('Visibility integration tests', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Public poll'))
+      const poll = statuses.find(
+        (s) => 'text' in s && s.text.includes('Public poll')
+      )
 
       expect(poll).toBeDefined()
       expect(poll?.to).toContain(ACTIVITY_STREAM_PUBLIC)
@@ -228,7 +230,9 @@ describe('Visibility integration tests', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Unlisted poll'))
+      const poll = statuses.find(
+        (s) => 'text' in s && s.text.includes('Unlisted poll')
+      )
 
       expect(poll).toBeDefined()
       expect(poll?.to).toContain(`${actor1.id}/followers`)
@@ -249,7 +253,9 @@ describe('Visibility integration tests', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Private poll'))
+      const poll = statuses.find(
+        (s) => 'text' in s && s.text.includes('Private poll')
+      )
 
       expect(poll).toBeDefined()
       expect(poll?.to).toContain(`${actor1.id}/followers`)
@@ -283,7 +289,9 @@ describe('Visibility integration tests', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) => s.text.includes('Direct poll'))
+      const poll = statuses.find(
+        (s) => 'text' in s && s.text.includes('Direct poll')
+      )
 
       expect(poll).toBeDefined()
       expect(poll?.to).not.toContain(ACTIVITY_STREAM_PUBLIC)
@@ -336,8 +344,9 @@ describe('Visibility integration tests', () => {
       const statuses = await database.getActorStatuses({
         actorId: actor1.id
       })
-      const poll = statuses.find((s) =>
-        s.text.includes('Poll reply without mention prefixes')
+      const poll = statuses.find(
+        (s) =>
+          'text' in s && s.text.includes('Poll reply without mention prefixes')
       )
 
       expect(poll).toBeDefined()

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -226,6 +226,11 @@ describe('getActorPosts', () => {
       throw new Error('Expected Announce status')
     }
 
+    expect(announceStatus.originalStatus.type).toBe(StatusType.enum.Note)
+    if (announceStatus.originalStatus.type !== StatusType.enum.Note) {
+      throw new Error('Expected Note status')
+    }
+
     expect(announceStatus.actorId).toBe(boosterActorId)
     expect(announceStatus.actor?.id).toBe(boosterActorId)
     expect(announceStatus.originalStatus.actorId).toBe(originalActorId)
@@ -313,6 +318,11 @@ describe('getActorPosts', () => {
     expect(announceStatus.type).toBe(StatusType.enum.Announce)
     if (announceStatus.type !== StatusType.enum.Announce) {
       throw new Error('Expected Announce status')
+    }
+
+    expect(announceStatus.originalStatus.type).toBe(StatusType.enum.Note)
+    if (announceStatus.originalStatus.type !== StatusType.enum.Note) {
+      throw new Error('Expected Note status')
     }
 
     expect(announceStatus.id).toBe(announceStatusId)
@@ -795,7 +805,6 @@ describe('getActorPosts', () => {
     const statusId = 'https://pixelfed.example/p/actor/12345'
     const person = MockActivityPubPerson({
       id: actorId,
-      preferredUsername: 'actor',
       withContext: true
     }) as Actor
 
@@ -875,8 +884,13 @@ describe('getActorPosts', () => {
 
     expect(response.statusesCount).toBe(413)
     expect(response.statuses).toHaveLength(1)
-    expect(response.statuses[0].id).toBe(statusId)
-    expect(response.statuses[0].text).toContain('Atom resolved post')
+    const status = response.statuses[0]
+    expect(status.type).toBe(StatusType.enum.Note)
+    if (status.type !== StatusType.enum.Note) {
+      throw new Error('Expected Note status')
+    }
+    expect(status.id).toBe(statusId)
+    expect(status.text).toContain('Atom resolved post')
   })
 
   it('does not fall back to Atom feed for non-Pixelfed instances', async () => {
@@ -987,7 +1001,6 @@ describe('getActorPosts', () => {
     const statusId = `${actorId}/statuses/1`
     const person = MockActivityPubPerson({
       id: actorId,
-      preferredUsername: 'critical',
       withContext: true
     }) as Actor
 
@@ -1128,6 +1141,9 @@ describe('getActorPosts', () => {
     expect(response.statuses).toHaveLength(1)
     const status = response.statuses[0]
     expect(status.type).toBe(StatusType.enum.Note)
+    if (status.type !== StatusType.enum.Note) {
+      throw new Error('Expected Note status')
+    }
     expect(status.text).toContain('Framasoft Video')
     expect(status.attachments).toHaveLength(1)
     expect(status.attachments[0].mediaType).toBe('video/mp4')
@@ -1341,7 +1357,6 @@ describe('getActorPosts', () => {
     const videoUri = 'https://framatube.org/videos/watch/abc-123'
     const person = MockActivityPubPerson({
       id: actorId,
-      preferredUsername: 'peertube',
       withContext: true
     }) as Actor
 
@@ -1417,12 +1432,15 @@ describe('getActorPosts', () => {
 
     const response = await getActorPosts({ database, person })
     expect(response.statuses).toHaveLength(1)
-    expect(response.statuses[0].id).toBe(videoUri)
-    expect(response.statuses[0].attachments).toHaveLength(1)
-    expect(response.statuses[0].attachments[0].url).toBe(
-      'https://framatube.org/video.mp4'
-    )
-    expect(response.statuses[0].attachments[0].thumbnailUrl).toBe(
+    const status = response.statuses[0]
+    expect(status.type).toBe(StatusType.enum.Note)
+    if (status.type !== StatusType.enum.Note) {
+      throw new Error('Expected Note status')
+    }
+    expect(status.id).toBe(videoUri)
+    expect(status.attachments).toHaveLength(1)
+    expect(status.attachments[0].url).toBe('https://framatube.org/video.mp4')
+    expect(status.attachments[0].thumbnailUrl).toBe(
       'https://framatube.org/thumb.jpg'
     )
   })
@@ -1474,10 +1492,13 @@ describe('getActorPosts', () => {
 
       const response = await getActorPosts({ database, person })
       expect(response.statuses).toHaveLength(1)
-      expect(response.statuses[0].id).toBe(statusId)
-      expect(response.statuses[0].text).toBe(
-        'Hello from root-only context definition'
-      )
+      const status = response.statuses[0]
+      expect(status.type).toBe(StatusType.enum.Note)
+      if (status.type !== StatusType.enum.Note) {
+        throw new Error('Expected Note status')
+      }
+      expect(status.id).toBe(statusId)
+      expect(status.text).toBe('Hello from root-only context definition')
       expect(response.statusesCount).toBe(1)
     })
 
@@ -1541,9 +1562,12 @@ describe('getActorPosts', () => {
 
       const response = await getActorPosts({ database, person })
       expect(response.statuses).toHaveLength(1)
-      expect(response.statuses[0].text).toBe(
-        'Hello from page-only context definition'
-      )
+      const status = response.statuses[0]
+      expect(status.type).toBe(StatusType.enum.Note)
+      if (status.type !== StatusType.enum.Note) {
+        throw new Error('Expected Note status')
+      }
+      expect(status.text).toBe('Hello from page-only context definition')
       expect(response.statusesCount).toBe(5)
       expect(response.nextPageUrl).toBe(`${actorId}/outbox?page=2`)
     })
@@ -1598,7 +1622,12 @@ describe('getActorPosts', () => {
 
       const response = await getActorPosts({ database, person })
       expect(response.statuses).toHaveLength(1)
-      expect(response.statuses[0].text).toBe(
+      const status = response.statuses[0]
+      expect(status.type).toBe(StatusType.enum.Note)
+      if (status.type !== StatusType.enum.Note) {
+        throw new Error('Expected Note status')
+      }
+      expect(status.text).toBe(
         'Overridden definition successfully parsed as content'
       )
     })
@@ -1670,8 +1699,17 @@ describe('getActorPosts', () => {
 
       const response = await getActorPosts({ database, person })
       expect(response.statuses).toHaveLength(2)
-      expect(response.statuses[0].text).toBe('Item 1 inherits root context')
-      expect(response.statuses[1].text).toBe('Item 2 plain content')
+      const [status1, status2] = response.statuses
+      expect(status1.type).toBe(StatusType.enum.Note)
+      expect(status2.type).toBe(StatusType.enum.Note)
+      if (
+        status1.type !== StatusType.enum.Note ||
+        status2.type !== StatusType.enum.Note
+      ) {
+        throw new Error('Expected Note statuses')
+      }
+      expect(status1.text).toBe('Item 1 inherits root context')
+      expect(status2.text).toBe('Item 2 plain content')
     })
 
     it('preserves extension terms like quote and sensitive under inherited context', async () => {
@@ -1725,7 +1763,12 @@ describe('getActorPosts', () => {
 
       const response = await getActorPosts({ database, person })
       expect(response.statuses).toHaveLength(1)
-      expect(response.statuses[0].text).toBe('Post with sensitive and quote')
+      const status = response.statuses[0]
+      expect(status.type).toBe(StatusType.enum.Note)
+      if (status.type !== StatusType.enum.Note) {
+        throw new Error('Expected Note status')
+      }
+      expect(status.text).toBe('Post with sensitive and quote')
     })
   })
 })

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/actions/updateNote.test.ts",
-    "lib/actions/visibility.integration.test.ts",
-    "lib/activities/getActorPosts.test.ts",
     "lib/activities/getFeaturedCollection.test.ts",
     "lib/activities/index.test.ts",
     "lib/activities/note.test.ts",


### PR DESCRIPTION
## Summary
Fixes typecheck errors in 3 test files and removes them from `tsconfig.typecheck.json`:
- `lib/actions/updateNote.test.ts`: Allow `Actor | null | undefined` for `actor1` returned by `database.getActorFromUsername`.
- `lib/actions/visibility.integration.test.ts`: Check `'text' in s` before accessing `s.text` on queried `Status` union in poll visibility integration tests.
- `lib/activities/getActorPosts.test.ts`: Remove redundant and invalid `preferredUsername` param from `MockActivityPubPerson` calls, and narrow `Status` / `originalStatus` union to `Note` before inspecting note-specific properties (`text`, `reply`, `attachments`).

## Ratchet Count
- H2 tracking list: 87 -> 84
- Total test files excluded: 89 -> 86