### PR TITLE
fix: advance status gallery one item per click

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1826,17 +1826,16 @@ system's `Attachments` component.
     at that level can carry the rule.
   - `STRIP_ITEM_MAX_WIDTH` (78%) means no item can fill the strip, so the next
     one always peeks past the edge. That peek is what says "this scrolls" on a
-    touch screen, where the back chevron never appears at all and the forward
-    one is easy to miss.
+    touch screen. Each media box is 240px tall, at least 160px wide, and has a
+    12px gap and 16px radius.
   - `scroll-snap-type: x proximity`, never `mandatory`: mandatory snapping pulls
     the peeking item flush with the edge as soon as the scroll settles and
     destroys the affordance the 78% cap creates.
-  - The forward chevron is always visible while there is more to the right; the
-    back chevron only appears on hover. Going back is worth chrome only once you
-    have gone forward — and `pointer-events-none` while it is `opacity-0` is
-    part of that, because `opacity-0` alone still hit-tests and `group-hover`
-    never latches on a touch screen, leaving a dead column over the leftmost
-    photo.
+  - The paired 44px Previous/Next controls sit below the row, remain
+    focusable, and expose their boundary state through `aria-disabled`. Each
+    click moves to exactly one adjacent card; a manual position between cards
+    goes to the first card boundary in the requested direction, and the ends
+    clamp. The hook preserves smooth scrolling unless reduced motion is active.
 - **There is no 4-item cap and no `+N` overlay.** Everything attached is in the
   strip, because scrolling reaches it. Re-adding a cap hides media the post
   actually carries. Strip images therefore pass `loading="lazy"` to `Media` —
@@ -1849,18 +1848,12 @@ system's `Attachments` component.
   decode, and the strip hides its controls, so deferring one leaves a bare empty
   box. Federated video always lands there: `thumbnailUrl` is written on the
   local-upload path alone.
-- **The edge fade is a `mask-image`, not a background gradient.** Posts render on
-  four different surfaces — `bg-card` when framed, `bg-background` on the status
-  detail, `bg-muted/30` for an ancestor row, and the page itself when unframed —
-  so a fade painted in any one token is visibly wrong on the other three, and a
-  literal white one is wrong in dark mode everywhere. A mask fades the strip's
-  own pixels and lets whatever is behind show through. It lives in
-  `buildEdgeFadeMask` rather than inline so the string itself is unit-testable:
-  jsdom's CSS parser rejects the two variants carrying `calc()` and stores
-  nothing for them, so a RENDERED node can only be asserted against the
-  left-edge-only form. Known cosmetic cost: the mask also fades the leading edge
-  of a focused item's outline, which is exactly where the browser scrolls a
-  Tab-focused item to.
+- **Captions belong to each item, not an overlay.** A trimmed attachment
+  description renders below its 240px media box through the shared caption
+  renderer, preserving emoji, selection and line breaks; long captions are
+  clamped to three lines with independent Show more/Show less controls. There
+  are no fades, badges, or alternate-text drawer controls layered over the
+  image.
 - **A strip item's focus indicator is an `outline` with a NEGATIVE offset, not
   a ring.** Its border box is exactly the strip's height and `overflow-x-auto`
   forces `overflow-y` to compute to `auto`, so an OUTSET ring's top and bottom
@@ -1874,15 +1867,10 @@ system's `Attachments` component.
   `MessageBubble`'s media cells carry `focus-visible:ring-inset` over the same
   full-bleed image shape, so their indicator is invisible too — a pre-existing
   bug, not a precedent to copy.)
-- **Keeping the chevrons out of the tab order takes BOTH `tabIndex={-1}` and a
-  mousedown guard.** They duplicate no function — every picture is a focusable
-  button and focusing one scrolls it into view — and each is unmounted by the
-  very scroll it performs, so a chevron holding focus drops it to `<body>` on
-  its last press and sends the next Tab back to the top of the page (WCAG
-  2.4.3). `tabindex="-1"` removes an element from the SEQUENTIAL order only; it
-  stays click-focusable, and Chrome and Firefox focus a `<button>` on click, so
-  `preventFocusOnPress` cancels the default on mousedown to close the mouse
-  path. Deleting either half reopens the failure.
+- **The paired media controls stay focusable.** They are mounted below the row,
+  expose their boundary state through `aria-disabled`, stop their click from
+  reaching the post, and leave focus in place when an end is reached. Keep the
+  picture buttons independently keyboard accessible as well.
 - **Every picture button carries an explicit `aria-label`.** `Media` names an
   image from its `alt`, but `attachment.name` is a required string that
   federation writes as `attachment.name || ''`, so an undescribed photo left the

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -886,10 +886,15 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
   them is a regression: `flex-none` on each item, without which they shrink to
   fit and nothing ever overflows (the whole feature turns off silently);
   `STRIP_ITEM_MAX_WIDTH` (78%) so the next item always
-  peeks — that peek is what says "this scrolls" on a touch screen, where the
-  back chevron never appears at all; `scroll-snap-type: x proximity`, never `mandatory`, which pulls the
-  peek flush the moment the scroll settles; and the forward chevron staying
-  visible while the back one appears on hover only.
+  peeks — that peek is what says "this scrolls" on a touch screen;
+  `scroll-snap-type: x proximity`, never `mandatory`, which pulls
+  the peek flush the moment the scroll settles; and the 240px media boxes use
+  160px minimum widths, a 78% maximum, 12px gaps and 16px corners.
+- The paired 44px controls sit below the row and remain focusable with
+  `aria-disabled` at the ends. An arrow click advances exactly one adjacent
+  card, choosing the first boundary in the requested direction when the user
+  is between cards, and clamps at either end. Smooth scrolling is retained
+  unless `prefers-reduced-motion` requests auto scrolling.
 - **There is no item cap and no `+N` overlay** — scrolling reaches everything —
   so anything the strip renders unboundedly needs a deferral: images pass
   `loading="lazy"`, videos `preload="none"` (`loading` is image-only) — but only
@@ -898,10 +903,10 @@ When reviewing code that interfaces with Mastodon APIs, ActivityPub, or JSON-LD 
   and federated video never has a poster. A lone picture or video is
   deliberately eager, being the post's largest element. Re-adding a cap hides
   media the post actually carries.
-- The edge fade is a **`mask-image`**, not a background gradient: posts render
-  on four surfaces (`bg-card`, `bg-background`, `bg-muted/30`, unframed) and a
-  fade painted in one token is wrong on the other three and in dark mode
-  everywhere.
+- Captions render below each image through the shared caption component, with
+  trimmed descriptions clamped to three lines with independent Show more/Show
+  less controls while preserving emoji, selection, and line breaks. The
+  approved gallery has no edge fades, badges, or alternate-text drawer.
 - **Filtering is layout-only.** `isVisualAttachment` picks what gets a picture
   box and `isAudibleAttachment` what becomes an inline player; a `.fit` file or
   PDF is skipped rather than rendering an empty box. But the lightbox is handed

