### PR TITLE
refactor: extract filters operations into lib/client/filters.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,11 +1,9 @@
 import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
-import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
-import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 import {
@@ -485,134 +483,9 @@ export * from './client/lists'
 
 export * from './client/collections'
 
-// Filters (https://docs.joinmastodon.org/methods/filters/).
-// Keyword filters for the account scope (/api/v2/filters) and the instance
-// scope (/api/v2/admin/filters). Server filters are returned merged into the
-// account list flagged read-only via the non-standard `server` field. Filter
-// ids are opaque UUIDs (not ActivityPub URLs), so unlike status/account ids
-// they never go through toIdPathSegment — they are still escaped with
-// encodeURIComponent when placed in a request path.
+// --- Filters ---
 
-export interface ClientFilter extends MastodonFilter {
-  // Present and true only on instance-wide server filters merged into the
-  // account list — these are read-only for regular accounts.
-  server?: boolean
-}
-
-export interface FilterKeywordInput {
-  // Set when editing an existing keyword; omit to create a new one.
-  id?: string
-  keyword: string
-  wholeWord: boolean
-  // Set on an existing keyword to remove it during an update.
-  _destroy?: boolean
-}
-
-export interface FilterInput {
-  title: string
-  context: FilterContext[]
-  filterAction: FilterAction
-  // Seconds until the filter expires, or null for "never".
-  expiresIn: number | null
-  keywords: FilterKeywordInput[]
-}
-
-const filterRequestBody = ({
-  title,
-  context,
-  filterAction,
-  expiresIn,
-  keywords
-}: FilterInput) => ({
-  title,
-  context,
-  filter_action: filterAction,
-  expires_in: expiresIn,
-  keywords_attributes: keywords.map((keyword) => ({
-    ...(keyword.id ? { id: keyword.id } : {}),
-    keyword: keyword.keyword,
-    whole_word: keyword.wholeWord,
-    ...(keyword._destroy ? { _destroy: true } : {})
-  }))
-})
-
-const requestFilters = async (path: string): Promise<ClientFilter[]> => {
-  const response = await fetch(path, {
-    method: 'GET',
-    headers: { Accept: 'application/json' }
-  })
-  // Throw (rather than returning []) so an HTTP error is surfaced by the
-  // caller's error handling instead of being indistinguishable from an
-  // empty list. Mirrors the throwing pattern used by createNote().
-  if (!response.ok) {
-    throw new Error(`Failed to load filters (${response.status})`)
-  }
-  return (await response.json()) as ClientFilter[]
-}
-
-const createFilterRequest = async (
-  path: string,
-  input: FilterInput
-): Promise<ClientFilter | null> => {
-  const response = await fetch(path, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(filterRequestBody(input))
-  })
-  if (!response.ok) return null
-  return (await response.json()) as ClientFilter
-}
-
-const updateFilterRequest = async (
-  path: string,
-  input: FilterInput
-): Promise<ClientFilter | null> => {
-  const response = await fetch(path, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(filterRequestBody(input))
-  })
-  if (!response.ok) return null
-  return (await response.json()) as ClientFilter
-}
-
-const deleteFilterRequest = async (path: string): Promise<boolean> => {
-  const response = await fetch(path, { method: 'DELETE' })
-  return response.ok
-}
-
-export const getFilters = (): Promise<ClientFilter[]> =>
-  requestFilters('/api/v2/filters')
-
-export const createFilter = (
-  input: FilterInput
-): Promise<ClientFilter | null> => createFilterRequest('/api/v2/filters', input)
-
-export const updateFilter = (
-  id: string,
-  input: FilterInput
-): Promise<ClientFilter | null> =>
-  updateFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`, input)
-
-export const deleteFilter = (id: string): Promise<boolean> =>
-  deleteFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`)
-
-export const getServerFilters = (): Promise<ClientFilter[]> =>
-  requestFilters('/api/v2/admin/filters')
-
-export const createServerFilter = (
-  input: FilterInput
-): Promise<ClientFilter | null> =>
-  createFilterRequest('/api/v2/admin/filters', input)
-
-export const updateServerFilter = (
-  id: string,
-  input: FilterInput
-): Promise<ClientFilter | null> =>
-  updateFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`, input)
-
-export const deleteServerFilter = (id: string): Promise<boolean> =>
-  deleteFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`)
+export * from './client/filters'
 
 export type ServerRule = AdminRule
 

