### PR TITLE
Bump version to v1.162.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.162.0",
+  "version": "1.162.1",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.162.0`
- Base main SHA: `e85dc176ad7b1873cb2d66e5cf06b0e7655cde11`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
