### PR TITLE
Bump version to v1.162.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.162.4",
+  "version": "1.162.5",
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Automated version bump to v1.162.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.162.4`
- Base main SHA: `8459ed0f17ad9357f5241182310284c2db07ac66`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
