### PR TITLE
test: strengthen database and fitness job fixture types

### DIFF
--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -5481,7 +5481,21 @@ describe('StatusDatabase', () => {
             createdAt: Date.now()
           })
 
-          const statusRows = [
+          type StatusBatchRow = {
+            id: string
+            url: string
+            urlHash: string
+            actorId: string
+            type: StatusType
+            content: string
+            reply: string
+            replyHash: string | null
+            originalStatusId: string | null
+            createdAt: Date
+            updatedAt: Date
+          }
+
+          const statusRows: StatusBatchRow[] = [
             {
               id: rootStatusId,
               url: rootStatusId,
@@ -5520,7 +5534,7 @@ describe('StatusDatabase', () => {
               }
             })
           ]
-          await knexDatabase.batchInsert('statuses', statusRows as any, 80)
+          await knexDatabase.batchInsert('statuses', statusRows, 80)
 
           knexDatabase.on('query', handleQuery)
           await sqlDatabase.deleteStatus({ statusId: rootStatusId, actorId })

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -19,6 +19,7 @@ import {
   saveMediaImageRendition
 } from '@/lib/services/medias'
 import { getQueue } from '@/lib/services/queue'
+import type { Queue } from '@/lib/services/queue/type'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
@@ -304,9 +305,11 @@ describe('processFitnessFileJob', () => {
       }
     })
 
-    const publishCalls = (getQueue().publish as jest.Mock).mock.calls
+    const publishCalls = (
+      getQueue().publish as jest.MockedFunction<Queue['publish']>
+    ).mock.calls
     const heatmapCalls = publishCalls.filter(
-      ([msg]: any) => msg.name === GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME
+      ([msg]) => msg.name === GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME
     )
     // Import must not trigger heatmap regeneration — that is decoupled to the
     // explicit generate route so the memory-heavy aggregation never runs on the
@@ -1176,14 +1179,16 @@ describe('processFitnessFileJob', () => {
     })
     expect(updatedFitnessFile?.processingStatus).toBe('completed')
 
-    const publishCalls = (getQueue().publish as jest.Mock).mock.calls
+    const publishCalls = (
+      getQueue().publish as jest.MockedFunction<Queue['publish']>
+    ).mock.calls
     const sendNoteCalls = publishCalls.filter(
-      ([msg]: any) => msg.name === SEND_NOTE_JOB_NAME
+      ([msg]) => msg.name === SEND_NOTE_JOB_NAME
     )
     expect(sendNoteCalls).toHaveLength(0)
 
     const heatmapCalls = publishCalls.filter(
-      ([msg]: any) => msg.name === GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME
+      ([msg]) => msg.name === GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME
     )
     expect(heatmapCalls).toHaveLength(0)
   })

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -1,8 +1,43 @@
+import type { JoinConfig } from 'better-auth/adapters'
 import knex, { Knex } from 'knex'
 
 import { logger } from '@/lib/utils/logger'
 
 import { knexAdapter } from './knexAdapter'
