### PR TITLE
fix: drain and close the queue worker once on shutdown

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,7 @@ Instance administrators can inspect terminally failed tasks, view formatted payl
 - **Database Queue (`ACTIVITIES_QUEUE_TYPE=database`)**:
   - Tasks are persisted directly into the `queue_jobs` table in the database.
   - Processed asynchronously by the in-process runner (bootstrapped via `instrumentation.ts` when configured) or by a standalone worker process (`scripts/maintenance/runQueueWorker.ts`).
+  - The standalone worker handles `SIGINT` and `SIGTERM` through one idempotent shutdown operation: it drains the runner, then closes the database within a shared 30-second deadline. Repeated signals do not bypass the drain. A failed or expired shutdown exits unsuccessfully, leaving any unfinished processing claim reclaimable by the queue's stalled-job recovery.
   - Workers atomically claim batches of due jobs (`pending` -> `processing`) using unique UUID ownership tokens (`claim_token`). Completion, retry, and failure settlement require matching the active token.
   - Operational note: Old workers must be drained before a mixed-version rollout to ensure claims are settled with compatible token parameters. Claim tokens protect against concurrent or stale queue state transitions, but do not promise exactly-once external effects.
   - Unhandled job errors trigger polynomial backoff retry scheduling (`attempt^4 + 15` seconds, up to `ACTIVITIES_QUEUE_DATABASE_MAX_RETRIES` / default 16 attempts spanning ~7.5 days, matching Mastodon queue retry resilience).

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -2,6 +2,21 @@
 
 This guide covers maintenance and administrative scripts available in Activity.next.
 
+## Database Queue Worker
+
+When the database queue runs in a separate process, start the worker with the
+same environment and local database configuration as the application:
+
+```bash
+node scripts/run.cjs scripts/maintenance/runQueueWorker.ts
+```
+
+`SIGINT` and `SIGTERM` share one shutdown operation. The worker stops accepting
+new queue work, waits for the current runner tick to drain, and then closes the
+database within a 30-second deadline. Repeated signals keep waiting for that
+same operation. A failed or expired shutdown exits unsuccessfully; any claim
+left in progress remains eligible for stalled-job recovery.
+
 ## Media Storage Cleanup
 
 The `cleanupMediaStorage.ts` script helps you clean up orphaned media files that are no longer referenced in the database. This is useful for reclaiming storage space after content deletion or database recovery.

--- a/scripts/maintenance/runQueueWorker.ts
+++ b/scripts/maintenance/runQueueWorker.ts
@@ -5,6 +5,8 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { startDatabaseQueueRunner } from '@/lib/services/queue/databaseRunner'
 
+import { createQueueWorkerShutdown } from './runQueueWorkerLifecycle'
+
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
 
@@ -27,31 +29,40 @@ async function runQueueWorker() {
     pollIntervalMs
   })
 
