### PR TITLE
Bump version to v1.161.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.45",
+  "version": "1.161.46",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.46.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.45`
- Base main SHA: `a03bc032ef071fd9f505d5aa2ebb89e3e872a994`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
