### PR TITLE
Bump version to v1.161.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.33",
+  "version": "1.161.51",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.161.51.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.161.50`
- Base main SHA: `cc939a05d028d1f17e76e86a3c07e393b4163a54`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
