### PR TITLE
refactor: extract admin operations into lib/client/

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -8,6 +8,7 @@ import { urlToId } from '@/lib/utils/urlToId'
 import {
   ApiRequestError,
   addCollectionAccounts,
+  adminDeleteAccount,
   approveCollectionMembership,
   bookmarkStatus,
   cancelActorDeletion,
@@ -40,6 +41,11 @@ import {
   getActorDomains,
   getActorMedia,
   getActorStatuses,
+  getAdminAccount,
+  getAdminAccounts,
+  getAdminReport,
+  getAdminReports,
+  getAdminServerSettings,
   getAppleMapsToken,
   getBookmarks,
   getCollectionFeed,
@@ -62,6 +68,7 @@ import {
   getHashtagTimeline,
   getListTimeline,
   getMutes,
+  getPasskeys,
   getPublicHeatmapTiles,
   getStravaSettings,
   getTimeline,
@@ -70,6 +77,8 @@ import {
   getTrendingTags,
   getVapidKey,
   likeStatus,
+  markNotificationsRead,
+  performAdminAccountAction,
   refitFitnessGearComponent,
   regenerateFitnessMaps,
   removeCollectionAccounts,
@@ -99,6 +108,8 @@ import {
   unshareFitnessRouteHeatmap,
   unsubscribePushNotifications,
   updateAccountName,
+  updateAdminReport,
+  updateAdminServerSettings,
   updateCollection,
   updateEmailNotifications,
   updateFitnessFileGear,
@@ -114,6 +125,9 @@ import {
   uploadMedia
 } from './client'
 import * as accountsModule from './client/accounts'
+import * as adminAccountsModule from './client/adminAccounts'
+import * as adminReportsModule from './client/adminReports'
+import * as adminServerSettingsModule from './client/adminServerSettings'
 import * as fitnessFilesModule from './client/fitnessFiles'
 import * as fitnessGearModule from './client/fitnessGear'
 import * as fitnessGeneralSettingsModule from './client/fitnessGeneralSettings'
@@ -123,6 +137,8 @@ import * as fitnessRoutesModule from './client/fitnessRoutes'
 import * as httpModule from './client/http'
 import * as mediaModule from './client/media'
 import * as notificationSettingsModule from './client/notificationSettings'
+import * as notificationsModule from './client/notifications'
+import * as passkeysModule from './client/passkeys'
 import * as statusesModule from './client/statuses'
 import * as timelinesModule from './client/timelines'
 
@@ -248,6 +264,50 @@ describe('client facade notification settings re-exports', () => {
     expect(updatePushNotifications).toBe(
       notificationSettingsModule.updatePushNotifications
     )
+  })
+})
+
+describe('client facade admin server settings re-exports', () => {
+  it('re-exports extracted admin server settings functions', () => {
+    expect(getAdminServerSettings).toBe(
+      adminServerSettingsModule.getAdminServerSettings
+    )
+    expect(updateAdminServerSettings).toBe(
+      adminServerSettingsModule.updateAdminServerSettings
+    )
+  })
+})
+
+describe('client facade passkeys re-exports', () => {
+  it('re-exports extracted passkeys functions', () => {
+    expect(getPasskeys).toBe(passkeysModule.getPasskeys)
+  })
+})
+
+describe('client facade notifications re-exports', () => {
+  it('re-exports extracted notifications functions', () => {
+    expect(markNotificationsRead).toBe(
+      notificationsModule.markNotificationsRead
+    )
+  })
+})
+
+describe('client facade admin accounts re-exports', () => {
+  it('re-exports extracted admin accounts functions', () => {
+    expect(getAdminAccounts).toBe(adminAccountsModule.getAdminAccounts)
+    expect(getAdminAccount).toBe(adminAccountsModule.getAdminAccount)
+    expect(performAdminAccountAction).toBe(
+      adminAccountsModule.performAdminAccountAction
+    )
+    expect(adminDeleteAccount).toBe(adminAccountsModule.adminDeleteAccount)
+  })
+})
+
+describe('client facade admin reports re-exports', () => {
+  it('re-exports extracted admin reports functions', () => {
+    expect(getAdminReports).toBe(adminReportsModule.getAdminReports)
+    expect(getAdminReport).toBe(adminReportsModule.getAdminReport)
+    expect(updateAdminReport).toBe(adminReportsModule.updateAdminReport)
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,6 +1,3 @@
-import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
-import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
-import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 import {
@@ -362,27 +359,9 @@ export {
   retryFitnessImportBatch
 }
 
-interface MarkNotificationsReadParams {
-  notificationIds: string[]
-}
+// --- Notifications ---
 
-/**
- * Marks the given notifications as read for the current actor
- */
-export const markNotificationsRead = async ({
-  notificationIds
-}: MarkNotificationsReadParams) => {
-  const response = await fetch('/api/v1/notifications/read', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      notification_ids: notificationIds
-    })
-  })
-  return response.ok
-}
+export * from './client/notifications'
 
 export {
   type FitnessActivitySummary,
@@ -438,39 +417,9 @@ export * from './client/directMessages'
 
 export * from './client/customEmojis'
 
-// Database-backed admin server settings. Resolved values plus per-field lock
-// metadata (env-pinned fields are locked and reject writes).
-export interface AdminServerSettingsResponse {
-  settings: ResolvedServerSettings
-  locks: Record<string, { locked: boolean; envVar?: string }>
-}
+// --- Admin server settings ---
 
-export const getAdminServerSettings =
-  async (): Promise<AdminServerSettingsResponse> => {
-    const response = await fetch('/api/v1/admin/server_settings', {
-      headers: { Accept: 'application/json' }
-    })
-    if (!response.ok) throw new Error('Failed to load server settings')
-    return (await response.json()) as AdminServerSettingsResponse
-  }
-
-// Partial { key: value } patch. Env-locked, unknown, or invalid keys are
-// rejected server-side and nothing is written; the thrown message surfaces to
-// the form.
-export const updateAdminServerSettings = async (
-  patch: Record<string, unknown>
-): Promise<AdminServerSettingsResponse> => {
-  const response = await fetch('/api/v1/admin/server_settings', {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(patch)
-  })
-  if (!response.ok) {
-    const error = await response.json().catch(() => null)
-    throw new Error(error?.error ?? 'Failed to save server settings')
-  }
-  return (await response.json()) as AdminServerSettingsResponse
-}
+export * from './client/adminServerSettings'
 
 // --- Lists ---
 
@@ -493,202 +442,17 @@ export * from './client/serverRules'
 export * from './client/announcements'
 export * from './client/serverAnnouncements'
 
-// A passkey as returned by `GET /api/v1/passkeys`, including the domain it was
-// registered on (a WebAuthn credential is bound to one domain).
-export interface Passkey {
-  id: string
-  name: string | null
-  domain: string
-  deviceType: string
-  backedUp: boolean
-  createdAt: string
-  aaguid: string | null
-}
+// --- Passkeys ---
 
-/**
- * Lists the signed-in account's passkeys with the domain each is bound to.
- * @see app/api/v1/passkeys/route.ts
- */
-export const getPasskeys = async (): Promise<Passkey[]> => {
-  const response = await fetch('/api/v1/passkeys', {
-    method: 'GET',
-    credentials: 'include'
-  })
-  if (!response.ok) {
-    throw new Error('Failed to load passkeys')
-  }
-  const data = await response.json()
-  return Array.isArray(data) ? data : []
-}
+export * from './client/passkeys'
 
 // ============================================================================
 // Admin moderation — accounts (Admin::Account) and reports (Admin::Report).
 // All calls go through the same-origin cookie session (AdminApiGuard).
 // ============================================================================
 
-export interface AdminAccountFilters {
-  origin?: 'local' | 'remote'
-  status?: 'active' | 'pending' | 'disabled' | 'silenced' | 'suspended'
-  username?: string
-  byDomain?: string
-}
-
-export const getAdminAccounts = async (
-  filters: AdminAccountFilters = {}
-): Promise<AdminAccount[]> => {
-  const params = new URLSearchParams()
-  if (filters.origin) params.set('origin', filters.origin)
-  if (filters.status) params.set('status', filters.status)
-  if (filters.username) params.set('username', filters.username)
-  if (filters.byDomain) params.set('by_domain', filters.byDomain)
-  const query = params.toString()
-  const response = await fetch(
-    `/api/v2/admin/accounts${query ? `?${query}` : ''}`,
-    { headers: { Accept: 'application/json' }, credentials: 'include' }
-  )
-  if (!response.ok) throw new Error('Failed to load admin accounts')
-  return (await response.json()) as AdminAccount[]
-}
-
-export const getAdminAccount = async (id: string): Promise<AdminAccount> => {
-  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
-    headers: { Accept: 'application/json' },
-    credentials: 'include'
-  })
-  if (!response.ok) throw new Error('Failed to load admin account')
-  return (await response.json()) as AdminAccount
-}
-
-export type AdminAccountActionType =
-  'none' | 'disable' | 'sensitive' | 'silence' | 'suspend'
-
-export const performAdminAccountAction = async ({
-  id,
-  type,
-  reportId,
-  text
-}: {
-  id: string
-  type: AdminAccountActionType
-  reportId?: string
-  text?: string
-}): Promise<void> => {
-  const response = await fetch(`/api/v1/admin/accounts/${id}/action`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({
-      type,
-      ...(reportId ? { report_id: reportId } : {}),
-      ...(text ? { text } : {})
-    })
-  })
-  if (!response.ok) {
-    const error = await response.json().catch(() => null)
-    throw new Error(error?.error ?? 'Failed to perform account action')
-  }
-}
-
-const adminAccountStateChange =
-  (action: string) =>
-  async (id: string): Promise<AdminAccount> => {
-    const response = await fetch(`/api/v1/admin/accounts/${id}/${action}`, {
-      method: 'POST',
-      credentials: 'include'
-    })
-    if (!response.ok) {
-      const error = await response.json().catch(() => null)
-      throw new Error(error?.error ?? `Failed to ${action} account`)
-    }
-    return (await response.json()) as AdminAccount
-  }
-
-export const adminEnableAccount = adminAccountStateChange('enable')
-export const adminUnsilenceAccount = adminAccountStateChange('unsilence')
-export const adminUnsuspendAccount = adminAccountStateChange('unsuspend')
-export const adminUnsensitiveAccount = adminAccountStateChange('unsensitive')
-export const adminApproveAccount = adminAccountStateChange('approve')
-export const adminRejectAccount = adminAccountStateChange('reject')
-
-export const adminDeleteAccount = async (id: string): Promise<AdminAccount> => {
-  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
-    method: 'DELETE',
-    credentials: 'include'
-  })
-  if (!response.ok) {
-    const error = await response.json().catch(() => null)
-    throw new Error(error?.error ?? 'Failed to delete account')
-  }
-  return (await response.json()) as AdminAccount
-}
-
-export const getAdminReports = async (
-  resolved?: boolean
-): Promise<AdminReport[]> => {
-  const params = new URLSearchParams()
-  if (resolved !== undefined)
-    params.set('resolved', resolved ? 'true' : 'false')
-  const query = params.toString()
-  const response = await fetch(
-    `/api/v1/admin/reports${query ? `?${query}` : ''}`,
-    { headers: { Accept: 'application/json' }, credentials: 'include' }
-  )
-  if (!response.ok) throw new Error('Failed to load admin reports')
-  return (await response.json()) as AdminReport[]
-}
-
-export const getAdminReport = async (id: string): Promise<AdminReport> => {
-  const response = await fetch(`/api/v1/admin/reports/${id}`, {
-    headers: { Accept: 'application/json' },
-    credentials: 'include'
-  })
-  if (!response.ok) throw new Error('Failed to load admin report')
-  return (await response.json()) as AdminReport
-}
-
-export const updateAdminReport = async ({
-  id,
-  category,
-  ruleIds
-}: {
-  id: string
-  category?: ReportCategory
-  ruleIds?: string[]
-}): Promise<AdminReport> => {
-  const response = await fetch(`/api/v1/admin/reports/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({
-      ...(category ? { category } : {}),
-      ...(ruleIds ? { rule_ids: ruleIds } : {})
-    })
-  })
-  if (!response.ok) {
-    const error = await response.json().catch(() => null)
-    throw new Error(error?.error ?? 'Failed to update report')
-  }
-  return (await response.json()) as AdminReport
-}
-
-const adminReportAction =
-  (action: string) =>
-  async (id: string): Promise<AdminReport> => {
-    const response = await fetch(`/api/v1/admin/reports/${id}/${action}`, {
-      method: 'POST',
-      credentials: 'include'
-    })
-    if (!response.ok) {
-      const error = await response.json().catch(() => null)
-      throw new Error(error?.error ?? `Failed to ${action} report`)
-    }
-    return (await response.json()) as AdminReport
-  }
-
-export const assignAdminReportToSelf = adminReportAction('assign_to_self')
-export const unassignAdminReport = adminReportAction('unassign')
-export const resolveAdminReport = adminReportAction('resolve')
-export const reopenAdminReport = adminReportAction('reopen')
+export * from './client/adminAccounts'
+export * from './client/adminReports'
 
 /**
  * Resolves where to send a logged-out visitor so they can follow a local

--- a/lib/client/adminAccounts.test.ts
+++ b/lib/client/adminAccounts.test.ts
@@ -1,0 +1,279 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
+
+import {
+  adminApproveAccount,
+  adminDeleteAccount,
+  adminEnableAccount,
+  adminRejectAccount,
+  adminUnsensitiveAccount,
+  adminUnsilenceAccount,
+  adminUnsuspendAccount,
+  getAdminAccount,
+  getAdminAccounts,
+  performAdminAccountAction
+} from './adminAccounts'
+
+describe('adminAccounts client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const mockAdminAccount: AdminAccount = {
+    id: 'account-1',
+    username: 'alice',
+    domain: null,
+    created_at: '2026-01-01T00:00:00Z',
+    email: 'alice@example.com',
+    ip: '127.0.0.1',
+    ips: [],
+    locale: null,
+    invite_request: null,
+    role: null,
+    confirmed: true,
+    approved: true,
+    disabled: false,
+    silenced: false,
+    suspended: false,
+    sensitized: false,
+    account: {} as AdminAccount['account']
+  }
+
+  describe('getAdminAccounts', () => {
+    it('fetches accounts with default empty filters', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAdminAccount]), {
+        status: 200
+      })
+
+      const result = await getAdminAccounts()
+
+      expect(result).toEqual([mockAdminAccount])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v2/admin/accounts', {
+        headers: { Accept: 'application/json' },
+        credentials: 'include'
+      })
+    })
+
+    it('appends query parameters when filters are provided', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAdminAccount]), {
+        status: 200
+      })
+
+      await getAdminAccounts({
+        origin: 'local',
+        status: 'active',
+        username: 'alice',
+        byDomain: 'example.com'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v2/admin/accounts?origin=local&status=active&username=alice&by_domain=example.com',
+        {
+          headers: { Accept: 'application/json' },
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(getAdminAccounts()).rejects.toThrow(
+        'Failed to load admin accounts'
+      )
+    })
+  })
+
+  describe('getAdminAccount', () => {
+    it('fetches single account by id', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockAdminAccount), {
+        status: 200
+      })
+
+      const result = await getAdminAccount('account-1')
+
+      expect(result).toEqual(mockAdminAccount)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/accounts/account-1',
+        {
+          headers: { Accept: 'application/json' },
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      await expect(getAdminAccount('account-1')).rejects.toThrow(
+        'Failed to load admin account'
+      )
+    })
+  })
+
+  describe('performAdminAccountAction', () => {
+    it('posts action payload with optional reportId and text', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      await performAdminAccountAction({
+        id: 'account-1',
+        type: 'silence',
+        reportId: 'rep-1',
+        text: 'Violated terms'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/accounts/account-1/action',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            type: 'silence',
+            report_id: 'rep-1',
+            text: 'Violated terms'
+          })
+        }
+      )
+    })
+
+    it('posts action without optional fields when omitted', async () => {
+      fetchMock.mockResponseOnce('', { status: 200 })
+
+      await performAdminAccountAction({
+        id: 'account-1',
+        type: 'disable'
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/accounts/account-1/action',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            type: 'disable'
+          })
+        }
+      )
+    })
+
+    it('throws custom error when response is not ok', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Cannot perform action on self' }),
+        { status: 422 }
+      )
+
+      await expect(
+        performAdminAccountAction({ id: 'account-1', type: 'suspend' })
+      ).rejects.toThrow('Cannot perform action on self')
+    })
+
+    it('throws fallback error when response has no error message', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      await expect(
+        performAdminAccountAction({ id: 'account-1', type: 'suspend' })
+      ).rejects.toThrow('Failed to perform account action')
+    })
+  })
+
+  describe('admin account state change actions', () => {
+    const actions = [
+      {
+        name: 'adminEnableAccount',
+        fn: adminEnableAccount,
+        endpoint: 'enable'
+      },
+      {
+        name: 'adminUnsilenceAccount',
+        fn: adminUnsilenceAccount,
+        endpoint: 'unsilence'
+      },
+      {
+        name: 'adminUnsuspendAccount',
+        fn: adminUnsuspendAccount,
+        endpoint: 'unsuspend'
+      },
+      {
+        name: 'adminUnsensitiveAccount',
+        fn: adminUnsensitiveAccount,
+        endpoint: 'unsensitive'
+      },
+      {
+        name: 'adminApproveAccount',
+        fn: adminApproveAccount,
+        endpoint: 'approve'
+      },
+      { name: 'adminRejectAccount', fn: adminRejectAccount, endpoint: 'reject' }
+    ]
+
+    for (const { name, fn, endpoint } of actions) {
+      it(`${name} calls correct endpoint and returns updated account`, async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(mockAdminAccount), {
+          status: 200
+        })
+
+        const result = await fn('account-1')
+
+        expect(result).toEqual(mockAdminAccount)
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/api/v1/admin/accounts/account-1/${endpoint}`,
+          {
+            method: 'POST',
+            credentials: 'include'
+          }
+        )
+      })
+
+      it(`${name} throws error when response fails`, async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({ error: `Could not ${endpoint}` }),
+          { status: 400 }
+        )
+
+        await expect(fn('account-1')).rejects.toThrow(`Could not ${endpoint}`)
+      })
+    }
+  })
+
+  describe('adminDeleteAccount', () => {
+    it('sends DELETE request and returns account', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockAdminAccount), {
+        status: 200
+      })
+
+      const result = await adminDeleteAccount('account-1')
+
+      expect(result).toEqual(mockAdminAccount)
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/accounts/account-1',
+        {
+          method: 'DELETE',
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('throws custom error when delete fails', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Cannot delete admin' }),
+        { status: 403 }
+      )
+
+      await expect(adminDeleteAccount('account-1')).rejects.toThrow(
+        'Cannot delete admin'
+      )
+    })
+
+    it('throws default error when delete fails without json error', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(adminDeleteAccount('account-1')).rejects.toThrow(
+        'Failed to delete account'
+      )
+    })
+  })
+})

