### PR TITLE
test: resolve types for reactionActivity, block-action, and HeatmapShareEmbed tests

### DIFF
--- a/lib/components/block-action/block-action.test.tsx
+++ b/lib/components/block-action/block-action.test.tsx
@@ -41,6 +41,7 @@ const relationship = (
   blocked_by: false,
   muting: false,
   muting_notifications: false,
+  muting_expires_at: null,
   requested: false,
   requested_by: false,
   domain_blocking: false,

--- a/lib/components/fitness/HeatmapShareEmbed.test.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import type { FitnessRouteHeatmapData } from '@/lib/client'
+import type { PublicMapProvider } from '@/lib/utils/mapProvider'
 
 import { HeatmapShareEmbed } from './HeatmapShareEmbed'
 
@@ -38,6 +39,7 @@ const defaultProps = {
   regionLabel: undefined as string | undefined,
   isWorld: true,
   heatmap,
+  mapProvider: { type: 'osm' } as PublicMapProvider,
   isSharing: false,
   onShare: vi.fn(),
   onUnshare: vi.fn()

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/activities/reactionActivity.test.ts",
-    "lib/components/block-action/block-action.test.tsx",
-    "lib/components/fitness/HeatmapShareEmbed.test.tsx",
     "lib/components/fitness/RegionHeatmapDetail.test.tsx",
     "lib/components/fitness/RegionMap.test.tsx",
     "lib/components/fitness/RouteHeatmapMap.test.tsx",


### PR DESCRIPTION
Resolves type check errors in:
- `lib/activities/reactionActivity.test.ts`
- `lib/components/block-action/block-action.test.tsx`
- `lib/components/fitness/HeatmapShareEmbed.test.tsx`

Removes these files from `tsconfig.typecheck.json` ratchet.