### PR TITLE
Bump version to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v2.0.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v2.0.0`
- Base main SHA: `76ca316a8f9134d2e4eacf7b9c2430f7a6bab837`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
