### PR TITLE
test: resolve types for RegionHeatmapDetail, RegionMap, and RouteHeatmapMap tests

### DIFF
--- a/lib/components/fitness/RegionHeatmapDetail.test.tsx
+++ b/lib/components/fitness/RegionHeatmapDetail.test.tsx
@@ -55,6 +55,7 @@ const defaultProps = {
   region: worldRegion,
   meta: { activity: 'All activities', period: 'All time' },
   heatmap: null as FitnessRouteHeatmapData | null,
+  mapProvider: { type: 'osm' as const },
   embedOrigin: 'https://llun.test',
   isSharing: false,
   onShare: vi.fn(),

--- a/lib/components/fitness/RegionMap.test.tsx
+++ b/lib/components/fitness/RegionMap.test.tsx
@@ -286,7 +286,9 @@ describe('RegionMap', () => {
 
     unmount()
     map.easeTo.mockClear()
-    success?.({
+    ;(
+      success as ((position: { coords: GeolocationCoordinates }) => void) | null
+    )?.({
       coords: { latitude: 5, longitude: 6 } as GeolocationCoordinates
     })
 

--- a/lib/components/fitness/RouteHeatmapMap.test.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.test.tsx
@@ -4,7 +4,10 @@
 import '@testing-library/jest-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 
-import type { FitnessRouteHeatmapData } from '@/lib/client'
+import type {
+  FitnessRouteHeatmapData,
+  FitnessRouteHeatmapTileRequest
+} from '@/lib/client'
 import {
   HEAT_COUNT_SATURATION,
   HEAT_VISIBLE_BASE_OPACITY,
@@ -244,7 +247,7 @@ describe('RouteHeatmapMap tiled rendering', () => {
 
   const tilePayload = encodeTile([{ count: 5, points: [0, 0, 32, 32] }])
   const fetchAll = () =>
-    vi.fn(async ({ tiles }: { tiles: Array<{ x: number; y: number }> }) => ({
+    vi.fn(async ({ tiles }: FitnessRouteHeatmapTileRequest) => ({
       version: 2,
       tiles: Object.fromEntries(
         tiles.map(({ x, y }) => [`${x}:${y}`, tilePayload])

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/fitness/RegionHeatmapDetail.test.tsx",
-    "lib/components/fitness/RegionMap.test.tsx",
-    "lib/components/fitness/RouteHeatmapMap.test.tsx",
     "lib/components/fitness/RouteHeatmapMapKit.test.tsx",
     "lib/components/fitness/useHeatmapTiles.test.ts",
     "lib/components/mute-action/mute-action.test.tsx",


### PR DESCRIPTION
Resolves type issues in RegionHeatmapDetail.test.tsx, RegionMap.test.tsx, and RouteHeatmapMap.test.tsx, and removes them from tsconfig.typecheck.json.