### PR TITLE
Bump version to v1.161.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.47",
+  "version": "1.161.48",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.48.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.47`
- Base main SHA: `d297c5cac3756a3784d97255da2595234ecf732c`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
