### PR TITLE
Bump version to v1.161.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.48",
+  "version": "1.161.49",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.49.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.48`
- Base main SHA: `814beadb5020ef826953562ff771582a69be8250`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