--- a/lib/client/adminAccounts.ts
+++ b/lib/client/adminAccounts.ts
@@ -1,0 +1,99 @@
+import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
+
+export interface AdminAccountFilters {
+  origin?: 'local' | 'remote'
+  status?: 'active' | 'pending' | 'disabled' | 'silenced' | 'suspended'
+  username?: string
+  byDomain?: string
+}
+
+export const getAdminAccounts = async (
+  filters: AdminAccountFilters = {}
+): Promise<AdminAccount[]> => {
+  const params = new URLSearchParams()
+  if (filters.origin) params.set('origin', filters.origin)
+  if (filters.status) params.set('status', filters.status)
+  if (filters.username) params.set('username', filters.username)
+  if (filters.byDomain) params.set('by_domain', filters.byDomain)
+  const query = params.toString()
+  const response = await fetch(
+    `/api/v2/admin/accounts${query ? `?${query}` : ''}`,
+    { headers: { Accept: 'application/json' }, credentials: 'include' }
+  )
+  if (!response.ok) throw new Error('Failed to load admin accounts')
+  return (await response.json()) as AdminAccount[]
+}
+
+export const getAdminAccount = async (id: string): Promise<AdminAccount> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include'
+  })
+  if (!response.ok) throw new Error('Failed to load admin account')
+  return (await response.json()) as AdminAccount
+}
+
+export type AdminAccountActionType =
+  'none' | 'disable' | 'sensitive' | 'silence' | 'suspend'
+
+export interface PerformAdminAccountActionParams {
+  id: string
+  type: AdminAccountActionType
+  reportId?: string
+  text?: string
+}
+
+export const performAdminAccountAction = async ({
+  id,
+  type,
+  reportId,
+  text
+}: PerformAdminAccountActionParams): Promise<void> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}/action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      type,
+      ...(reportId ? { report_id: reportId } : {}),
+      ...(text ? { text } : {})
+    })
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to perform account action')
+  }
+}
+
+const adminAccountStateChange =
+  (action: string) =>
+  async (id: string): Promise<AdminAccount> => {
+    const response = await fetch(`/api/v1/admin/accounts/${id}/${action}`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => null)
+      throw new Error(error?.error ?? `Failed to ${action} account`)
+    }
+    return (await response.json()) as AdminAccount
+  }
+
+export const adminEnableAccount = adminAccountStateChange('enable')
+export const adminUnsilenceAccount = adminAccountStateChange('unsilence')
+export const adminUnsuspendAccount = adminAccountStateChange('unsuspend')
+export const adminUnsensitiveAccount = adminAccountStateChange('unsensitive')
+export const adminApproveAccount = adminAccountStateChange('approve')
+export const adminRejectAccount = adminAccountStateChange('reject')
+
+export const adminDeleteAccount = async (id: string): Promise<AdminAccount> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
+    method: 'DELETE',
+    credentials: 'include'
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to delete account')
+  }
+  return (await response.json()) as AdminAccount
+}

