### PR TITLE
test: resolve types for utils and types tests

### DIFF
--- a/lib/types/domain/status.test.ts
+++ b/lib/types/domain/status.test.ts
@@ -1,5 +1,6 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
+import { BaseNote } from '@/lib/activities/note'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { mockRequests } from '@/lib/stub/activities'
@@ -7,6 +8,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { MockMastodonActivityPubNote } from '@/lib/stub/note'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { Document } from '@/lib/types/activitypub/objects'
 import { Actor } from '@/lib/types/domain/actor'
 import {
   Status,
@@ -230,8 +232,8 @@ describe('Status', () => {
   })
 
   describe('toActivityPubObject', () => {
-    let actor1: Actor | undefined
-    let actor2: Actor | undefined
+    let actor1: Actor | null | undefined
+    let actor2: Actor | null | undefined
 
     beforeAll(async () => {
       actor1 = await database.getActorFromUsername({
@@ -443,7 +445,9 @@ describe('Status', () => {
           ? note.attachment
           : []
         expect(attachments).toHaveLength(MAX_FEDERATION_MEDIA_ATTACHMENTS)
-        expect(attachments.map((attachment) => attachment.url)).toEqual(
+        expect(
+          attachments.map((attachment) => (attachment as Document).url)
+        ).toEqual(
           Array.from(
             { length: MAX_FEDERATION_MEDIA_ATTACHMENTS },
             (_, index) => `https://example.com/files/image-${index}.png`

--- a/lib/utils/mapkit.test.ts
+++ b/lib/utils/mapkit.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/client', () => ({
   getAppleMapsToken: vi.fn()

--- a/lib/utils/maplibre.test.ts
+++ b/lib/utils/maplibre.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const removeInjected = () => {
   document

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -324,7 +324,8 @@ describe('safeRemoteFetch', () => {
 
   it('only allows loopback addresses for the development localhost exception', async () => {
     const originalNodeEnv = process.env.NODE_ENV
-    process.env.NODE_ENV = 'development'
+    const env = process.env as Record<string, string | undefined>
+    env.NODE_ENV = 'development'
     try {
       const safeRemoteFetch = createSafeRemoteFetch({
         resolveHost: async () => [{ address: '10.0.0.5', family: 4 }],
@@ -336,9 +337,9 @@ describe('safeRemoteFetch', () => {
       ).rejects.toThrow('Unsafe remote address')
     } finally {
       if (typeof originalNodeEnv === 'undefined') {
-        delete process.env.NODE_ENV
+        delete env.NODE_ENV
       } else {
-        process.env.NODE_ENV = originalNodeEnv
+        env.NODE_ENV = originalNodeEnv
       }
     }
   })

--- a/lib/utils/text/getMentions.test.ts
+++ b/lib/utils/text/getMentions.test.ts
@@ -8,8 +8,8 @@ import { getMentions } from '@/lib/utils/text/getMentions'
 
 describe('getMentions', () => {
   const database = getTestSQLDatabase()
-  let actor1: Actor | undefined
-  let actor2: Actor | undefined
+  let actor1: Actor | null | undefined
+  let actor2: Actor | null | undefined
 
   beforeAll(async () => {
     await database.migrate()

--- a/lib/utils/traceApiRoute.ts
+++ b/lib/utils/traceApiRoute.ts
@@ -20,8 +20,8 @@ export interface TraceApiRouteOptions<P = unknown> {
     req: NextRequest,
     context: { params: Promise<P> }
   ) =>
-    | Promise<Record<string, string | number | boolean>>
-    | Record<string, string | number | boolean>
+    | Promise<Record<string, string | number | boolean | undefined>>
+    | Record<string, string | number | boolean | undefined>
 }
 
 export const parseCloudTraceContext = (

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -18,13 +18,6 @@
     // this list is empty, delete this file and point `yarn typecheck` at
 
     "lib/components/posts/status-translation.test.tsx",
-    "lib/types/domain/status.test.ts",
-    "lib/utils/getPersonFromActor.test.ts",
-    "lib/utils/mapkit.test.ts",
-    "lib/utils/maplibre.test.ts",
-    "lib/utils/safeRemoteFetch.test.ts",
-    "lib/utils/text/getMentions.test.ts",
-    "lib/utils/traceApiRoute.test.ts",
     "next.config.test.ts",
     "scripts/backup/productionArchive.test.ts",
     "scripts/fitness/gearImportPlan.test.ts"


### PR DESCRIPTION
Resolves types for 7 test files across utils and domain types and removes them from the tsconfig.typecheck.json exclude list:

1. `lib/types/domain/status.test.ts`
2. `lib/utils/getPersonFromActor.test.ts`
3. `lib/utils/mapkit.test.ts`
4. `lib/utils/maplibre.test.ts`
5. `lib/utils/safeRemoteFetch.test.ts`
6. `lib/utils/text/getMentions.test.ts`
7. `lib/utils/traceApiRoute.test.ts`