### PR TITLE
test: resolve types for post-box, reducers, and reply-preview tests

### DIFF
--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -15,7 +15,12 @@ import { InstanceLimitsProvider } from '@/lib/components/instance-limits'
 import { createDeferred } from '@/lib/testing/deferred'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
-import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
+import {
+  EditableStatus,
+  Status,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 import { resizeImage } from '@/lib/utils/resizeImage'
 
 import { PostBox, getQuotePrefix, getQuoteUrl } from './post-box'
@@ -111,6 +116,7 @@ const editStatus: EditableStatus = {
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   totalShares: 0,
   attachments: [existingAttachment],
@@ -122,7 +128,7 @@ describe('PostBox edit media', () => {
     vi.clearAllMocks()
     global.URL.createObjectURL = vi.fn(() => 'blob:new-media')
     global.URL.revokeObjectURL = vi.fn()
-    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id')
+    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id' as never)
     uploadAttachmentMock.mockResolvedValue({
       type: 'upload',
       id: 'uploaded-media',
@@ -942,8 +948,6 @@ describe('PostBox edit media', () => {
             original: {
               width: 1280,
               height: 720,
-              size: '1280x720',
-              aspect: 1.7777777777777777,
               duration: 12,
               frame_rate: '30/1',
               bitrate: 1000000
@@ -1673,7 +1677,7 @@ describe('PostBox edit character limit', () => {
     vi.clearAllMocks()
     global.URL.createObjectURL = vi.fn(() => 'blob:new-media')
     global.URL.revokeObjectURL = vi.fn()
-    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id')
+    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id' as never)
     uploadAttachmentMock.mockResolvedValue({
       type: 'upload',
       id: 'uploaded-media',
@@ -1751,6 +1755,8 @@ describe('PostBox edit character limit', () => {
         screen.getByRole('button', { name: 'Remove media replacement.png' })
       ).toBeInTheDocument()
     )
+    // hasEditPostChanged runs from the attachment call site here — a hardcoded
+    // 500 would wrongly re-enable Post for this 120-character draft.
     expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled()
   })
 })
@@ -1762,7 +1768,7 @@ describe('PostBox poll creation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id')
+    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id' as never)
     createPollMock.mockResolvedValue(undefined)
     global.ResizeObserver = class {
       observe() {}
@@ -1807,7 +1813,7 @@ describe('PostBox new post character limit with attachments', () => {
     vi.clearAllMocks()
     global.URL.createObjectURL = vi.fn(() => 'blob:new-media')
     global.URL.revokeObjectURL = vi.fn()
-    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id')
+    global.crypto.randomUUID = vi.fn(() => 'temporary-media-id' as never)
   })
 
   it('keeps an over-limit new post unsubmittable when media is attached', async () => {
@@ -1857,7 +1863,7 @@ describe('PostBox attachment ref guard', () => {
     global.URL.createObjectURL = vi.fn(() => 'blob:test-media')
     global.URL.revokeObjectURL = vi.fn()
     let counter = 0
-    global.crypto.randomUUID = vi.fn(() => `temp-media-${counter++}`)
+    global.crypto.randomUUID = vi.fn(() => `temp-media-${counter++}` as never)
     uploadAttachmentMock.mockImplementation((file) =>
       Promise.resolve({
         type: 'upload',

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -129,6 +129,7 @@ describe('post-box reducers', () => {
           size: 2048,
           type: 'application/vnd.ant.fit'
         } as File,
+        uploading: false,
         uploadedId: 'fitness-file-id'
       }
     }

--- a/lib/components/post-box/reply-preview.test.tsx
+++ b/lib/components/post-box/reply-preview.test.tsx
@@ -5,7 +5,9 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
+import { ActorProfile } from '@/lib/types/domain/actor'
 import {
+  Status,
   StatusAnnounce,
   StatusNote,
   StatusType
@@ -15,13 +17,14 @@ import { ReplyPreview } from './reply-preview'
 
 // Mock the processStatusText utility
 vi.mock('@/lib/utils/text/processStatusText', async () => ({
-  processStatusText: vi.fn((host: string, status: StatusNote) => {
+  processStatusText: vi.fn((_host: string, status: Status) => {
     if (status.type === 'Announce') {
-      return (status as unknown as StatusAnnounce).originalStatus.text
+      const original = status.originalStatus
+      return 'text' in original ? original.text : ''
     }
-    return status.text
+    return 'text' in status ? status.text : ''
   }),
-  getActualStatus: vi.fn((status: StatusNote) => status)
+  getActualStatus: vi.fn((status: Status) => status)
 }))
 
 // Mock the cleanClassName utility
@@ -39,6 +42,25 @@ vi.mock('@/lib/components/posts/actor', async () => ({
 describe('ReplyPreview', () => {
   const mockOnClose = vi.fn()
 
+  const createMockActor = (
+    overrides: Partial<ActorProfile> = {}
+  ): ActorProfile => ({
+    id: 'https://example.com/users/testuser',
+    username: 'testuser',
+    domain: 'example.com',
+    name: 'Test User',
+    summary: '',
+    followersUrl: 'https://example.com/users/testuser/followers',
+    inboxUrl: 'https://example.com/users/testuser/inbox',
+    sharedInboxUrl: 'https://example.com/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: Date.now(),
+    ...overrides
+  })
+
   const createMockStatus = (
     overrides: Partial<StatusNote> = {}
   ): StatusNote => ({
@@ -50,24 +72,14 @@ describe('ReplyPreview', () => {
     reply: '',
     replies: [],
     actorId: 'https://example.com/users/testuser',
-    actor: {
-      id: 'https://example.com/users/testuser',
-      name: 'Test User',
-      preferredUsername: 'testuser',
-      url: 'https://example.com/@testuser',
-      icon: null,
-      summary: null,
-      followersCount: 0,
-      followingCount: 0,
-      statusesCount: 0,
-      createdAt: Date.now()
-    },
+    actor: createMockActor(),
     to: [],
     cc: [],
     edits: [],
     isLocalActor: false,
     actorAnnounceStatusId: null,
     isActorLiked: false,
+    isActorBookmarked: false,
     totalLikes: 0,
     totalShares: 0,
     attachments: [],
@@ -81,18 +93,11 @@ describe('ReplyPreview', () => {
     id: 'announce-1',
     type: StatusType.enum.Announce,
     actorId: 'https://example.com/users/booster',
-    actor: {
+    actor: createMockActor({
       id: 'https://example.com/users/booster',
-      name: 'Booster User',
-      preferredUsername: 'booster',
-      url: 'https://example.com/@booster',
-      icon: null,
-      summary: null,
-      followersCount: 0,
-      followingCount: 0,
-      statusesCount: 0,
-      createdAt: Date.now()
-    },
+      username: 'booster',
+      name: 'Booster User'
+    }),
     to: [],
     cc: [],
     edits: [],
@@ -263,18 +268,14 @@ describe('ReplyPreview', () => {
   describe('actor display', () => {
     it('displays actor name when actor is present', () => {
       const status = createMockStatus({
-        actor: {
+        actor: createMockActor({
           id: 'https://example.com/users/jane',
           name: 'Jane Doe',
-          preferredUsername: 'jane',
-          url: 'https://example.com/@jane',
-          icon: null,
-          summary: null,
+          username: 'jane',
           followersCount: 100,
           followingCount: 50,
-          statusesCount: 25,
-          createdAt: Date.now()
-        }
+          statusCount: 25
+        })
       })
       render(<ReplyPreview host="example.com" status={status} />)
 

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/post-box/post-box.test.tsx",
-    "lib/components/post-box/reducers.test.ts",
-    "lib/components/post-box/reply-preview.test.tsx",
     "lib/components/post-box/upload-media-button.test.tsx",
     "lib/components/posts/actions/bookmark-button.test.tsx",
     "lib/components/posts/actions/post-menu.test.tsx",


### PR DESCRIPTION
## Summary
Resolves TypeScript errors for Task H2 (Batch 31) and removes the following target files from `tsconfig.typecheck.json`:
1. `lib/components/post-box/post-box.test.tsx`
2. `lib/components/post-box/reducers.test.ts`
3. `lib/components/post-box/reply-preview.test.tsx`

## Changes
- In `lib/components/post-box/post-box.test.tsx`:
  - Imported `StatusNote` from `@/lib/types/domain/status`.
  - Added required `isActorBookmarked: false` to the `editStatus` fixture.
  - Adjusted `video.meta.original` fixture to match Mastodon video attachment schema (removing unsupported `size` and `aspect` properties on `original`).
  - Cast `crypto.randomUUID` mocks as `never` to satisfy the DOM UUID template-literal return type.
- In `lib/components/post-box/reducers.test.ts`:
  - Added required `uploading: false` property to `fitnessFile` in test state fixture.
- In `lib/components/post-box/reply-preview.test.tsx`:
  - Imported `Status` and `ActorProfile`.
  - Updated `processStatusText` mock signature and handling to accept `Status`.
  - Added `createMockActor` fixture helper providing valid `ActorProfile` objects.
  - Added required `isActorBookmarked: false` to the `StatusNote` mock fixture.
- Removed all 3 files from `tsconfig.typecheck.json`.

## DoD Verification
- `yarn run prettier --write .` - Clean
- `yarn lint` - Passed (0 errors)
- `yarn typecheck` - Passed cleanly
- `yarn build` - Passed cleanly
- `yarn test` - Passed (1022 test files, 14216 tests passed)