### PR TITLE
Bump version to v1.161.44

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.43",
+  "version": "1.161.44",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.44.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.43`
- Base main SHA: `19817442d2be8e33ae25afd6a402b6a607f4eb68`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
