### PR TITLE
Bump version to v1.161.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.44",
+  "version": "1.161.45",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.45.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.44`
- Base main SHA: `6c9745e689d36d5346fe2d13b71ce651d83d6ff5`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
