### PR TITLE
refactor: extract lists operations into lib/client/lists.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -7,7 +7,6 @@ import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
 import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
-import type { ListEntity } from '@/lib/types/mastodon/list'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 import {
@@ -479,90 +478,9 @@ export const updateAdminServerSettings = async (
   return (await response.json()) as AdminServerSettingsResponse
 }
 
-// Lists (https://docs.joinmastodon.org/methods/lists/).
-// The user's curated timelines and their members. Every list call goes through
-// here so components never call fetch() directly. List ids are opaque strings
-// (UUIDs), so unlike status/account ids they are not url/id encoded.
+// --- Lists ---
 
-export interface ListParams {
-  title: string
-  repliesPolicy?: ListEntity['replies_policy']
-  exclusive?: boolean
-}
-
-const listRequestBody = ({ title, repliesPolicy, exclusive }: ListParams) => ({
-  title,
-  ...(repliesPolicy !== undefined ? { replies_policy: repliesPolicy } : {}),
-  ...(exclusive !== undefined ? { exclusive } : {})
-})
-
-export const createList = async (
-  params: ListParams
-): Promise<ListEntity | null> => {
-  const response = await fetch('/api/v1/lists', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(listRequestBody(params))
-  })
-  if (!response.ok) return null
-  return (await response.json()) as ListEntity
-}
-
-export interface UpdateListParams extends ListParams {
-  listId: string
-}
-
-export const updateList = async ({
-  listId,
-  ...params
-}: UpdateListParams): Promise<ListEntity | null> => {
-  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(listRequestBody(params))
-  })
-  if (!response.ok) return null
-  return (await response.json()) as ListEntity
-}
-
-export const deleteList = async (listId: string): Promise<boolean> => {
-  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
-    method: 'DELETE'
-  })
-  return response.ok
-}
-
-export interface ListAccountsMutationParams {
-  listId: string
-  accountIds: string[]
-}
-
-const mutateListAccounts = async (
-  method: 'POST' | 'DELETE',
-  { listId, accountIds }: ListAccountsMutationParams
-): Promise<boolean> => {
-  if (accountIds.length === 0) return true
-  const response = await fetch(
-    `/api/v1/lists/${encodeURIComponent(listId)}/accounts`,
-    {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      // accountIds are already Mastodon Account ids (a publicId, or the legacy
-      // `urlToId` form on a pre-backfill row); the route resolves either back
-      // to an actor URI, so pass them through unchanged.
-      body: JSON.stringify({ account_ids: accountIds })
-    }
-  )
-  return response.ok
-}
-
-export const addListAccounts = (
-  params: ListAccountsMutationParams
-): Promise<boolean> => mutateListAccounts('POST', params)
-
-export const removeListAccounts = (
-  params: ListAccountsMutationParams
-): Promise<boolean> => mutateListAccounts('DELETE', params)
+export * from './client/lists'
 
 // Collections (Mastodon 4.6 Collections API + activities.next feed extension).
 // A collection is a shareable, consent-gated feed of accounts the owner

