### PR TITLE
test: resolve types for poll, post, and status-reply-box tests

### DIFF
--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -35,6 +35,7 @@ const pollStatus: StatusPoll = {
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   totalShares: 0,
   attachments: [],

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -114,7 +114,7 @@ const status: StatusNote = {
   tags: []
 }
 
-const boostedStatus: StatusAnnounce = {
+const boostedStatus: StatusAnnounce & { originalStatus: StatusNote } = {
   id: 'https://remote.example/users/booster/statuses/boost-1/activity',
   actorId: 'https://remote.example/users/booster',
   actor: {
@@ -175,7 +175,7 @@ describe('Post', () => {
         currentTime={currentTime}
         status={status}
         collapsible
-        postLineLimit={1}
+        postLineLimit={5}
         onShowAttachment={vi.fn()}
       />
     )

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -73,6 +73,7 @@ export interface PostProps {
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
   onQuote?: (status: Status) => void
+  onShowEdits?: (status: Status) => void
   onPostDeleted?: (status: Status) => void
   onBookmarkChanged?: (
     status: StatusNote | StatusPoll,

--- a/lib/components/posts/status-reply-box.test.tsx
+++ b/lib/components/posts/status-reply-box.test.tsx
@@ -57,6 +57,7 @@ const replyStatus: StatusNote = {
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   totalShares: 0,
   attachments: [],

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,9 +17,6 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/posts/poll.test.tsx",
-    "lib/components/posts/post.test.tsx",
-    "lib/components/posts/status-reply-box.test.tsx",
     "lib/components/posts/status-translation.test.tsx",
     "lib/database/sql/account.test.ts",
     "lib/database/sql/actor.test.ts",


### PR DESCRIPTION
### Summary

Resolves TypeScript type errors for:
- `lib/components/posts/poll.test.tsx`
- `lib/components/posts/post.test.tsx`
- `lib/components/posts/status-reply-box.test.tsx`

And removes these 3 files from `tsconfig.typecheck.json`.

### Changes
- Added missing `isActorBookmarked: false` to test status fixtures in `poll.test.tsx` and `status-reply-box.test.tsx`
- Fixed `postLineLimit` value to match allowed literal union `0 | 5 | 10` in `post.test.tsx`
- Refined `boostedStatus` typing in `post.test.tsx` to preserve `originalStatus` Note properties
- Added `onShowEdits` prop definition to `PostProps` in `lib/components/posts/post.tsx`
- Removed 3 files from exclusion list in `tsconfig.typecheck.json`

### DoD Validation
- [x] `yarn run prettier --write .`
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test`