### PR TITLE
refactor: extract collections operations into lib/client/collections.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -5,7 +5,6 @@ import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
-import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
@@ -482,151 +481,9 @@ export const updateAdminServerSettings = async (
 
 export * from './client/lists'
 
-// Collections (Mastodon 4.6 Collections API + activities.next feed extension).
-// A collection is a shareable, consent-gated feed of accounts the owner
-// highlights. Like list ids, collection ids are opaque UUIDs (not url/id
-// encoded). Account ids are Mastodon Account ids (a publicId, or the legacy
-// `urlToId` form on a pre-backfill row); the routes resolve either back to an
-// actor URI, so pass them through unchanged.
+// --- Collections ---
 
-export interface CollectionParams {
-  title?: string
-  description?: string | null
-  topic?: string | null
-  language?: string | null
-  visibility?: CollectionEntity['visibility']
-  feedEnabled?: boolean
-}
-
-const collectionRequestBody = ({
-  title,
-  description,
-  topic,
-  language,
-  visibility,
-  feedEnabled
-}: CollectionParams) => ({
-  ...(title !== undefined ? { title } : {}),
-  // description/topic/language are nullable: an explicit `null` clears them, so
-  // forward `null` while still omitting an `undefined` (untouched) field.
-  ...(description !== undefined ? { description } : {}),
-  ...(topic !== undefined ? { topic } : {}),
-  ...(language !== undefined ? { language } : {}),
-  ...(visibility !== undefined ? { visibility } : {}),
-  ...(feedEnabled !== undefined ? { feed_enabled: feedEnabled } : {})
-})
-
-export interface CreateCollectionParams extends CollectionParams {
-  title: string
-}
-
-export const createCollection = async (
-  params: CreateCollectionParams
-): Promise<CollectionEntity | null> => {
-  const response = await fetch('/api/v1/collections', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(collectionRequestBody(params))
-  })
-  if (!response.ok) return null
-  // Mastodon 4.6 wraps the created collection; unwrap so component callers
-  // keep receiving the entity itself.
-  const data = (await response.json()) as { collection: CollectionEntity }
-  return data.collection
-}
-
-export interface UpdateCollectionParams extends CollectionParams {
-  collectionId: string
-}
-
-export const updateCollection = async ({
-  collectionId,
-  ...params
-}: UpdateCollectionParams): Promise<CollectionEntity | null> => {
-  const response = await fetch(
-    `/api/v1/collections/${encodeURIComponent(collectionId)}`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(collectionRequestBody(params))
-    }
-  )
-  if (!response.ok) return null
-  // Mastodon 4.6 wraps the updated collection; unwrap for component callers.
-  const data = (await response.json()) as { collection: CollectionEntity }
-  return data.collection
-}
-
-export const deleteCollection = async (
-  collectionId: string
-): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/collections/${encodeURIComponent(collectionId)}`,
-    { method: 'DELETE' }
-  )
-  return response.ok
-}
-
-export interface CollectionAccountsMutationParams {
-  collectionId: string
-  accountIds: string[]
-}
-
-const mutateCollectionAccounts = async (
-  method: 'POST' | 'DELETE',
-  { collectionId, accountIds }: CollectionAccountsMutationParams
-): Promise<boolean> => {
-  if (accountIds.length === 0) return true
-  const response = await fetch(
-    `/api/v1/collections/${encodeURIComponent(collectionId)}/items`,
-    {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ account_ids: accountIds })
-    }
-  )
-  return response.ok
-}
-
-export const addCollectionAccounts = (
-  params: CollectionAccountsMutationParams
-): Promise<boolean> => mutateCollectionAccounts('POST', params)
-
-export const removeCollectionAccounts = (
-  params: CollectionAccountsMutationParams
-): Promise<boolean> => mutateCollectionAccounts('DELETE', params)
-
-export interface CollectionMembershipParams {
-  collectionId: string
-  // The acting member's own Mastodon Account id (a publicId, or the legacy
-  // `urlToId` form on a pre-backfill row). The approve/revoke routes accept it
-  // as an extension alongside the Mastodon 4.6 CollectionItem id and require it
-  // to resolve to the authenticated caller.
-  accountId: string
-}
-
-const setCollectionMembership = async (
-  action: 'approve' | 'revoke',
-  { collectionId, accountId }: CollectionMembershipParams
-): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/collections/${encodeURIComponent(
-      collectionId
-    )}/items/${encodeURIComponent(accountId)}/${action}`,
-    { method: 'POST' }
-  )
-  return response.ok
-}
-
-// A member opts IN to a collection's public projection (consent gate).
-export const approveCollectionMembership = (
-  params: CollectionMembershipParams
-): Promise<boolean> => setCollectionMembership('approve', params)
-
-// A member opts OUT of a collection's public projection.
-export const revokeCollectionMembership = (
-  params: CollectionMembershipParams
-): Promise<boolean> => setCollectionMembership('revoke', params)
+export * from './client/collections'
 
 // Filters (https://docs.joinmastodon.org/methods/filters/).
 // Keyword filters for the account scope (/api/v2/filters) and the instance

