### PR TITLE
fix: replace inline post expansion with read full post navigation and fix Safari spacing

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -46,8 +46,17 @@ vi.mock('@/lib/utils/maplibre', () => ({
   OPENFREEMAP_HEATMAP_STYLE_URL: 'https://tiles.openfreemap.org/styles/positron'
 }))
 
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() })
+  useRouter: () => ({ refresh: mockRefresh, push: mockPush })
+}))
+
+vi.mock('@/lib/utils/getStatusDetailPathClient', () => ({
+  getStatusDetailPathClient: vi.fn(
+    async (status: { id: string }) => `/@actor/${status.id}`
+  )
 }))
 
 vi.mock('@/lib/components/posts/actor', () => ({
@@ -79,8 +88,25 @@ vi.mock('@/lib/components/fitness/ActivityRouteMapKit', () => ({
 }))
 
 vi.mock('@/lib/components/posts/post', () => ({
-  Post: ({ status }: { status: { id: string } }) => (
-    <div data-testid="reply-post">{status.id}</div>
+  Post: ({
+    status,
+    onOpenStatus
+  }: {
+    status: { id: string }
+    onOpenStatus?: (status: { id: string }) => void
+  }) => (
+    <div data-testid="reply-post">
+      {status.id}
+      {onOpenStatus && (
+        <button
+          type="button"
+          data-testid={`open-reply-${status.id}`}
+          onClick={() => onOpenStatus(status)}
+        >
+          Open
+        </button>
+      )}
+    </div>
   )
 }))
 
@@ -440,6 +466,8 @@ const expectNoGearOnMetaLine = () =>
 
 describe('FitnessStatusDetail', () => {
   beforeEach(() => {
+    mockPush.mockReset()
+    mockRefresh.mockReset()
     mockGetFitnessFilesByStatus.mockReset()
     mockGetFitnessRouteData.mockReset()
     mockGetFitnessGearList.mockReset()
@@ -679,6 +707,28 @@ describe('FitnessStatusDetail', () => {
     )
     // No composer for logged-out viewers.
     expect(screen.queryByTestId('comment-composer')).not.toBeInTheDocument()
+  })
+
+  it('navigates to reply status detail when reply openStatus is triggered', async () => {
+    const reply = {
+      id: 'reply-1',
+      type: 'Note',
+      actorId: actor.id,
+      actor
+    } as unknown as Status
+
+    renderDetail({ replies: [reply] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }))
+
+    expect(screen.getByTestId('reply-post')).toHaveTextContent('reply-1')
+    expect(screen.getByTestId('open-reply-reply-1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('open-reply-reply-1'))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/@actor/reply-1')
+    })
   })
 
   it('renders the 25 W power distribution section', async () => {

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -70,6 +70,7 @@ import {
   normalizeFitnessSourceUrl
 } from '@/lib/utils/fitness'
 import { getDeviceDisplayLabel } from '@/lib/utils/fitnessDeviceBrands'
+import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 import {
   type MastodonVisibility,
   getVisibility
@@ -424,6 +425,12 @@ export const FitnessStatusDetail: FC<Props> = ({
   onShowAttachment
 }) => {
   const router = useRouter()
+  const openStatus = (statusToOpen: Status) => {
+    void (async () => {
+      const detailPath = await getStatusDetailPathClient(statusToOpen)
+      if (detailPath) router.push(detailPath)
+    })()
+  }
   const [activeSection, setActiveSection] = useState<SectionKey>('overview')
   // `separate` (the default) stacks each selected graph into its own row; the new
   // `combined` option overlays them in one chart.
@@ -1920,6 +1927,7 @@ export const FitnessStatusDetail: FC<Props> = ({
                       currentTime={currentTime}
                       status={reply}
                       collapsible
+                      onOpenStatus={openStatus}
                       onShowAttachment={onShowAttachment}
                     />
                   </article>

--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { CollapsibleContent } from './collapsible-content'
 
@@ -165,5 +165,56 @@ describe('CollapsibleContent', () => {
     ).toHaveTextContent(
       'Long status content that exceeds the timeline line limit.'
     )
+  })
+
+  it('renders a Read full post button when onReadMore is provided and invokes it on click', async () => {
+    const handleReadMore = vi.fn()
+    render(
+      <CollapsibleContent maxLines={5} onReadMore={handleReadMore}>
+        Long status content that exceeds the timeline line limit.
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Read full post' })
+      ).toBeInTheDocument()
+    })
+
+    const button = screen.getByRole('button', { name: 'Read full post' })
+    fireEvent.click(button)
+
+    expect(handleReadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a Show more button when onReadMore is omitted and expands content on click', async () => {
+    render(
+      <CollapsibleContent maxLines={5}>
+        Long status content that exceeds the timeline line limit.
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Show more content' })
+      ).toBeInTheDocument()
+    })
+
+    const button = screen.getByRole('button', { name: 'Show more content' })
+    const content = document.getElementById(
+      button.getAttribute('aria-controls')!
+    )
+    expect(content).toHaveClass('overflow-hidden')
+    expect(content?.style.height).toBe(COLLAPSED_HEIGHT_REM)
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Show more content' })
+      ).not.toBeInTheDocument()
+    })
+    expect(content).not.toHaveClass('overflow-hidden')
+    expect(content?.style.height).toBe('')
   })
 })

--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -217,4 +217,31 @@ describe('CollapsibleContent', () => {
     expect(content).not.toHaveClass('overflow-hidden')
     expect(content?.style.height).toBe('')
   })
+
+  it('does not collapse or show a button for content that fits within the line limit', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 50
+    })
+
+    render(
+      <CollapsibleContent maxLines={5} onReadMore={vi.fn()}>
+        Short status content.
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Read full post' })
+      ).not.toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Show more content' })
+    ).not.toBeInTheDocument()
+
+    const content = screen.getByText('Short status content.').parentElement
+    expect(content).not.toHaveClass('overflow-hidden')
+    expect(content?.style.height).toBe('')
+    expect(content?.style.maxHeight).toBe('')
+  })
 })

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -68,12 +68,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   const shouldClamp = needsCollapse || (!hasCheckedOverflow && !isExpanded)
 
   return (
-    <div
-      className={cn(
-        'relative min-h-0',
-        (needsCollapse || shouldClamp) && 'overflow-hidden'
-      )}
-    >
+    <div className={cn('relative min-h-0', shouldClamp && 'overflow-hidden')}>
       <div
         id={contentId}
         className={cn(className, shouldClamp && 'overflow-hidden min-h-0')}
@@ -96,7 +91,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
               type="button"
               aria-controls={contentId}
               aria-label="Read full post"
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2.5 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2.5 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
               onClick={(e) => {
                 e.stopPropagation()
                 onReadMore()
@@ -111,7 +106,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
               aria-expanded={isExpanded}
               aria-controls={contentId}
               aria-label="Show more content"
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
               onClick={(e) => {
                 e.stopPropagation()
                 setIsExpanded(true)

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import {
   FC,
   ReactNode,
@@ -18,6 +18,7 @@ interface CollapsibleContentProps {
   className?: string
   contentClassName?: string
   maxLines?: number
+  onReadMore?: () => void
 }
 
 const LINE_HEIGHT_REM = 1.4375 // ~line height for text-sm leading-relaxed
@@ -26,9 +27,11 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   children,
   className,
   contentClassName,
-  maxLines = 5
+  maxLines = 5,
+  onReadMore
 }) => {
   const measuredContentRef = useRef<HTMLDivElement>(null)
+  const [hasCheckedOverflow, setHasCheckedOverflow] = useState(false)
   const [isOverflowing, setIsOverflowing] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const contentId = useId()
@@ -43,6 +46,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
       maxHeightRem *
       parseFloat(getComputedStyle(document.documentElement).fontSize)
     setIsOverflowing(el.scrollHeight > maxHeightPx + 2) // 2px tolerance
+    setHasCheckedOverflow(true)
   }, [maxHeightRem])
 
   useEffect(() => {
@@ -61,13 +65,25 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   }, [checkOverflow])
 
   const needsCollapse = isOverflowing && !isExpanded
+  const shouldClamp = needsCollapse || (!hasCheckedOverflow && !isExpanded)
 
   return (
-    <div className="relative min-h-0">
+    <div
+      className={cn(
+        'relative min-h-0',
+        (needsCollapse || shouldClamp) && 'overflow-hidden'
+      )}
+    >
       <div
         id={contentId}
-        className={cn(className, needsCollapse && 'overflow-hidden min-h-0')}
-        style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
+        className={cn(className, shouldClamp && 'overflow-hidden min-h-0')}
+        style={
+          needsCollapse
+            ? { height: `${maxHeightRem}rem` }
+            : shouldClamp
+              ? { maxHeight: `${maxHeightRem}rem` }
+              : undefined
+        }
       >
         <div ref={measuredContentRef} className={contentClassName}>
           {children}
@@ -75,20 +91,36 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
       </div>
       {needsCollapse && (
         <div className="absolute bottom-0 left-0 right-0 flex items-end justify-center bg-gradient-to-t from-background to-transparent pt-8 pb-0">
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            aria-controls={contentId}
-            aria-label="Show more content"
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2 py-0.5 rounded-full border border-border/60 cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation()
-              setIsExpanded(true)
-            }}
-          >
-            <span>Show more</span>
-            <ChevronDown className="size-3" />
-          </button>
+          {onReadMore ? (
+            <button
+              type="button"
+              aria-controls={contentId}
+              aria-label="Read full post"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2.5 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs"
+              onClick={(e) => {
+                e.stopPropagation()
+                onReadMore()
+              }}
+            >
+              <span>Read full post</span>
+              <ChevronRight className="size-3" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              aria-controls={contentId}
+              aria-label="Show more content"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs"
+              onClick={(e) => {
+                e.stopPropagation()
+                setIsExpanded(true)
+              }}
+            >
+              <span>Show more</span>
+              <ChevronDown className="size-3" />
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -30,8 +30,25 @@ import {
 import { Post } from './post'
 
 vi.mock('./collapsible-content', () => ({
-  CollapsibleContent: ({ children }: { children: ReactNode }) => (
-    <div data-testid="collapsible-content">{children}</div>
+  CollapsibleContent: ({
+    children,
+    onReadMore
+  }: {
+    children: ReactNode
+    onReadMore?: () => void
+  }) => (
+    <div data-testid="collapsible-content">
+      {children}
+      {onReadMore && (
+        <button
+          type="button"
+          data-testid="read-more-button"
+          onClick={onReadMore}
+        >
+          Read full post
+        </button>
+      )}
+    </div>
   )
 }))
 
@@ -183,6 +200,44 @@ describe('Post', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show content' }))
 
     expect(screen.queryByTestId('collapsible-content')).not.toBeInTheDocument()
+  })
+
+  it('wires onReadMore to onOpenStatus when collapsible and postLineLimit are enabled', () => {
+    const handleOpenStatus = vi.fn()
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{ ...status, summary: null }}
+        collapsible
+        postLineLimit={5}
+        onOpenStatus={handleOpenStatus}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    const readMoreBtn = screen.getByTestId('read-more-button')
+    expect(readMoreBtn).toBeInTheDocument()
+    fireEvent.click(readMoreBtn)
+    expect(handleOpenStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ id: status.id })
+    )
+  })
+
+  it('omits onReadMore when onOpenStatus is not provided', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{ ...status, summary: null }}
+        collapsible
+        postLineLimit={5}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('collapsible-content')).toBeInTheDocument()
+    expect(screen.queryByTestId('read-more-button')).not.toBeInTheDocument()
   })
 
   describe('quote-inline RE: fallback', () => {

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -134,7 +134,14 @@ export const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
 }
 
 export const Post: FC<PostProps> = (props) => {
-  const { host, status, onShowAttachment, collapsible, postLineLimit } = props
+  const {
+    host,
+    status,
+    onShowAttachment,
+    collapsible,
+    postLineLimit,
+    onOpenStatus
+  } = props
   const actualStatus = getActualStatus(status)
   // Held here because the chips and the action-row trigger are two halves of
   // one control. An Announce wrapper carries no reactions of its own — they
@@ -280,6 +287,7 @@ export const Post: FC<PostProps> = (props) => {
             className="mt-1 text-sm leading-relaxed break-words"
             contentClassName="markdown-content"
             maxLines={postLineLimit}
+            onReadMore={onOpenStatus ? () => onOpenStatus(status) : undefined}
           >
             {processedAndCleanedText}
           </CollapsibleContent>


### PR DESCRIPTION
## Summary
On macOS Safari and iOS Mobile Safari, collapsed long timeline posts displayed large unexplained blank space beneath them due to WebKit retaining initial unconstrained SSR layout geometry inside nested flex containers when children dynamically clamp post-hydration.

This PR addresses the issue comprehensively:
1. **Pre-clamp on SSR**: `CollapsibleContent` now applies `maxHeight` and `overflow-hidden min-h-0` before hydration overflow checks complete (`shouldClamp = needsCollapse || (!hasCheckedOverflow && !isExpanded)`), ensuring WebKit never lays out the post unconstrained on initial render.
2. **Read Full Post Navigation**: Replaces inline expansion with a `Read full post` button that navigates directly to the status detail page via `onOpenStatus`, avoiding inline content expansion bugs and improving UX on long posts.
3. **Backwards Compatibility**: Preserves fallback to inline `Show more` expansion if `onReadMore` / `onOpenStatus` is omitted.
4. **Replies Support**: Wires `onOpenStatus` in `FitnessStatusDetail` so reply posts also navigate cleanly.

## Verification
- Prettier, Oxlint, Typecheck, Build, and full Test Suite (1040 test files, 14,436 tests) all pass in order.
- Verified in WebKit with iPhone 15 emulation via Playwright: measured 0 extra gap between collapsed post actions and succeeding feed posts.