### PR TITLE
Bump version to v1.161.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.39",
+  "version": "1.161.40",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.40.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.39`
- Base main SHA: `7d334f3878e94af106d666194278f8132e9421d8`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
