### PR TITLE
test: resolve types for upload-media-button, bookmark-button, and post-menu tests

### DIFF
--- a/lib/components/post-box/upload-media-button.test.tsx
+++ b/lib/components/post-box/upload-media-button.test.tsx
@@ -44,7 +44,10 @@ describe('UploadMediaButton', () => {
 
     // Mock crypto.randomUUID
     let counter = 0
-    global.crypto.randomUUID = vi.fn(() => `uuid-${counter++}`)
+    global.crypto.randomUUID = vi.fn(
+      () =>
+        `uuid-0000-0000-0000-${counter++}` as `${string}-${string}-${string}-${string}-${string}`
+    )
 
     // Mock URL.createObjectURL
     global.URL.createObjectURL = vi.fn(() => 'blob:test-url')

--- a/lib/components/posts/actions/bookmark-button.test.tsx
+++ b/lib/components/posts/actions/bookmark-button.test.tsx
@@ -7,7 +7,7 @@ import { FC } from 'react'
 
 import { bookmarkStatus, undoBookmarkStatus } from '@/lib/client'
 import { createDeferred } from '@/lib/testing/deferred'
-import { StatusNote, StatusType } from '@/lib/types/domain/status'
+import { StatusNote, StatusPoll, StatusType } from '@/lib/types/domain/status'
 
 import { BookmarkButton } from './bookmark-button'
 import { useBookmarkState } from './useBookmarkState'
@@ -58,8 +58,11 @@ const status: StatusNote = {
 }
 
 interface HarnessProps {
-  status: StatusNote
-  onBookmarkChanged?: (status: StatusNote, isBookmarked: boolean) => void
+  status: StatusNote | StatusPoll
+  onBookmarkChanged?: (
+    status: StatusNote | StatusPoll,
+    isBookmarked: boolean
+  ) => void
 }
 
 // The action row owns the state and the button only renders it, so the tests

--- a/lib/components/posts/actions/post-menu.test.tsx
+++ b/lib/components/posts/actions/post-menu.test.tsx
@@ -114,6 +114,7 @@ const relationship = (
   blocked_by: false,
   muting: false,
   muting_notifications: false,
+  muting_expires_at: null,
   requested: false,
   requested_by: false,
   domain_blocking: false,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/post-box/upload-media-button.test.tsx",
-    "lib/components/posts/actions/bookmark-button.test.tsx",
-    "lib/components/posts/actions/post-menu.test.tsx",
     "lib/components/posts/poll.test.tsx",
     "lib/components/posts/post.test.tsx",
     "lib/components/posts/status-reply-box.test.tsx",


### PR DESCRIPTION
Resolves TypeScript errors for:
- `lib/components/post-box/upload-media-button.test.tsx`
- `lib/components/posts/actions/bookmark-button.test.tsx`
- `lib/components/posts/actions/post-menu.test.tsx`

And removes these 3 files from `tsconfig.typecheck.json`.