### PR TITLE
fix: match Read full post button size to load more button

### DIFF
--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -182,6 +182,9 @@ describe('CollapsibleContent', () => {
     })
 
     const button = screen.getByRole('button', { name: 'Read full post' })
+    expect(button).toHaveAttribute('data-slot', 'button')
+    expect(button).toHaveAttribute('data-variant', 'outline')
+    expect(button).toHaveAttribute('data-size', 'default')
     fireEvent.click(button)
 
     expect(handleReadMore).toHaveBeenCalledTimes(1)
@@ -201,6 +204,9 @@ describe('CollapsibleContent', () => {
     })
 
     const button = screen.getByRole('button', { name: 'Show more content' })
+    expect(button).toHaveAttribute('data-slot', 'button')
+    expect(button).toHaveAttribute('data-variant', 'outline')
+    expect(button).toHaveAttribute('data-size', 'default')
     const content = document.getElementById(
       button.getAttribute('aria-controls')!
     )

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -11,6 +11,7 @@ import {
   useState
 } from 'react'
 
+import { Button } from '@/lib/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface CollapsibleContentProps {
@@ -87,34 +88,36 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
       {needsCollapse && (
         <div className="absolute bottom-0 left-0 right-0 flex items-end justify-center bg-gradient-to-t from-background to-transparent pt-8 pb-0">
           {onReadMore ? (
-            <button
+            <Button
               type="button"
+              variant="outline"
               aria-controls={contentId}
               aria-label="Read full post"
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2.5 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="bg-background/80 backdrop-blur-sm"
               onClick={(e) => {
                 e.stopPropagation()
                 onReadMore()
               }}
             >
               <span>Read full post</span>
-              <ChevronRight className="size-3" />
-            </button>
+              <ChevronRight className="size-4" />
+            </Button>
           ) : (
-            <button
+            <Button
               type="button"
+              variant="outline"
               aria-expanded={isExpanded}
               aria-controls={contentId}
               aria-label="Show more content"
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors bg-background/80 backdrop-blur-sm px-2 py-0.5 rounded-full border border-border/60 cursor-pointer shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="bg-background/80 backdrop-blur-sm"
               onClick={(e) => {
                 e.stopPropagation()
                 setIsExpanded(true)
               }}
             >
               <span>Show more</span>
-              <ChevronDown className="size-3" />
-            </button>
+              <ChevronDown className="size-4" />
+            </Button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

Updates the "Read full post" button (and fallback "Show more" button) in `CollapsibleContent` to match the size and styling of the timeline "Load more" button by utilizing the shared `<Button variant="outline">` component.

- Uses `<Button variant="outline">` from `@/lib/components/ui/button` with `bg-background/80 backdrop-blur-sm`.
- Matches the default button height `h-9` (`36px`), typography `text-sm font-medium`, `rounded-md` corner radius, and `size-4` chevron icon.
- Updates unit tests in `collapsible-content.test.tsx` to assert button slots, variant, and size.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)