### PR TITLE
Bump version to v1.161.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.41",
+  "version": "1.161.42",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.42.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.41`
- Base main SHA: `16994372f495efeeb094e0ff9b00a77cb78173b7`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