--- a/lib/client/adminReports.test.ts
+++ b/lib/client/adminReports.test.ts
@@ -1,0 +1,210 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+import {
+  assignAdminReportToSelf,
+  getAdminReport,
+  getAdminReports,
+  reopenAdminReport,
+  resolveAdminReport,
+  unassignAdminReport,
+  updateAdminReport
+} from './adminReports'
+
+describe('adminReports client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const mockAdminReport: AdminReport = {
+    id: 'report-1',
+    action_taken: false,
+    action_taken_at: null,
+    category: 'spam',
+    comment: 'spamming links',
+    forwarded: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    account: {} as AdminReport['account'],
+    target_account: {} as AdminReport['target_account'],
+    assigned_account: null,
+    action_taken_by_account: null,
+    statuses: [],
+    rules: []
+  }
+
+  describe('getAdminReports', () => {
+    it('fetches reports without query param when resolved is undefined', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAdminReport]), {
+        status: 200
+      })
+
+      const result = await getAdminReports()
+
+      expect(result).toEqual([mockAdminReport])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/reports', {
+        headers: { Accept: 'application/json' },
+        credentials: 'include'
+      })
+    })
+
+    it('fetches reports with resolved=true', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAdminReport]), {
+        status: 200
+      })
+
+      await getAdminReports(true)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/reports?resolved=true',
+        {
+          headers: { Accept: 'application/json' },
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('fetches reports with resolved=false', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockAdminReport]), {
+        status: 200
+      })
+
+      await getAdminReports(false)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/reports?resolved=false',
+        {
+          headers: { Accept: 'application/json' },
+          credentials: 'include'
+        }
+      )
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(getAdminReports()).rejects.toThrow(
+        'Failed to load admin reports'
+      )
+    })
+  })
+
+  describe('getAdminReport', () => {
+    it('fetches report by id', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockAdminReport), {
+        status: 200
+      })
+
+      const result = await getAdminReport('report-1')
+
+      expect(result).toEqual(mockAdminReport)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/reports/report-1', {
+        headers: { Accept: 'application/json' },
+        credentials: 'include'
+      })
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 })
+
+      await expect(getAdminReport('report-1')).rejects.toThrow(
+        'Failed to load admin report'
+      )
+    })
+  })
+
+  describe('updateAdminReport', () => {
+    it('sends PUT request with category and ruleIds', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockAdminReport), {
+        status: 200
+      })
+
+      const result = await updateAdminReport({
+        id: 'report-1',
+        category: 'violation',
+        ruleIds: ['rule-1', 'rule-2']
+      })
+
+      expect(result).toEqual(mockAdminReport)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/reports/report-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          category: 'violation',
+          rule_ids: ['rule-1', 'rule-2']
+        })
+      })
+    })
+
+    it('throws custom error message from response', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Invalid report category' }),
+        { status: 422 }
+      )
+
+      await expect(
+        updateAdminReport({ id: 'report-1', category: 'spam' })
+      ).rejects.toThrow('Invalid report category')
+    })
+
+    it('throws fallback error when response has no error payload', async () => {
+      fetchMock.mockResponseOnce('Server error', { status: 500 })
+
+      await expect(
+        updateAdminReport({ id: 'report-1', category: 'spam' })
+      ).rejects.toThrow('Failed to update report')
+    })
+  })
+
+  describe('admin report actions', () => {
+    const actions = [
+      {
+        name: 'assignAdminReportToSelf',
+        fn: assignAdminReportToSelf,
+        endpoint: 'assign_to_self'
+      },
+      {
+        name: 'unassignAdminReport',
+        fn: unassignAdminReport,
+        endpoint: 'unassign'
+      },
+      {
+        name: 'resolveAdminReport',
+        fn: resolveAdminReport,
+        endpoint: 'resolve'
+      },
+      { name: 'reopenAdminReport', fn: reopenAdminReport, endpoint: 'reopen' }
+    ]
+
+    for (const { name, fn, endpoint } of actions) {
+      it(`${name} calls endpoint and returns report`, async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(mockAdminReport), {
+          status: 200
+        })
+
+        const result = await fn('report-1')
+
+        expect(result).toEqual(mockAdminReport)
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/api/v1/admin/reports/report-1/${endpoint}`,
+          {
+            method: 'POST',
+            credentials: 'include'
+          }
+        )
+      })
+
+      it(`${name} throws error when request fails`, async () => {
+        fetchMock.mockResponseOnce(
+          JSON.stringify({ error: `Could not ${endpoint}` }),
+          { status: 400 }
+        )
+
+        await expect(fn('report-1')).rejects.toThrow(`Could not ${endpoint}`)
+      })
+    }
+  })
+})

--- a/lib/client/adminReports.ts
+++ b/lib/client/adminReports.ts
@@ -1,0 +1,73 @@
+import type { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+import type { ReportCategory } from './accounts'
+
+export interface UpdateAdminReportParams {
+  id: string
+  category?: ReportCategory
+  ruleIds?: string[]
+}
+
+export const getAdminReports = async (
+  resolved?: boolean
+): Promise<AdminReport[]> => {
+  const params = new URLSearchParams()
+  if (resolved !== undefined)
+    params.set('resolved', resolved ? 'true' : 'false')
+  const query = params.toString()
+  const response = await fetch(
+    `/api/v1/admin/reports${query ? `?${query}` : ''}`,
+    { headers: { Accept: 'application/json' }, credentials: 'include' }
+  )
+  if (!response.ok) throw new Error('Failed to load admin reports')
+  return (await response.json()) as AdminReport[]
+}
+
+export const getAdminReport = async (id: string): Promise<AdminReport> => {
+  const response = await fetch(`/api/v1/admin/reports/${id}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include'
+  })
+  if (!response.ok) throw new Error('Failed to load admin report')
+  return (await response.json()) as AdminReport
+}
+
+export const updateAdminReport = async ({
+  id,
+  category,
+  ruleIds
+}: UpdateAdminReportParams): Promise<AdminReport> => {
+  const response = await fetch(`/api/v1/admin/reports/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      ...(category ? { category } : {}),
+      ...(ruleIds ? { rule_ids: ruleIds } : {})
+    })
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to update report')
+  }
+  return (await response.json()) as AdminReport
+}
+
+const adminReportAction =
+  (action: string) =>
+  async (id: string): Promise<AdminReport> => {
+    const response = await fetch(`/api/v1/admin/reports/${id}/${action}`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => null)
+      throw new Error(error?.error ?? `Failed to ${action} report`)
+    }
+    return (await response.json()) as AdminReport
+  }
+
+export const assignAdminReportToSelf = adminReportAction('assign_to_self')
+export const unassignAdminReport = adminReportAction('unassign')
+export const resolveAdminReport = adminReportAction('resolve')
+export const reopenAdminReport = adminReportAction('reopen')

--- a/lib/client/adminServerSettings.test.ts
+++ b/lib/client/adminServerSettings.test.ts
@@ -1,0 +1,82 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import {
+  type AdminServerSettingsResponse,
+  getAdminServerSettings,
+  updateAdminServerSettings
+} from './adminServerSettings'
+
+describe('adminServerSettings client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const mockResponse: AdminServerSettingsResponse = {
+    settings: {
+      serverTitle: 'My ActivityPub Server',
+      serverDescription: 'A test server'
+    } as unknown as ResolvedServerSettings,
+    locks: {
+      serverTitle: { locked: false }
+    }
+  }
+
+  describe('getAdminServerSettings', () => {
+    it('fetches server settings successfully', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), { status: 200 })
+
+      const result = await getAdminServerSettings()
+
+      expect(result).toEqual(mockResponse)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/server_settings', {
+        headers: { Accept: 'application/json' }
+      })
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 })
+
+      await expect(getAdminServerSettings()).rejects.toThrow(
+        'Failed to load server settings'
+      )
+    })
+  })
+
+  describe('updateAdminServerSettings', () => {
+    it('updates server settings with PATCH', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), { status: 200 })
+
+      const patch = { serverTitle: 'Updated Server' }
+      const result = await updateAdminServerSettings(patch)
+
+      expect(result).toEqual(mockResponse)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/server_settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch)
+      })
+    })
+
+    it('throws custom error message from server', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ error: 'Server title is locked by env' }),
+        { status: 422 }
+      )
+
+      await expect(
+        updateAdminServerSettings({ serverTitle: 'Blocked' })
+      ).rejects.toThrow('Server title is locked by env')
+    })
+
+    it('throws default error message when server error has no json error payload', async () => {
+      fetchMock.mockResponseOnce('Non-JSON error', { status: 500 })
+
+      await expect(
+        updateAdminServerSettings({ serverTitle: 'Blocked' })
+      ).rejects.toThrow('Failed to save server settings')
+    })
+  })
+})

--- a/lib/client/adminServerSettings.ts
+++ b/lib/client/adminServerSettings.ts
@@ -1,0 +1,35 @@
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+// Database-backed admin server settings. Resolved values plus per-field lock
+// metadata (env-pinned fields are locked and reject writes).
+export interface AdminServerSettingsResponse {
+  settings: ResolvedServerSettings
+  locks: Record<string, { locked: boolean; envVar?: string }>
+}
+
+export const getAdminServerSettings =
+  async (): Promise<AdminServerSettingsResponse> => {
+    const response = await fetch('/api/v1/admin/server_settings', {
+      headers: { Accept: 'application/json' }
+    })
+    if (!response.ok) throw new Error('Failed to load server settings')
+    return (await response.json()) as AdminServerSettingsResponse
+  }
+
+// Partial { key: value } patch. Env-locked, unknown, or invalid keys are
+// rejected server-side and nothing is written; the thrown message surfaces to
+// the form.
+export const updateAdminServerSettings = async (
+  patch: Record<string, unknown>
+): Promise<AdminServerSettingsResponse> => {
+  const response = await fetch('/api/v1/admin/server_settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch)
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to save server settings')
+  }
+  return (await response.json()) as AdminServerSettingsResponse
+}

--- a/lib/client/notifications.test.ts
+++ b/lib/client/notifications.test.ts
@@ -1,0 +1,39 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { markNotificationsRead } from './notifications'
+
+describe('notifications client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  describe('markNotificationsRead', () => {
+    it('sends notification IDs and returns true on success', async () => {
+      fetchMock.mockResponseOnce('{}', { status: 200 })
+
+      const result = await markNotificationsRead({
+        notificationIds: ['notif-1', 'notif-2']
+      })
+
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/notifications/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          notification_ids: ['notif-1', 'notif-2']
+        })
+      })
+    })
+
+    it('returns false when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Unauthorized', { status: 401 })
+
+      const result = await markNotificationsRead({
+        notificationIds: ['notif-1']
+      })
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/lib/client/notifications.ts
+++ b/lib/client/notifications.ts
@@ -1,0 +1,21 @@
+export interface MarkNotificationsReadParams {
+  notificationIds: string[]
+}
+
+/**
+ * Marks the given notifications as read for the current actor
+ */
+export const markNotificationsRead = async ({
+  notificationIds
+}: MarkNotificationsReadParams) => {
+  const response = await fetch('/api/v1/notifications/read', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      notification_ids: notificationIds
+    })
+  })
+  return response.ok
+}

--- a/lib/client/passkeys.test.ts
+++ b/lib/client/passkeys.test.ts
@@ -1,0 +1,50 @@
+import fetchMock from 'jest-fetch-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { type Passkey, getPasskeys } from './passkeys'
+
+describe('passkeys client module', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  const mockPasskey: Passkey = {
+    id: 'passkey-1',
+    name: 'My MacBook',
+    domain: 'example.com',
+    deviceType: 'singleDevice',
+    backedUp: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    aaguid: null
+  }
+
+  describe('getPasskeys', () => {
+    it('fetches and returns passkeys array', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([mockPasskey]), { status: 200 })
+
+      const result = await getPasskeys()
+
+      expect(result).toEqual([mockPasskey])
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/passkeys', {
+        method: 'GET',
+        credentials: 'include'
+      })
+    })
+
+    it('returns empty array when response payload is not an array', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ notAnArray: true }), {
+        status: 200
+      })
+
+      const result = await getPasskeys()
+
+      expect(result).toEqual([])
+    })
+
+    it('throws error when response is not ok', async () => {
+      fetchMock.mockResponseOnce('Unauthorized', { status: 401 })
+
+      await expect(getPasskeys()).rejects.toThrow('Failed to load passkeys')
+    })
+  })
+})

--- a/lib/client/passkeys.ts
+++ b/lib/client/passkeys.ts
@@ -1,0 +1,27 @@
+// A passkey as returned by `GET /api/v1/passkeys`, including the domain it was
+// registered on (a WebAuthn credential is bound to one domain).
+export interface Passkey {
+  id: string
+  name: string | null
+  domain: string
+  deviceType: string
+  backedUp: boolean
+  createdAt: string
+  aaguid: string | null
+}
+
+/**
+ * Lists the signed-in account's passkeys with the domain each is bound to.
+ * @see app/api/v1/passkeys/route.ts
+ */
+export const getPasskeys = async (): Promise<Passkey[]> => {
+  const response = await fetch('/api/v1/passkeys', {
+    method: 'GET',
+    credentials: 'include'
+  })
+  if (!response.ok) {
+    throw new Error('Failed to load passkeys')
+  }
+  const data = await response.json()
+  return Array.isArray(data) ? data : []
+}


### PR DESCRIPTION
## Summary
Extracts admin operations and notifications read helper from `lib/client.ts` into modular files under `lib/client/`:
- `updateAdminServerSettings` and `getAdminServerSettings` -> `lib/client/adminServerSettings.ts`
- `getPasskeys` -> `lib/client/passkeys.ts`
- `markNotificationsRead` -> `lib/client/notifications.ts`
- Admin Accounts operations (`getAdminAccounts`, `getAdminAccount`, `performAdminAccountAction`, `adminDeleteAccount`, state change actions) -> `lib/client/adminAccounts.ts`
- Admin Reports operations (`getAdminReports`, `getAdminReport`, `updateAdminReport`, report actions) -> `lib/client/adminReports.ts`
- Re-exported all extracted functions from `lib/client.ts`
- Added comprehensive unit tests for each new module

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)