### PR TITLE
Bump version to v1.161.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.36",
+  "version": "1.161.37",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.37.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.36`
- Base main SHA: `44903a10ea619820d6f4019d55935fe0367548bd`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