--- a/lib/components/posts/attachments.test.tsx
+++ b/lib/components/posts/attachments.test.tsx
@@ -2,27 +2,59 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { createEvent, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 
-import { Attachments, buildEdgeFadeMask } from './attachments'
+import { Attachments } from './attachments'
 
 // jsdom has no ResizeObserver. useMediaStripScroll already no-ops when it is
 // undefined, but the strip still calls `measure()` eagerly on mount, so a
 // stub keeps that path exercised the same way it would run in a browser.
+let resizeCallbacks: (() => void)[] = []
+let observedElements: Element[] = []
+let createdObservers = 0
+let disconnectedObservers = 0
+const captionHeights = new Map<string, number>()
+
 class ResizeObserverStub {
-  observe() {}
+  private readonly callback: () => void
+
+  constructor(callback: () => void) {
+    createdObservers += 1
+    this.callback = callback
+    resizeCallbacks.push(callback)
+  }
+
+  observe(element: Element) {
+    observedElements.push(element)
+  }
   unobserve() {}
-  disconnect() {}
+  disconnect() {
+    disconnectedObservers += 1
+    resizeCallbacks = resizeCallbacks.filter(
+      (callback) => callback !== this.callback
+    )
+  }
 }
 
 beforeEach(() => {
+  resizeCallbacks = []
+  observedElements = []
+  createdObservers = 0
+  disconnectedObservers = 0
+  captionHeights.clear()
+  vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return captionHeights.get(this.textContent ?? '') ?? 0
+    }
+  )
   vi.stubGlobal('ResizeObserver', ResizeObserverStub)
 })
 
 afterEach(() => {
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
@@ -279,7 +311,7 @@ describe('Attachments', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('renders subtle alt text underneath a single image when name is provided', () => {
+    it('renders a short caption underneath without an expansion control', () => {
       render(
         <Attachments
           status={buildNoteStatus([
@@ -293,70 +325,46 @@ describe('Attachments', () => {
         />
       )
 
-      // Single image collapses alt text by default
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
-      })
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-      expect(
-        screen.queryByText('A mountaineer hiking on a ridge')
-      ).not.toBeInTheDocument()
-
-      // Expand
-      fireEvent.click(toggleButton)
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
-      const alt = screen.getByText('A mountaineer hiking on a ridge')
-      expect(alt).toBeInTheDocument()
-      expect(alt).toHaveClass('text-muted-foreground', 'text-sm')
-
-      // Single image should not render an ALT badge
-      expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
+      const caption = screen.getByText('A mountaineer hiking on a ridge')
+      expect(caption).toHaveClass('line-clamp-3')
+      expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull()
     })
 
-    it('collapses alt text by default and allows expanding and re-collapsing for a single image', () => {
+    it('measures a long caption and allows expanding and collapsing it', () => {
+      const description =
+        'A detailed description that spans more than three lines'
+      captionHeights.set(description, 100)
       render(
         <Attachments
           status={buildNoteStatus([
             buildAttachment({
               width: 800,
               height: 600,
-              name: 'A mountaineer hiking on a ridge'
+              name: description
             })
           ])}
           onMediaSelected={vi.fn()}
         />
       )
 
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
-      })
+      const caption = screen.getByText(description)
+      const toggleButton = screen.getByRole('button', { name: 'Show more' })
       expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-      expect(toggleButton).not.toHaveAttribute('aria-controls')
-      expect(
-        screen.queryByText('A mountaineer hiking on a ridge')
-      ).not.toBeInTheDocument()
+      expect(toggleButton).toHaveAttribute('aria-controls', caption.id)
+      expect(caption).toHaveClass('line-clamp-3')
 
-      // Expand
       fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
-      expect(toggleButton).toHaveAttribute('aria-controls')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
-      expect(
-        screen.getByText('A mountaineer hiking on a ridge')
-      ).toBeInTheDocument()
+      expect(toggleButton).toHaveTextContent('Show less')
+      expect(caption).not.toHaveClass('line-clamp-3')
 
-      // Collapse
       fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Expand alt text')
-      expect(toggleButton).not.toHaveAttribute('aria-controls')
-      expect(
-        screen.queryByText('A mountaineer hiking on a ridge')
-      ).not.toBeInTheDocument()
+      expect(toggleButton).toHaveTextContent('Show more')
+      expect(caption).toHaveClass('line-clamp-3')
     })
 
-    it('does not render alt text underneath when name is empty or whitespace', () => {
+    it('does not render a caption when name is empty or whitespace', () => {
       const { container } = render(
         <Attachments
           status={buildNoteStatus([
@@ -371,13 +379,13 @@ describe('Attachments', () => {
       )
 
       expect(container.querySelector('p')).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('button', { name: /alt text/i })
-      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull()
     })
 
-    it('stops click propagation when clicking on the alt text', () => {
+    it('keeps caption and expansion clicks inside the attachment', () => {
       const parentOnClick = vi.fn()
+      const onMediaSelected = vi.fn()
+      captionHeights.set('Description', 100)
       render(
         <div onClick={parentOnClick}>
           <Attachments
@@ -388,38 +396,15 @@ describe('Attachments', () => {
                 name: 'Description'
               })
             ])}
-            onMediaSelected={vi.fn()}
+            onMediaSelected={onMediaSelected}
           />
         </div>
       )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
       fireEvent.click(screen.getByText('Description'))
+      fireEvent.click(screen.getByRole('button', { name: 'Show more' }))
       expect(parentOnClick).not.toHaveBeenCalled()
-    })
-
-    it('stops click propagation when clicking on the single image collapse/expand button', () => {
-      const parentOnClick = vi.fn()
-      render(
-        <div onClick={parentOnClick}>
-          <Attachments
-            status={buildNoteStatus([
-              buildAttachment({
-                width: 800,
-                height: 600,
-                name: 'Description'
-              })
-            ])}
-            onMediaSelected={vi.fn()}
-          />
-        </div>
-      )
-
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
-      })
-      fireEvent.click(toggleButton)
-      expect(parentOnClick).not.toHaveBeenCalled()
+      expect(onMediaSelected).not.toHaveBeenCalled()
     })
   })
 
@@ -471,7 +456,7 @@ describe('Attachments', () => {
 
       const strip = screen.getByRole('group', { name: '3 media attachments' })
       expect(strip).toHaveClass('no-scrollbar', 'overflow-x-auto')
-      expect(strip.style.height).toBe('240px')
+      expect(strip.style.minHeight).toBe('240px')
       expect(strip.style.scrollSnapType).toBe('x proximity')
     })
 
@@ -509,10 +494,10 @@ describe('Attachments', () => {
 
       const buttons = screen.getAllByRole('button')
       const button = buttons.find(
-        (candidate) => candidate.style.width === expectedWidth
+        (candidate) => candidate.parentElement?.style.width === expectedWidth
       )
       expect(button).toBeDefined()
-      expect(button?.style.maxWidth).toBe('78%')
+      expect(button?.parentElement?.style.maxWidth).toBe('78%')
       expect(button?.style.scrollSnapAlign).toBe('start')
     })
 
@@ -543,7 +528,7 @@ describe('Attachments', () => {
       )
     })
 
-    it('renders every attachment with no cap and no overlay', () => {
+    it('renders every visual attachment with no item cap', () => {
       const attachments = Array.from({ length: 7 }, () =>
         buildAttachment({ width: 800, height: 600 })
       )
@@ -555,109 +540,65 @@ describe('Attachments', () => {
       )
 
       expect(screen.getAllByRole('button')).toHaveLength(7)
-      expect(screen.queryByText(/^\+\d/)).not.toBeInTheDocument()
     })
 
-    it('renders ALT badges and numbered alt text list for multiple images with descriptions', () => {
-      const first = buildAttachment({
-        width: 800,
-        height: 600,
-        name: 'First cat eating'
-      })
-      const second = buildAttachment({
-        width: 600,
-        height: 900,
-        name: 'Second cat resting'
-      })
-      const third = buildAttachment({
-        width: 1200,
-        height: 500,
-        name: ''
-      })
-
+    it('keeps long captions independently expandable', () => {
+      const descriptions = ['First long caption', 'Second long caption']
+      descriptions.forEach((description) =>
+        captionHeights.set(description, 100)
+      )
       render(
         <Attachments
-          status={buildNoteStatus([first, second, third])}
+          status={buildNoteStatus(
+            descriptions.map((name) =>
+              buildAttachment({ width: 800, height: 600, name })
+            )
+          )}
           onMediaSelected={vi.fn()}
         />
       )
 
-      // First and second have alt text -> ALT¹ and ALT² badges
-      expect(
-        screen.getByText(
-          (_content, element) =>
-            element?.tagName.toLowerCase() === 'span' &&
-            element.textContent === 'ALT1'
-        )
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          (_content, element) =>
-            element?.tagName.toLowerCase() === 'span' &&
-            element.textContent === 'ALT2'
-        )
-      ).toBeInTheDocument()
-      // Third has no alt text -> no ALT³ badge
-      expect(
-        screen.queryByText(
-          (_content, element) =>
-            element?.tagName.toLowerCase() === 'span' &&
-            element.textContent === 'ALT3'
-        )
-      ).not.toBeInTheDocument()
-
-      // Numbered alt text list underneath (after expanding)
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
+      const [firstToggle, secondToggle] = screen.getAllByRole('button', {
+        name: 'Show more'
       })
-      fireEvent.click(toggleButton)
-      expect(screen.getByText('First cat eating')).toBeInTheDocument()
-      expect(screen.getByText('Second cat resting')).toBeInTheDocument()
+      fireEvent.click(firstToggle)
+
+      expect(firstToggle).toHaveTextContent('Show less')
+      expect(secondToggle).toHaveTextContent('Show more')
+      expect(screen.getByText(descriptions[0])).not.toHaveClass('line-clamp-3')
+      expect(screen.getByText(descriptions[1])).toHaveClass('line-clamp-3')
+
+      fireEvent.click(firstToggle)
+      expect(firstToggle).toHaveTextContent('Show more')
+      expect(screen.getByText(descriptions[0])).toHaveClass('line-clamp-3')
     })
 
-    it('groups indices when multiple images share identical alt text', () => {
-      const first = buildAttachment({
-        width: 800,
-        height: 600,
-        name: 'Same landscape view'
-      })
-      const second = buildAttachment({
-        width: 600,
-        height: 900,
-        name: 'Same landscape view'
-      })
-
+    it('adds and removes the expansion control after an actual resize', () => {
+      const description = 'Caption whose wrapping changes with the card width'
+      captionHeights.set(description, 40)
       render(
         <Attachments
-          status={buildNoteStatus([first, second])}
+          status={buildNoteStatus([
+            buildAttachment({ width: 800, height: 600, name: description }),
+            buildAttachment({ width: 800, height: 600 })
+          ])}
           onMediaSelected={vi.fn()}
         />
       )
+      expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull()
 
+      captionHeights.set(description, 100)
+      act(() => resizeCallbacks.forEach((callback) => callback()))
       expect(
-        screen.getByText(
-          (_content, element) =>
-            element?.tagName.toLowerCase() === 'span' &&
-            element.textContent === 'ALT1'
-        )
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          (_content, element) =>
-            element?.tagName.toLowerCase() === 'span' &&
-            element.textContent === 'ALT2'
-        )
+        screen.getByRole('button', { name: 'Show more' })
       ).toBeInTheDocument()
 
-      // Expand the alt text list
-      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
-
-      // The grouped item shows indices "1 2" together
-      expect(screen.getByText('1 2')).toBeInTheDocument()
-      expect(screen.getByText('Same landscape view')).toBeInTheDocument()
+      captionHeights.set(description, 40)
+      act(() => resizeCallbacks.forEach((callback) => callback()))
+      expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull()
     })
 
-    it('does not render alt text section or badges if none have descriptions', () => {
+    it('renders no captions when none have descriptions', () => {
       const first = buildAttachment({ width: 800, height: 600 })
       const second = buildAttachment({ width: 800, height: 600 })
 
@@ -668,14 +609,14 @@ describe('Attachments', () => {
         />
       )
 
-      expect(screen.queryByText(/ALT/)).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('button', { name: /alt text/i })
-      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('paragraph')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull()
     })
 
-    it('stops click propagation when clicking on the alt text list item', () => {
+    it('keeps caption and expansion clicks from navigating or opening media', () => {
       const parentOnClick = vi.fn()
+      const onMediaSelected = vi.fn()
+      captionHeights.set('Cat photo', 100)
       const first = buildAttachment({
         width: 800,
         height: 600,
@@ -691,18 +632,20 @@ describe('Attachments', () => {
         <div onClick={parentOnClick}>
           <Attachments
             status={buildNoteStatus([first, second])}
-            onMediaSelected={vi.fn()}
+            onMediaSelected={onMediaSelected}
           />
         </div>
       )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
       fireEvent.click(screen.getByText('Cat photo'))
+      fireEvent.click(screen.getByRole('button', { name: 'Show more' }))
       expect(parentOnClick).not.toHaveBeenCalled()
+      expect(onMediaSelected).not.toHaveBeenCalled()
     })
 
-    it('collapses alt text by default and allows expanding and re-collapsing', () => {
+    it('resets expansion when a description is replaced', () => {
       const first = buildAttachment({
+        id: 'stable-attachment',
         width: 800,
         height: 600,
         name: 'First description'
@@ -712,74 +655,36 @@ describe('Attachments', () => {
         height: 600,
         name: 'Second description'
       })
+      captionHeights.set('First description', 100)
+      captionHeights.set('Replacement description', 100)
 
-      render(
+      const { rerender } = render(
         <Attachments
           status={buildNoteStatus([first, second])}
           onMediaSelected={vi.fn()}
         />
       )
 
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
-      })
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-      expect(toggleButton).not.toHaveAttribute('aria-controls')
-      expect(screen.queryByText('First description')).not.toBeInTheDocument()
-      expect(screen.queryByText('Second description')).not.toBeInTheDocument()
-
-      // Expand
+      const toggleButton = screen.getByRole('button', { name: 'Show more' })
       fireEvent.click(toggleButton)
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
-      expect(toggleButton).toHaveAttribute('aria-controls')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
-      expect(screen.getByText('First description')).toBeInTheDocument()
-      expect(screen.getByText('Second description')).toBeInTheDocument()
-
-      // Collapse
-      fireEvent.click(toggleButton)
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Expand alt text')
-      expect(toggleButton).not.toHaveAttribute('aria-controls')
-      expect(screen.queryByText('First description')).not.toBeInTheDocument()
-      expect(screen.queryByText('Second description')).not.toBeInTheDocument()
-
-      // Re-expand
-      fireEvent.click(toggleButton)
-      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
-      expect(toggleButton).toHaveAttribute('aria-controls')
-      expect(toggleButton).toHaveAttribute('aria-label', 'Collapse alt text')
-      expect(screen.getByText('First description')).toBeInTheDocument()
-      expect(screen.getByText('Second description')).toBeInTheDocument()
-    })
-
-    it('stops click propagation when clicking on the collapse/expand button', () => {
-      const parentOnClick = vi.fn()
-      const first = buildAttachment({
-        width: 800,
-        height: 600,
-        name: 'Cat photo'
-      })
-      const second = buildAttachment({
-        width: 800,
-        height: 600,
-        name: 'Dog photo'
-      })
-
-      render(
-        <div onClick={parentOnClick}>
-          <Attachments
-            status={buildNoteStatus([first, second])}
-            onMediaSelected={vi.fn()}
-          />
-        </div>
+      rerender(
+        <Attachments
+          status={buildNoteStatus([
+            { ...first, name: 'Replacement description' },
+            second
+          ])}
+          onMediaSelected={vi.fn()}
+        />
       )
 
-      const toggleButton = screen.getByRole('button', {
-        name: 'Expand alt text'
-      })
-      fireEvent.click(toggleButton)
-      expect(parentOnClick).not.toHaveBeenCalled()
+      expect(screen.getByText('Replacement description')).toHaveClass(
+        'line-clamp-3'
+      )
+      expect(screen.getByRole('button', { name: 'Show more' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
     })
   })
 
@@ -843,7 +748,7 @@ describe('Attachments', () => {
       )
 
       const [video] = screen.getAllByRole('button')
-      expect(video.style.width).toBe('576px')
+      expect(video.parentElement?.style.width).toBe('576px')
       expect(container.querySelector('video')).toBeInTheDocument()
     })
 
@@ -1020,30 +925,32 @@ describe('Attachments', () => {
       ).toBeInTheDocument()
     })
 
-    it('shows only the forward chevron before the strip has been scrolled', () => {
-      renderScrolledStrip({ scrollLeft: 0 })
+    it.each([
+      { scrollLeft: 0, disabledName: 'Previous media' },
+      { scrollLeft: 500, disabledName: 'Next media' }
+    ])(
+      'keeps both arrows mounted and guards $disabledName at a boundary',
+      ({ scrollLeft, disabledName }) => {
+        const strip = renderScrolledStrip({ scrollLeft })
+        const scrollBy = vi.fn()
+        Object.defineProperty(strip, 'scrollBy', {
+          configurable: true,
+          value: scrollBy
+        })
 
-      expect(
-        screen.getByRole('button', { name: 'More media' })
-      ).toBeInTheDocument()
-      expect(
-        screen.queryByRole('button', { name: 'Previous media' })
-      ).not.toBeInTheDocument()
-    })
+        const previous = screen.getByRole('button', { name: 'Previous media' })
+        const next = screen.getByRole('button', { name: 'Next media' })
+        const disabled = screen.getByRole('button', { name: disabledName })
+        expect(previous).toBeInTheDocument()
+        expect(next).toBeInTheDocument()
+        expect(disabled).toHaveAttribute('aria-disabled', 'true')
 
-    it('keeps the hidden back chevron from swallowing taps on the leftmost photo', () => {
-      // `opacity-0` alone still hit-tests, and `group-hover` never latches on a
-      // touch screen, so without `pointer-events-none` the invisible Previous
-      // button sits over the leftmost image as a dead column.
-      renderScrolledStrip({ scrollLeft: 250 })
-
-      const back = screen.getByRole('button', { name: 'Previous media' })
-      expect(back).toHaveClass('opacity-0', 'pointer-events-none')
-      expect(back).toHaveClass(
-        'group-hover/media:opacity-100',
-        'group-hover/media:pointer-events-auto'
-      )
-    })
+        disabled.focus()
+        fireEvent.click(disabled)
+        expect(disabled).toHaveFocus()
+        expect(scrollBy).not.toHaveBeenCalled()
+      }
+    )
 
     it('re-measures when an edit changes item widths but not their count', () => {
       // The hook is keyed on the laid-out WIDTHS for exactly this case: the
@@ -1078,7 +985,7 @@ describe('Attachments', () => {
       })
       fireEvent.scroll(strip)
       expect(
-        screen.getByRole('button', { name: 'More media' })
+        screen.getByRole('button', { name: 'Next media' })
       ).toBeInTheDocument()
 
       // 576 + 160 becomes 160 + 160: same two items, and now it all fits.
@@ -1091,60 +998,12 @@ describe('Attachments', () => {
       )
 
       expect(
-        screen.queryByRole('button', { name: 'More media' })
+        screen.queryByRole('button', { name: 'Next media' })
       ).not.toBeInTheDocument()
     })
 
-    it('attaches the edge fade to the strip itself', () => {
-      // Scrolled fully to the end, so the mask has no calc() stop — that is
-      // the one variant jsdom's CSS parser will store and hand back.
-      const strip = renderScrolledStrip({ scrollLeft: 500 })
-
-      expect(strip.style.maskImage).toContain('linear-gradient')
-      expect(strip.style.maskImage).toContain('48px')
-    })
-
     it.each([
-      { description: 'the forward chevron', name: 'More media' },
-      { description: 'the back chevron', name: 'Previous media' }
-    ])('$description does not take focus from a pointer press', ({ name }) => {
-      // tabIndex={-1} only removes it from the SEQUENTIAL tab order; Chrome
-      // and Firefox still focus a button on click, and the chevron is
-      // unmounted by its own scroll, which would drop focus to <body>.
-      renderScrolledStrip({ scrollLeft: 250 })
-
-      const chevron = screen.getByRole('button', { name })
-      const event = createEvent.mouseDown(chevron)
-      fireEvent(chevron, event)
-
-      expect(event.defaultPrevented).toBe(true)
-    })
-
-    it('keeps the forward chevron visible without a pointer', () => {
-      // group-hover never latches on a touch screen, so hover-gating this one
-      // would make the "there is more" cue permanently invisible there.
-      renderScrolledStrip({ scrollLeft: 250 })
-
-      const forward = screen.getByRole('button', { name: 'More media' })
-      expect(forward.className).not.toContain('opacity-0')
-      expect(forward.className).not.toContain('pointer-events-none')
-    })
-
-    it('keeps both chevrons out of the tab order', () => {
-      // Each is unmounted by the scroll it performs, so a focused one would
-      // drop focus to <body>; the picture buttons are the keyboard path.
-      renderScrolledStrip({ scrollLeft: 250 })
-
-      expect(
-        screen.getByRole('button', { name: 'Previous media' })
-      ).toHaveAttribute('tabindex', '-1')
-      expect(
-        screen.getByRole('button', { name: 'More media' })
-      ).toHaveAttribute('tabindex', '-1')
-    })
-
-    it.each([
-      { description: 'the forward chevron', name: 'More media' },
+      { description: 'the forward arrow', name: 'Next media' },
       { description: 'the back chevron', name: 'Previous media' }
     ])(
       '$description stops its click from reaching an ancestor click handler',
@@ -1190,18 +1049,9 @@ describe('Attachments', () => {
     )
 
     it.each([
-      {
-        description: 'the forward chevron nudges forward by 70% of the strip',
-        name: 'More media',
-        expectedLeft: 350
-      },
-      {
-        description: 'the back chevron nudges backward by the same amount',
-        name: 'Previous media',
-        expectedLeft: -350
-      }
-    ])('$description', ({ name, expectedLeft }) => {
-      // Scrolled to the middle so both chevrons are mounted.
+      { name: 'Next media', expectedLeft: 250 },
+      { name: 'Previous media', expectedLeft: -250 }
+    ])('$name moves in its enabled direction', ({ name, expectedLeft }) => {
       const strip = renderScrolledStrip({ scrollLeft: 250 })
       const scrollBy = vi.fn()
       Object.defineProperty(strip, 'scrollBy', {
@@ -1325,40 +1175,6 @@ describe('Attachments', () => {
     })
   })
 
-  describe('buildEdgeFadeMask', () => {
-    it.each([
-      {
-        description: 'paints no mask while nothing is out of view',
-        canScrollLeft: false,
-        canScrollRight: false,
-        expected: undefined
-      },
-      {
-        description: 'fades only the right edge at the start of the strip',
-        canScrollLeft: false,
-        canScrollRight: true,
-        expected:
-          'linear-gradient(to right, #000 0, #000 calc(100% - 48px), transparent 100%)'
-      },
-      {
-        description: 'fades only the left edge at the end of the strip',
-        canScrollLeft: true,
-        canScrollRight: false,
-        expected:
-          'linear-gradient(to right, transparent 0, #000 48px, #000 100%)'
-      },
-      {
-        description: 'fades both edges in the middle of the strip',
-        canScrollLeft: true,
-        canScrollRight: true,
-        expected:
-          'linear-gradient(to right, transparent 0, #000 48px, #000 calc(100% - 48px), transparent 100%)'
-      }
-    ])('$description', ({ canScrollLeft, canScrollRight, expected }) => {
-      expect(buildEdgeFadeMask(canScrollLeft, canScrollRight)).toBe(expected)
-    })
-  })
-
   it('renders nothing for a non-Note status', () => {
     const announce = buildAnnounceStatus(
       buildNoteStatus([buildAttachment({ width: 800, height: 600 })])
@@ -1388,7 +1204,7 @@ describe('Attachments', () => {
     expect(parentOnClick).not.toHaveBeenCalled()
   })
 
-  it('renders custom emoji images in single-image alt text', () => {
+  it('renders custom emoji images in a single-image caption', () => {
     const status = {
       ...buildNoteStatus([
         buildAttachment({
@@ -1412,14 +1228,13 @@ describe('Attachments', () => {
 
     render(<Attachments status={status} onMediaSelected={vi.fn()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
     const img = screen.getByRole('img', { name: ':blobcat:' })
     expect(img).toBeInTheDocument()
     expect(img).toHaveAttribute('src', 'https://example.com/blobcat.png')
     expect(screen.getByText(/A photo with/)).toBeInTheDocument()
   })
 
-  it('renders custom emoji images in multi-image alt text drawer', () => {
+  it('renders custom emoji images in each matching strip caption', () => {
     const status = {
       ...buildNoteStatus([
         buildAttachment({
@@ -1450,9 +1265,44 @@ describe('Attachments', () => {
 
     render(<Attachments status={status} onMediaSelected={vi.fn()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand alt text' }))
     const imgs = screen.getAllByRole('img', { name: ':blobcat:' })
-    expect(imgs.length).toBeGreaterThanOrEqual(1)
+    expect(imgs).toHaveLength(2)
     expect(imgs[0]).toHaveAttribute('src', 'https://example.com/blobcat.png')
+  })
+
+  it('preserves caption line breaks', () => {
+    render(
+      <Attachments
+        status={buildNoteStatus([
+          buildAttachment({
+            width: 800,
+            height: 600,
+            name: 'First line\nSecond line'
+          })
+        ])}
+        onMediaSelected={vi.fn()}
+      />
+    )
+
+    const caption = screen.getByText(/First line/)
+    expect(caption).toHaveClass('whitespace-pre-wrap')
+    expect(caption).toHaveTextContent('First line Second line')
+  })
+
+  it('disconnects every caption and strip resize observer on unmount', () => {
+    const { unmount } = render(
+      <Attachments
+        status={buildNoteStatus([
+          buildAttachment({ width: 800, height: 600, name: 'First caption' }),
+          buildAttachment({ width: 800, height: 600, name: 'Second caption' })
+        ])}
+        onMediaSelected={vi.fn()}
+      />
+    )
+
+    expect(observedElements).toHaveLength(3)
+    unmount()
+    expect(disconnectedObservers).toBe(createdObservers)
+    expect(resizeCallbacks).toHaveLength(0)
   })
 })

--- a/lib/components/posts/attachments.tsx
+++ b/lib/components/posts/attachments.tsx
@@ -1,7 +1,18 @@
 'use client'
 
-import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
-import { CSSProperties, FC, MouseEvent, useId, useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import {
+  CSSProperties,
+  FC,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import { CustomEmojiText } from '@/lib/components/actors/ActorDisplayName'
 import {
@@ -9,7 +20,7 @@ import {
   isAudibleAttachment,
   isVisualAttachment
 } from '@/lib/types/domain/attachment'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
 import { Media } from './media'
@@ -20,63 +31,16 @@ export type OnMediaSelectedHandle = (
   selectedMediaIndex: number
 ) => void
 
-/**
- * The row height two or more attachments lay out at, and the height a single
- * one is scaled down to. Both come from the design system's media strip.
- */
 const STRIP_ROW_HEIGHT = 240
 const SINGLE_MAX_HEIGHT = 420
-
-/**
- * No single item may fill the strip, so the next one always peeks past the
- * edge. That peek is what says "this scrolls" on a touch screen, where the back
- * chevron never appears at all (it is gated on hover) and the forward one is
- * easy to miss.
- */
 const STRIP_ITEM_MAX_WIDTH = '78%'
-
-/**
- * `proximity`, never `mandatory`: mandatory snapping would pull the peeking
- * item flush with the edge the moment the scroll settled and undo the very
- * affordance the 78% cap creates.
- */
 const STRIP_SNAP_TYPE = 'x proximity'
-
-/** How far the fade at each scrollable edge reaches. */
-const EDGE_FADE_WIDTH = 48
-
-/**
- * An attachment federated without dimensions still needs a box to reserve, or
- * the blurhash placeholder has nothing to paint into and the strip measures
- * itself before any width exists. 4:3 is the shape most photos arrive in; the
- * grid this replaced assumed 16:9 for the same reason.
- */
 const FALLBACK_ASPECT_RATIO = 4 / 3
 const FALLBACK_ASPECT_RATIO_CSS = '4 / 3'
-
-/**
- * The shapes a media box is allowed to take. A 10x10000 sliver would round one
- * axis of its box to zero and render an invisible, unclickable item, and remote
- * dimensions are whatever the origin server said they were. `object-cover`
- * crops whatever the clamp trims.
- */
 const MIN_ASPECT_RATIO = 1 / 3
 const MAX_ASPECT_RATIO = 3
-
-/**
- * A single box is capped at the file's own pixels so a thumbnail is not
- * upscaled, which for a genuinely tiny image leaves a target too small to hit.
- * 44px is the WCAG 2.5.8 minimum.
- */
 const MIN_MEDIA_WIDTH = 44
 
-/**
- * A stored `0` means "dimensions unknown", NOT "zero pixels wide" — several
- * media-storage paths persist `metaData.width ?? 0` (`lib/services/medias/`),
- * and a federated `Document` carries whatever the remote server sent. So every
- * consumer of a dimension has to apply this same guard; reading
- * `attachment.width` raw collapses the box to nothing.
- */
 const getMediaGeometry = ({ width, height }: Attachment) => {
   if (!width || !height || width <= 0 || height <= 0) {
     return {
@@ -91,121 +55,89 @@ const getMediaGeometry = ({ width, height }: Attachment) => {
   )
   return {
     ratio,
-    // Keep the exact `W / H` form whenever the shape was not clamped: it is
-    // what a reader sees in devtools, and it avoids float drift on a very tall
-    // image. A clamped box has to declare the shape it is actually laid out at
-    // or its width and its ratio would disagree.
     aspectRatio:
       ratio === width / height ? `${width} / ${height}` : String(ratio),
     naturalWidth: width
   }
 }
 
-/**
- * A gradient MASK rather than a gradient background: posts render on four
- * different surfaces (`bg-card` when framed, `bg-background` on the status
- * detail, `bg-muted/30` for an ancestor row, and the page itself when
- * unframed), so a fade painted in any one token is visibly wrong on the other
- * three — and wrong in both themes. Masking fades the strip's own pixels and
- * lets whatever is behind show through.
- *
- * A standalone function so the string itself is unit-testable: jsdom's CSS
- * parser rejects the two variants carrying `calc()` and stores nothing for
- * them, so a rendered node can only ever be asserted against the left-edge-only
- * form.
- */
-export const buildEdgeFadeMask = (
-  canScrollLeft: boolean,
-  canScrollRight: boolean
-) => {
-  if (!canScrollLeft && !canScrollRight) return undefined
-  const start = canScrollLeft
-    ? `transparent 0, #000 ${EDGE_FADE_WIDTH}px`
-    : '#000 0'
-  const end = canScrollRight
-    ? `#000 calc(100% - ${EDGE_FADE_WIDTH}px), transparent 100%`
-    : '#000 100%'
-  return `linear-gradient(to right, ${start}, ${end})`
-}
-
-/**
- * A pointer press must not move focus to the chevron — see CHEVRON_CLASS below.
- * Cancelling the default on mousedown is what stops the browser focusing it,
- * and it leaves the click itself, and every keyboard path, untouched.
- */
-const preventFocusOnPress = (event: MouseEvent) => event.preventDefault()
-
 const MEDIA_BOX_CLASS =
-  'relative block cursor-zoom-in overflow-hidden rounded-xl border border-border/60 bg-muted/20'
-
-/**
- * A lone picture is not inside an overflow container, so an ordinary outset
- * ring paints in the clear space around it.
- */
+  'relative block cursor-zoom-in overflow-hidden rounded-2xl border border-border/60 bg-muted/20'
 const SINGLE_FOCUS_CLASS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50'
-
-/**
- * A strip item cannot use that ring. Its border box is exactly the strip's
- * height and `overflow-x-auto` forces `overflow-y` to compute to `auto`, so an
- * OUTSET ring's top and bottom bars fall outside the scrollport and are clipped
- * away. An INSET one is worse: an inset `box-shadow` paints with the element's
- * background, underneath its content, and the button's only child is an opaque
- * image filling the whole box — so it is occluded on all four sides and there
- * is no indicator at all. An outline with a negative offset draws inside the
- * border box AND paints above content, which is the combination this needs.
- */
 const STRIP_FOCUS_CLASS =
   'focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring/50'
 
-/**
- * The chevrons are POINTER affordances. They duplicate no function — every
- * picture is a focusable button and focusing one scrolls it into view, which is
- * the whole of what a chevron does — and each is unmounted by the very scroll
- * it performs, so a chevron holding focus would drop it to `<body>` on its last
- * press and send the next Tab back to the top of the page (WCAG 2.4.3).
- *
- * Keeping them out of the tab order takes BOTH `tabIndex={-1}` and the
- * mousedown guard below. `tabindex="-1"` removes an element from the SEQUENTIAL
- * tab order only; it stays click-focusable, and Chrome and Firefox focus a
- * `<button>` on click, so the mouse path reaches the same dropped focus the
- * keyboard path avoids.
- */
-const CHEVRON_CLASS =
-  'absolute top-1/2 flex size-8 -translate-y-1/2 items-center justify-center rounded-full border bg-popover text-foreground shadow-sm hover:bg-muted'
-
-interface AltTextToggleProps {
-  isExpanded: boolean
-  controlsId: string
-  onToggle: () => void
+interface CaptionProps {
+  identity: string
+  text: string
+  tags: StatusNote['tags']
 }
 
-const AltTextToggle: FC<AltTextToggleProps> = ({
-  isExpanded,
-  controlsId,
-  onToggle
-}) => (
-  <button
-    type="button"
-    aria-expanded={isExpanded}
-    aria-controls={isExpanded ? controlsId : undefined}
-    aria-label={isExpanded ? 'Collapse alt text' : 'Expand alt text'}
-    onClick={(e) => {
-      e.stopPropagation()
-      onToggle()
-    }}
-    className="flex items-center gap-1 self-start text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-sm"
-  >
-    <span>Alt text</span>
-    <ChevronDown
-      className={cn(
-        'size-3.5 transition-transform duration-200',
-        isExpanded && 'rotate-180'
-      )}
-      aria-hidden="true"
-    />
-  </button>
-)
+const Caption: FC<CaptionProps> = ({ identity, text, tags }) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const captionRef = useRef<HTMLParagraphElement | null>(null)
+  const captionId = useId()
+
+  const measure = useCallback(() => {
+    const element = captionRef.current
+    if (!element) return
+    const styles = window.getComputedStyle(element)
+    const parsedLineHeight = Number.parseFloat(styles.lineHeight)
+    const lineHeight = Number.isFinite(parsedLineHeight) ? parsedLineHeight : 21
+    setCanExpand(element.scrollHeight > lineHeight * 3 + 1)
+  }, [])
+
+  useLayoutEffect(() => {
+    setIsExpanded(false)
+    setCanExpand(false)
+  }, [identity, text])
+
+  useLayoutEffect(() => {
+    measure()
+  }, [measure, isExpanded, identity, text])
+
+  useEffect(() => {
+    const element = captionRef.current
+    if (!element || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [measure, identity, text])
+
+  return (
+    <div
+      className="mt-2 select-text text-sm leading-relaxed text-muted-foreground"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <p
+        ref={captionRef}
+        id={captionId}
+        className={cn(
+          'break-words whitespace-pre-wrap',
+          !isExpanded && 'line-clamp-3'
+        )}
+      >
+        <CustomEmojiText text={text} tags={tags} />
+      </p>
+      {canExpand ? (
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={captionId}
+          className="mt-1 cursor-pointer rounded-sm font-medium text-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          onClick={(event) => {
+            event.stopPropagation()
+            setIsExpanded((expanded) => !expanded)
+          }}
+        >
+          {isExpanded ? 'Show less' : 'Show more'}
+        </button>
+      ) : null}
+    </div>
+  )
+}
 
 interface Props {
   status: Status
@@ -213,17 +145,10 @@ interface Props {
 }
 
 export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
-  const [isAltExpanded, setIsAltExpanded] = useState(false)
-  const altListId = useId()
   const attachments = useMemo(
     () => (status.type === StatusType.enum.Note ? status.attachments : []),
     [status]
   )
-
-  // The lightbox is handed exactly the pictures the post shows, and an index
-  // into THAT list — never the raw attachment array. Anything filtered out here
-  // is something `Media` renders as nothing, so passing it on would give the
-  // modal a blank slide, an empty thumbnail and a wrong "n of m" count.
   const pictures = useMemo(
     () => attachments.filter(isVisualAttachment),
     [attachments]
@@ -232,54 +157,28 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
     () => attachments.filter(isAudibleAttachment),
     [attachments]
   )
-
-  // Each item's width is decided here rather than in the map so it can also key
-  // the scroll measurement: the observer watches the container, which does not
-  // resize when an edit swaps one attachment for another of a different shape.
   const items = useMemo(
     () =>
       pictures.map((attachment) => ({
         attachment,
-        width: Math.round(STRIP_ROW_HEIGHT * getMediaGeometry(attachment).ratio)
+        width: Math.max(
+          160,
+          Math.round(STRIP_ROW_HEIGHT * getMediaGeometry(attachment).ratio)
+        )
       })),
     [pictures]
   )
-
-  const altEntries = useMemo(() => {
-    const entries: { indices: number[]; text: string }[] = []
-    pictures.forEach((pic, i) => {
-      const text = pic.name?.trim()
-      if (!text) return
-      const existing = entries.find((e) => e.text === text)
-      if (existing) {
-        existing.indices.push(i + 1)
-      } else {
-        entries.push({ indices: [i + 1], text })
-      }
-    })
-    return entries
-  }, [pictures])
-
   const strip = useMediaStripScroll(items.map((item) => item.width).join(','))
   const { canScrollLeft, canScrollRight } = strip
-
-  const edgeFadeMask = buildEdgeFadeMask(canScrollLeft, canScrollRight)
 
   if (status.type !== StatusType.enum.Note) return null
   if (!pictures.length && !players.length) return null
 
   const openMedia = (index: number) => (event: MouseEvent) => {
-    // The post row is itself clickable — opening the lightbox must not also
-    // navigate to the status.
     event.stopPropagation()
     onMediaSelected(pictures, index)
   }
 
-  // `Media` names the image from its `alt`, but `attachment.name` is a required
-  // string that federation writes as `attachment.name || ''`, so an undescribed
-  // photo leaves the button with no accessible name at all — a screen reader
-  // announces "button" with nothing to tell one photo from the next. Same
-  // wording as `ActorMediaGallery`, which already solved this.
   const mediaLabel = (attachment: Attachment, index: number) =>
     attachment.name
       ? `Open media: ${attachment.name}`
@@ -297,13 +196,6 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
     </div>
   ) : null
 
-  // A lone picture keeps its own shape and hugs the post's left edge instead of
-  // being cropped to a full-width banner. It is scaled by WIDTH, never by
-  // capping the height of an aspect-ratio box: the width that puts the image at
-  // SINGLE_MAX_HEIGHT is plain arithmetic, and `min(100%, …)` then keeps it
-  // inside a narrow post with the ratio intact. A capped max-height would leave
-  // the ratio to be re-derived from a clamped axis, which browsers resolve
-  // inconsistently.
   if (pictures.length === 1) {
     const attachment = pictures[0]
     const { ratio, aspectRatio, naturalWidth } = getMediaGeometry(attachment)
@@ -314,7 +206,7 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
         Math.round(SINGLE_MAX_HEIGHT * ratio)
       )
     )
-    const altText = attachment.name?.trim()
+    const caption = attachment.name?.trim()
     return (
       <>
         <div className="mt-3 flex flex-col justify-start">
@@ -330,25 +222,12 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
               attachment={attachment}
             />
           </button>
-          {altText ? (
-            <div
-              className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <AltTextToggle
-                isExpanded={isAltExpanded}
-                controlsId={altListId}
-                onToggle={() => setIsAltExpanded((prev) => !prev)}
-              />
-              {isAltExpanded ? (
-                <p
-                  id={altListId}
-                  className="text-sm leading-relaxed text-muted-foreground break-words"
-                >
-                  <CustomEmojiText text={altText} tags={status.tags} />
-                </p>
-              ) : null}
-            </div>
+          {caption ? (
+            <Caption
+              identity={attachment.id}
+              text={caption}
+              tags={status.tags}
+            />
           ) : null}
         </div>
         {audioPlayers}
@@ -356,140 +235,91 @@ export const Attachments: FC<Props> = ({ status, onMediaSelected }) => {
     )
   }
 
+  const overflowing = canScrollLeft || canScrollRight
   const stripStyle: CSSProperties = {
-    height: STRIP_ROW_HEIGHT,
-    scrollSnapType: STRIP_SNAP_TYPE,
-    maskImage: edgeFadeMask,
-    WebkitMaskImage: edgeFadeMask
+    minHeight: STRIP_ROW_HEIGHT,
+    scrollSnapType: STRIP_SNAP_TYPE
   }
 
   return (
     <>
       {items.length ? (
-        <>
-          <div className="group/media relative mt-3">
-            <div
-              ref={strip.ref}
-              onScroll={strip.measure}
-              role="group"
-              // Only promise more once the measurement says there is more: a
-              // strip whose items all fit tells a screen-reader user to scroll to
-              // content that does not exist.
-              aria-label={
-                canScrollLeft || canScrollRight
-                  ? `${items.length} media attachments, scroll for more`
-                  : `${items.length} media attachments`
-              }
-              className="no-scrollbar flex gap-1.5 overflow-x-auto"
-              style={stripStyle}
-            >
-              {items.map(({ attachment, width }, index) => {
-                const alt = attachment.name?.trim()
-                return (
+        <div className="mt-3">
+          <div
+            ref={strip.ref}
+            onScroll={strip.measure}
+            role="group"
+            aria-label={`${items.length} media attachments${overflowing ? ', scroll for more' : ''}`}
+            className="no-scrollbar relative flex gap-3 overflow-x-auto"
+            style={stripStyle}
+          >
+            {items.map(({ attachment, width }, index) => {
+              const caption = attachment.name?.trim()
+              return (
+                <div
+                  key={attachment.id}
+                  className="flex flex-none flex-col"
+                  style={{ width, maxWidth: STRIP_ITEM_MAX_WIDTH }}
+                >
                   <button
-                    key={attachment.id}
                     type="button"
                     onClick={openMedia(index)}
                     aria-label={mediaLabel(attachment, index)}
                     className={cn(
                       MEDIA_BOX_CLASS,
                       STRIP_FOCUS_CLASS,
-                      'h-full flex-none'
+                      'h-[240px] w-full flex-none'
                     )}
-                    style={{
-                      width,
-                      maxWidth: STRIP_ITEM_MAX_WIDTH,
-                      scrollSnapAlign: 'start'
-                    }}
+                    style={{ scrollSnapAlign: 'start' }}
                   >
                     <Media
                       className="h-full w-full object-cover"
                       attachment={attachment}
                       loading="lazy"
                     />
-                    {alt ? (
-                      <span
-                        className="pointer-events-none absolute bottom-2 left-2 flex items-center rounded bg-black/60 px-1.5 py-0.5 text-xs font-semibold text-white shadow-sm backdrop-blur-xs"
-                        aria-hidden="true"
-                      >
-                        ALT<sup>{index + 1}</sup>
-                      </span>
-                    ) : null}
                   </button>
-                )
-              })}
-            </div>
-            {canScrollLeft ? (
+                  {caption ? (
+                    <Caption
+                      identity={attachment.id}
+                      text={caption}
+                      tags={status.tags}
+                    />
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+          {overflowing ? (
+            <div className="mt-3 flex justify-end gap-2">
               <button
                 type="button"
-                tabIndex={-1}
                 aria-label="Previous media"
-                onMouseDown={preventFocusOnPress}
+                aria-disabled={!canScrollLeft}
                 onClick={(event) => {
                   event.stopPropagation()
+                  if (!canScrollLeft) return
                   strip.scrollByPage(-1)
                 }}
-                // Hidden until the strip is hovered — going back is only worth
-                // chrome once you have gone forward. The forward chevron opposite
-                // stays visible so "there is more" is discoverable without a
-                // pointer. `pointer-events-none` while invisible is load-bearing:
-                // `opacity-0` alone still hit-tests, and on a touch screen —
-                // where `group-hover` never latches — that leaves a dead column
-                // swallowing taps on the leftmost photo.
-                className={cn(
-                  CHEVRON_CLASS,
-                  'pointer-events-none left-2 opacity-0 transition-opacity group-hover/media:pointer-events-auto group-hover/media:opacity-100'
-                )}
+                className="flex size-11 items-center justify-center rounded-full border bg-background text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 aria-disabled:cursor-default aria-disabled:opacity-50"
               >
-                <ChevronLeft className="size-4" />
+                <ChevronLeft className="size-5" aria-hidden="true" />
               </button>
-            ) : null}
-            {canScrollRight ? (
               <button
                 type="button"
-                tabIndex={-1}
-                aria-label="More media"
-                onMouseDown={preventFocusOnPress}
+                aria-label="Next media"
+                aria-disabled={!canScrollRight}
                 onClick={(event) => {
                   event.stopPropagation()
+                  if (!canScrollRight) return
                   strip.scrollByPage(1)
                 }}
-                className={cn(CHEVRON_CLASS, 'right-2')}
+                className="flex size-11 items-center justify-center rounded-full border bg-background text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 aria-disabled:cursor-default aria-disabled:opacity-50"
               >
-                <ChevronRight className="size-4" />
+                <ChevronRight className="size-5" aria-hidden="true" />
               </button>
-            ) : null}
-          </div>
-          {altEntries.length ? (
-            <div
-              className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground select-text"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <AltTextToggle
-                isExpanded={isAltExpanded}
-                controlsId={altListId}
-                onToggle={() => setIsAltExpanded((prev) => !prev)}
-              />
-              {isAltExpanded ? (
-                <div id={altListId} className="flex flex-col gap-1">
-                  {altEntries.map((entry) => (
-                    <div
-                      key={entry.indices.join('-')}
-                      className="flex items-start gap-1 leading-relaxed"
-                    >
-                      <sup className="shrink-0 pt-0.5 text-xs font-semibold select-none">
-                        {entry.indices.join(' ')}
-                      </sup>
-                      <span className="break-words">
-                        <CustomEmojiText text={entry.text} tags={status.tags} />
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
             </div>
           ) : null}
-        </>
+        </div>
       ) : null}
       {audioPlayers}
     </>

--- a/lib/components/posts/useMediaStripScroll.test.tsx
+++ b/lib/components/posts/useMediaStripScroll.test.tsx
@@ -218,36 +218,144 @@ describe('useMediaStripScroll', () => {
     expect(screen.getByTestId(testId)).toHaveTextContent(String(expected))
   })
 
-  it.each([
-    {
-      description:
-        'scrolls right by 0.7 of the visible width on scrollByPage(1)',
-      direction: 1 as const,
-      expectedLeft: 233
-    },
-    {
-      description:
-        'scrolls left by 0.7 of the visible width on scrollByPage(-1)',
-      direction: -1 as const,
-      expectedLeft: -233
-    }
-  ])('$description', ({ direction, expectedLeft }) => {
-    render(<Probe scrollWidth={1000} clientWidth={333} scrollLeft={0} />)
+  it('advances exactly one adjacent card in either direction', () => {
+    render(<Probe scrollWidth={1600} clientWidth={500} scrollLeft={600} />)
     const scroller = screen.getByTestId('scroller')
+    const containerLeft = 100
+    Object.defineProperty(scroller, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: containerLeft })
+    })
+    ;[0, 220, 500, 860].forEach((offset) => {
+      const card = document.createElement('span')
+      Object.defineProperty(card, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left: containerLeft + offset - 600 })
+      })
+      scroller.append(card)
+    })
     const scrollBy = vi.fn()
-    // jsdom has no scrollBy implementation to spy on.
     Object.defineProperty(scroller, 'scrollBy', {
       configurable: true,
       value: scrollBy
     })
 
-    act(() => capturedScrollByPage?.(direction))
+    act(() => capturedScrollByPage?.(-1))
+    expect(scrollBy).toHaveBeenCalledWith({ left: -100, behavior: 'smooth' })
 
-    expect(scrollBy).toHaveBeenCalledWith({
-      left: expectedLeft,
-      behavior: 'smooth'
+    scrollBy.mockClear()
+    Object.defineProperty(scroller, 'scrollLeft', {
+      configurable: true,
+      value: 220
     })
+    ;[0, 220, 500, 860].forEach((offset, index) => {
+      const card = scroller.children[index]
+      Object.defineProperty(card, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left: containerLeft + offset - 220 })
+      })
+    })
+    act(() => capturedScrollByPage?.(1))
+    expect(scrollBy).toHaveBeenCalledWith({ left: 280, behavior: 'smooth' })
   })
+
+  it('uses the nearest directional card boundary relative to the container', () => {
+    render(<Probe scrollWidth={1200} clientWidth={500} scrollLeft={100} />)
+    const scroller = screen.getByTestId('scroller')
+    const cards = [100, 350, 550, 900].map((left) => {
+      const card = document.createElement('span')
+      Object.defineProperty(card, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left })
+      })
+      scroller.append(card)
+      return card
+    })
+    Object.defineProperty(scroller, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 100 })
+    })
+    const scrollBy = vi.fn()
+    Object.defineProperty(scroller, 'scrollBy', {
+      configurable: true,
+      value: scrollBy
+    })
+
+    act(() => capturedScrollByPage?.(1))
+    expect(scrollBy).toHaveBeenCalledWith({ left: 250, behavior: 'smooth' })
+    expect(cards).toHaveLength(4)
+  })
+
+  it('uses the nearest backward card boundary relative to the container', () => {
+    render(<Probe scrollWidth={1200} clientWidth={500} scrollLeft={600} />)
+    const scroller = screen.getByTestId('scroller')
+    ;[-500, -250, -50, 300].forEach((left) => {
+      const card = document.createElement('span')
+      Object.defineProperty(card, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left })
+      })
+      scroller.append(card)
+    })
+    Object.defineProperty(scroller, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 100 })
+    })
+    const scrollBy = vi.fn()
+    Object.defineProperty(scroller, 'scrollBy', {
+      configurable: true,
+      value: scrollBy
+    })
+
+    act(() => capturedScrollByPage?.(-1))
+    expect(scrollBy).toHaveBeenCalledWith({ left: -150, behavior: 'smooth' })
+  })
+
+  it('honors reduced motion and clamps to progress at an end', () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: true }))
+    render(<Probe scrollWidth={1200} clientWidth={500} scrollLeft={500} />)
+    const scroller = screen.getByTestId('scroller')
+    const scrollBy = vi.fn()
+    Object.defineProperty(scroller, 'scrollBy', {
+      configurable: true,
+      value: scrollBy
+    })
+
+    const card = document.createElement('span')
+    Object.defineProperty(card, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 500 })
+    })
+    Object.defineProperty(scroller, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 0 })
+    })
+    scroller.append(card)
+
+    act(() => capturedScrollByPage?.(1))
+    expect(scrollBy).toHaveBeenCalledWith({ left: 200, behavior: 'auto' })
+  })
+
+  it.each([
+    { scrollLeft: 0, direction: -1 as const },
+    { scrollLeft: 500, direction: 1 as const }
+  ])(
+    'does not request movement beyond the strip at $scrollLeft',
+    ({ scrollLeft, direction }) => {
+      render(
+        <Probe scrollWidth={1000} clientWidth={500} scrollLeft={scrollLeft} />
+      )
+      const scroller = screen.getByTestId('scroller')
+      const scrollBy = vi.fn()
+      Object.defineProperty(scroller, 'scrollBy', {
+        configurable: true,
+        value: scrollBy
+      })
+
+      act(() => capturedScrollByPage?.(direction))
+      expect(scrollBy).not.toHaveBeenCalled()
+    }
+  )
 
   it('re-measures when the content key changes without the container resizing', () => {
     // The observer watches the container, so a strip whose items were swapped

--- a/lib/components/posts/useMediaStripScroll.ts
+++ b/lib/components/posts/useMediaStripScroll.ts
@@ -9,9 +9,6 @@ import { useCallback, useEffect, useState } from 'react'
  */
 export const SCROLL_EDGE_TOLERANCE = 8
 
-/** How much of the visible strip one chevron press travels. */
-const SCROLL_PAGE_RATIO = 0.7
-
 interface MediaStripScroll {
   /**
    * Attach to the scroll container. A callback ref rather than a ref object:
@@ -39,8 +36,8 @@ interface MediaStripScroll {
  * not merely how many things there are. The observer watches the CONTAINER, and
  * editing a post to swap a panorama for a portrait changes what overflows
  * without changing the container's box, the item count, or `scrollLeft` — so a
- * count would leave a forward chevron pointing at content that no longer exists
- * and the edge fade dimming a photo for no reason.
+ * count would leave a forward arrow pointing at content that no longer exists
+ * and an overflow affordance present for no reason.
  */
 export const useMediaStripScroll = (contentKey: string): MediaStripScroll => {
   const [element, setElement] = useState<HTMLDivElement | null>(null)
@@ -76,9 +73,48 @@ export const useMediaStripScroll = (contentKey: string): MediaStripScroll => {
   const scrollByPage = useCallback(
     (direction: 1 | -1) => {
       if (!element) return
+      const maxScrollLeft = Math.max(
+        0,
+        element.scrollWidth - element.clientWidth
+      )
+      const current = element.scrollLeft
+      const containerLeft = element.getBoundingClientRect().left
+      const boundaries = Array.from(element.children)
+        .map(
+          (child) =>
+            (child as HTMLElement).getBoundingClientRect().left -
+            containerLeft +
+            current
+        )
+        .filter((offset) => Number.isFinite(offset))
+      const candidates =
+        direction > 0
+          ? boundaries.filter((offset) => offset > current + 1)
+          : boundaries.filter((offset) => offset < current - 1)
+      const boundary =
+        direction > 0 ? candidates[0] : candidates[candidates.length - 1]
+      // A browser can report zero offsets while layout is pending. Use one
+      // visible width as a conservative fallback until card boundaries exist;
+      // once they do, the normal path always advances exactly one card.
+      const fallbackTarget = current + direction * element.clientWidth
+      const target = Math.max(
+        0,
+        Math.min(maxScrollLeft, boundary ?? fallbackTarget)
+      )
+      if (
+        (direction < 0 && current <= 0) ||
+        (direction > 0 && current >= maxScrollLeft)
+      )
+        return
+      const left = target - current
+      if (!left) return
+      const reducedMotion =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
       element.scrollBy({
-        left: direction * Math.round(element.clientWidth * SCROLL_PAGE_RATIO),
-        behavior: 'smooth'
+        left,
+        behavior: reducedMotion ? 'auto' : 'smooth'
       })
     },
     [element]


### PR DESCRIPTION
Arrows now move to the immediately adjacent media card on each click, instead of paging across a percentage of the gallery. From a position between cards, they choose the first boundary in the requested direction and clamp at either end. Smooth scrolling, reduced motion, keyboard focus, and native scrolling are preserved.

This also restores the captioned gallery from #2016: the later dependency update #1959 reverted its component and scroll hook. Only the gallery files and their corresponding guidance are restored; unrelated changes from that merge remain outside this PR.

Validation: Node.js 24; Prettier → lint → typecheck → build → tests. Real-browser verification covers exact adjacent-card navigation in both directions, boundaries and focus retention, caption expansion, desktop/mobile sizing, light/dark themes, touch and wheel scrolling, reduced motion, and viewer selection. Regression tests cover mixed widths, media filtering, geometry changes, and observer cleanup.

No dependency, API, schema, or package-version changes.
