### PR TITLE
Bump version to v1.161.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.46",
+  "version": "1.161.47",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.47.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.46`
- Base main SHA: `567eb8d900cb7d3c0ea700672e5aa4b6841ef859`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
