### PR TITLE
Bump version to v1.162.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.162.3",
+  "version": "1.162.4",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.162.3`
- Base main SHA: `77c29644e7a81c5e30253f2ccfefa9055ea3f353`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
