### PR TITLE
none: require human approval for major releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- Title rule: PRs are squash-merged, so the PR title becomes the commit
-subject on main. It MUST start with a conventional prefix. Use `minor:` or
-`major:` in the TITLE to trigger those version bumps; `none:` for no release.
+subject on main. It MUST start with a conventional prefix. Use `minor:` in the
+TITLE to trigger an automated minor bump; `major:` records a breaking change but
+is capped at minor, and `none:` requests no release.
 See AGENTS.md → Commit & Pull Request Guidelines. -->
 
 ## Summary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!-- Title rule: PRs are squash-merged, so the PR title becomes the commit
 subject on main. It MUST start with a conventional prefix. Use `minor:` in the
-TITLE to trigger an automated minor bump; `major:` records a breaking change but
-is capped at minor, and `none:` requests no release.
+TITLE to trigger an automated minor bump. A `major:` title triggers a major bump
+only when a human maintainer has applied the `release:major` label; agents must
+never apply that label. Use `none:` to request no release.
 See AGENTS.md → Commit & Pull Request Guidelines. -->
 
 ## Summary

--- a/.github/scripts/determine-version-bump.mjs
+++ b/.github/scripts/determine-version-bump.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { appendFileSync } from 'node:fs'
 import process from 'node:process'
 
+import { hasHumanMajorApproval } from './major-release-approval.mjs'
 import { nextVersion, selectVersionBump } from './version-bump-policy.mjs'
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
@@ -9,27 +10,6 @@ const output = (name, value) =>
   appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`)
 const majorMarker = (subject, body) =>
   /^major:/.test(subject) || /(^|\n)\s*[-*]?\s*major:/.test(body)
-
-const hasHumanMajorApproval = (hash) => {
-  try {
-    const pullRequests = JSON.parse(
-      execFileSync(
-        'gh',
-        ['api', `repos/${process.env.GITHUB_REPOSITORY}/commits/${hash}/pulls`],
-        { encoding: 'utf8' }
-      )
-    )
-    return pullRequests.some(
-      (pullRequest) =>
-        pullRequest.merged_at &&
-        pullRequest.labels.some((label) => label.name === 'release:major')
-    )
-  } catch {
-    // Fail closed: without the maintainer approval record, a major marker is
-    // intentionally treated as a minor release request.
-    return false
-  }
-}
 
 const baseSha = git('rev-parse', 'origin/main')
 output('base_sha', baseSha)

--- a/.github/scripts/determine-version-bump.mjs
+++ b/.github/scripts/determine-version-bump.mjs
@@ -1,0 +1,104 @@
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+import process from 'node:process'
+
+import { nextVersion, selectVersionBump } from './version-bump-policy.mjs'
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+const output = (name, value) =>
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`)
+const majorMarker = (subject, body) =>
+  /^major:/.test(subject) || /(^|\n)\s*[-*]?\s*major:/.test(body)
+
+const hasHumanMajorApproval = (hash) => {
+  try {
+    const pullRequests = JSON.parse(
+      execFileSync(
+        'gh',
+        ['api', `repos/${process.env.GITHUB_REPOSITORY}/commits/${hash}/pulls`],
+        { encoding: 'utf8' }
+      )
+    )
+    return pullRequests.some(
+      (pullRequest) =>
+        pullRequest.merged_at &&
+        pullRequest.labels.some((label) => label.name === 'release:major')
+    )
+  } catch {
+    // Fail closed: without the maintainer approval record, a major marker is
+    // intentionally treated as a minor release request.
+    return false
+  }
+}
+
+const baseSha = git('rev-parse', 'origin/main')
+output('base_sha', baseSha)
+
+if (process.env.GITHUB_SHA !== baseSha) {
+  output('new_version', '')
+  process.exit(0)
+}
+
+const headMessage = git('log', '-1', '--pretty=format:%s', baseSha)
+if (/^Bump version to v\d+\.\d+\.\d+/.test(headMessage)) {
+  output('new_version', '')
+  process.exit(0)
+}
+
+git('checkout', '--detach', baseSha)
+const latestTag = git(
+  'tag',
+  '--merged',
+  'HEAD',
+  '--list',
+  'v[0-9]*',
+  '--sort=-v:refname'
+).split('\n')[0]
+
+if (!latestTag) {
+  output('bump', 'initial')
+  output('commit_count', '0')
+  output('latest_tag', '')
+  output('new_version', '1.0.0')
+  process.exit(0)
+}
+
+output('latest_tag', latestTag)
+const hashes = git(
+  'log',
+  `${latestTag}..HEAD`,
+  '--pretty=format:%H',
+  '--no-merges'
+)
+  .split('\n')
+  .filter(Boolean)
+
+if (hashes.length === 0) {
+  output('new_version', '')
+  process.exit(0)
+}
+
+const commits = hashes.map((hash) => {
+  const subject = git('log', '-1', '--pretty=format:%s', hash)
+  const body = git('log', '-1', '--pretty=format:%b', hash)
+  return {
+    subject,
+    body,
+    changedFiles: git(
+      'diff-tree',
+      '--no-commit-id',
+      '--name-only',
+      '-r',
+      '--root',
+      hash
+    )
+      .split('\n')
+      .filter(Boolean),
+    majorApproved: majorMarker(subject, body) && hasHumanMajorApproval(hash)
+  }
+})
+
+const { bump, commitCount } = selectVersionBump(commits)
+output('bump', bump)
+output('commit_count', String(commitCount))
+output('new_version', bump === 'none' ? '' : nextVersion(latestTag, bump))

