### PR TITLE
test: type federation queue publication spies

### DIFF
--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -1,5 +1,6 @@
 import { decode } from 'blurhash'
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import type { MockInstance } from 'vitest'
 
 import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
@@ -9,6 +10,7 @@ import {
   FORWARD_ACTIVITY_JOB_NAME
 } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import type { JobMessage, Queue } from '@/lib/services/queue/type'
 import {
   buildQuoteAuthorizationObject,
   buildQuoteAuthorizationUri
@@ -1499,7 +1501,7 @@ describe('createNoteJob', () => {
 
   describe('ActivityPub Outbound Inbox Forwarding', () => {
     const originalEnv = process.env.ACTIVITIES_ENABLE_INBOX_FORWARDING
-    let queueSpy: ReturnType<typeof vi.spyOn>
+    let queueSpy: MockInstance<Queue['publish']>
 
     beforeEach(() => {
       queueSpy = vi.spyOn(getQueue(), 'publish').mockResolvedValue(undefined)
@@ -1555,7 +1557,7 @@ describe('createNoteJob', () => {
       })
 
       const forwardCalls = queueSpy.mock.calls.filter(
-        (call: any) => call[0]?.name === FORWARD_ACTIVITY_JOB_NAME
+        ([message]: [JobMessage]) => message.name === FORWARD_ACTIVITY_JOB_NAME
       )
       expect(forwardCalls).toHaveLength(1)
       const data = forwardCalls[0][0].data as {
@@ -1597,7 +1599,7 @@ describe('createNoteJob', () => {
       })
 
       const forwardCalls = queueSpy.mock.calls.filter(
-        (call: any) => call[0]?.name === FORWARD_ACTIVITY_JOB_NAME
+        ([message]: [JobMessage]) => message.name === FORWARD_ACTIVITY_JOB_NAME
       )
       expect(forwardCalls).toHaveLength(0)
     })
@@ -1633,7 +1635,7 @@ describe('createNoteJob', () => {
       })
 
       const forwardCalls = queueSpy.mock.calls.filter(
-        (call: any) => call[0]?.name === FORWARD_ACTIVITY_JOB_NAME
+        ([message]: [JobMessage]) => message.name === FORWARD_ACTIVITY_JOB_NAME
       )
       expect(forwardCalls).toHaveLength(0)
     })

--- a/lib/jobs/deleteObjectJob.test.ts
+++ b/lib/jobs/deleteObjectJob.test.ts
@@ -1,4 +1,5 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import type { MockInstance } from 'vitest'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { deleteObjectJob } from '@/lib/jobs/deleteObjectJob'
@@ -7,6 +8,7 @@ import {
   FORWARD_ACTIVITY_JOB_NAME
 } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import type { JobMessage, Queue } from '@/lib/services/queue/type'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
@@ -529,7 +531,7 @@ describe('deleteObjectJob', () => {
 
   describe('Outbound Inbox Forwarding on Delete', () => {
     const originalEnv = process.env.ACTIVITIES_ENABLE_INBOX_FORWARDING
-    let queueSpy: ReturnType<typeof vi.spyOn>
+    let queueSpy: MockInstance<Queue['publish']>
 
     beforeEach(() => {
       queueSpy = vi.spyOn(getQueue(), 'publish').mockResolvedValue(undefined)
@@ -592,7 +594,7 @@ describe('deleteObjectJob', () => {
       })
 
       const forwardCalls = queueSpy.mock.calls.filter(
-        (call: any) => call[0]?.name === FORWARD_ACTIVITY_JOB_NAME
+        ([message]: [JobMessage]) => message.name === FORWARD_ACTIVITY_JOB_NAME
       )
       expect(forwardCalls).toHaveLength(1)
       const data = forwardCalls[0][0].data as {

--- a/lib/jobs/updateNoteJob.test.ts
+++ b/lib/jobs/updateNoteJob.test.ts
@@ -1,4 +1,5 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import type { MockInstance } from 'vitest'
 
 import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
@@ -10,6 +11,7 @@ import {
 } from '@/lib/jobs/names'
 import { updateNoteJob } from '@/lib/jobs/updateNoteJob'
 import { getQueue } from '@/lib/services/queue'
+import type { JobMessage, Queue } from '@/lib/services/queue/type'
 import {
   buildQuoteAuthorizationObject,
   buildQuoteAuthorizationUri
@@ -829,7 +831,7 @@ describe('updateNoteJob', () => {
 
   describe('Outbound Inbox Forwarding on Update', () => {
     const originalEnv = process.env.ACTIVITIES_ENABLE_INBOX_FORWARDING
-    let queueSpy: ReturnType<typeof vi.spyOn>
+    let queueSpy: MockInstance<Queue['publish']>
 
     beforeEach(() => {
       queueSpy = vi.spyOn(getQueue(), 'publish').mockResolvedValue(undefined)
@@ -906,7 +908,7 @@ describe('updateNoteJob', () => {
       })
 
       const forwardCalls = queueSpy.mock.calls.filter(
-        (call: any) => call[0]?.name === FORWARD_ACTIVITY_JOB_NAME
+        ([message]: [JobMessage]) => message.name === FORWARD_ACTIVITY_JOB_NAME
       )
       expect(forwardCalls).toHaveLength(1)
       const data = forwardCalls[0][0].data as {


### PR DESCRIPTION
The recent typing cleanup bypassed queue-publication checks with broad any callback parameters. Type the three federation job spies from Queue.publish and inspect concrete JobMessage call tuples, preserving the original forwarding assertions.

Only createNoteJob.test.ts, deleteObjectJob.test.ts, and updateNoteJob.test.ts change. No production interfaces, runtime behavior, exclusions, or package version changes.

Validation: 80 focused tests pass; ordered Node24 prettier → lint → typecheck → build → full tests pass. Fresh independent Luna max review will complete before merge.
