### PR TITLE
fix: remove nested boost rows by original status

### DIFF
--- a/app/(timeline)/bookmarks/BookmarksTimeline.test.tsx
+++ b/app/(timeline)/bookmarks/BookmarksTimeline.test.tsx
@@ -101,6 +101,12 @@ const boostedBookmarkedStatus: StatusAnnounce = {
   originalStatus: bookmarkedStatus
 }
 
+const nestedBoostedBookmarkedStatus: StatusAnnounce = {
+  ...boostedBookmarkedStatus,
+  id: 'https://activities.local/users/booster/statuses/boost-2',
+  originalStatus: boostedBookmarkedStatus
+}
+
 describe('BookmarksTimeline', () => {
   let intersectionObserverCallback:
     ((entries: IntersectionObserverEntry[]) => void) | null = null
@@ -241,6 +247,29 @@ describe('BookmarksTimeline', () => {
         currentActor={actor}
         currentTime={currentTime}
         statuses={[boostedBookmarkedStatus]}
+        initialNextMaxBookmarkId={null}
+      />
+    )
+
+    expect(screen.getByText('Bookmarked post')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove bookmark' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bookmarked post')).not.toBeInTheDocument()
+    })
+    expect(undoBookmarkStatus).toHaveBeenCalledWith({
+      statusId: bookmarkedStatus.id
+    })
+    expect(screen.getByText('No bookmarks yet')).toBeInTheDocument()
+  })
+
+  it('removes a nested boosted post when unbookmarking its root original', async () => {
+    render(
+      <BookmarksTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[nestedBoostedBookmarkedStatus]}
         initialNextMaxBookmarkId={null}
       />
     )

--- a/app/(timeline)/favorites/FavoritesTimeline.test.tsx
+++ b/app/(timeline)/favorites/FavoritesTimeline.test.tsx
@@ -101,6 +101,12 @@ const boostedFavouritedStatus: StatusAnnounce = {
   originalStatus: favouritedStatus
 }
 
+const nestedBoostedFavouritedStatus: StatusAnnounce = {
+  ...boostedFavouritedStatus,
+  id: 'https://activities.local/users/booster/statuses/boost-2',
+  originalStatus: boostedFavouritedStatus
+}
+
 describe('FavoritesTimeline', () => {
   let intersectionObserverCallback:
     ((entries: IntersectionObserverEntry[]) => void) | null = null
@@ -241,6 +247,29 @@ describe('FavoritesTimeline', () => {
         currentActor={actor}
         currentTime={currentTime}
         statuses={[boostedFavouritedStatus]}
+        initialNextMaxFavouriteId={null}
+      />
+    )
+
+    expect(screen.getByText('Favourited post')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Unlike/ }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Favourited post')).not.toBeInTheDocument()
+    })
+    expect(undoLikeStatus).toHaveBeenCalledWith({
+      statusId: favouritedStatus.id
+    })
+    expect(screen.getByText('No favorites yet')).toBeInTheDocument()
+  })
+
+  it('removes a nested boosted post when unliking its root original', async () => {
+    render(
+      <FavoritesTimeline
+        host="activities.local"
+        currentActor={actor}
+        currentTime={currentTime}
+        statuses={[nestedBoostedFavouritedStatus]}
         initialNextMaxFavouriteId={null}
       />
     )

--- a/lib/components/posts/statusArray.test.ts
+++ b/lib/components/posts/statusArray.test.ts
@@ -281,6 +281,50 @@ describe('removeOriginalStatus', () => {
     expect(result[0]).toBe(other)
   })
 
+  it('removes a nested Announce status when deleting by root original identity', () => {
+    const original = createNoteStatus('https://example.com/notes/target')
+    const innerBoost = createAnnounceStatus(
+      'https://example.com/boosts/inner',
+      original
+    )
+    const outerBoost = createAnnounceStatus(
+      'https://example.com/boosts/outer',
+      innerBoost
+    )
+    const other = createNoteStatus('https://example.com/notes/other')
+    const statuses: Status[] = [outerBoost, other]
+
+    const result = removeOriginalStatus(
+      statuses,
+      'https://example.com/notes/target'
+    )
+
+    expect(result).toEqual([other])
+    expect(result[0]).toBe(other)
+  })
+
+  it('removes an outer Announce status when deleting by its immediate wrapper identity', () => {
+    const original = createNoteStatus('https://example.com/notes/target')
+    const innerBoost = createAnnounceStatus(
+      'https://example.com/boosts/inner',
+      original
+    )
+    const outerBoost = createAnnounceStatus(
+      'https://example.com/boosts/outer',
+      innerBoost
+    )
+    const other = createNoteStatus('https://example.com/notes/other')
+    const statuses: Status[] = [outerBoost, other]
+
+    const result = removeOriginalStatus(
+      statuses,
+      'https://example.com/boosts/inner'
+    )
+
+    expect(result).toEqual([other])
+    expect(result[0]).toBe(other)
+  })
+
   it('removes repeated representations of one original (direct post and multiple boosts)', () => {
     const original = createNoteStatus('https://example.com/notes/target')
     const boost1 = createAnnounceStatus(

--- a/lib/components/posts/statusArray.ts
+++ b/lib/components/posts/statusArray.ts
@@ -2,7 +2,8 @@ import {
   Status,
   StatusNote,
   StatusPoll,
-  StatusType
+  StatusType,
+  getOriginalStatus
 } from '@/lib/types/domain/status'
 
 export type StatusTarget = string | { id: string }
@@ -52,13 +53,12 @@ export const removeOriginalStatus = (
   const targetId = typeof target === 'string' ? target : target.id
   let hasRemoval = false
   const updated = statuses.filter((item) => {
-    if (item.id === targetId) {
-      hasRemoval = true
-      return false
-    }
+    const originalStatus = getOriginalStatus(item)
     if (
-      item.type === StatusType.enum.Announce &&
-      item.originalStatus.id === targetId
+      item.id === targetId ||
+      originalStatus.id === targetId ||
+      (item.type === StatusType.enum.Announce &&
+        item.originalStatus.id === targetId)
     ) {
       hasRemoval = true
       return false


### PR DESCRIPTION
Deleting the root Note of a nested boost left the outer card in Favorites/Bookmarks/home after the shared status-array migration. Resolve the root original during removal while preserving row IDs and the previous immediate-wrapper match; interaction patching and pagination cursors remain unchanged.

Validation: Node 24; `yarn run prettier --write .` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test --maxWorkers=4` all pass. Four focused regressions cover nested root removal, intermediate wrapper removal, and Favorites/Bookmarks interaction callbacks; focused suites pass 29 tests. The initial three regressions failed before the fix.

Browser verification: local SQLite test account on the production build; deleting the root Note from the nested Favorites card immediately showed the empty state, and removing a bookmark immediately cleared Bookmarks. Bookmark creation normalizes to the original server-side, so the nested bookmark callback is additionally covered by the component regression. Screenshots waived by the user.

Independent Luna max review will run against this PR head before merge. No package version change.
