### PR TITLE
Bump version to v1.161.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.49",
+  "version": "1.161.50",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.50.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.49`
- Base main SHA: `2dedc411cd1ce80bce110cf72c2a0801cb64b047`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
