### PR TITLE
test: resolve types for components, config, and scripts tests

### DIFF
--- a/lib/components/posts/status-translation.test.tsx
+++ b/lib/components/posts/status-translation.test.tsx
@@ -45,6 +45,7 @@ const pollStatus: StatusPoll = {
   replies: [],
   actorAnnounceStatusId: null,
   isActorLiked: false,
+  isActorBookmarked: false,
   totalLikes: 0,
   totalShares: 0,
   attachments: [],

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -47,6 +47,14 @@ const withEnv = <T>(
   }
 }
 
+const setNodeEnv = (value?: string) => {
+  if (value === undefined) {
+    delete (process.env as Record<string, string | undefined>).NODE_ENV
+  } else {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = value
+  }
+}
+
 const getCspDirectiveSources = (directiveName: string) => {
   const csp = getSecurityHeaders().find(
     (header) => header.key === 'Content-Security-Policy'
@@ -76,7 +84,7 @@ describe('next config runtime isolation', () => {
     process.env.ACTIVITIES_ALLOW_MEDIA_DOMAINS = 'not-json'
     process.env.ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS = 'not-json'
     process.env.ACTIVITIES_HOST = 'build-host-should-not-be-used.example.com'
-    process.env.NODE_ENV = 'production'
+    setNodeEnv('production')
     fs.writeFileSync(
       path.join(tempDirectory, 'config.json'),
       JSON.stringify({
@@ -1083,7 +1091,7 @@ describe('next config security hardening', () => {
 
   it('uses static HTTPS image patterns in production', () => {
     const originalNodeEnv = process.env.NODE_ENV
-    process.env.NODE_ENV = 'production'
+    setNodeEnv('production')
 
     try {
       expect(getImageRemotePatterns()).toEqual([
@@ -1093,17 +1101,13 @@ describe('next config security hardening', () => {
         }
       ])
     } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV
-      } else {
-        process.env.NODE_ENV = originalNodeEnv
-      }
+      setNodeEnv(originalNodeEnv)
     }
   })
 
   it('allows safe local image hosts in development without app config', () => {
     const originalNodeEnv = process.env.NODE_ENV
-    process.env.NODE_ENV = 'development'
+    setNodeEnv('development')
 
     try {
       expect(getImageRemotePatterns()).toEqual([
@@ -1125,11 +1129,7 @@ describe('next config security hardening', () => {
         }
       ])
     } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV
-      } else {
-        process.env.NODE_ENV = originalNodeEnv
-      }
+      setNodeEnv(originalNodeEnv)
     }
   })
 })

--- a/scripts/backup/productionArchive.test.ts
+++ b/scripts/backup/productionArchive.test.ts
@@ -680,7 +680,7 @@ describe('production archive scripts', () => {
       database.on('query', (query) => {
         statements.push(query.sql)
       })
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       try {
         await database.schema.createTable('events', (table) => {
@@ -755,7 +755,7 @@ describe('production archive scripts', () => {
       database.on('query', (query) => {
         statements.push(query.sql)
       })
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       try {
         await database.schema.createTable('events', (table) => {
@@ -813,7 +813,7 @@ describe('production archive scripts', () => {
       database.on('query', (query) => {
         statements.push(query.sql)
       })
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       try {
         await database.schema.createTable('events', (table) => {
@@ -871,7 +871,7 @@ describe('production archive scripts', () => {
       database.on('query', (query) => {
         statements.push(query.sql)
       })
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       try {
         await database.schema.createTable('events', (table) => {
@@ -1105,8 +1105,8 @@ describe('production archive scripts', () => {
 
           return { Body: Readable.from([Buffer.from('ok')]) }
         }) as typeof S3Client.prototype.send)
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       try {
         await fs.mkdir(path.join(tempDir, 'storage', 'media', 'files'), {
@@ -1206,8 +1206,8 @@ describe('production archive scripts', () => {
           .mockImplementation((async () => {
             throw error
           }) as typeof S3Client.prototype.send)
-        const logSpy = vi.spyOn(console, 'log').mockImplementation()
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
         try {
           const manifest = await archiveStorage(
@@ -1242,8 +1242,8 @@ describe('production archive scripts', () => {
 
     it('keeps the local storage root out of a failed file entry', async () => {
       const missingRoot = path.join(tempDir, 'missing-storage-root')
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       try {
         const manifest = await archiveStorage(
@@ -1291,8 +1291,8 @@ describe('production archive scripts', () => {
       global.fetch = vi.fn(
         async () => new Response('nope', { status: 503 })
       ) as typeof fetch
-      const logSpy = vi.spyOn(console, 'log').mockImplementation()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       try {
         const manifest = await archiveStorage(

--- a/scripts/fitness/gearImportPlan.test.ts
+++ b/scripts/fitness/gearImportPlan.test.ts
@@ -1,5 +1,6 @@
 import {
   ImportGear,
+  ImportGearInput,
   MatchableFitnessFile,
   applyWindows,
   diffGearComponents,
@@ -8,7 +9,7 @@ import {
   parseGearImportFile
 } from './gearImportPlan'
 
-const gearEntry = (overrides: Partial<ImportGear> = {}) => ({
+const gearEntry = (overrides: Partial<ImportGearInput> = {}) => ({
   name: 'Moots',
   kind: 'bike' as const,
   ...overrides
@@ -581,13 +582,13 @@ describe('findUnattributedActivities', () => {
 })
 
 describe('applyWindows', () => {
-  const gear = (overrides: Partial<ImportGear> = {}) =>
+  const gear = (overrides: Partial<ImportGearInput> = {}) =>
     parseGearImportFile({
       gears: [{ name: 'Moots', kind: 'bike', ...overrides }],
       assignments: []
     })
 
-  const gearsOf = (overrides: Partial<ImportGear> = {}): ImportGear[] => {
+  const gearsOf = (overrides: Partial<ImportGearInput> = {}): ImportGear[] => {
     const result = gear(overrides)
     if (!result.ok) throw new Error(result.errors.join('; '))
     return result.file.gears

--- a/scripts/fitness/gearImportPlan.ts
+++ b/scripts/fitness/gearImportPlan.ts
@@ -144,6 +144,12 @@ export type ImportComponent = ImportGear['components'][number]
 export type ImportWindow = ImportGear['windows'][number]
 export type ImportAssignment = GearImportFile['assignments'][number]
 
+export type GearImportFileInput = z.input<typeof GearImportFileSchema>
+export type ImportGearInput = z.input<typeof ImportGearSchema>
+export type ImportComponentInput = z.input<typeof ImportComponentSchema>
+export type ImportWindowInput = z.input<typeof ImportWindowSchema>
+export type ImportAssignmentInput = z.input<typeof ImportAssignmentSchema>
+
 export type ParseGearImportFileResult =
   { ok: true; file: GearImportFile } | { ok: false; errors: string[] }
 

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -17,16 +17,12 @@
     // type-clean; NEVER add one — a new or edited test file must pass. When
     // this list is empty, delete this file and point `yarn typecheck` at
 
-    "lib/components/posts/status-translation.test.tsx",
     "lib/types/domain/status.test.ts",
     "lib/utils/getPersonFromActor.test.ts",
     "lib/utils/mapkit.test.ts",
     "lib/utils/maplibre.test.ts",
     "lib/utils/safeRemoteFetch.test.ts",
     "lib/utils/text/getMentions.test.ts",
-    "lib/utils/traceApiRoute.test.ts",
-    "next.config.test.ts",
-    "scripts/backup/productionArchive.test.ts",
-    "scripts/fitness/gearImportPlan.test.ts"
+    "lib/utils/traceApiRoute.test.ts"
   ]
 }


### PR DESCRIPTION
Resolves types for 4 test files across components, config, and scripts, removing them from `tsconfig.typecheck.json`:
- `lib/components/posts/status-translation.test.tsx`
- `next.config.test.ts`
- `scripts/backup/productionArchive.test.ts`
- `scripts/fitness/gearImportPlan.test.ts`