-  let isShuttingDown = false
-  const shutdown = async (signal: string) => {
-    if (isShuttingDown) {
-      console.log(`Received ${signal} again, forcing immediate exit...`)
-      process.exit(1)
+  const shutdownQueueWorker = createQueueWorkerShutdown({
+    runner,
+    database
+  })
+  let shutdownExitPromise: Promise<void> | undefined
+  const shutdown = (signal: string) => {
+    if (shutdownExitPromise) {
+      return shutdownExitPromise
     }
-    isShuttingDown = true
+
     console.log(`Received ${signal}. Shutting down queue worker gracefully...`)
 
-    const forceExitTimer = setTimeout(() => {
-      console.error('Graceful shutdown timed out after 30s. Forcing exit.')
-      process.exit(1)
-    }, 30000)
-    forceExitTimer.unref()
+    shutdownExitPromise = shutdownQueueWorker()
+      .then((result) => {
+        if (result.succeeded) {
+          console.log('Queue worker drained and database closed successfully.')
+          process.exit(0)
+          return
+        }
 
-    try {
-      await runner.stop()
-      console.log('Queue worker drained and stopped successfully.')
-      clearTimeout(forceExitTimer)
-      process.exit(0)
-    } catch (error) {
-      console.error('Error while stopping queue worker:', error)
-      clearTimeout(forceExitTimer)
-      process.exit(1)
-    }
+        for (const failure of result.failures) {
+          console.error(
+            `Error while shutting down queue worker (${failure.stage}):`,
+            failure.error
+          )
+        }
+        process.exit(1)
+      })
+      .catch((error) => {
+        console.error('Unexpected queue worker shutdown error:', error)
+        process.exit(1)
+      })
+
+    return shutdownExitPromise
   }
 
   process.on('SIGINT', () => {

--- a/scripts/maintenance/runQueueWorkerLifecycle.test.ts
+++ b/scripts/maintenance/runQueueWorkerLifecycle.test.ts
@@ -1,0 +1,194 @@
+import { createDeferred } from '@/lib/testing/deferred'
+
+import {
+  QUEUE_WORKER_SHUTDOWN_TIMEOUT_MS,
+  QueueWorkerShutdownTimeoutError,
+  createQueueWorkerShutdown
+} from './runQueueWorkerLifecycle'
+
+describe('createQueueWorkerShutdown', () => {
+  it('stops the runner before destroying the database', async () => {
+    const events: string[] = []
+    const runner = {
+      stop: vi.fn(async () => {
+        events.push('runner.stop')
+      })
+    }
+    const database = {
+      destroy: vi.fn(async () => {
+        events.push('database.destroy')
+      })
+    }
+
+    const result = await createQueueWorkerShutdown({
+      runner,
+      database
+    })()
+
+    expect(result).toEqual({ succeeded: true, failures: [] })
+    expect(events).toEqual(['runner.stop', 'database.destroy'])
+  })
+
+  it('coalesces repeated signals into one shutdown operation', async () => {
+    const stopDeferred = createDeferred<void>()
+    const runner = { stop: vi.fn(() => stopDeferred.promise) }
+    const database = { destroy: vi.fn(async () => undefined) }
+    const shutdown = createQueueWorkerShutdown({ runner, database })
+
+    const first = shutdown()
+    const second = shutdown()
+
+    expect(second).toBe(first)
+    await Promise.resolve()
+    expect(runner.stop).toHaveBeenCalledTimes(1)
+    expect(database.destroy).not.toHaveBeenCalled()
+
+    stopDeferred.resolve(undefined)
+    await first
+    expect(database.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys the database when runner stop rejects and reports failure', async () => {
+    const stopError = new Error('runner stop failed')
+    const runner = {
+      stop: vi.fn(async () => {
+        throw stopError
+      })
+    }
+    const database = { destroy: vi.fn(async () => undefined) }
+
+    const result = await createQueueWorkerShutdown({
+      runner,
+      database
+    })()
+
+    expect(result.succeeded).toBe(false)
+    expect(result.failures).toEqual([
+      { stage: 'runner.stop', error: stopError }
+    ])
+    expect(database.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports database destruction failure after a successful drain', async () => {
+    const destroyError = new Error('database destroy failed')
+    const runner = { stop: vi.fn(async () => undefined) }
+    const database = {
+      destroy: vi.fn(async () => {
+        throw destroyError
+      })
+    }
+
+    const result = await createQueueWorkerShutdown({
+      runner,
+      database
+    })()
+
+    expect(result.succeeded).toBe(false)
+    expect(result.failures).toEqual([
+      { stage: 'database.destroy', error: destroyError }
+    ])
+  })
+
+  it('fails when runner stop hangs until the shared deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const runner = { stop: vi.fn(() => createDeferred<void>().promise) }
+      const database = { destroy: vi.fn(async () => undefined) }
+      const shutdown = createQueueWorkerShutdown({
+        runner,
+        database,
+        timeoutMs: 20
+      })
+
+      const resultPromise = shutdown()
+      await vi.advanceTimersByTimeAsync(20)
+      const result = await resultPromise
+
+      expect(result.succeeded).toBe(false)
+      expect(result.failures).toHaveLength(1)
+      expect(result.failures[0]?.stage).toBe('runner.stop')
+      expect(result.failures[0]?.error).toBeInstanceOf(
+        QueueWorkerShutdownTimeoutError
+      )
+      expect(database.destroy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails when database destruction hangs until the shared deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const destroyDeferred = createDeferred<void>()
+      const runner = { stop: vi.fn(async () => undefined) }
+      const database = {
+        destroy: vi.fn(() => destroyDeferred.promise)
+      }
+      const shutdown = createQueueWorkerShutdown({
+        runner,
+        database,
+        timeoutMs: 20
+      })
+
+      const resultPromise = shutdown()
+      await vi.advanceTimersByTimeAsync(20)
+      const result = await resultPromise
+
+      expect(result.succeeded).toBe(false)
+      expect(result.failures[0]?.stage).toBe('database.destroy')
+      expect(result.failures[0]?.error).toBeInstanceOf(
+        QueueWorkerShutdownTimeoutError
+      )
+      expect(runner.stop).toHaveBeenCalledTimes(1)
+      expect(database.destroy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses the remaining shared deadline for database destruction', async () => {
+    vi.useFakeTimers()
+    try {
+      const destroyDeferred = createDeferred<void>()
+      const runner = {
+        stop: vi.fn(
+          () => new Promise<void>((resolve) => setTimeout(resolve, 15))
+        )
+      }
+      const database = {
+        destroy: vi.fn(() => destroyDeferred.promise)
+      }
+      const shutdown = createQueueWorkerShutdown({
+        runner,
+        database,
+        timeoutMs: 20
+      })
+
+      const resultPromise = shutdown()
+      let settled = false
+      void resultPromise.then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(15)
+      expect(database.destroy).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(4)
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      const result = await resultPromise
+
+      expect(result.succeeded).toBe(false)
+      expect(result.failures[0]?.stage).toBe('database.destroy')
+      expect(result.failures[0]?.error).toBeInstanceOf(
+        QueueWorkerShutdownTimeoutError
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses the documented 30 second default deadline', () => {
+    expect(QUEUE_WORKER_SHUTDOWN_TIMEOUT_MS).toBe(30_000)
+  })
+})

--- a/scripts/maintenance/runQueueWorkerLifecycle.ts
+++ b/scripts/maintenance/runQueueWorkerLifecycle.ts
@@ -1,0 +1,113 @@
+export const QUEUE_WORKER_SHUTDOWN_TIMEOUT_MS = 30_000
+
+export type QueueWorkerShutdownFailureStage = 'runner.stop' | 'database.destroy'
+
+export interface QueueWorkerShutdownFailure {
+  stage: QueueWorkerShutdownFailureStage
+  error: unknown
+}
+
+export interface QueueWorkerShutdownResult {
+  succeeded: boolean
+  failures: QueueWorkerShutdownFailure[]
+}
+
+export interface QueueWorkerShutdownRunner {
+  stop: () => Promise<void>
+}
+
+export interface QueueWorkerShutdownDatabase {
+  destroy: () => Promise<void>
+}
+
+export interface CreateQueueWorkerShutdownOptions {
+  runner: QueueWorkerShutdownRunner
+  database: QueueWorkerShutdownDatabase
+  timeoutMs?: number
+}
+
+export class QueueWorkerShutdownTimeoutError extends Error {
+  constructor() {
+    super('Queue worker shutdown deadline exceeded')
+    this.name = 'QueueWorkerShutdownTimeoutError'
+  }
+}
+
+const waitWithinDeadline = async (
+  operation: () => Promise<void>,
+  deadline: number
+): Promise<void> => {
+  const remainingMs = deadline - Date.now()
+  if (remainingMs <= 0) {
+    throw new QueueWorkerShutdownTimeoutError()
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new QueueWorkerShutdownTimeoutError())
+        }, remainingMs)
+      })
+    ])
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+const shutdownQueueWorker = async ({
+  runner,
+  database,
+  timeoutMs = QUEUE_WORKER_SHUTDOWN_TIMEOUT_MS
+}: CreateQueueWorkerShutdownOptions): Promise<QueueWorkerShutdownResult> => {
+  const deadline = Date.now() + timeoutMs
+  const failures: QueueWorkerShutdownFailure[] = []
+
+  try {
+    await waitWithinDeadline(() => runner.stop(), deadline)
+  } catch (error) {
+    failures.push({ stage: 'runner.stop', error })
+  }
+
+  if (Date.now() >= deadline) {
+    if (failures.length === 0) {
+      failures.push({
+        stage: 'database.destroy',
+        error: new QueueWorkerShutdownTimeoutError()
+      })
+    }
+
+    return {
+      succeeded: false,
+      failures
+    }
+  }
+
+  try {
+    await waitWithinDeadline(() => database.destroy(), deadline)
+  } catch (error) {
+    failures.push({ stage: 'database.destroy', error })
+  }
+
+  return {
+    succeeded: failures.length === 0,
+    failures
+  }
+}
+
+export const createQueueWorkerShutdown = ({
+  runner,
+  database,
+  timeoutMs = QUEUE_WORKER_SHUTDOWN_TIMEOUT_MS
+}: CreateQueueWorkerShutdownOptions): (() => Promise<QueueWorkerShutdownResult>) => {
+  let shutdownPromise: Promise<QueueWorkerShutdownResult> | undefined
+
+  return () => {
+    shutdownPromise ??= shutdownQueueWorker({ runner, database, timeoutMs })
+    return shutdownPromise
+  }
+}


### PR DESCRIPTION
Repeated shutdown signals previously forced the queue CLI to exit while draining, and successful draining exited without closing the database. Share one shutdown promise for SIGINT/SIGTERM, await runner.stop followed by database.destroy, and apply one 30-second deadline across both operations. Failures and deadline expiry exit unsuccessfully; unfinished claims remain reclaimable.

Extract a small lifecycle helper so ordering, repeated calls, stop/destroy failures, hanging operations, and shared-deadline exhaustion can be tested without importing a process-starting CLI. Update architecture and maintenance guidance.

Validation: ordered Node24 prettier → lint → typecheck → build → full tests pass. Lifecycle + runner focused suites: 21 tests pass. Actual worker script against disposable local SQLite received SIGINT and SIGTERM, performed one drain/database close, and exited 0. No schema, queue-runner settlement, or package-version changes.

Two fresh independent Luna max review angles will complete before merge.