--- a/lib/client/collections.test.ts
+++ b/lib/client/collections.test.ts
@@ -1,0 +1,352 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import type { CollectionEntity } from '@/lib/types/mastodon/collection'
+
+import {
+  addCollectionAccounts,
+  approveCollectionMembership,
+  collectionRequestBody,
+  createCollection,
+  deleteCollection,
+  mutateCollectionAccounts,
+  removeCollectionAccounts,
+  revokeCollectionMembership,
+  setCollectionMembership,
+  updateCollection
+} from './collections'
+
+enableFetchMocks()
+
+describe('client collections module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('collectionRequestBody', () => {
+    it('returns empty object when no fields are specified', () => {
+      expect(collectionRequestBody({})).toEqual({})
+    })
+
+    it('serializes all fields and maps feedEnabled to feed_enabled', () => {
+      expect(
+        collectionRequestBody({
+          title: 'Builders',
+          description: 'who I read',
+          topic: 'fediverse',
+          language: 'en',
+          visibility: 'public',
+          feedEnabled: true
+        })
+      ).toEqual({
+        title: 'Builders',
+        description: 'who I read',
+        topic: 'fediverse',
+        language: 'en',
+        visibility: 'public',
+        feed_enabled: true
+      })
+    })
+
+    it('forwards null description, topic, and language to clear them', () => {
+      expect(
+        collectionRequestBody({
+          description: null,
+          topic: null,
+          language: null,
+          feedEnabled: false
+        })
+      ).toEqual({
+        description: null,
+        topic: null,
+        language: null,
+        feed_enabled: false
+      })
+    })
+  })
+
+  describe('createCollection', () => {
+    const mockCollection: CollectionEntity = {
+      id: 'col-123',
+      title: 'Tech',
+      visibility: 'public',
+      feed_enabled: true
+    } as CollectionEntity
+
+    it('creates a collection and unwraps the nested collection entity on 200', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ collection: mockCollection }),
+        { status: 200 }
+      )
+
+      const res = await createCollection({
+        title: 'Tech',
+        visibility: 'public',
+        feedEnabled: true
+      })
+
+      expect(res).toEqual(mockCollection)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Tech',
+            visibility: 'public',
+            feed_enabled: true
+          })
+        })
+      )
+    })
+
+    it('returns null when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Unprocessable Entity', { status: 422 })
+
+      const res = await createCollection({ title: 'Invalid' })
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('updateCollection', () => {
+    const mockCollection: CollectionEntity = {
+      id: 'col-123',
+      title: 'Tech Updated',
+      visibility: 'unlisted',
+      feed_enabled: false
+    } as CollectionEntity
+
+    it('updates a collection and unwraps the nested collection entity on 200', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ collection: mockCollection }),
+        { status: 200 }
+      )
+
+      const res = await updateCollection({
+        collectionId: 'col-123',
+        title: 'Tech Updated',
+        topic: null
+      })
+
+      expect(res).toEqual(mockCollection)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123',
+        expect.objectContaining({
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Tech Updated',
+            topic: null
+          })
+        })
+      )
+    })
+
+    it('encodes the collectionId in the URL', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ collection: mockCollection }),
+        { status: 200 }
+      )
+
+      await updateCollection({
+        collectionId: 'col/special id',
+        title: 'Special'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col%2Fspecial%20id',
+        expect.anything()
+      )
+    })
+
+    it('returns null when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Not found', { status: 404 })
+
+      const res = await updateCollection({
+        collectionId: 'col-123',
+        title: 'Tech'
+      })
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('deleteCollection', () => {
+    it('returns true when DELETE succeeds', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await deleteCollection('col-123')
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('encodes the collectionId in the URL', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      await deleteCollection('col/123')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col%2F123',
+        expect.anything()
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Error', { status: 500 })
+
+      const res = await deleteCollection('col-123')
+
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('mutateCollectionAccounts', () => {
+    it('returns true immediately without fetch when accountIds is empty', async () => {
+      const res = await mutateCollectionAccounts('POST', {
+        collectionId: 'col-123',
+        accountIds: []
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('sends request and returns true when response is ok', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await mutateCollectionAccounts('POST', {
+        collectionId: 'col-123',
+        accountIds: ['acc-1', 'acc-2']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123/items',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1', 'acc-2'] })
+        })
+      )
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Forbidden', { status: 403 })
+
+      const res = await mutateCollectionAccounts('DELETE', {
+        collectionId: 'col-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('addCollectionAccounts', () => {
+    it('calls mutateCollectionAccounts with POST', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await addCollectionAccounts({
+        collectionId: 'col-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123/items',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1'] })
+        })
+      )
+    })
+  })
+
+  describe('removeCollectionAccounts', () => {
+    it('calls mutateCollectionAccounts with DELETE', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const res = await removeCollectionAccounts({
+        collectionId: 'col-123',
+        accountIds: ['acc-1']
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123/items',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ account_ids: ['acc-1'] })
+        })
+      )
+    })
+  })
+
+  describe('setCollectionMembership', () => {
+    it('posts to the membership action endpoint with encoded IDs', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await setCollectionMembership('approve', {
+        collectionId: 'col/1',
+        accountId: 'acc/2'
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col%2F1/items/acc%2F2/approve',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('returns false when membership action fails', async () => {
+      fetchMock.mockResponseOnce('Forbidden', { status: 403 })
+
+      const res = await setCollectionMembership('revoke', {
+        collectionId: 'col-1',
+        accountId: 'acc-2'
+      })
+
+      expect(res).toBe(false)
+    })
+  })
+
+  describe('approveCollectionMembership', () => {
+    it('calls setCollectionMembership with approve', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await approveCollectionMembership({
+        collectionId: 'col-123',
+        accountId: 'acc-1'
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123/items/acc-1/approve',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  describe('revokeCollectionMembership', () => {
+    it('calls setCollectionMembership with revoke', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const res = await revokeCollectionMembership({
+        collectionId: 'col-123',
+        accountId: 'acc-1'
+      })
+
+      expect(res).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/collections/col-123/items/acc-1/revoke',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+})

--- a/lib/client/collections.ts
+++ b/lib/client/collections.ts
@@ -1,0 +1,147 @@
+import type { CollectionEntity } from '@/lib/types/mastodon/collection'
+
+// Collections (Mastodon 4.6 Collections API + activities.next feed extension).
+// A collection is a shareable, consent-gated feed of accounts the owner
+// highlights. Like list ids, collection ids are opaque UUIDs (not url/id
+// encoded). Account ids are Mastodon Account ids (a publicId, or the legacy
+// `urlToId` form on a pre-backfill row); the routes resolve either back to an
+// actor URI, so pass them through unchanged.
+
+export interface CollectionParams {
+  title?: string
+  description?: string | null
+  topic?: string | null
+  language?: string | null
+  visibility?: CollectionEntity['visibility']
+  feedEnabled?: boolean
+}
+
+export const collectionRequestBody = ({
+  title,
+  description,
+  topic,
+  language,
+  visibility,
+  feedEnabled
+}: CollectionParams) => ({
+  ...(title !== undefined ? { title } : {}),
+  // description/topic/language are nullable: an explicit `null` clears them, so
+  // forward `null` while still omitting an `undefined` (untouched) field.
+  ...(description !== undefined ? { description } : {}),
+  ...(topic !== undefined ? { topic } : {}),
+  ...(language !== undefined ? { language } : {}),
+  ...(visibility !== undefined ? { visibility } : {}),
+  ...(feedEnabled !== undefined ? { feed_enabled: feedEnabled } : {})
+})
+
+export interface CreateCollectionParams extends CollectionParams {
+  title: string
+}
+
+export const createCollection = async (
+  params: CreateCollectionParams
+): Promise<CollectionEntity | null> => {
+  const response = await fetch('/api/v1/collections', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(collectionRequestBody(params))
+  })
+  if (!response.ok) return null
+  // Mastodon 4.6 wraps the created collection; unwrap so component callers
+  // keep receiving the entity itself.
+  const data = (await response.json()) as { collection: CollectionEntity }
+  return data.collection
+}
+
+export interface UpdateCollectionParams extends CollectionParams {
+  collectionId: string
+}
+
+export const updateCollection = async ({
+  collectionId,
+  ...params
+}: UpdateCollectionParams): Promise<CollectionEntity | null> => {
+  const response = await fetch(
+    `/api/v1/collections/${encodeURIComponent(collectionId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(collectionRequestBody(params))
+    }
+  )
+  if (!response.ok) return null
+  // Mastodon 4.6 wraps the updated collection; unwrap for component callers.
+  const data = (await response.json()) as { collection: CollectionEntity }
+  return data.collection
+}
+
+export const deleteCollection = async (
+  collectionId: string
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/collections/${encodeURIComponent(collectionId)}`,
+    { method: 'DELETE' }
+  )
+  return response.ok
+}
+
+export interface CollectionAccountsMutationParams {
+  collectionId: string
+  accountIds: string[]
+}
+
+export const mutateCollectionAccounts = async (
+  method: 'POST' | 'DELETE',
+  { collectionId, accountIds }: CollectionAccountsMutationParams
+): Promise<boolean> => {
+  if (accountIds.length === 0) return true
+  const response = await fetch(
+    `/api/v1/collections/${encodeURIComponent(collectionId)}/items`,
+    {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ account_ids: accountIds })
+    }
+  )
+  return response.ok
+}
+
+export const addCollectionAccounts = (
+  params: CollectionAccountsMutationParams
+): Promise<boolean> => mutateCollectionAccounts('POST', params)
+
+export const removeCollectionAccounts = (
+  params: CollectionAccountsMutationParams
+): Promise<boolean> => mutateCollectionAccounts('DELETE', params)
+
+export interface CollectionMembershipParams {
+  collectionId: string
+  // The acting member's own Mastodon Account id (a publicId, or the legacy
+  // `urlToId` form on a pre-backfill row). The approve/revoke routes accept it
+  // as an extension alongside the Mastodon 4.6 CollectionItem id and require it
+  // to resolve to the authenticated caller.
+  accountId: string
+}
+
+export const setCollectionMembership = async (
+  action: 'approve' | 'revoke',
+  { collectionId, accountId }: CollectionMembershipParams
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/collections/${encodeURIComponent(
+      collectionId
+    )}/items/${encodeURIComponent(accountId)}/${action}`,
+    { method: 'POST' }
+  )
+  return response.ok
+}
+
+// A member opts IN to a collection's public projection (consent gate).
+export const approveCollectionMembership = (
+  params: CollectionMembershipParams
+): Promise<boolean> => setCollectionMembership('approve', params)
+
+// A member opts OUT of a collection's public projection.
+export const revokeCollectionMembership = (
+  params: CollectionMembershipParams
+): Promise<boolean> => setCollectionMembership('revoke', params)


### PR DESCRIPTION
Extract collections operations and associated types/helpers into `lib/client/collections.ts` and re-export them from `lib/client.ts` for backward compatibility. Added corresponding unit tests in `lib/client/collections.test.ts`.