+
+type UserRow = {
+  id: string
+  display_name: string
+  email: string
+}
+
+type SessionDateRow = {
+  createdAt: Date
+  expireAt: Date
+}
+
+type SessionInvalidDateRow = {
+  createdAt: string
+  expireAt: Date
+}
+
+type SessionRow = {
+  id: string
+  user_id: string | null
+  token: string
+}
+
+type UserWithSessions = UserRow & {
+  sessions: SessionRow[]
+}
+
+type SessionWithAccount = SessionRow & {
+  accounts: {
+    id: string
+    user_id: string
+    provider: string
+  } | null
+}
 
 vi.mock('better-auth/adapters', () => {
   // Mirrors the schema better-auth hands the adapter: keyed by model name, with
@@ -557,10 +592,12 @@ describe('knexAdapter', () => {
         expireAt
       })
 
-      const result: any = await adapter.findOne({
+      const result = await adapter.findOne<SessionDateRow>({
         model: 'sessions',
         where: [{ field: 'id', value: 's1', operator: 'eq' as const }]
       })
+
+      if (!result) throw new Error('Expected a session row')
 
       expect(result.createdAt).toBeInstanceOf(Date)
       expect(result.createdAt.getTime()).toBe(createdAt)
@@ -578,12 +615,14 @@ describe('knexAdapter', () => {
         expireAt
       })
 
-      const result: any = await adapter.findOne({
+      const result = await adapter.findOne<SessionInvalidDateRow>({
         model: 'sessions',
         where: [
           { field: 'id', value: 's-invalid-date', operator: 'eq' as const }
         ]
       })
+
+      if (!result) throw new Error('Expected a session row')
 
       expect(result.createdAt).toBe('not-a-date')
       expect(result.expireAt).toBeInstanceOf(Date)
@@ -606,7 +645,7 @@ describe('knexAdapter', () => {
     })
 
     it('filters with where clause', async () => {
-      const results: any[] = await adapter.findMany({
+      const results = await adapter.findMany<UserRow>({
         model: 'users',
         where: [
           { field: 'display_name', value: 'Bob', operator: 'eq' as const }
@@ -622,7 +661,7 @@ describe('knexAdapter', () => {
     })
 
     it('respects offset', async () => {
-      const results: any[] = await adapter.findMany({
+      const results = await adapter.findMany<UserRow>({
         model: 'users',
         limit: 2,
         offset: 1,
@@ -633,7 +672,7 @@ describe('knexAdapter', () => {
     })
 
     it('sorts by field', async () => {
-      const results: any[] = await adapter.findMany({
+      const results = await adapter.findMany<UserRow>({
         model: 'users',
         sortBy: { field: 'email', direction: 'desc' }
       })
@@ -662,6 +701,27 @@ describe('knexAdapter', () => {
     const userJoin = {
       users: {
         on: { from: 'user_id', to: 'id' },
+        limit: 1,
+        relation: 'one-to-one' as const
+      }
+    }
+    const sessionsJoin: JoinConfig = {
+      sessions: {
+        on: { from: 'id', to: 'user_id' },
+        limit: 100,
+        relation: 'one-to-many' as const
+      }
+    }
+    const sessionsLimitedJoin: JoinConfig = {
+      sessions: {
+        on: { from: 'id', to: 'user_id' },
+        limit: 1,
+        relation: 'one-to-many' as const
+      }
+    }
+    const accountsJoin: JoinConfig = {
+      accounts: {
+        on: { from: 'accountId', to: 'id' },
         limit: 1,
         relation: 'one-to-one' as const
       }
@@ -783,17 +843,13 @@ describe('knexAdapter', () => {
     })
 
     it('returns an array for a one-to-many join', async () => {
-      const result: any = await adapter.findOne({
+      const result = await adapter.findOne<UserWithSessions>({
         model: 'users',
         where: [{ field: 'id', value: 'u1', operator: 'eq' as const }],
-        join: {
-          sessions: {
-            on: { from: 'id', to: 'user_id' },
-            limit: 100,
-            relation: 'one-to-many' as const
-          }
-        } as any
+        join: sessionsJoin
       })
+
+      if (!result) throw new Error('Expected a user row')
 
       expect(result.sessions.map((row: any) => row.id).sort()).toEqual([
         's1',
@@ -802,16 +858,10 @@ describe('knexAdapter', () => {
     })
 
     it('bounds a one-to-many join by its per-parent limit', async () => {
-      const results: any[] = await adapter.findMany({
+      const results = await adapter.findMany<UserWithSessions>({
         model: 'users',
         sortBy: { field: 'id', direction: 'asc' as const },
-        join: {
-          sessions: {
-            on: { from: 'id', to: 'user_id' },
-            limit: 1,
-            relation: 'one-to-many' as const
-          }
-        } as any
+        join: sessionsLimitedJoin
       })
 
       // u1 owns two sessions but the limit applies per parent row, which is why
@@ -822,17 +872,13 @@ describe('knexAdapter', () => {
     it('returns an empty array for a one-to-many join with no related rows', async () => {
       await db('sessions').delete()
 
-      const result: any = await adapter.findOne({
+      const result = await adapter.findOne<UserWithSessions>({
         model: 'users',
         where: [{ field: 'id', value: 'u1', operator: 'eq' as const }],
-        join: {
-          sessions: {
-            on: { from: 'id', to: 'user_id' },
-            limit: 100,
-            relation: 'one-to-many' as const
-          }
-        } as any
+        join: sessionsJoin
       })
+
+      if (!result) throw new Error('Expected a user row')
 
       expect(result.sessions).toEqual([])
     })
@@ -844,17 +890,13 @@ describe('knexAdapter', () => {
         provider: 'credential'
       })
 
-      const result: any = await adapter.findOne({
+      const result = await adapter.findOne<SessionWithAccount>({
         model: 'sessions',
         where: [{ field: 'id', value: 's1', operator: 'eq' as const }],
-        join: {
-          accounts: {
-            on: { from: 'accountId', to: 'id' },
-            limit: 1,
-            relation: 'one-to-one' as const
-          }
-        } as any
+        join: accountsJoin
       })
+
+      if (!result) throw new Error('Expected a session row')
 
       expect(result.id).toBe('s1')
       expect(result.accounts).toMatchObject({ id: 'a1', user_id: 'u1' })
@@ -881,11 +923,13 @@ describe('knexAdapter', () => {
     })
 
     it('updates the record and returns updated row', async () => {
-      const result: any = await adapter.update({
+      const result = await adapter.update<UserRow>({
         model: 'users',
         where: [{ field: 'id', value: 'u1', operator: 'eq' as const }],
         update: { display_name: 'Alice Updated' }
       })
+
+      if (!result) throw new Error('Expected an updated user row')
 
       expect(result.display_name).toBe('Alice Updated')
     })
@@ -1549,7 +1593,7 @@ describe('knexAdapter', () => {
         email: 'd@test.com'
       })
 
-      const results: any[] = await adapter.findMany({
+      const results = await adapter.findMany<UserRow>({
         model: 'users',
         where: [
           {


### PR DESCRIPTION
The recent typing cleanup introduced broad any escapes in status fixtures, adapter results/joins, and fitness-file queue mock calls. Replace those 15 new escapes with concrete SQL fixture rows, the adapter generic result and JoinConfig interfaces, and a queue-publication mock typed from its production signature.

Only status.test.ts, knexAdapter.test.ts, and processFitnessFileJob.test.ts change. Preserve their runtime assertions and leave unrelated pre-existing adapter casts alone. No production changes, type-check exclusions, or version edits.

Validation: 303 focused tests and typecheck pass. Ordered Node24 prettier → lint → typecheck → build → full tests pass. Fresh independent Luna max review will complete before merge.
