### PR TITLE
fix: prevent excessive blank space beneath collapsed posts in Safari

### DIFF
--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -93,6 +93,8 @@ describe('CollapsibleContent', () => {
     )
 
     expect(content).toHaveClass('overflow-hidden')
+    expect(content).toHaveClass('min-h-0')
+    expect(content?.parentElement).toHaveClass('min-h-0')
     expect(content?.style.height).toBe(COLLAPSED_HEIGHT_REM)
     expect(content?.style.maxHeight).toBe('')
   })

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -63,10 +63,10 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   const needsCollapse = isOverflowing && !isExpanded
 
   return (
-    <div className="relative">
+    <div className="relative min-h-0">
       <div
         id={contentId}
-        className={cn(className, needsCollapse && 'overflow-hidden')}
+        className={cn(className, needsCollapse && 'overflow-hidden min-h-0')}
         style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
       >
         <div ref={measuredContentRef} className={contentClassName}>

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -2390,4 +2390,26 @@ describe('Post', () => {
       expect(screen.getByText('A linked article')).toBeInTheDocument()
     })
   })
+
+  describe('layout constraints', () => {
+    it('applies min-h-0 and min-w-0 to outer flex containers and content column to avoid WebKit height inflation', () => {
+      const { container } = render(
+        <Post
+          host="activities.local"
+          currentTime={currentTime}
+          status={status}
+          onShowAttachment={vi.fn()}
+        />
+      )
+
+      const outerCol = container.querySelector('.flex.flex-col')
+      expect(outerCol).toHaveClass('min-h-0', 'min-w-0')
+
+      const innerRow = container.querySelector('.flex.gap-3')
+      expect(innerRow).toHaveClass('min-h-0', 'min-w-0')
+
+      const contentCol = container.querySelector('.flex-1')
+      expect(contentCol).toHaveClass('min-h-0', 'min-w-0')
+    })
+  })
 })

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -437,9 +437,9 @@ export const Post: FC<PostProps> = (props) => {
   )
 
   return (
-    <div className="flex min-w-0 flex-col gap-1">
+    <div className="flex min-h-0 min-w-0 flex-col gap-1">
       <BoostStatus status={status} />
-      <div className="flex min-w-0 gap-3">
+      <div className="flex min-h-0 min-w-0 gap-3">
         <div className="shrink-0">
           <ActorAvatar
             actor={actualStatus.actor}
@@ -447,7 +447,7 @@ export const Post: FC<PostProps> = (props) => {
             statusUrl={actualStatus.url}
           />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-h-0 min-w-0">
           <div className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5 text-sm">
             <ActorInfo
               actor={actualStatus.actor}

--- a/lib/components/posts/posts.test.tsx
+++ b/lib/components/posts/posts.test.tsx
@@ -210,4 +210,15 @@ describe('Posts', () => {
       expect(mockPush).toHaveBeenCalledWith('/@llun/poll-1')
     })
   })
+
+  it('renders article elements with min-h-0 to avoid WebKit flex sizing retention', () => {
+    const { container } = render(
+      <Posts
+        host="activities.local"
+        currentTime={pollStatusCurrentTime}
+        statuses={[pollStatusFixture]}
+      />
+    )
+    expect(container.querySelector('article')).toHaveClass('min-h-0', 'min-w-0')
+  })
 })

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -131,7 +131,7 @@ export const Posts: FC<Props> = ({
             <article
               key={status.id}
               className={cn(
-                'min-w-0 px-4 py-3',
+                'min-h-0 min-w-0 px-4 py-3',
                 // Match the framed box's corners so any child background can't
                 // bleed past the rounded edges now that overflow-hidden is gone.
                 framed && 'first:rounded-t-xl last:rounded-b-xl'


### PR DESCRIPTION
## Summary

Fixes excessive blank space beneath collapsed long timeline posts in Safari (macOS Safari and iOS/iPadOS Safari).

### Root Cause
In CSS Flexible Box Layout, flex items default to `min-height: auto`. In WebKit/Safari, when a flex item has `overflow: visible`, its `min-height: auto` calculation evaluates the intrinsic min-content height of its descendants. Even though `CollapsibleContent` clamped its inner element with fixed height and `overflow: hidden`, WebKit evaluated the uncollapsed descendant text's intrinsic size through ancestor flex containers (`.flex-1`, `.flex.gap-3`, `.flex.flex-col`), holding open the post height and rendering an empty gap between the truncated text and the actions bar.

### Changes
- Added `min-h-0` (`min-height: 0`) explicitly to break the intrinsic height retention chain:
  - `lib/components/posts/collapsible-content.tsx`: Added `min-h-0` to the outer `.relative.min-h-0` container and collapsed content wrapper `.overflow-hidden.min-h-0`.
  - `lib/components/posts/post.tsx`: Added `min-h-0` to the outer column container (`flex min-h-0 min-w-0 flex-col`), row container (`flex min-h-0 min-w-0 gap-3`), and content column (`flex-1 min-h-0 min-w-0`).
  - `lib/components/posts/posts.tsx`: Added `min-h-0` to `<article className="min-h-0 min-w-0 px-4 py-3 ...">`.
- Kept `overflow: visible` on all ancestor containers so overlays, focus outlines, edit history popovers, and reaction pickers continue to escape normally.
- Added regression tests in `collapsible-content.test.tsx`, `post.test.tsx`, and `posts.test.tsx`.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)