### PR TITLE
Bump version to v1.161.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.38",
+  "version": "1.161.39",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.39.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.38`
- Base main SHA: `ff37a59908e545faaa474b47483cf8f2254da68d`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
