### PR TITLE
Bump version to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.161.52",
+  "version": "2.0.0",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v2.0.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `major`
- Base tag: `v1.161.52`
- Base main SHA: `b051e39eef1a555a49e42a00c32064bcc7da8088`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
