### PR TITLE
Bump version to v1.161.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.42",
+  "version": "1.161.43",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.43.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.42`
- Base main SHA: `7e56296b5a35816ce19e3a3821d8865fdd9d9328`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
