### PR TITLE
Bump version to v1.161.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.35",
+  "version": "1.161.36",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.36.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.35`
- Base main SHA: `f16d5c5099c6e3dc9ce19e7278496300ea9c4472`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
