### PR TITLE
Bump version to v1.161.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.37",
+  "version": "1.161.38",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.38.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.37`
- Base main SHA: `ab7ed5e9f0d6a552feb1f6e1f69e34178b9a658a`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
