### PR TITLE
test: cover queue transactions in PostgreSQL CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,8 @@ jobs:
           echo "All test shards succeeded."
 
   # Bounded PostgreSQL integration test job covering database access layers:
-  # media, fitness files, gear, component periods, and heatmap tiles.
+  # media, fitness files, gear, component periods, heatmap tiles, queue jobs,
+  # and status deletion queue transactions.
   # Vitest worker concurrency is bounded (--maxWorkers=2) to avoid exhausting
   # database connections or overloading disposable service containers.
   test-pg:
@@ -196,7 +197,9 @@ jobs:
             lib/database/sql/fitnessFile.test.ts \
             lib/database/sql/fitnessGear.test.ts \
             lib/database/sql/fitnessGearComponentPeriods.test.ts \
-            lib/database/sql/fitnessRouteHeatmapTile.test.ts
+            lib/database/sql/fitnessRouteHeatmapTile.test.ts \
+            lib/database/sql/queueJob.test.ts \
+            lib/database/sql/statusDeletionQueue.test.ts
         env:
           TEST_DATABASE_TYPE: pg
           TEST_DATABASE_HOST: 127.0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,9 @@ yarn test --maxWorkers=2 \
   lib/database/sql/fitnessFile.test.ts \
   lib/database/sql/fitnessGear.test.ts \
   lib/database/sql/fitnessGearComponentPeriods.test.ts \
-  lib/database/sql/fitnessRouteHeatmapTile.test.ts
+  lib/database/sql/fitnessRouteHeatmapTile.test.ts \
+  lib/database/sql/queueJob.test.ts \
+  lib/database/sql/statusDeletionQueue.test.ts
 ```
 
 3. When finished, stop the container:

--- a/lib/database/sql/queueJob.test.ts
+++ b/lib/database/sql/queueJob.test.ts
@@ -512,33 +512,78 @@ describe('QueueJobDatabase', () => {
       expect(dlq?.errorStack).toBeDefined()
     })
 
-    it('safely handles corrupt non-JSON payload in queue_jobs without throwing', async () => {
+    // SQLite's JSON column accepts raw text, while PostgreSQL rejects invalid
+    // JSON before failQueueJobWithDeadLetter can exercise its fallback.
+    it.skipIf(process.env.TEST_DATABASE_TYPE === 'pg')(
+      'safely handles corrupt non-JSON payload in SQLite queue_jobs without throwing',
+      async () => {
+        await database.createQueueJob({
+          id: 'fail-dlq-corrupt-1',
+          name: 'deliverActivity',
+          payload: samplePayload
+        })
+
+        const claim = await database.claimQueueJob({
+          id: 'fail-dlq-corrupt-1'
+        })
+        expect(claim).not.toBeNull()
+
+        // Corrupt the payload directly in the database after claim
+        await knexDatabase('queue_jobs')
+          .where({ id: 'fail-dlq-corrupt-1' })
+          .update({ payload: 'corrupt-non-json-payload{{{' })
+
+        const success = await database.failQueueJobWithDeadLetter({
+          id: 'fail-dlq-corrupt-1',
+          claimToken: claim!.claimToken,
+          attempts: 16,
+          error: new Error('Corrupt job terminal error')
+        })
+
+        expect(success).toBe(true)
+
+        const dlq = await database.getDeadLetterJobById('fail-dlq-corrupt-1')
+        expect(dlq).not.toBeNull()
+        expect(dlq?.payload).toEqual({ raw: 'corrupt-non-json-payload{{{' })
+      }
+    )
+
+    it('preserves a valid but logically malformed JSON payload in the dead-letter record', async () => {
+      const malformedPayload = {
+        malformed: true,
+        raw: 'payload-without-job-fields'
+      }
+
       await database.createQueueJob({
-        id: 'fail-dlq-corrupt-1',
+        id: 'fail-dlq-malformed-json-1',
         name: 'deliverActivity',
         payload: samplePayload
       })
 
-      const claim = await database.claimQueueJob({ id: 'fail-dlq-corrupt-1' })
+      const claim = await database.claimQueueJob({
+        id: 'fail-dlq-malformed-json-1'
+      })
       expect(claim).not.toBeNull()
 
-      // Corrupt the payload directly in the database after claim
+      // JSON columns accept this value on every backend, even though it is not
+      // a complete JobMessage. Dead-lettering must preserve the payload data.
       await knexDatabase('queue_jobs')
-        .where({ id: 'fail-dlq-corrupt-1' })
-        .update({ payload: 'corrupt-non-json-payload{{{' })
+        .where({ id: 'fail-dlq-malformed-json-1' })
+        .update({ payload: JSON.stringify(malformedPayload) })
 
       const success = await database.failQueueJobWithDeadLetter({
-        id: 'fail-dlq-corrupt-1',
+        id: 'fail-dlq-malformed-json-1',
         claimToken: claim!.claimToken,
         attempts: 16,
-        error: new Error('Corrupt job terminal error')
+        error: new Error('Malformed job terminal error')
       })
 
       expect(success).toBe(true)
 
-      const dlq = await database.getDeadLetterJobById('fail-dlq-corrupt-1')
-      expect(dlq).not.toBeNull()
-      expect(dlq?.payload).toEqual({ raw: 'corrupt-non-json-payload{{{' })
+      const dlq = await database.getDeadLetterJobById(
+        'fail-dlq-malformed-json-1'
+      )
+      expect(dlq?.payload).toEqual(malformedPayload)
     })
   })
 


### PR DESCRIPTION
The queue dead-letter test injected invalid JSON into a PostgreSQL JSON column, so it failed before exercising terminal settlement. Keep the raw-storage corruption case on SQLite and exercise valid JSON with an invalid logical job shape on both backends.

Add queue ownership/failure/replay and atomic status-deletion suites to the existing bounded PostgreSQL CI job, preserving its other suites, worker limit, and CI Success dependency. Update the contributor command accordingly.

Validation: Node24; ordered prettier → lint → typecheck → build → full `yarn test --maxWorkers=4` all pass. Expanded seven-suite run on disposable localhost PostgreSQL17: 310 tests pass, one explicitly SQLite-only corruption case skipped. Focused SQLite queue/deletion run:31 tests pass. No production query/schema changes or version edits.

Two independent Luna max review angles will run against this PR before merge.
