### PR TITLE
refactor: extract announcements operations into lib/client/announcements.ts

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,7 +1,6 @@
 import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
 import type { AdminReport } from '@/lib/types/mastodon/admin/report'
-import type { Announcement } from '@/lib/types/mastodon/announcement'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 import {
@@ -491,88 +490,8 @@ export * from './client/serverRules'
 
 // --- Server Announcements ---
 
+export * from './client/announcements'
 export * from './client/serverAnnouncements'
-
-// Public announcements (https://docs.joinmastodon.org/methods/announcements/).
-// The active server announcements shown to a signed-in user, each carrying a
-// per-actor `read` flag. Distinct from the admin `getServerAnnouncements`
-// management list above — these render published content for the timeline
-// banner.
-
-// Returns the active announcements for the current actor. Returns [] on a
-// non-OK response so the timeline banner degrades to showing nothing rather
-// than surfacing an error to the reader.
-export const getAnnouncements = async (): Promise<Announcement[]> => {
-  const response = await fetch('/api/v1/announcements', {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json'
-    }
-  })
-  if (!response.ok) return []
-  return (await response.json()) as Announcement[]
-}
-
-/**
- * Dismisses (marks as read) a single announcement for the current actor using
- * the Mastodon-compatible announcements API.
- * @see https://docs.joinmastodon.org/methods/announcements/#dismiss
- */
-export const dismissAnnouncement = async (id: string): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/announcements/${encodeURIComponent(id)}/dismiss`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.ok
-}
-
-/**
- * Adds the current actor's reaction (unicode emoji or custom-emoji shortcode)
- * to an announcement. Returns true on success. Mirrors `dismissAnnouncement`'s
- * boolean-ok style so the banner can fall back to its optimistic state.
- * @see https://docs.joinmastodon.org/methods/announcements/#put-reactions
- */
-export const addAnnouncementReaction = async (
-  id: string,
-  name: string
-): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.ok
-}
-
-/**
- * Removes the current actor's reaction from an announcement. Returns true on
- * success.
- * @see https://docs.joinmastodon.org/methods/announcements/#delete-reactions
- */
-export const removeAnnouncementReaction = async (
-  id: string,
-  name: string
-): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }
-  )
-  return response.ok
-}
 
 // A passkey as returned by `GET /api/v1/passkeys`, including the domain it was
 // registered on (a WebAuthn credential is bound to one domain).

--- a/lib/client/announcements.test.ts
+++ b/lib/client/announcements.test.ts
@@ -1,0 +1,148 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { Announcement } from '@/lib/types/mastodon/announcement'
+
+import {
+  addAnnouncementReaction,
+  dismissAnnouncement,
+  getAnnouncements,
+  removeAnnouncementReaction
+} from './announcements'
+
+describe('announcements client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const mockAnnouncement: Announcement = {
+    id: 'announcement-1',
+    content: '<p>Hello world</p>',
+    starts_at: null,
+    ends_at: null,
+    all_day: false,
+    published_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    read: false,
+    mentions: [],
+    statuses: [],
+    tags: [],
+    emojis: [],
+    reactions: []
+  }
+
+  describe('getAnnouncements', () => {
+    it('fetches and returns announcements on successful response', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAnnouncement]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+
+      const result = await getAnnouncements()
+
+      expect(result).toEqual([mockAnnouncement])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/announcements', {
+        method: 'GET',
+        headers: { Accept: 'application/json' }
+      })
+    })
+
+    it('returns empty array when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      const result = await getAnnouncements()
+
+      expect(result).toEqual([])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/announcements', {
+        method: 'GET',
+        headers: { Accept: 'application/json' }
+      })
+    })
+  })
+
+  describe('dismissAnnouncement', () => {
+    it('returns true on successful dismissal', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const result = await dismissAnnouncement('announcement-1')
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/announcements/announcement-1/dismiss',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    })
+
+    it('returns false when dismissal fails', async () => {
+      fetchMock.mockResponseOnce('Error', { status: 400 })
+
+      const result = await dismissAnnouncement('announcement-1')
+
+      expect(result).toBe(false)
+    })
+
+    it('encodes URI components in the URL', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      await dismissAnnouncement('id with spaces')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/announcements/id%20with%20spaces/dismiss',
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('addAnnouncementReaction', () => {
+    it('returns true on successful reaction addition', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const result = await addAnnouncementReaction('announcement-1', '👍')
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/announcements/announcement-1/reactions/${encodeURIComponent('👍')}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    })
+
+    it('returns false when reaction addition fails', async () => {
+      fetchMock.mockResponseOnce('Error', { status: 400 })
+
+      const result = await addAnnouncementReaction('announcement-1', '👍')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('removeAnnouncementReaction', () => {
+    it('returns true on successful reaction removal', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      const result = await removeAnnouncementReaction('announcement-1', '👍')
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/announcements/announcement-1/reactions/${encodeURIComponent('👍')}`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    })
+
+    it('returns false when reaction removal fails', async () => {
+      fetchMock.mockResponseOnce('Error', { status: 400 })
+
+      const result = await removeAnnouncementReaction('announcement-1', '👍')
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/lib/client/announcements.ts
+++ b/lib/client/announcements.ts
@@ -1,0 +1,81 @@
+import type { Announcement } from '@/lib/types/mastodon/announcement'
+
+// Public announcements (https://docs.joinmastodon.org/methods/announcements/).
+// The active server announcements shown to a signed-in user, each carrying a
+// per-actor `read` flag. Distinct from the admin `getServerAnnouncements`
+// management list — these render published content for the timeline banner.
+
+// Returns the active announcements for the current actor. Returns [] on a
+// non-OK response so the timeline banner degrades to showing nothing rather
+// than surfacing an error to the reader.
+export const getAnnouncements = async (): Promise<Announcement[]> => {
+  const response = await fetch('/api/v1/announcements', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) return []
+  return (await response.json()) as Announcement[]
+}
+
+/**
+ * Dismisses (marks as read) a single announcement for the current actor using
+ * the Mastodon-compatible announcements API.
+ * @see https://docs.joinmastodon.org/methods/announcements/#dismiss
+ */
+export const dismissAnnouncement = async (id: string): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/announcements/${encodeURIComponent(id)}/dismiss`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}
+
+/**
+ * Adds the current actor's reaction (unicode emoji or custom-emoji shortcode)
+ * to an announcement. Returns true on success. Mirrors `dismissAnnouncement`'s
+ * boolean-ok style so the banner can fall back to its optimistic state.
+ * @see https://docs.joinmastodon.org/methods/announcements/#put-reactions
+ */
+export const addAnnouncementReaction = async (
+  id: string,
+  name: string
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}
+
+/**
+ * Removes the current actor's reaction from an announcement. Returns true on
+ * success.
+ * @see https://docs.joinmastodon.org/methods/announcements/#delete-reactions
+ */
+export const removeAnnouncementReaction = async (
+  id: string,
+  name: string
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}


### PR DESCRIPTION
Extract public announcements client operations into `lib/client/announcements.ts` and re-export them from `lib/client.ts` to maintain backwards compatibility.

Operations extracted:
- `getAnnouncements`
- `dismissAnnouncement`
- `addAnnouncementReaction`
- `removeAnnouncementReaction`