### PR TITLE
test: resolve types for RouteHeatmapMapKit, useHeatmapTiles, and mute-action tests

### DIFF
--- a/lib/components/fitness/RouteHeatmapMapKit.test.tsx
+++ b/lib/components/fitness/RouteHeatmapMapKit.test.tsx
@@ -4,7 +4,10 @@
 import '@testing-library/jest-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 
-import type { FitnessRouteHeatmapData } from '@/lib/client'
+import type {
+  FitnessRouteHeatmapData,
+  FitnessRouteHeatmapTileRequest
+} from '@/lib/client'
 import { createMapKitTestDouble } from '@/lib/components/fitness/mapkitTestDouble'
 import { TILE_EXTENT } from '@/lib/services/fitness-files/heatmapTiles/constants'
 import {
@@ -200,7 +203,7 @@ describe('RouteHeatmapMapKit tiled rendering', () => {
   const cool = encodeTile([{ count: 1, points: [8, 8, 40, 40] }])
 
   const fetchWith = (payload: string) =>
-    vi.fn(async ({ tiles }: { tiles: Array<{ x: number; y: number }> }) => ({
+    vi.fn(async ({ tiles }: FitnessRouteHeatmapTileRequest) => ({
       version: 2,
       tiles: Object.fromEntries(tiles.map(({ x, y }) => [`${x}:${y}`, payload]))
     }))

--- a/lib/components/fitness/useHeatmapTiles.test.ts
+++ b/lib/components/fitness/useHeatmapTiles.test.ts
@@ -12,6 +12,7 @@ import { encodeTile } from '@/lib/services/fitness-files/heatmapTiles/tileCodec'
 import { createDeferred } from '@/lib/testing/deferred'
 
 import {
+  type HeatmapTileFetcher,
   MAX_TILES_PER_VIEW,
   TILE_CACHE_MAX_TILES,
   VIEW_SETTLE_MS,
@@ -502,7 +503,7 @@ describe('useHeatmapTiles', () => {
 
   it('leaves the previous view standing when a fetch fails', async () => {
     const fetchTiles = vi
-      .fn(async () => {
+      .fn<HeatmapTileFetcher>(async () => {
         throw new Error('network down')
       })
       .mockImplementationOnce(async ({ tiles }) => batchOf(tiles))

--- a/lib/components/mute-action/mute-action.test.tsx
+++ b/lib/components/mute-action/mute-action.test.tsx
@@ -42,6 +42,7 @@ const relationship = (
   blocked_by: false,
   muting: false,
   muting_notifications: false,
+  muting_expires_at: null,
   requested: false,
   requested_by: false,
   domain_blocking: false,
@@ -52,8 +53,8 @@ const relationship = (
 })
 
 describe('MuteAction', () => {
-  const muteMock = mute as jest.Mock
-  const unmuteMock = unmute as jest.Mock
+  const muteMock = vi.mocked(mute)
+  const unmuteMock = vi.mocked(unmute)
 
   beforeEach(() => {
     muteMock.mockReset()

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/fitness/RouteHeatmapMapKit.test.tsx",
-    "lib/components/fitness/useHeatmapTiles.test.ts",
-    "lib/components/mute-action/mute-action.test.tsx",
     "lib/components/post-box/post-box.test.tsx",
     "lib/components/post-box/reducers.test.ts",
     "lib/components/post-box/reply-preview.test.tsx",


### PR DESCRIPTION
Resolves type errors in RouteHeatmapMapKit.test.tsx, useHeatmapTiles.test.ts, and mute-action.test.tsx and removes them from tsconfig.typecheck.json.