### PR TITLE
test: require the headless signer before exclusion checks

### DIFF
--- a/lib/database/sql/moderation.test.ts
+++ b/lib/database/sql/moderation.test.ts
@@ -346,6 +346,7 @@ describe('ModerationDatabase', () => {
         // Materialize the headless federation signing actor (accountId null on
         // the configured host) — it must never appear in the admin listing.
         const signer = await database.getFederationSigningActor()
+        if (!signer) throw new Error('Expected a federation signing actor')
 
         const records = await database.getAdminAccounts({ limit: 100 })
         const ids = records.map((record) => record.actor.id)
@@ -353,7 +354,7 @@ describe('ModerationDatabase', () => {
         expect(ids).toContain(localActorId)
         expect(ids).toContain(suspendedActorId)
         expect(ids).toContain(remoteActorId)
-        expect(ids).not.toContain(signer?.id)
+        expect(ids).not.toContain(signer.id)
       })
     })
 


### PR DESCRIPTION
The headless-signer exclusion test could pass when signer creation returned null because not.toContain(signer?.id) reduced to checking for undefined. Require the signer fixture before asserting its absence from the admin account IDs.

The original account-list assertions remain unchanged. The 38-test moderation suite passes; a temporary missing-signer mutation failed at the new guard and was restored. Ordered Node24 prettier → lint → typecheck → build → full tests pass. No production changes, exclusions, or package version edits. Fresh independent Luna max review will complete before merge.
