### PR TITLE
Bump version to v1.162.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.162.1",
+  "version": "1.162.2",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.162.1`
- Base main SHA: `a151bf12749ecdceb26c9a3da293119dec41ce97`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