--- a/lib/client/filters.test.ts
+++ b/lib/client/filters.test.ts
@@ -1,0 +1,253 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  type ClientFilter,
+  type FilterInput,
+  createFilter,
+  createFilterRequest,
+  createServerFilter,
+  deleteFilter,
+  deleteFilterRequest,
+  deleteServerFilter,
+  filterRequestBody,
+  getFilters,
+  getServerFilters,
+  requestFilters,
+  updateFilter,
+  updateFilterRequest,
+  updateServerFilter
+} from './filters'
+
+enableFetchMocks()
+
+describe('client filters module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const sampleInput: FilterInput = {
+    title: 'Muted words',
+    context: ['home', 'public'],
+    filterAction: 'warn',
+    expiresIn: 3600,
+    keywords: [
+      { keyword: 'crypto', wholeWord: true },
+      { id: 'kw-1', keyword: 'spam', wholeWord: false, _destroy: true }
+    ]
+  }
+
+  const mockFilter: ClientFilter = {
+    id: 'filter-123',
+    title: 'Muted words',
+    context: ['home', 'public'],
+    filter_action: 'warn',
+    expires_at: '2026-09-08T12:00:00Z',
+    keywords: [{ id: 'kw-1', keyword: 'crypto', whole_word: true }],
+    statuses: []
+  }
+
+  describe('filterRequestBody', () => {
+    it('correctly maps input fields to API payload format', () => {
+      const body = filterRequestBody(sampleInput)
+      expect(body).toEqual({
+        title: 'Muted words',
+        context: ['home', 'public'],
+        filter_action: 'warn',
+        expires_in: 3600,
+        keywords_attributes: [
+          { keyword: 'crypto', whole_word: true },
+          { id: 'kw-1', keyword: 'spam', whole_word: false, _destroy: true }
+        ]
+      })
+    })
+
+    it('handles keywords without id or _destroy', () => {
+      const body = filterRequestBody({
+        title: 'Test',
+        context: ['notifications'],
+        filterAction: 'hide',
+        expiresIn: null,
+        keywords: [{ keyword: 'test', wholeWord: false }]
+      })
+      expect(body.keywords_attributes).toEqual([
+        { keyword: 'test', whole_word: false }
+      ])
+    })
+  })
+
+  describe('requestFilters', () => {
+    it('returns filters on successful response', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockFilter]), { status: 200 })
+
+      const result = await requestFilters('/api/v2/filters')
+      expect(result).toEqual([mockFilter])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v2/filters', {
+        method: 'GET',
+        headers: { Accept: 'application/json' }
+      })
+    })
+
+    it('throws when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Internal Error', { status: 500 })
+
+      await expect(requestFilters('/api/v2/filters')).rejects.toThrow(
+        'Failed to load filters (500)'
+      )
+    })
+  })
+
+  describe('createFilterRequest', () => {
+    it('creates filter and returns ClientFilter on 200', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter), { status: 200 })
+
+      const result = await createFilterRequest('/api/v2/filters', sampleInput)
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(filterRequestBody(sampleInput))
+        })
+      )
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponseOnce('Unauthorized', { status: 401 })
+
+      const result = await createFilterRequest('/api/v2/filters', sampleInput)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('updateFilterRequest', () => {
+    it('updates filter and returns ClientFilter on 200', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter), { status: 200 })
+
+      const result = await updateFilterRequest(
+        '/api/v2/filters/123',
+        sampleInput
+      )
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters/123',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(filterRequestBody(sampleInput))
+        })
+      )
+    })
+
+    it('returns null on failure', async () => {
+      fetchMock.mockResponseOnce('Bad Request', { status: 400 })
+
+      const result = await updateFilterRequest(
+        '/api/v2/filters/123',
+        sampleInput
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('deleteFilterRequest', () => {
+    it('returns true on 200', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const result = await deleteFilterRequest('/api/v2/filters/123')
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v2/filters/123', {
+        method: 'DELETE'
+      })
+    })
+
+    it('returns false on error', async () => {
+      fetchMock.mockResponseOnce('Not Found', { status: 404 })
+
+      const result = await deleteFilterRequest('/api/v2/filters/123')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('convenience methods', () => {
+    it('getFilters calls /api/v2/filters', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockFilter]))
+      const result = await getFilters()
+      expect(result).toEqual([mockFilter])
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters',
+        expect.anything()
+      )
+    })
+
+    it('createFilter calls /api/v2/filters with POST', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter))
+      const result = await createFilter(sampleInput)
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('updateFilter calls /api/v2/filters/:id with PUT', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter))
+      const result = await updateFilter('id with space', sampleInput)
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters/id%20with%20space',
+        expect.objectContaining({ method: 'PUT' })
+      )
+    })
+
+    it('deleteFilter calls /api/v2/filters/:id with DELETE', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+      const result = await deleteFilter('id with space')
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/filters/id%20with%20space',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('getServerFilters calls /api/v2/admin/filters', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockFilter]))
+      const result = await getServerFilters()
+      expect(result).toEqual([mockFilter])
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/admin/filters',
+        expect.anything()
+      )
+    })
+
+    it('createServerFilter calls /api/v2/admin/filters with POST', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter))
+      const result = await createServerFilter(sampleInput)
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/admin/filters',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('updateServerFilter calls /api/v2/admin/filters/:id with PUT', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockFilter))
+      const result = await updateServerFilter('id with space', sampleInput)
+      expect(result).toEqual(mockFilter)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/admin/filters/id%20with%20space',
+        expect.objectContaining({ method: 'PUT' })
+      )
+    })
+
+    it('deleteServerFilter calls /api/v2/admin/filters/:id with DELETE', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+      const result = await deleteServerFilter('id with space')
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/admin/filters/id%20with%20space',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+})

--- a/lib/client/filters.ts
+++ b/lib/client/filters.ts
@@ -1,0 +1,131 @@
+import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
+import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
+
+// Filters (https://docs.joinmastodon.org/methods/filters/).
+// Keyword filters for the account scope (/api/v2/filters) and the instance
+// scope (/api/v2/admin/filters). Server filters are returned merged into the
+// account list flagged read-only via the non-standard `server` field. Filter
+// ids are opaque UUIDs (not ActivityPub URLs), so unlike status/account ids
+// they never go through toIdPathSegment — they are still escaped with
+// encodeURIComponent when placed in a request path.
+
+export interface ClientFilter extends MastodonFilter {
+  // Present and true only on instance-wide server filters merged into the
+  // account list — these are read-only for regular accounts.
+  server?: boolean
+}
+
+export interface FilterKeywordInput {
+  // Set when editing an existing keyword; omit to create a new one.
+  id?: string
+  keyword: string
+  wholeWord: boolean
+  // Set on an existing keyword to remove it during an update.
+  _destroy?: boolean
+}
+
+export interface FilterInput {
+  title: string
+  context: FilterContext[]
+  filterAction: FilterAction
+  // Seconds until the filter expires, or null for "never".
+  expiresIn: number | null
+  keywords: FilterKeywordInput[]
+}
+
+export const filterRequestBody = ({
+  title,
+  context,
+  filterAction,
+  expiresIn,
+  keywords
+}: FilterInput) => ({
+  title,
+  context,
+  filter_action: filterAction,
+  expires_in: expiresIn,
+  keywords_attributes: keywords.map((keyword) => ({
+    ...(keyword.id ? { id: keyword.id } : {}),
+    keyword: keyword.keyword,
+    whole_word: keyword.wholeWord,
+    ...(keyword._destroy ? { _destroy: true } : {})
+  }))
+})
+
+export const requestFilters = async (path: string): Promise<ClientFilter[]> => {
+  const response = await fetch(path, {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  // Throw (rather than returning []) so an HTTP error is surfaced by the
+  // caller's error handling instead of being indistinguishable from an
+  // empty list. Mirrors the throwing pattern used by createNote().
+  if (!response.ok) {
+    throw new Error(`Failed to load filters (${response.status})`)
+  }
+  return (await response.json()) as ClientFilter[]
+}
+
+export const createFilterRequest = async (
+  path: string,
+  input: FilterInput
+): Promise<ClientFilter | null> => {
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(filterRequestBody(input))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ClientFilter
+}
+
+export const updateFilterRequest = async (
+  path: string,
+  input: FilterInput
+): Promise<ClientFilter | null> => {
+  const response = await fetch(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(filterRequestBody(input))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ClientFilter
+}
+
+export const deleteFilterRequest = async (path: string): Promise<boolean> => {
+  const response = await fetch(path, { method: 'DELETE' })
+  return response.ok
+}
+
+export const getFilters = (): Promise<ClientFilter[]> =>
+  requestFilters('/api/v2/filters')
+
+export const createFilter = (
+  input: FilterInput
+): Promise<ClientFilter | null> => createFilterRequest('/api/v2/filters', input)
+
+export const updateFilter = (
+  id: string,
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  updateFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`, input)
+
+export const deleteFilter = (id: string): Promise<boolean> =>
+  deleteFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`)
+
+export const getServerFilters = (): Promise<ClientFilter[]> =>
+  requestFilters('/api/v2/admin/filters')
+
+export const createServerFilter = (
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  createFilterRequest('/api/v2/admin/filters', input)
+
+export const updateServerFilter = (
+  id: string,
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  updateFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`, input)
+
+export const deleteServerFilter = (id: string): Promise<boolean> =>
+  deleteFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`)


### PR DESCRIPTION
Modularize filters client operations by extracting them from `lib/client.ts` into `lib/client/filters.ts` and re-exporting via `export * from './client/filters'`.

- Extracted:
  - `getFilters`
  - `createFilter`
  - `updateFilter`
  - `deleteFilter`
  - `getServerFilters`
  - `createServerFilter`
  - `updateServerFilter`
  - `deleteServerFilter`
  - `ClientFilter`, `FilterKeywordInput`, `FilterInput`
  - `filterRequestBody`, `requestFilters`, `createFilterRequest`, `updateFilterRequest`, `deleteFilterRequest`
- Re-exported everything in `lib/client.ts`
- Added comprehensive unit tests in `lib/client/filters.test.ts`