### PR TITLE
Bump version to v1.162.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.162.2",
+  "version": "1.162.3",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.162.2`
- Base main SHA: `e9791641f7e4fc5b28d20204747a8bb023beb861`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