--- a/lib/client/lists.test.ts
+++ b/lib/client/lists.test.ts
@@ -1,0 +1,274 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+import {
+  addListAccounts,
+  createList,
+  deleteList,
+  listRequestBody,
+  mutateListAccounts,
+  removeListAccounts,
+  updateList
+} from './lists'
+
+enableFetchMocks()
+
+describe('client lists module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('listRequestBody', () => {
+    it('serializes title only when optional fields are undefined', () => {
+      expect(listRequestBody({ title: 'Tech' })).toEqual({
+        title: 'Tech'
+      })
+    })
+
+    it('includes repliesPolicy and exclusive when specified', () => {
+      expect(
+        listRequestBody({
+          title: 'News',
+          repliesPolicy: 'list',
+          exclusive: true
+        })
+      ).toEqual({
+        title: 'News',
+        replies_policy: 'list',
+        exclusive: true
+      })
+    })
+
+    it('includes exclusive when false', () => {
+      expect(
+        listRequestBody({
+          title: 'Friends',
+          exclusive: false
+        })
+      ).toEqual({
+        title: 'Friends',
+        exclusive: false
+      })
+    })
+  })
+
+  describe('createList', () => {
+    const mockList: ListEntity = {
+      id: 'list-123',
+      title: 'Running',
+      replies_policy: 'list',
+      exclusive: false
+    }
+
+    it('creates a list and returns ListEntity on 200', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockList), { status: 200 })
+
+      const res = await createList({
+        title: 'Running',
+        repliesPolicy: 'list',
+        exclusive: false
+      })
+
+      expect(res).toEqual(mockList)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Running',
+            replies_policy: 'list',
+            exclusive: false
+          })
+        })
+      )
+    })
+
+    it('returns null when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Unauthorized', { status: 401 })
+
+      const res = await createList({ title: 'Running' })
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('updateList', () => {
+    const mockList: ListEntity = {
+      id: 'list-123',
+      title: 'Running Updated',
+      replies_policy: 'followed',
+      exclusive: true
+    }
+
+    it('updates a list and returns ListEntity on 200', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockList), { status: 200 })
+
+      const res = await updateList({
+        listId: 'list-123',
+        title: 'Running Updated',
+        repliesPolicy: 'followed',
+        exclusive: true
+      })
+
+      expect(res).toEqual(mockList)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list-123',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Running Updated',
+            replies_policy: 'followed',
+            exclusive: true
+          })
+        })
+      )
+    })
+
+    it('encodes the listId in the URL', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockList), { status: 200 })
+
+      await updateList({
+        listId: 'list/special id',
+        title: 'Special'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list%2Fspecial%20id',
+        expect.anything()
+      )
+    })
+
+    it('returns null when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Not found', { status: 404 })
+
+      const res = await updateList({
+        listId: 'list-123',
+        title: 'Running'
+      })
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('deleteList', () => {
+    it('returns true when DELETE succeeds', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await deleteList('list-123')
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list-123',
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      )
+    })
+
+    it('encodes the listId in the URL', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      await deleteList('list/123')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list%2F123',
+        expect.anything()
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Error', { status: 500 })
+
+      const res = await deleteList('list-123')
+
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('mutateListAccounts', () => {
+    it('returns true immediately without fetch when accountIds is empty', async () => {
+      const res = await mutateListAccounts('POST', {
+        listId: 'list-123',
+        accountIds: []
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('sends request and returns true when response is ok', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await mutateListAccounts('POST', {
+        listId: 'list-123',
+        accountIds: ['acc-1', 'acc-2']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list-123/accounts',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1', 'acc-2'] })
+        })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Forbidden', { status: 403 })
+
+      const res = await mutateListAccounts('DELETE', {
+        listId: 'list-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('addListAccounts', () => {
+    it('calls mutateListAccounts with POST', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await addListAccounts({
+        listId: 'list-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list-123/accounts',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1'] })
+        })
+      )
+    })
+  })
+
+  describe('removeListAccounts', () => {
+    it('calls mutateListAccounts with DELETE', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await removeListAccounts({
+        listId: 'list-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/lists/list-123/accounts',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1'] })
+        })
+      )
+    })
+  })
+})

--- a/lib/client/lists.ts
+++ b/lib/client/lists.ts
@@ -1,0 +1,90 @@
+import type { ListEntity } from '@/lib/types/mastodon/list'
+
+// Lists (https://docs.joinmastodon.org/methods/lists/).
+// The user's curated timelines and their members. Every list call goes through
+// here so components never call fetch() directly. List ids are opaque strings
+// (UUIDs), so unlike status/account ids they are not url/id encoded.
+
+export interface ListParams {
+  title: string
+  repliesPolicy?: ListEntity['replies_policy']
+  exclusive?: boolean
+}
+
+export const listRequestBody = ({
+  title,
+  repliesPolicy,
+  exclusive
+}: ListParams) => ({
+  title,
+  ...(repliesPolicy !== undefined ? { replies_policy: repliesPolicy } : {}),
+  ...(exclusive !== undefined ? { exclusive } : {})
+})
+
+export const createList = async (
+  params: ListParams
+): Promise<ListEntity | null> => {
+  const response = await fetch('/api/v1/lists', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(listRequestBody(params))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ListEntity
+}
+
+export interface UpdateListParams extends ListParams {
+  listId: string
+}
+
+export const updateList = async ({
+  listId,
+  ...params
+}: UpdateListParams): Promise<ListEntity | null> => {
+  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(listRequestBody(params))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ListEntity
+}
+
+export const deleteList = async (listId: string): Promise<boolean> => {
+  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
+    method: 'DELETE'
+  })
+  return response.ok
+}
+
+export interface ListAccountsMutationParams {
+  listId: string
+  accountIds: string[]
+}
+
+export const mutateListAccounts = async (
+  method: 'POST' | 'DELETE',
+  { listId, accountIds }: ListAccountsMutationParams
+): Promise<boolean> => {
+  if (accountIds.length === 0) return true
+  const response = await fetch(
+    `/api/v1/lists/${encodeURIComponent(listId)}/accounts`,
+    {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      // accountIds are already Mastodon Account ids (a publicId, or the legacy
+      // `urlToId` form on a pre-backfill row); the route resolves either back
+      // to an actor URI, so pass them through unchanged.
+      body: JSON.stringify({ account_ids: accountIds })
+    }
+  )
+  return response.ok
+}
+
+export const addListAccounts = (
+  params: ListAccountsMutationParams
+): Promise<boolean> => mutateListAccounts('POST', params)
+
+export const removeListAccounts = (
+  params: ListAccountsMutationParams
+): Promise<boolean> => mutateListAccounts('DELETE', params)


### PR DESCRIPTION
Extract lists operations (`createList`, `updateList`, `deleteList`, `addListAccounts`, `removeListAccounts`) and associated interfaces/helpers into `lib/client/lists.ts` and re-export from `lib/client.ts`.