### PR TITLE
test: resolve types for getFeaturedCollection, activities index, and note tests

### DIFF
--- a/lib/activities/getFeaturedCollection.test.ts
+++ b/lib/activities/getFeaturedCollection.test.ts
@@ -9,6 +9,7 @@ const baseCollection: Collection = {
   topic: 'fediverse',
   language: 'en',
   visibility: 'public',
+  sensitive: false,
   publicFeed: true,
   createdAt: 1700000000000,
   updatedAt: 1700000100000

--- a/lib/activities/index.test.ts
+++ b/lib/activities/index.test.ts
@@ -47,7 +47,7 @@ enableFetchMocks()
 
 describe('activities', () => {
   const database = getTestSQLDatabase()
-  let actor1: Actor | undefined
+  let actor1: Actor | null = null
 
   beforeAll(async () => {
     await database.migrate()

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -56,9 +56,9 @@ describe('note entity utilities', () => {
     })
 
     it('returns id from object', () => {
-      expect(
-        getReply({ id: 'https://example.com/note/parent', type: 'Note' })
-      ).toEqual('https://example.com/note/parent')
+      expect(getReply({ id: 'https://example.com/note/parent' })).toEqual(
+        'https://example.com/note/parent'
+      )
     })
 
     it('returns undefined for null', () => {

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/activities/getFeaturedCollection.test.ts",
-    "lib/activities/index.test.ts",
-    "lib/activities/note.test.ts",
     "lib/activities/reactionActivity.test.ts",
     "lib/components/block-action/block-action.test.tsx",
     "lib/components/fitness/HeatmapShareEmbed.test.tsx",


### PR DESCRIPTION
### Summary

Resolves typecheck errors in the next 3 test files and removes them from `tsconfig.typecheck.json`:

1. `lib/activities/getFeaturedCollection.test.ts` - Added required `sensitive: false` property to `baseCollection` mock.
2. `lib/activities/index.test.ts` - Updated `actor1` type from `Actor | undefined` to `Actor | null` to match database method return type.
3. `lib/activities/note.test.ts` - Simplified `getReply` object argument to pass `{ id: '...' }` avoiding excess property check error against `ReplyValue`.

### Ratchet Status
- H2 ratchet tracking: down from 84 to 81
- Total excluded test files: down from 86 to 83