--- a/.github/scripts/major-release-approval.mjs
+++ b/.github/scripts/major-release-approval.mjs
@@ -26,7 +26,8 @@ export const hasHumanMajorLabelEvent = (pullRequest, events) => {
     )
     .sort(
       (left, right) =>
-        Date.parse(right.created_at) - Date.parse(left.created_at)
+        Date.parse(right.created_at) - Date.parse(left.created_at) ||
+        Number(right.id) - Number(left.id)
     )[0]
 
   return (

--- a/.github/scripts/major-release-approval.mjs
+++ b/.github/scripts/major-release-approval.mjs
@@ -1,0 +1,38 @@
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+
+const githubApi = (...args) =>
+  JSON.parse(execFileSync('gh', ['api', ...args], { encoding: 'utf8' }))
+
+export const hasHumanMajorLabelEvent = (pullRequest, events) =>
+  Boolean(pullRequest.merged_at) &&
+  pullRequest.labels.some((label) => label.name === 'release:major') &&
+  events.some(
+    (event) =>
+      event.event === 'labeled' &&
+      event.label?.name === 'release:major' &&
+      event.actor?.type === 'User'
+  )
+
+export const hasHumanMajorApproval = (hash) => {
+  const pullRequests = githubApi(
+    `repos/${process.env.GITHUB_REPOSITORY}/commits/${hash}/pulls`
+  )
+
+  return pullRequests.some((pullRequest) => {
+    if (
+      !pullRequest.merged_at ||
+      !pullRequest.labels.some((label) => label.name === 'release:major')
+    ) {
+      return false
+    }
+
+    const events = githubApi(
+      `repos/${process.env.GITHUB_REPOSITORY}/issues/${pullRequest.number}/events?per_page=100`
+    )
+    return hasHumanMajorLabelEvent(pullRequest, events)
+  })
+}
+
+export const getPullRequestsForCommit = (hash) =>
+  githubApi(`repos/${process.env.GITHUB_REPOSITORY}/commits/${hash}/pulls`)

--- a/.github/scripts/major-release-approval.mjs
+++ b/.github/scripts/major-release-approval.mjs
@@ -3,16 +3,37 @@ import process from 'node:process'
 
 const githubApi = (...args) =>
   JSON.parse(execFileSync('gh', ['api', ...args], { encoding: 'utf8' }))
+const githubApiPages = (...args) =>
+  JSON.parse(
+    execFileSync('gh', ['api', '--paginate', '--slurp', ...args], {
+      encoding: 'utf8'
+    })
+  ).flat()
 
-export const hasHumanMajorLabelEvent = (pullRequest, events) =>
-  Boolean(pullRequest.merged_at) &&
-  pullRequest.labels.some((label) => label.name === 'release:major') &&
-  events.some(
-    (event) =>
-      event.event === 'labeled' &&
-      event.label?.name === 'release:major' &&
-      event.actor?.type === 'User'
+export const hasHumanMajorLabelEvent = (pullRequest, events) => {
+  if (
+    !pullRequest.merged_at ||
+    !pullRequest.labels.some((label) => label.name === 'release:major')
+  ) {
+    return false
+  }
+
+  const latestLabelEvent = events
+    .filter(
+      (event) =>
+        ['labeled', 'unlabeled'].includes(event.event) &&
+        event.label?.name === 'release:major'
+    )
+    .sort(
+      (left, right) =>
+        Date.parse(right.created_at) - Date.parse(left.created_at)
+    )[0]
+
+  return (
+    latestLabelEvent?.event === 'labeled' &&
+    latestLabelEvent.actor?.type === 'User'
   )
+}
 
 export const hasHumanMajorApproval = (hash) => {
   const pullRequests = githubApi(
@@ -27,12 +48,9 @@ export const hasHumanMajorApproval = (hash) => {
       return false
     }
 
-    const events = githubApi(
+    const events = githubApiPages(
       `repos/${process.env.GITHUB_REPOSITORY}/issues/${pullRequest.number}/events?per_page=100`
     )
     return hasHumanMajorLabelEvent(pullRequest, events)
   })
 }
-
-export const getPullRequestsForCommit = (hash) =>
-  githubApi(`repos/${process.env.GITHUB_REPOSITORY}/commits/${hash}/pulls`)

--- a/.github/scripts/verify-major-tag-approval.mjs
+++ b/.github/scripts/verify-major-tag-approval.mjs
@@ -1,26 +1,14 @@
 import { execFileSync } from 'node:child_process'
 import process from 'node:process'
 
-import {
-  getPullRequestsForCommit,
-  hasHumanMajorApproval
-} from './major-release-approval.mjs'
+import { hasHumanMajorApproval } from './major-release-approval.mjs'
 import { isMajorTransition } from './version-bump-policy.mjs'
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
 const nextTag = process.argv[2]
 const majorMarker = (subject, body) =>
   /^major:/.test(subject) || /(^|\n)\s*[-*]?\s*major:/.test(body)
-const getSourceMainSha = () => {
-  const pullRequest = getPullRequestsForCommit(process.env.GITHUB_SHA).find(
-    (candidate) => candidate.merged_at
-  )
-  const match = pullRequest?.body?.match(/^- Base main SHA: `([0-9a-f]{40})`$/m)
-
-  return match?.[1] ?? process.env.GITHUB_SHA
-}
-
-const sourceMainSha = getSourceMainSha()
+const sourceMainSha = process.env.SOURCE_MAIN_SHA ?? git('rev-parse', 'HEAD^')
 const previousTag = git(
   'tag',
   '--merged',

--- a/.github/scripts/verify-major-tag-approval.mjs
+++ b/.github/scripts/verify-major-tag-approval.mjs
@@ -1,0 +1,39 @@
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+
+import { isMajorTransition } from './version-bump-policy.mjs'
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+const nextTag = process.argv[2]
+const previousTag = git(
+  'tag',
+  '--merged',
+  'HEAD^',
+  '--list',
+  'v[0-9]*',
+  '--sort=-v:refname'
+).split('\n')[0]
+
+if (!previousTag || !isMajorTransition(previousTag, nextTag)) process.exit(0)
+
+const pullRequests = JSON.parse(
+  execFileSync(
+    'gh',
+    [
+      'api',
+      `repos/${process.env.GITHUB_REPOSITORY}/commits/${process.env.GITHUB_SHA}/pulls`
+    ],
+    { encoding: 'utf8' }
+  )
+)
+const approved = pullRequests.some(
+  (pullRequest) =>
+    pullRequest.merged_at &&
+    pullRequest.labels.some((label) => label.name === 'release:major')
+)
+
+if (!approved) {
+  throw new Error(
+    `Refusing to create ${nextTag}: major tags require the human-applied release:major label`
+  )
+}

--- a/.github/scripts/verify-major-tag-approval.mjs
+++ b/.github/scripts/verify-major-tag-approval.mjs
@@ -1,14 +1,30 @@
 import { execFileSync } from 'node:child_process'
 import process from 'node:process'
 
+import {
+  getPullRequestsForCommit,
+  hasHumanMajorApproval
+} from './major-release-approval.mjs'
 import { isMajorTransition } from './version-bump-policy.mjs'
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
 const nextTag = process.argv[2]
+const majorMarker = (subject, body) =>
+  /^major:/.test(subject) || /(^|\n)\s*[-*]?\s*major:/.test(body)
+const getSourceMainSha = () => {
+  const pullRequest = getPullRequestsForCommit(process.env.GITHUB_SHA).find(
+    (candidate) => candidate.merged_at
+  )
+  const match = pullRequest?.body?.match(/^- Base main SHA: `([0-9a-f]{40})`$/m)
+
+  return match?.[1] ?? process.env.GITHUB_SHA
+}
+
+const sourceMainSha = getSourceMainSha()
 const previousTag = git(
   'tag',
   '--merged',
-  'HEAD^',
+  sourceMainSha,
   '--list',
   'v[0-9]*',
   '--sort=-v:refname'
@@ -16,24 +32,23 @@ const previousTag = git(
 
 if (!previousTag || !isMajorTransition(previousTag, nextTag)) process.exit(0)
 
-const pullRequests = JSON.parse(
-  execFileSync(
-    'gh',
-    [
-      'api',
-      `repos/${process.env.GITHUB_REPOSITORY}/commits/${process.env.GITHUB_SHA}/pulls`
-    ],
-    { encoding: 'utf8' }
-  )
+const hashes = git(
+  'log',
+  `${previousTag}..${sourceMainSha}`,
+  '--pretty=format:%H',
+  '--no-merges'
 )
-const approved = pullRequests.some(
-  (pullRequest) =>
-    pullRequest.merged_at &&
-    pullRequest.labels.some((label) => label.name === 'release:major')
-)
+  .split('\n')
+  .filter(Boolean)
+const approved = hashes.some((hash) => {
+  const subject = git('log', '-1', '--pretty=format:%s', hash)
+  const body = git('log', '-1', '--pretty=format:%b', hash)
+
+  return majorMarker(subject, body) && hasHumanMajorApproval(hash)
+})
 
 if (!approved) {
   throw new Error(
-    `Refusing to create ${nextTag}: major tags require the human-applied release:major label`
+    `Refusing to create ${nextTag}: major tags require a human-applied release:major label on the source PR`
   )
 }

--- a/.github/scripts/version-bump-policy.mjs
+++ b/.github/scripts/version-bump-policy.mjs
@@ -1,0 +1,75 @@
+const BUMP_RANK = { none: 0, patch: 1, minor: 2, major: 3 }
+
+const isVersionBumpCommit = (subject) =>
+  /^Bump version to v\d+\.\d+\.\d+/.test(subject)
+
+const explicitBump = (line, majorApproved) => {
+  if (/^major:/.test(line)) return majorApproved ? 'major' : 'minor'
+  if (/^minor:/.test(line)) return 'minor'
+  return null
+}
+
+export const getCommitBump = ({
+  subject,
+  body,
+  changedFiles,
+  majorApproved = false
+}) => {
+  if (isVersionBumpCommit(subject)) return null
+
+  const subjectBump = explicitBump(subject, majorApproved)
+  if (subjectBump) return subjectBump
+  if (/^none:/.test(subject)) return 'none'
+
+  let bodyBump = null
+  for (const line of body.split('\n')) {
+    const lineBump = explicitBump(
+      line.replace(/^[\s]*[-*][\s]+/, ''),
+      majorApproved
+    )
+
+    if (lineBump === 'major') return 'major'
+    if (lineBump === 'minor') bodyBump = 'minor'
+  }
+  if (bodyBump) return bodyBump
+
+  return changedFiles.every((path) => path.startsWith('.github/'))
+    ? 'none'
+    : 'patch'
+}
+
+export const selectVersionBump = (commits) => {
+  let bump = 'none'
+  let commitCount = 0
+
+  for (const commit of commits) {
+    const commitBump = getCommitBump(commit)
+    if (commitBump === null) continue
+
+    commitCount += 1
+    if (BUMP_RANK[commitBump] > BUMP_RANK[bump]) bump = commitBump
+  }
+
+  return { bump, commitCount }
+}
+
+export const nextVersion = (latestTag, bump) => {
+  let [major, minor, patch] = latestTag.slice(1).split('.').map(Number)
+
+  if (bump === 'major') {
+    major += 1
+    minor = 0
+    patch = 0
+  } else if (bump === 'minor') {
+    minor += 1
+    patch = 0
+  } else if (bump === 'patch') {
+    patch += 1
+  }
+
+  return `${major}.${minor}.${patch}`
+}
+
+export const isMajorTransition = (previousTag, nextTag) =>
+  Number(nextTag.slice(1).split('.')[0]) >
+  Number(previousTag.slice(1).split('.')[0])

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   tag:
@@ -25,6 +26,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create tag if version bump commit
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           HEAD_MSG=$(git log -1 --pretty=format:"%s")
 
@@ -46,6 +49,8 @@ jobs:
             echo "Tag $NEW_VERSION already exists, skipping."
             exit 0
           fi
+
+          node .github/scripts/verify-major-tag-approval.mjs "$NEW_VERSION"
 
           git tag -a "$NEW_VERSION" -m "Version ${NEW_VERSION#v}"
           git push origin "$NEW_VERSION"

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/version-bump.test.ts
+++ b/.github/workflows/version-bump.test.ts
@@ -63,6 +63,7 @@ describe('automatic version-bump policy', () => {
       hasHumanMajorLabelEvent(pullRequest, [
         {
           event: 'labeled',
+          id: 1,
           label: { name: 'release:major' },
           actor: { type: 'Bot' },
           created_at: '2026-09-09T12:00:00Z'
@@ -73,6 +74,7 @@ describe('automatic version-bump policy', () => {
       hasHumanMajorLabelEvent(pullRequest, [
         {
           event: 'labeled',
+          id: 1,
           label: { name: 'release:major' },
           actor: { type: 'User' },
           created_at: '2026-09-09T12:00:00Z'
@@ -83,21 +85,42 @@ describe('automatic version-bump policy', () => {
       hasHumanMajorLabelEvent(pullRequest, [
         {
           event: 'labeled',
+          id: 1,
           label: { name: 'release:major' },
           actor: { type: 'User' },
           created_at: '2026-09-09T12:00:00Z'
         },
         {
           event: 'unlabeled',
+          id: 2,
           label: { name: 'release:major' },
           actor: { type: 'User' },
           created_at: '2026-09-09T12:01:00Z'
         },
         {
           event: 'labeled',
+          id: 3,
           label: { name: 'release:major' },
           actor: { type: 'Bot' },
           created_at: '2026-09-09T12:02:00Z'
+        }
+      ])
+    ).toBe(false)
+    expect(
+      hasHumanMajorLabelEvent(pullRequest, [
+        {
+          event: 'labeled',
+          id: 1,
+          label: { name: 'release:major' },
+          actor: { type: 'User' },
+          created_at: '2026-09-09T12:00:00Z'
+        },
+        {
+          event: 'labeled',
+          id: 2,
+          label: { name: 'release:major' },
+          actor: { type: 'Bot' },
+          created_at: '2026-09-09T12:00:00Z'
         }
       ])
     ).toBe(false)

--- a/.github/workflows/version-bump.test.ts
+++ b/.github/workflows/version-bump.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+
+const WORKFLOW_PATH = '.github/workflows/version-bump.yml'
+
+describe('automatic version-bump policy', () => {
+  const workflow = readFileSync(WORKFLOW_PATH, 'utf8')
+
+  it('caps major-prefixed commits at a minor release', () => {
+    expect(workflow).toMatch(/\^major:[\s\S]{0,200}COMMIT_BUMP="minor"/)
+    expect(workflow).toMatch(/\^major:[\s\S]{0,200}BODY_BUMP="minor"/)
+    expect(workflow).not.toContain('BUMP="major"')
+    expect(workflow).not.toContain('MAJOR=$((MAJOR + 1))')
+  })
+})

--- a/.github/workflows/version-bump.test.ts
+++ b/.github/workflows/version-bump.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 
+import { hasHumanMajorLabelEvent } from '../scripts/major-release-approval.mjs'
 import {
   getCommitBump,
   isMajorTransition,
@@ -50,6 +51,32 @@ describe('automatic version-bump policy', () => {
   it('recognizes a major version transition for the tag guard', () => {
     expect(isMajorTransition('v1.161.52', 'v1.162.0')).toBe(false)
     expect(isMajorTransition('v1.161.52', 'v2.0.0')).toBe(true)
+  })
+
+  it('accepts approval only when a user applied the current major label', () => {
+    const pullRequest = {
+      merged_at: '2026-09-09T12:00:00Z',
+      labels: [{ name: 'release:major' }]
+    }
+
+    expect(
+      hasHumanMajorLabelEvent(pullRequest, [
+        {
+          event: 'labeled',
+          label: { name: 'release:major' },
+          actor: { type: 'Bot' }
+        }
+      ])
+    ).toBe(false)
+    expect(
+      hasHumanMajorLabelEvent(pullRequest, [
+        {
+          event: 'labeled',
+          label: { name: 'release:major' },
+          actor: { type: 'User' }
+        }
+      ])
+    ).toBe(true)
   })
 
   it('runs the executable policy and tag approval guards in both workflows', () => {

--- a/.github/workflows/version-bump.test.ts
+++ b/.github/workflows/version-bump.test.ts
@@ -1,14 +1,63 @@
 import { readFileSync } from 'node:fs'
 
-const WORKFLOW_PATH = '.github/workflows/version-bump.yml'
+import {
+  getCommitBump,
+  isMajorTransition,
+  nextVersion,
+  selectVersionBump
+} from '../scripts/version-bump-policy.mjs'
 
 describe('automatic version-bump policy', () => {
-  const workflow = readFileSync(WORKFLOW_PATH, 'utf8')
+  it('turns an unapproved major marker into a minor release', () => {
+    const result = selectVersionBump([
+      {
+        subject: 'major: remove legacy endpoints',
+        body: '',
+        changedFiles: ['lib/api.ts']
+      }
+    ])
 
-  it('caps major-prefixed commits at a minor release', () => {
-    expect(workflow).toMatch(/\^major:[\s\S]{0,200}COMMIT_BUMP="minor"/)
-    expect(workflow).toMatch(/\^major:[\s\S]{0,200}BODY_BUMP="minor"/)
-    expect(workflow).not.toContain('BUMP="major"')
-    expect(workflow).not.toContain('MAJOR=$((MAJOR + 1))')
+    expect(result).toEqual({ bump: 'minor', commitCount: 1 })
+    expect(nextVersion('v1.161.52', result.bump)).toBe('1.162.0')
+  })
+
+  it('requires approval for major markers in subjects and squash bodies', () => {
+    expect(
+      getCommitBump({
+        subject: 'major: remove legacy endpoints',
+        body: '',
+        changedFiles: ['lib/api.ts'],
+        majorApproved: true
+      })
+    ).toBe('major')
+    expect(
+      getCommitBump({
+        subject: 'feat: use new API',
+        body: '- minor: add a compatible option\n- major: remove the old API',
+        changedFiles: ['lib/api.ts'],
+        majorApproved: true
+      })
+    ).toBe('major')
+    expect(
+      getCommitBump({
+        subject: 'feat: use new API',
+        body: '- major: remove the old API',
+        changedFiles: ['lib/api.ts']
+      })
+    ).toBe('minor')
+  })
+
+  it('recognizes a major version transition for the tag guard', () => {
+    expect(isMajorTransition('v1.161.52', 'v1.162.0')).toBe(false)
+    expect(isMajorTransition('v1.161.52', 'v2.0.0')).toBe(true)
+  })
+
+  it('runs the executable policy and tag approval guards in both workflows', () => {
+    expect(
+      readFileSync('.github/workflows/version-bump.yml', 'utf8')
+    ).toContain('node .github/scripts/determine-version-bump.mjs')
+    expect(readFileSync('.github/workflows/tag-version.yml', 'utf8')).toContain(
+      'node .github/scripts/verify-major-tag-approval.mjs'
+    )
   })
 })

--- a/.github/workflows/version-bump.test.ts
+++ b/.github/workflows/version-bump.test.ts
@@ -64,7 +64,8 @@ describe('automatic version-bump policy', () => {
         {
           event: 'labeled',
           label: { name: 'release:major' },
-          actor: { type: 'Bot' }
+          actor: { type: 'Bot' },
+          created_at: '2026-09-09T12:00:00Z'
         }
       ])
     ).toBe(false)
@@ -73,10 +74,33 @@ describe('automatic version-bump policy', () => {
         {
           event: 'labeled',
           label: { name: 'release:major' },
-          actor: { type: 'User' }
+          actor: { type: 'User' },
+          created_at: '2026-09-09T12:00:00Z'
         }
       ])
     ).toBe(true)
+    expect(
+      hasHumanMajorLabelEvent(pullRequest, [
+        {
+          event: 'labeled',
+          label: { name: 'release:major' },
+          actor: { type: 'User' },
+          created_at: '2026-09-09T12:00:00Z'
+        },
+        {
+          event: 'unlabeled',
+          label: { name: 'release:major' },
+          actor: { type: 'User' },
+          created_at: '2026-09-09T12:01:00Z'
+        },
+        {
+          event: 'labeled',
+          label: { name: 'release:major' },
+          actor: { type: 'Bot' },
+          created_at: '2026-09-09T12:02:00Z'
+        }
+      ])
+    ).toBe(false)
   })
 
   it('runs the executable policy and tag approval guards in both workflows', () => {

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -154,7 +154,7 @@ jobs:
               exit 0
             fi
 
-            node .github/scripts/verify-major-tag-approval.mjs "v${NEW_VERSION}"
+            SOURCE_MAIN_SHA="$BASE_SHA" node .github/scripts/verify-major-tag-approval.mjs "v${NEW_VERSION}"
             git tag -a "v${NEW_VERSION}" -m "Version ${NEW_VERSION}" "$BASE_SHA"
             git push origin "v${NEW_VERSION}"
             exit 0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: write
   contents: write
+  issues: read
   pull-requests: write
 
 env:
@@ -220,13 +221,6 @@ jobs:
               --base main \
               --head "$VERSION_BUMP_BRANCH")
             echo "Created PR: $PR_URL"
-          fi
-
-          PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
-          if [ "$BUMP" = "major" ]; then
-            gh pr edit "$PR_NUMBER" --add-label release:major
-          else
-            gh pr edit "$PR_NUMBER" --remove-label release:major || true
           fi
 
           HEAD_SHA=$(git rev-parse HEAD)
@@ -457,27 +451,9 @@ jobs:
             return 1
           }
 
-          # Hand the PR to GitHub instead of dropping it whenever this run gives
-          # up. Every abandon path used to exit having armed nothing, so the
-          # bump then waited for an entirely new run — which only happens on the
-          # next push to main, i.e. hours on a quiet day. Arming is safe even
-          # for a bump whose version may be stale, because branch protection is
-          # `strict`: an armed PR can merge only while it is both green *and*
-          # up to date with main, and a stale bump goes BEHIND the moment main
-          # moves, staying blocked until the next run force-pushes the
-          # recomputed version onto it.
-          arm_auto_merge() {
-            local pr_url="$1"
-
-            if gh pr merge --auto --squash --delete-branch "$pr_url"; then
-              echo "Armed auto-merge on ${pr_url}; GitHub will merge it once branch protection is satisfied."
-            else
-              echo "::warning::Could not arm auto-merge on ${pr_url}."
-            fi
-          }
-
           CHECKS_ERROR=$(mktemp)
           trap 'rm -f "$CHECKS_ERROR"' EXIT
+          CHECKS_VERIFIED=0
 
           set +e
           BRANCH_PROTECTION_CHECK_NAMES=$(read_branch_protection_required_checks "$CHECKS_ERROR")
@@ -485,18 +461,16 @@ jobs:
           set -e
 
           if [ "$BRANCH_PROTECTION_CHECKS_EXIT" -ne 0 ] || [ -z "$BRANCH_PROTECTION_CHECK_NAMES" ]; then
-            # With no expected set to wait on there is nothing to gate locally.
-            # Enabling auto-merge is still safe: GitHub will not merge the PR
-            # until branch protection is satisfied.
-            echo "::warning::No branch-protection required status checks to wait on; relying on auto-merge to gate the merge."
+            echo "::warning::No branch-protection required status checks to wait on; leaving $PR_URL open."
           else
             echo "Branch-protection required checks: $(join_check_names "$BRANCH_PROTECTION_CHECK_NAMES")."
 
             if ! wait_for_required_checks "$PR_URL" "$HEAD_SHA" "$BRANCH_PROTECTION_CHECK_NAMES"; then
               echo "::warning::Required PR checks did not pass; leaving $PR_URL open."
-              arm_auto_merge "$PR_URL"
               exit 0
             fi
+
+            CHECKS_VERIFIED=1
           fi
 
           git fetch --force origin main
@@ -504,45 +478,16 @@ jobs:
 
           if [ "$LATEST_MAIN_SHA" != "$BASE_SHA" ]; then
             echo "Leaving $PR_URL open: main moved from $BASE_SHA to $LATEST_MAIN_SHA while checks were running."
-            arm_auto_merge "$PR_URL"
             exit 0
           fi
 
-          if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
-            echo "Enabled auto-merge for $PR_URL"
+          if [ "$CHECKS_VERIFIED" -ne 1 ]; then
+            echo "::warning::Required checks were not independently verified; leaving $PR_URL open."
             exit 0
           fi
 
-          # Auto-merge can only be *enabled* while the PR is still blocked, and
-          # by now the required checks have usually all passed, so GitHub
-          # rejects the request with "Pull request is in clean status". Merging
-          # directly is the right answer for that case only — never for an
-          # arbitrary --auto failure. PAT_TOKEN belongs to a repo admin and
-          # `enforce_admins` is false on main, so a blind direct merge here
-          # could push a bump past required checks this gate never verified
-          # (most sharply on the "could not read branch protection" path above,
-          # which does no local gating at all). Re-read the merge state and
-          # merge only what GitHub itself already considers CLEAN.
-          MERGE_STATE=""
-
-          for merge_state_attempt in 1 2 3; do
-            MERGE_STATE=$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || true)
-
-            # UNKNOWN means GitHub has not finished computing mergeability yet,
-            # not that the PR is unmergeable; the read itself kicks that off.
-            if [ -n "$MERGE_STATE" ] && [ "$MERGE_STATE" != "UNKNOWN" ]; then
-              break
-            fi
-
-            if [ "$merge_state_attempt" -lt 3 ]; then
-              sleep 5
-            fi
-          done
-
-          if [ "$MERGE_STATE" = "CLEAN" ]; then
-            echo "Auto-merge was refused and $PR_URL is CLEAN; merging it directly."
-            gh pr merge --squash --delete-branch "$PR_URL"
+          if gh pr merge --squash --delete-branch "$PR_URL"; then
             echo "Merged $PR_URL"
           else
-            echo "::warning::Could not enable auto-merge for $PR_URL and its merge state is ${MERGE_STATE:-unreadable}; leaving it open."
+            echo "::warning::Could not merge $PR_URL after verification; leaving it open."
           fi

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -152,8 +152,11 @@ jobs:
 
             COMMIT_COUNT=$((COMMIT_COUNT + 1))
 
+            # Automatic releases are capped at a minor bump. A breaking-change
+            # prefix documents the compatibility impact, but a major release
+            # needs the separate maintainer-led release process.
             if echo "$SUBJECT" | grep -qE '^major:'; then
-              COMMIT_BUMP="major"
+              COMMIT_BUMP="minor"
             elif echo "$SUBJECT" | grep -qE '^minor:'; then
               COMMIT_BUMP="minor"
             elif echo "$SUBJECT" | grep -qE '^none:'; then
@@ -167,7 +170,7 @@ jobs:
                   clean_line=$(echo "$line" | sed -E 's/^[[:space:]]*[-*][[:space:]]+//')
 
                   if echo "$clean_line" | grep -qE '^major:'; then
-                    BODY_BUMP="major"
+                    BODY_BUMP="minor"
                     break
                   elif echo "$clean_line" | grep -qE '^minor:'; then
                     BODY_BUMP="minor"
@@ -186,9 +189,6 @@ jobs:
             fi
 
             case "$COMMIT_BUMP" in
-              major)
-                BUMP="major"
-                ;;
               minor)
                 if [ "$BUMP" = "none" ] || [ "$BUMP" = "patch" ]; then
                   BUMP="minor"
@@ -216,11 +216,6 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
           case "$BUMP" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
             minor)
               MINOR=$((MINOR + 1))
               PATCH=0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -94,142 +94,13 @@ jobs:
 
       - name: Determine version bump
         id: bump
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           git fetch --force origin main '+refs/tags/*:refs/tags/*'
-
-          BASE_SHA=$(git rev-parse origin/main)
-          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
-
-          if [ "$GITHUB_SHA" != "$BASE_SHA" ]; then
-            echo "Skipping: $GITHUB_SHA is no longer the latest main commit ($BASE_SHA)."
-            echo "new_version=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          HEAD_MSG=$(git log -1 --pretty=format:"%s" "$BASE_SHA")
-          if echo "$HEAD_MSG" | grep -qE '^Bump version to v[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "Skipping: latest main commit is already a version bump."
-            echo "new_version=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git checkout --detach "$BASE_SHA"
-
-          LATEST_TAG=$(git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname | sed -n '1p')
-
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No existing version tag found. Will create v1.0.0."
-            echo "bump=initial" >> "$GITHUB_OUTPUT"
-            echo "commit_count=0" >> "$GITHUB_OUTPUT"
-            echo "latest_tag=" >> "$GITHUB_OUTPUT"
-            echo "new_version=1.0.0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Latest reachable tag: $LATEST_TAG"
-          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-
-          COMMIT_HASHES=$(git log "$LATEST_TAG"..HEAD --pretty=format:"%H" --no-merges)
-
-          if [ -z "$COMMIT_HASHES" ]; then
-            echo "No new commits since $LATEST_TAG"
-            echo "new_version=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          BUMP="none"
-          COMMIT_COUNT=0
-
-          while IFS= read -r hash; do
-            SUBJECT=$(git log -1 --pretty=format:"%s" "$hash")
-            COMMIT_BUMP="patch"
-
-            if echo "$SUBJECT" | grep -qE '^Bump version to v[0-9]+\.[0-9]+\.[0-9]+'; then
-              continue
-            fi
-
-            COMMIT_COUNT=$((COMMIT_COUNT + 1))
-
-            # Automatic releases are capped at a minor bump. A breaking-change
-            # prefix documents the compatibility impact, but a major release
-            # needs the separate maintainer-led release process.
-            if echo "$SUBJECT" | grep -qE '^major:'; then
-              COMMIT_BUMP="minor"
-            elif echo "$SUBJECT" | grep -qE '^minor:'; then
-              COMMIT_BUMP="minor"
-            elif echo "$SUBJECT" | grep -qE '^none:'; then
-              COMMIT_BUMP="none"
-            else
-              BODY=$(git log -1 --pretty=format:"%b" "$hash")
-              BODY_BUMP=""
-
-              if [ -n "$BODY" ]; then
-                while IFS= read -r line; do
-                  clean_line=$(echo "$line" | sed -E 's/^[[:space:]]*[-*][[:space:]]+//')
-
-                  if echo "$clean_line" | grep -qE '^major:'; then
-                    BODY_BUMP="minor"
-                    break
-                  elif echo "$clean_line" | grep -qE '^minor:'; then
-                    BODY_BUMP="minor"
-                  fi
-                done <<< "$BODY"
-              fi
-
-              if [ -n "$BODY_BUMP" ]; then
-                COMMIT_BUMP="$BODY_BUMP"
-              else
-                CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r --root "$hash")
-                if [ -n "$CHANGED_FILES" ] && ! echo "$CHANGED_FILES" | grep -qvE '^(\.github/|$)'; then
-                  COMMIT_BUMP="none"
-                fi
-              fi
-            fi
-
-            case "$COMMIT_BUMP" in
-              minor)
-                if [ "$BUMP" = "none" ] || [ "$BUMP" = "patch" ]; then
-                  BUMP="minor"
-                fi
-                ;;
-              patch)
-                if [ "$BUMP" = "none" ]; then
-                  BUMP="patch"
-                fi
-                ;;
-            esac
-          done <<< "$COMMIT_HASHES"
-
-          if [ "$BUMP" = "none" ]; then
-            echo "Skipping: no releasable commits found since $LATEST_TAG."
-            echo "bump=none" >> "$GITHUB_OUTPUT"
-            echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
-            echo "new_version=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Bump type: $BUMP"
-
-          CURRENT="${LATEST_TAG#v}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-
-          case "$BUMP" in
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
-
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          echo "New version: $NEW_VERSION"
-          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
-          echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          node .github/scripts/determine-version-bump.mjs
 
       - name: Use Node.js 24
         if: steps.bump.outputs.new_version != ''
@@ -282,6 +153,7 @@ jobs:
               exit 0
             fi
 
+            node .github/scripts/verify-major-tag-approval.mjs "v${NEW_VERSION}"
             git tag -a "v${NEW_VERSION}" -m "Version ${NEW_VERSION}" "$BASE_SHA"
             git push origin "v${NEW_VERSION}"
             exit 0
@@ -348,6 +220,13 @@ jobs:
               --base main \
               --head "$VERSION_BUMP_BRANCH")
             echo "Created PR: $PR_URL"
+          fi
+
+          PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+          if [ "$BUMP" = "major" ]; then
+            gh pr edit "$PR_NUMBER" --add-label release:major
+          else
+            gh pr edit "$PR_NUMBER" --remove-label release:major || true
           fi
 
           HEAD_SHA=$(git rev-parse HEAD)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Use Node.js 24 and Yarn for all repository commands. The canonical local gate is
 
 For every change, read the [testing rules](CONTRIBUTING.md#agents-testing-guidelines), [commit and PR rules](CONTRIBUTING.md#agents-commit-pull-request-guidelines), [review loop](CONTRIBUTING.md#agents-code-review-loop-sub-agents), and [documentation rules](CONTRIBUTING.md#agents-documentation-maintenance). These apply even when the change does not touch those files.
 
-Open a feature-branch PR after all five local gates pass. Independently review the entire PR, post findings, address them, reply and resolve discussions, and repeat until clean or 20 rounds. Use the documented self-review exception only when sub-agents are unavailable. Never manually change the package version; use a conventional commit subject and PR title. Automated releases are capped at minor; a major release is maintainer-led.
+Open a feature-branch PR after all five local gates pass. Independently review the entire PR, post findings, address them, reply and resolve discussions, and repeat until clean or 20 rounds. Use the documented self-review exception only when sub-agents are unavailable. Never manually change the package version; use a conventional commit subject and PR title. A `major:` release requires a human maintainer to apply the `release:major` label; agents must never apply that label.
 
 ## Required subsystem reading map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Use Node.js 24 and Yarn for all repository commands. The canonical local gate is
 
 For every change, read the [testing rules](CONTRIBUTING.md#agents-testing-guidelines), [commit and PR rules](CONTRIBUTING.md#agents-commit-pull-request-guidelines), [review loop](CONTRIBUTING.md#agents-code-review-loop-sub-agents), and [documentation rules](CONTRIBUTING.md#agents-documentation-maintenance). These apply even when the change does not touch those files.
 
-Open a feature-branch PR after all five local gates pass. Independently review the entire PR, post findings, address them, reply and resolve discussions, and repeat until clean or 20 rounds. Use the documented self-review exception only when sub-agents are unavailable. Never manually change the package version; use a conventional commit subject and PR title.
+Open a feature-branch PR after all five local gates pass. Independently review the entire PR, post findings, address them, reply and resolve discussions, and repeat until clean or 20 rounds. Use the documented self-review exception only when sub-agents are unavailable. Never manually change the package version; use a conventional commit subject and PR title. Automated releases are capped at minor; a major release is maintainer-led.
 
 ## Required subsystem reading map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -998,7 +998,7 @@ The version-bump workflow reads commit prefixes to determine the next semver ver
 
 PRs are **squash-merged**, so the **PR title becomes the commit subject** on `main`. The workflow checks the commit subject first, then falls back to scanning the commit body (which contains the individual commit messages).
 
-**To ensure a minor version bump, the PR title MUST start with `minor:`.** A `major:` title produces a major bump only after a human maintainer applies the `release:major` label to the feature PR. Agents must never apply this label. Without it, `major:` produces a minor bump. The generated version-bump PR carries the label forward so the tag workflow can verify the approval. For example:
+**To ensure a minor version bump, the PR title MUST start with `minor:`.** A `major:` title produces a major bump only after a human maintainer applies the `release:major` label to the feature PR. Agents must never apply this label. Without it, `major:` produces a minor bump. The tag workflow independently verifies that approval on the source PR. For example:
 
 ```text
 minor: add hashtag timeline support        ← PR title → minor bump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -974,7 +974,7 @@ each ends with the Definition of Done gate.
 - **Work reaches `main` as a pull request**: commit to the feature branch, push it, and open a PR. Nothing is merged by committing to `main` directly (Definition of Done item 1), and the review loop below has no PR to attach to until this has happened.
 - Commit messages must start with one of these prefixes followed by a short imperative description:
   - `none:` to mark that commit as no-release unless another commit in the range requests a higher bump
-  - `major:` for breaking changes (recorded as breaking; automatic releases cap it at a minor bump)
+  - `major:` for breaking changes (a major release requires a human maintainer to apply the `release:major` label)
   - `minor:` for backwards-compatible new features (minor version bump)
   - `fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`, etc. for everything else (patch version bump)
 - PRs should include a clear summary, linked issues (if any), test results, and notes for config/migrations.
@@ -990,7 +990,7 @@ The version-bump workflow reads commit prefixes to determine the next semver ver
 | Prefix               | Version bump    | When to use                                                                                                                  |
 | -------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `none:`              | None            | For internal-only changes that do not require a release (e.g. documentation, CI configuration)                               |
-| `major:`             | Minor (`x.Y.0`) | Records a breaking change. Automated releases are capped at minor; a major release uses the separate maintainer-led process. |
+| `major:`             | Major (`X.0.0`) | Breaking change approved by a human maintainer with the `release:major` label. Without that label, it produces a minor bump. |
 | `minor:`             | Minor (`x.Y.0`) | New backwards-compatible features users can opt into (e.g. new endpoint, new UI page, new optional config)                   |
 | _(any other prefix)_ | Patch (`x.y.Z`) | Bug fixes, refactors, chores, docs, tests — anything that doesn't change the public-facing contract                          |
 
@@ -998,11 +998,11 @@ The version-bump workflow reads commit prefixes to determine the next semver ver
 
 PRs are **squash-merged**, so the **PR title becomes the commit subject** on `main`. The workflow checks the commit subject first, then falls back to scanning the commit body (which contains the individual commit messages).
 
-**To ensure a minor version bump, the PR title MUST start with `minor:`.** A `major:` title records a breaking change but is intentionally capped at a minor bump by automation. For example:
+**To ensure a minor version bump, the PR title MUST start with `minor:`.** A `major:` title produces a major bump only after a human maintainer applies the `release:major` label to the feature PR. Agents must never apply this label. Without it, `major:` produces a minor bump. The generated version-bump PR carries the label forward so the tag workflow can verify the approval. For example:
 
 ```text
 minor: add hashtag timeline support        ← PR title → minor bump
-major: remove legacy v1 API endpoints      ← PR title → minor bump; major release is maintainer-led
+major: remove legacy v1 API endpoints      ← PR title + human `release:major` label → major bump
 feat: fix button alignment                 ← PR title → patch bump (default)
 ```
 
@@ -1018,7 +1018,7 @@ Examples:
 ```text
 none: update internal CI docs without cutting a release
 chore: tweak GitHub Actions cache keys              ← no bump if the commit only changes `.github/`
-major: remove legacy v1 API endpoints      ← automatic minor; major release is maintainer-led
+major: remove legacy v1 API endpoints      ← major only with a human `release:major` label; otherwise minor
 minor: add support for S3 media storage
 fix: correct timestamp parsing in ActivityPub inbox   ← patch
 chore: update dependencies                            ← patch
@@ -1161,9 +1161,10 @@ attachment ref guard` is exactly that: it passed with the bug present until
   `chore:`, `refactor:`, `test:`, `docs:`, `none:`, `minor:`, `major:`).
 - `version` in `package.json` is never edited by hand — CI bumps it from prefixes.
 - For a `minor` bump the **PR title** carries the prefix (PRs squash-merge, so the
-  title is the commit subject). `major:` records a breaking change but automation
-  caps it at minor; a major release is maintainer-led. `.github/`-only changes are
-  no-bump unless explicitly `minor:` or `major:`.
+  title is the commit subject). A `major:` PR becomes a major release only when a
+  human maintainer applies the `release:major` label; agents must never apply it.
+  Without the label, it becomes a minor release. `.github/`-only changes are no-bump
+  unless explicitly `minor:` or `major:`.
 - Pre-commit gate is green in order: `yarn run prettier --write .`, `yarn lint`,
   `yarn typecheck`, `yarn build`, `yarn test`.
 - All required CI status checks pass (`All Tests`, `Lint and Prettier`, `Build`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -974,7 +974,7 @@ each ends with the Definition of Done gate.
 - **Work reaches `main` as a pull request**: commit to the feature branch, push it, and open a PR. Nothing is merged by committing to `main` directly (Definition of Done item 1), and the review loop below has no PR to attach to until this has happened.
 - Commit messages must start with one of these prefixes followed by a short imperative description:
   - `none:` to mark that commit as no-release unless another commit in the range requests a higher bump
-  - `major:` for breaking changes (major version bump)
+  - `major:` for breaking changes (recorded as breaking; automatic releases cap it at a minor bump)
   - `minor:` for backwards-compatible new features (minor version bump)
   - `fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`, etc. for everything else (patch version bump)
 - PRs should include a clear summary, linked issues (if any), test results, and notes for config/migrations.
@@ -987,22 +987,22 @@ each ends with the Definition of Done gate.
 
 The version-bump workflow reads commit prefixes to determine the next semver version. Use these prefixes to control version bumping:
 
-| Prefix               | Version bump    | When to use                                                                                                                                      |
-| -------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `none:`              | None            | For internal-only changes that do not require a release (e.g. documentation, CI configuration)                                                   |
-| `major:`             | Major (`X.0.0`) | Breaking changes that require users to update configs, migrations, or integrations (e.g. removed API, changed auth flow, incompatible DB schema) |
-| `minor:`             | Minor (`x.Y.0`) | New backwards-compatible features users can opt into (e.g. new endpoint, new UI page, new optional config)                                       |
-| _(any other prefix)_ | Patch (`x.y.Z`) | Bug fixes, refactors, chores, docs, tests — anything that doesn't change the public-facing contract                                              |
+| Prefix               | Version bump    | When to use                                                                                                                  |
+| -------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `none:`              | None            | For internal-only changes that do not require a release (e.g. documentation, CI configuration)                               |
+| `major:`             | Minor (`x.Y.0`) | Records a breaking change. Automated releases are capped at minor; a major release uses the separate maintainer-led process. |
+| `minor:`             | Minor (`x.Y.0`) | New backwards-compatible features users can opt into (e.g. new endpoint, new UI page, new optional config)                   |
+| _(any other prefix)_ | Patch (`x.y.Z`) | Bug fixes, refactors, chores, docs, tests — anything that doesn't change the public-facing contract                          |
 
 #### Squash-merge and PR titles
 
 PRs are **squash-merged**, so the **PR title becomes the commit subject** on `main`. The workflow checks the commit subject first, then falls back to scanning the commit body (which contains the individual commit messages).
 
-**To ensure a `minor` or `major` version bump, the PR title MUST start with `minor:` or `major:`.** For example:
+**To ensure a minor version bump, the PR title MUST start with `minor:`.** A `major:` title records a breaking change but is intentionally capped at a minor bump by automation. For example:
 
 ```text
 minor: add hashtag timeline support        ← PR title → minor bump
-major: remove legacy v1 API endpoints      ← PR title → major bump
+major: remove legacy v1 API endpoints      ← PR title → minor bump; major release is maintainer-led
 feat: fix button alignment                 ← PR title → patch bump (default)
 ```
 
@@ -1018,7 +1018,7 @@ Examples:
 ```text
 none: update internal CI docs without cutting a release
 chore: tweak GitHub Actions cache keys              ← no bump if the commit only changes `.github/`
-major: remove legacy v1 API endpoints
+major: remove legacy v1 API endpoints      ← automatic minor; major release is maintainer-led
 minor: add support for S3 media storage
 fix: correct timestamp parsing in ActivityPub inbox   ← patch
 chore: update dependencies                            ← patch
@@ -1160,9 +1160,10 @@ attachment ref guard` is exactly that: it passed with the bug present until
 - Every commit subject starts with a conventional prefix (`fix:`, `feat:`,
   `chore:`, `refactor:`, `test:`, `docs:`, `none:`, `minor:`, `major:`).
 - `version` in `package.json` is never edited by hand — CI bumps it from prefixes.
-- For a `minor`/`major` bump the **PR title** carries the prefix (PRs squash-merge,
-  so the title is the commit subject). `.github/`-only changes are no-bump unless
-  explicitly `minor:`/`major:`.
+- For a `minor` bump the **PR title** carries the prefix (PRs squash-merge, so the
+  title is the commit subject). `major:` records a breaking change but automation
+  caps it at minor; a major release is maintainer-led. `.github/`-only changes are
+  no-bump unless explicitly `minor:` or `major:`.
 - Pre-commit gate is green in order: `yarn run prettier --write .`, `yarn lint`,
   `yarn typecheck`, `yarn build`, `yarn test`.
 - All required CI status checks pass (`All Tests`, `Lint and Prettier`, `Build`,


### PR DESCRIPTION
## Summary

- Delete the accidental `v2.0.0` and `v2.0.1` tags, then restore the pending release line to `v1.162.0`.
- Require a human maintainer to apply `release:major` before a `major:` marker can produce a major release; unapproved markers produce a minor release.
- Verify the approval again before any major tag is created, including the direct-tag fallback, and document that agents must never apply the approval label.

## Validation

- `yarn run prettier --write .`
- `yarn lint`
- `yarn test .github/workflows/version-bump.test.ts`
- `yarn typecheck` is blocked by pre-existing generated Next route-type errors outside this diff.
- `yarn build` is blocked in this workspace because Turbopack cannot bind its required local helper port; this occurs with and without sandbox escalation.
- Full CI is required before merge.
