### PR TITLE
Bump version to v1.162.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "2.0.1",
+  "version": "1.162.0",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.161.52`
- Base main SHA: `74d4b96ea85eb102a863bcf46382d581b93772ba`
- Included commits: `5`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
