### PR TITLE
Bump version to v1.161.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.40",
+  "version": "1.161.41",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.41.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.40`
- Base main SHA: `c3587c342056296474850cd0deb8d0bc5858365f`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
